### PR TITLE
Fix golr urls

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -229,7 +229,7 @@
             description="Copy client into webapp plugin directory.">
         <echo>copying plugin to webapp ...</echo>
         <copy todir="${jbrowse.download.directory}/plugins/WebApollo" failonerror="true">
-            <fileset dir="${apollo.client.directory}"/>
+            <fileset dir="${apollo.client.directory}" includes="**/*.js" />
             <filterset>
                 <!--<filter token="GOLR_URL" value="http://golr.berkeleybop.org/"/>-->
                 <!--Alternate GOLR URL's-->

--- a/build.xml
+++ b/build.xml
@@ -225,10 +225,10 @@
         </copy>
     </target>
 
-    <target name="copy.apollo.plugin.webapp" unless="jbrowse.precompiled" if="jbrowse.webapp.installed"
+    <target name="copy.apollo.plugin.webapp" unless="jbrowse.precompiled" if="jbrowse.git.present"
             description="Copy client into webapp plugin directory.">
         <echo>copying plugin to webapp ...</echo>
-        <copy todir="${apollo.jbrowse.directory}/plugins/WebApollo" failonerror="true">
+        <copy todir="${jbrowse.download.directory}/plugins/WebApollo" failonerror="true">
             <fileset dir="${apollo.client.directory}"/>
             <filterset>
                 <!--<filter token="GOLR_URL" value="http://golr.berkeleybop.org/"/>-->


### PR DESCRIPTION
This is a proposed fix for #148 that copies the plugin to the jbrowse.download.directory instead of the webapp directory and only applies the filter to the js files


CC @deepakunni3 @nathandunn 