### PR TITLE
1.0.4 various fixes

### DIFF
--- a/client/apollo/css/main.css
+++ b/client/apollo/css/main.css
@@ -15,3 +15,4 @@
 @import url("annotation_info_editor.css");
 @import url("confirm_dialog.css");
 @import url("information_editor_panel.css");
+@import url("maker_darkbackground.css");

--- a/client/apollo/css/maker_darkbackground.css
+++ b/client/apollo/css/maker_darkbackground.css
@@ -3,8 +3,11 @@
 .Dark div.track  {
     /* based on CoolWorld color palette from kuler.adobe.com */
     /*background-color: #142933;*/
+    border:0px;
 }
-
+.Dark .sequence_blur {
+    background-color: #999;
+}
 .Dark div.pin_underlay {
     background-color: #142933;
 }
@@ -13,7 +16,7 @@
     color: #FAFFF9;
 }
 
-div.outerTrackContainer {
+.Dark div.outerTrackContainer {
 
     background-color: rgb(59, 59, 61);
 }
@@ -176,7 +179,7 @@ div.outerTrackContainer {
     background-color: rgb(0,204,0);
 }
 
-.upd-UTR {
+.Dark .upd-UTR {
     height: 80%;
     top: 10%;
     border-style: solid;
@@ -342,3 +345,7 @@ div.outerTrackContainer {
 }
 
 /* end of MAKER styles */
+.Dark .global_highlight {
+    background: rgba(62,100,150,0.7);
+    border: 0px;
+}

--- a/client/apollo/css/maker_darkbackground.css
+++ b/client/apollo/css/maker_darkbackground.css
@@ -54,8 +54,8 @@
     color: #FAFFF9;
 }
 
-.Dark div.track_annotations {
-    background-color: #70D2D0;
+.Dark .track_annotations .feature-label {
+    color: #000;
 }
 
 /* UI elements */
@@ -345,7 +345,3 @@
 }
 
 /* end of MAKER styles */
-.Dark .global_highlight {
-    background: rgba(62,100,150,0.7);
-    border: 0px;
-}

--- a/client/apollo/css/maker_darkbackground.css
+++ b/client/apollo/css/maker_darkbackground.css
@@ -1,4 +1,11 @@
 /* styles for MAKER tracks and additional customization of WebApollo */
+.Dark .track_jbrowse_view_track_wiggle_xyplot .canvas-track {
+    background-color: #DDD;
+}
+
+.Dark .track_jbrowse_view_track_wiggle_density .canvas-track {
+    background-color: #DDD;
+}
 
 .Dark div.track  {
     /* based on CoolWorld color palette from kuler.adobe.com */

--- a/client/apollo/css/webapollo_track_styles.css
+++ b/client/apollo/css/webapollo_track_styles.css
@@ -1,4 +1,4 @@
-/*
+//*
 *  naming conventions
 
 */
@@ -111,17 +111,17 @@ div.wa-sequence .aa-residues  {
 /*    outline: 1px solid orange; */
 }
 
-div.wa-sequence .aa-residues.frame0 {
+div.wa-sequence .aa-residues.cds-frame0 {
     background-color: #999999; 
     z-index: 5;
 }
 
-div.wa-sequence .aa-residues.frame1 {
+div.wa-sequence .aa-residues.cds-frame1 {
     background-color: #BBBBBB; 
     z-index: 5;
 }
 
-div.wa-sequence .aa-residues.frame2 {
+div.wa-sequence .aa-residues.cds-frame2 {
     background-color: #DDDDDD; 
     z-index: 5;
 }
@@ -621,16 +621,16 @@ div.basic-hist {
     z-index: 15;
 }
 
-.cds-frame0 {
-    background-color: #FF8080 !important;
+.colorCds .cds-frame0 {
+    background-color: #FF8080;
 }
 
-.cds-frame1 {
-    background-color: #80FF80 !important;
+.colorCds .cds-frame1 {
+    background-color: #80FF80;
 }
 
-.cds-frame2 {
-    background-color: #8080FF !important;
+.colorCds .cds-frame2 {
+    background-color: #8080FF;
 }
 
 /**

--- a/client/apollo/css/webapollo_track_styles.css
+++ b/client/apollo/css/webapollo_track_styles.css
@@ -111,17 +111,17 @@ div.wa-sequence .aa-residues  {
 /*    outline: 1px solid orange; */
 }
 
-div.wa-sequence .aa-residues.cds-frame0 {
+.aa-residues.cds-frame0 {
     background-color: #999999; 
     z-index: 5;
 }
 
-div.wa-sequence .aa-residues.cds-frame1 {
+.aa-residues.cds-frame1 {
     background-color: #BBBBBB; 
     z-index: 5;
 }
 
-div.wa-sequence .aa-residues.cds-frame2 {
+.aa-residues.cds-frame2 {
     background-color: #DDDDDD; 
     z-index: 5;
 }

--- a/client/apollo/css/webapollo_track_styles.css
+++ b/client/apollo/css/webapollo_track_styles.css
@@ -39,7 +39,7 @@
 }
 
 
-div.track_annotations {
+.track.track_annotations {
     background-color: #FFFFDD;
 }
 

--- a/client/apollo/css/webapollo_track_styles.css
+++ b/client/apollo/css/webapollo_track_styles.css
@@ -40,11 +40,11 @@
 
 
 div.track_annotations {
-    background-color: #FFFFDD !important;
+    background-color: #FFFFDD;
 }
 
 div.track_localannot {
-    background-color: #DDDDCC !important;
+    background-color: #DDDDCC;
 }
 
 /* 

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -732,11 +732,8 @@ var AnnotTrack = declare( DraggableFeatureTrack,
         else  {
             var tracks = this.gview.tracks;
             for (var i = 0; i < tracks.length; i++)  {
-                // if (tracks[i] instanceof SequenceTrack) {
-                // if (tracks[i].config.type == "WebApollo/View/Track/AnnotSequenceTrack") {
                 if (tracks[i].isWebApolloSequenceTrack)  {
                     this.seqTrack = tracks[i];
-                   // tracks[i].setAnnotTrack(this);
                     break;
                 }
             }
@@ -5483,20 +5480,21 @@ var AnnotTrack = declare( DraggableFeatureTrack,
         var browser = this.browser;
         var clabel = this.name+"-collapsed";
         var options = this.inherited(arguments) || [];
-
+        
         options.push({ label: "Collapsed view",
                  title: "Collapsed view",
                  type: 'dijit/CheckedMenuItem',
                  checked: browser.cookie(clabel)=="true",
                  onClick: function(event) {
-                     console.log("Updated collapse");
                      thisB.collapsedMode=this.get("checked");
                      browser.cookie(clabel,this.get("checked")?"true":"false");
                      var temp=thisB.showLabels;
-                     if(this.get("checked")) {thisB.showLabels=false;}
+                     if(this.get("checked")) {thisB.showLabels=false; }
                      else if(thisB.previouslyShowLabels) {thisB.showLabels=true;}
                      thisB.previouslyShowLabels=temp;
-                     thisB.changed();
+                     delete thisB.trackMenu;
+                     thisB.makeTrackMenu();
+                     thisB.redraw();
                  }
                });
 

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -5461,16 +5461,13 @@ var AnnotTrack = declare( DraggableFeatureTrack,
         var clabel = this.name+"-collapsed";
         return declare.safeMixin( layout, { 
             addRect: function( id, left, right, height, data ) {
+                var cm = thisB.collapsedMode||browser.cookie(clabel)=="true";
                 //store height for collapsed mode
-                var cm=thisB.collapsedMode||browser.cookie(clabel)=="true";
-                if( cm) {
+                if( cm ) {
                     var pHeight = Math.ceil(  height / this.pitchY );
                     this.pTotalHeight = Math.max( this.pTotalHeight||0, pHeight );
                 }
                 return cm?0:this.inherited(arguments);
-            },
-            getTotalHeight: function() {
-                return browser.cookie(clabel)=="true"?this.pTotalHeight||30:this.inherited(arguments);
             }
         });
     },

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -1,5 +1,6 @@
 define( [
             'dojo/_base/declare',
+            'dojo/_base/lang',
             'jquery',
             'jqueryui/draggable',
             'jqueryui/droppable',
@@ -40,12 +41,47 @@ define( [
             'dojo/store/Memory',
             'dojo/data/ObjectStore'
         ],
-        function( declare, $, draggable, droppable, resizable, autocomplete, dialog,
-          dijitMenu, dijitMenuItem, dijitMenuSeparator , dijitPopupMenuItem, dijitButton, dijitDropDownButton, dijitDropDownMenu,
-          dijitComboBox, dijitTextBox, dijitValidationTextBox, dijitRadioButton,
-          dojoxDialogSimple, dojoxDataGrid, dojoxCells, dojoItemFileWriteStore, 
-          DraggableFeatureTrack, FeatureSelectionManager, JSONUtils, BioFeatureUtils, Permission, SequenceSearch, EUtils, SequenceOntologyUtils,
-          SimpleFeature, Util, Layout, xhr, Standby, Tooltip, FormatUtils, Select, Memory, ObjectStore ) {
+        function( declare,
+            lang,
+            $,
+            draggable
+            droppable
+            resizable
+            autocomplete
+            dialog,
+            dijitMenu
+            dijitMenuItem
+            dijitMenuSeparator 
+            dijitPopupMenuItem
+            dijitButton
+            dijitDropDownButton
+            dijitDropDownMenu,
+            dijitComboBox
+            dijitTextBox
+            dijitValidationTextBox
+            dijitRadioButton,
+            dojoxDialogSimple
+            dojoxDataGrid
+            dojoxCells
+            dojoItemFileWriteStore
+            DraggableFeatureTrack
+            FeatureSelectionManager
+            JSONUtils
+            BioFeatureUtils
+            Permission
+            SequenceSearch
+            EUtils
+            SequenceOntologyUtils,
+            SimpleFeature
+            Util
+            Layout
+            xhr
+            Standby
+            Tooltip
+            FormatUtils
+            Select
+            Memory
+            ObjectStore ) {
 
 // var listeners = [];
 // var listener;
@@ -5418,16 +5454,6 @@ var AnnotTrack = declare( DraggableFeatureTrack,
                                if (start1 != start2)  { return start1 - start2; }
                                else if (end1 != end2) { return end1 - end2; }
                                else                   { return annot1.id().localeCompare(annot2.id()); }
-                               /*
-                                 * if (annot1[track.fields["start"]] !=
-                                 * annot2[track.fields["start"]]) { return
-                                 * annot1[track.fields["start"]] -
-                                 * annot2[track.fields["start"]]; } if
-                                 * (annot1[track.fields["end"]] !=
-                                 * annot2[track.fields["end"]]) { return
-                                 * annot1[track.fields["end"]] -
-                                 * annot2[track.fields["end"]]; } return 0;
-                                 */
                            });
     },
 
@@ -5436,24 +5462,28 @@ var AnnotTrack = declare( DraggableFeatureTrack,
     _getLayout: function( ) {
         var thisB=this; 
         var layout=this.inherited( arguments ); 
-        return dojo.safeMixin(layout, { 
+        return lang.safeMixin( layout, { 
             addRect: function( id, left, right, height, data ) {
                 var top=this.inherited(arguments); 
-                return thisB.browser.cookie('Collapsed')=="1"?0:top;
+                return thisB.browser.cookie(thisB.label+'Collapsed')=="true"?0:top;
             }
         });
     },
 
     _trackMenuOptions: function() {
         var thisB = this;
+        var browser = this.browser;
+        var clabel = this.label+"-collapsed";
         var options = this.inherited(arguments) || [];
 
         options.push({ label: "Collapsed view",
                  title: "Collapsed view",
                  type: 'dijit/CheckedMenuItem',
-                 checked: this.browser.cookie('Collapsed')==1,
+                 checked: browser.cookie(clabel)=="true",
                  onClick: function(event) {
-                     thisB.browser.cookie('Collapsed',this.get("checked")?"1":"0");
+                     browser.cookie(clabel,this.get("checked")?"true":"false");
+                     if(this.get("checked")) {thisB.showLabels=false;}
+                     thisB.changed();
                      thisB.redraw();
                  }
                });

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -47,7 +47,7 @@ define( [
             resizable,
             autocomplete,
             dialog,
-            dijitMenm,
+            dijitMenu,
             dijitMenuItem,
             dijitMenuSeparator,
             dijitPopupMenuItem,

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -5465,11 +5465,12 @@ var AnnotTrack = declare( DraggableFeatureTrack,
         return declare.safeMixin( layout, { 
             addRect: function( id, left, right, height, data ) {
                 //store height for collapsed mode
-                if( browser.cookie(clabel)=="true") {
+                var cm=thisB.collapsedMode||browser.cookie(clabel)=="true";
+                if( cm) {
                     var pHeight = Math.ceil(  height / this.pitchY );
                     this.pTotalHeight = Math.max( this.pTotalHeight||0, pHeight );
                 }
-                return browser.cookie(clabel)=="true"?0:this.inherited(arguments);
+                return cm?0:this.inherited(arguments);
             },
             getTotalHeight: function() {
                 return browser.cookie(clabel)=="true"?this.pTotalHeight||30:this.inherited(arguments);
@@ -5489,14 +5490,13 @@ var AnnotTrack = declare( DraggableFeatureTrack,
                  checked: browser.cookie(clabel)=="true",
                  onClick: function(event) {
                      console.log("Updated collapse");
+                     thisB.collapsedMode=this.get("checked");
                      browser.cookie(clabel,this.get("checked")?"true":"false");
                      var temp=thisB.showLabels;
                      if(this.get("checked")) {thisB.showLabels=false;}
                      else if(thisB.previouslyShowLabels) {thisB.showLabels=true;}
                      thisB.previouslyShowLabels=temp;
-                     
                      thisB.changed();
-                     thisB.redraw();
                  }
                });
 

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -5484,7 +5484,7 @@ var AnnotTrack = declare( DraggableFeatureTrack,
         options.push({ label: "Collapsed view",
                  title: "Collapsed view",
                  type: 'dijit/CheckedMenuItem',
-                 checked: browser.cookie(clabel)=="true",
+                 checked: !!('collapsedMode' in thisB ? thisB.collapsedMode : browser.cookie(clabel)=="true"),
                  onClick: function(event) {
                      thisB.collapsedMode=this.get("checked");
                      browser.cookie(clabel,this.get("checked")?"true":"false");

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -5465,12 +5465,15 @@ var AnnotTrack = declare( DraggableFeatureTrack,
         return declare.safeMixin( layout, { 
             addRect: function( id, left, right, height, data ) {
                 //store height for collapsed mode
-                this._pHeight=Math.ceil(  height / this.pitchY );
+                if( browser.cookie(clabel)=="true") {
+                    var pHeight = Math.ceil(  height / this.pitchY );
+                    this.pTotalHeight = Math.max( this.pTotalHeight||0, pHeight );
+                }
                 return browser.cookie(clabel)=="true"?0:this.inherited(arguments);
             },
             getTotalHeight: function() {
-                console.log("here");
-                return browser.cookie(clabel)=="true"?this._pHeight||30:this.inherited(arguments);
+                console.log("here",this.pTotalHeight);
+                return browser.cookie(clabel)=="true"?this.pTotalHeight||30:this.inherited(arguments);
             }
         });
     },
@@ -5488,7 +5491,11 @@ var AnnotTrack = declare( DraggableFeatureTrack,
                  onClick: function(event) {
                      console.log("Updated collapse");
                      browser.cookie(clabel,this.get("checked")?"true":"false");
+                     var temp=thisB.showLabels;
                      if(this.get("checked")) {thisB.showLabels=false;}
+                     else if(thisB.previouslyShowLabels) {thisB.showLabels=true;}
+                     thisB.previouslyShowLabels=temp;
+                     
                      thisB.changed();
                      thisB.redraw();
                  }

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -1,6 +1,5 @@
 define( [
             'dojo/_base/declare',
-            'dojo/_base/lang',
             'jquery',
             'jqueryui/draggable',
             'jqueryui/droppable',
@@ -42,45 +41,44 @@ define( [
             'dojo/data/ObjectStore'
         ],
         function( declare,
-            lang,
             $,
-            draggable
-            droppable
-            resizable
-            autocomplete
+            draggable,
+            droppable,
+            resizable,
+            autocomplete,
             dialog,
-            dijitMenu
-            dijitMenuItem
-            dijitMenuSeparator 
-            dijitPopupMenuItem
-            dijitButton
-            dijitDropDownButton
+            dijitMenm,
+            dijitMenuItem,
+            dijitMenuSeparator,
+            dijitPopupMenuItem,
+            dijitButton,
+            dijitDropDownButton,
             dijitDropDownMenu,
-            dijitComboBox
-            dijitTextBox
-            dijitValidationTextBox
+            dijitComboBox,
+            dijitTextBox,
+            dijitValidationTextBox,
             dijitRadioButton,
-            dojoxDialogSimple
-            dojoxDataGrid
-            dojoxCells
-            dojoItemFileWriteStore
-            DraggableFeatureTrack
-            FeatureSelectionManager
-            JSONUtils
-            BioFeatureUtils
-            Permission
-            SequenceSearch
-            EUtils
+            dojoxDialogSimple,
+            dojoxDataGrid,
+            dojoxCell,
+            dojoItemFileWriteStore,
+            DraggableFeatureTrack,
+            FeatureSelectionManager,
+            JSONUtil,
+            BioFeatureUtil,
+            Permission,
+            SequenceSearch,
+            EUtils,
             SequenceOntologyUtils,
-            SimpleFeature
-            Util
-            Layout
-            xhr
-            Standby
-            Tooltip
-            FormatUtils
-            Select
-            Memory
+            SimpleFeature,
+            Util,
+            Layout,
+            xhr,
+            Standby,
+            Tooltip,
+            FormatUtils,
+            Select,
+            Memory,
             ObjectStore ) {
 
 // var listeners = [];
@@ -5461,11 +5459,18 @@ var AnnotTrack = declare( DraggableFeatureTrack,
     // override getLayout to access addRect method
     _getLayout: function( ) {
         var thisB=this; 
+        var browser = this.browser;
         var layout=this.inherited( arguments ); 
-        return lang.safeMixin( layout, { 
+        var clabel = this.label+"-collapsed";
+        return declare.safeMixin( layout, { 
             addRect: function( id, left, right, height, data ) {
-                var top=this.inherited(arguments); 
-                return thisB.browser.cookie(thisB.label+'Collapsed')=="true"?0:top;
+                //store height for collapsed mode
+                this._pHeight=Math.ceil(  height / this.pitchY );
+                return browser.cookie(clabel)=="true"?0:this.inherited(arguments);
+            },
+            getTotalHeight: function() {
+                console.log("here");
+                return browser.cookie(clabel)=="true"?this._pHeight||30:this.inherited(arguments);
             }
         });
     },
@@ -5481,6 +5486,7 @@ var AnnotTrack = declare( DraggableFeatureTrack,
                  type: 'dijit/CheckedMenuItem',
                  checked: browser.cookie(clabel)=="true",
                  onClick: function(event) {
+                     console.log("Updated collapse");
                      browser.cookie(clabel,this.get("checked")?"true":"false");
                      if(this.get("checked")) {thisB.showLabels=false;}
                      thisB.changed();

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -5461,7 +5461,7 @@ var AnnotTrack = declare( DraggableFeatureTrack,
         var thisB=this; 
         var browser = this.browser;
         var layout=this.inherited( arguments ); 
-        var clabel = this.label+"-collapsed";
+        var clabel = this.name+"-collapsed";
         return declare.safeMixin( layout, { 
             addRect: function( id, left, right, height, data ) {
                 //store height for collapsed mode
@@ -5472,7 +5472,6 @@ var AnnotTrack = declare( DraggableFeatureTrack,
                 return browser.cookie(clabel)=="true"?0:this.inherited(arguments);
             },
             getTotalHeight: function() {
-                console.log("here",this.pTotalHeight);
                 return browser.cookie(clabel)=="true"?this.pTotalHeight||30:this.inherited(arguments);
             }
         });
@@ -5481,7 +5480,7 @@ var AnnotTrack = declare( DraggableFeatureTrack,
     _trackMenuOptions: function() {
         var thisB = this;
         var browser = this.browser;
-        var clabel = this.label+"-collapsed";
+        var clabel = this.name+"-collapsed";
         var options = this.inherited(arguments) || [];
 
         options.push({ label: "Collapsed view",

--- a/client/apollo/js/View/Track/DraggableHTMLFeatures.js
+++ b/client/apollo/js/View/Track/DraggableHTMLFeatures.js
@@ -1314,7 +1314,6 @@ var draggableTrack = declare( HTMLFeatureTrack,
             if( ! block || ! this.label )
                 return;
             var viewLeft = 100 * ( (this.label.offsetLeft+(showLabels?this.label.offsetWidth:0)) - block.domNode.offsetLeft ) / block.domNode.offsetWidth + 2;
-            console.log(viewLeft);
 
             // if the view start is unknown, or is to the
             // left of this block, we don't have to worry

--- a/client/apollo/js/View/Track/DraggableHTMLFeatures.js
+++ b/client/apollo/js/View/Track/DraggableHTMLFeatures.js
@@ -1299,6 +1299,49 @@ var draggableTrack = declare( HTMLFeatureTrack,
             this.contextMenuItems["create_annotation"].set("disabled", false);
         }
 
+    },
+    updateFeatureLabelPositions: function( coords ) {
+        var showLabels=this.webapollo._showLabels;
+        if( ! 'x' in coords )
+            return;
+
+        array.forEach( this.blocks, function( block, blockIndex ) {
+
+
+            // calculate the view left coord relative to the
+            // block left coord in units of pct of the block
+            // width
+            if( ! block || ! this.label )
+                return;
+            var viewLeft = 100 * ( (this.label.offsetLeft+(showLabels?this.label.offsetWidth:0)) - block.domNode.offsetLeft ) / block.domNode.offsetWidth + 2;
+            console.log(viewLeft);
+
+            // if the view start is unknown, or is to the
+            // left of this block, we don't have to worry
+            // about adjusting the feature labels
+            if( ! viewLeft )
+                return;
+
+            var blockWidth = block.endBase - block.startBase;
+
+            array.forEach( block.domNode.childNodes, function( featDiv ) {
+                              if( ! featDiv.label ) return;
+                              var labelDiv = featDiv.label;
+                              var feature = featDiv.feature;
+
+                              // get the feature start and end in terms of block width pct
+                              var minLeft = parseInt( feature.get('start') );
+                              minLeft = 100 * (minLeft - block.startBase) / blockWidth;
+                              var maxLeft = parseInt( feature.get('end') );
+                              maxLeft = 100 * ( (maxLeft - block.startBase) / blockWidth
+                                                - labelDiv.offsetWidth / block.domNode.offsetWidth
+                                              );
+
+                              // move our label div to the view start if the start is between the feature start and end
+                              labelDiv.style.left = Math.max( minLeft, Math.min( viewLeft, maxLeft ) ) + '%';
+
+                          },this);
+        },this);
     }
 
 });

--- a/client/apollo/js/View/Track/DraggableHTMLFeatures.js
+++ b/client/apollo/js/View/Track/DraggableHTMLFeatures.js
@@ -731,9 +731,7 @@ var draggableTrack = declare( HTMLFeatureTrack,
                 segDiv.style.cssText =
                     "left: " + (100 * ((cdsSegStart - subStart) / subLength)) + "%;"
                     + "width: " + (100 * ((cdsSegEnd - cdsSegStart) / subLength)) + "%;";
-                if (this.config.style.colorCdsFrame || this.browser.cookie("colorCdsByFrame")=="true") {
-                    dojo.addClass(segDiv, "cds-frame" + cdsFrame);
-                }
+                dojo.addClass(segDiv, "cds-frame" + cdsFrame);
                 subDiv.appendChild(segDiv);
             }
             priorCdsLength += (cdsSegEnd - cdsSegStart);

--- a/client/apollo/js/View/Track/DraggableHTMLFeatures.js
+++ b/client/apollo/js/View/Track/DraggableHTMLFeatures.js
@@ -664,9 +664,7 @@ var draggableTrack = declare( HTMLFeatureTrack,
                 segDiv.style.cssText =
                     "left: " + (100 * ((subStart - subStart) / subLength)) + "%;"
                     + "width: " + (100 * ((subEnd - subStart) / subLength)) + "%;";
-                if (this.config.style.colorCdsFrame || this.browser.cookie("colorCdsByFrame")=="true") {
-                    dojo.addClass(segDiv, "cds-frame" + cdsFrame);
-                }
+                dojo.addClass(segDiv, "cds-frame" + cdsFrame);
                 subDiv.appendChild(segDiv);
             }
             priorCdsLength += subLength;

--- a/client/apollo/js/View/Track/SequenceTrack.js
+++ b/client/apollo/js/View/Track/SequenceTrack.js
@@ -537,12 +537,7 @@ function( declare, StaticChunked, ScratchPad, DraggableFeatureTrack, JSONUtils, 
                                 // frame = (frame + (3 - (track.refSeq.length % 3))) % 3;
                                 frame = (Math.abs(frame - 2) + (track.refSeq.length % 3)) % 3;
                                 var transProtein = track.renderTranslation( extendedStartResidues, i, blockLength, true);
-                                if (track.browser.cookie("colorCdsByFrame")=="true") {
-                                    $(transProtein).addClass("cds-frame" + frame);
-                                }
-                                else  {
-                                    $(transProtein).addClass("frame" + frame);
-                                }
+                                $(transProtein).addClass("cds-frame" + frame);
                                 framedivs[frame] = transProtein;
                             }
                             // for (var i=2; i>=0; i--) {

--- a/client/apollo/js/View/Track/SequenceTrack.js
+++ b/client/apollo/js/View/Track/SequenceTrack.js
@@ -427,12 +427,7 @@ function( declare, StaticChunked, ScratchPad, DraggableFeatureTrack, JSONUtils, 
                                 var transProtein = track.renderTranslation( extendedEndResidues, i, blockLength);
                                 // if coloring CDS in feature tracks by frame, use same "cds-frame" styling,
                                 //    otherwise use more muted "frame" styling
-                                if (track.browser.cookie("colorCdsByFrame")=="true") {
-                                    $(transProtein).addClass("cds-frame" + frame);
-                                }
-                                else  {
-                                    $(transProtein).addClass("frame" + frame);
-                                }
+                                $(transProtein).addClass("cds-frame" + frame);
                                 framedivs[frame] = transProtein;
                             }
                             for (var i=2; i>=0; i--) {

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -403,7 +403,7 @@ return declare( [JBPlugin, HelpMixin],
         var thisB = this;
 
         var strandFilter = function(name,callback,toggle) {
-            if(toggle||browser.cookie(name)=="true") {
+            if(toggle) {
                 browser.removeFeatureFilter(name);
             } else {
                 browser.addFeatureFilter(callback,name);
@@ -422,7 +422,7 @@ return declare( [JBPlugin, HelpMixin],
         var plus_strand_toggle = new dijitCheckedMenuItem(
                 {
                     label: "Show plus strand",
-                    checked: browser.cookie("plusStrandFilter")=="true",
+                    checked: !(browser.cookie("plusStrandFilter")=="true"),
                     onClick: function(event) {
                         browser.cookie("plusStrandFilter",this.get("checked")?"true":"false");
                         strandFilter("plusStrandFilter",plusStrandFilter,this.get("checked"));
@@ -432,7 +432,7 @@ return declare( [JBPlugin, HelpMixin],
         var minus_strand_toggle = new dijitCheckedMenuItem(
                 {
                     label: "Show minus strand",
-                    checked: browser.cookie("minusStandFilter")=="true",
+                    checked: !(browser.cookie("minusStrandFilter")=="true"),
                     onClick: function(event) {
                         browser.cookie("minusStrandFilter",this.get("checked")?"true":"false");
                         strandFilter("minusStrandFilter",minusStrandFilter,this.get("checked"));
@@ -442,8 +442,8 @@ return declare( [JBPlugin, HelpMixin],
         browser.addGlobalMenuItem( 'view', plus_strand_toggle );
         browser.addGlobalMenuItem( 'view', minus_strand_toggle );
 
-        strandFilter("minusStrandFilter",minusStrandFilter);
-        strandFilter("plusStrandFilter",plusStrandFilter);
+        strandFilter("minusStrandFilter",minusStrandFilter, !(browser.cookie("minusStrandFilter")=="true"));
+        strandFilter("plusStrandFilter",plusStrandFilter, !(browser.cookie("plusStrandFilter")=="true"));
     },
         
     addNavigationOptions: function()  {

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -404,8 +404,8 @@ return declare( [JBPlugin, HelpMixin],
         var browser=this.browser;
         var thisB = this;
 
-        var strandFilter = function(name,callback) {
-            if(browser.cookie(name)=="true") {
+        var strandFilter = function(name,callback,toggle) {
+            if(toggle||browser.cookie(name)=="true") {
                 browser.addFeatureFilter(callback,name);
             } else {
                 browser.removeFeatureFilter(name);
@@ -427,7 +427,7 @@ return declare( [JBPlugin, HelpMixin],
                     checked: browser.cookie("plusStrandFilter")=="true",
                     onClick: function(event) {
                         browser.cookie("plusStrandFilter",this.get("checked")?"true":"false");
-                        strandFilter("plusStrandFilter",plusStrandFilter);
+                        strandFilter("plusStrandFilter",plusStrandFilter,this.get("checked"));
                         browser.view.redrawTracks();
                     }
                 });
@@ -437,7 +437,7 @@ return declare( [JBPlugin, HelpMixin],
                     checked: browser.cookie("minusStandFilter")=="true",
                     onClick: function(event) {
                         browser.cookie("minusStrandFilter",this.get("checked")?"true":"false");
-                        strandFilter("minusStrandFilter",minusStrandFilter);
+                        strandFilter("minusStrandFilter",minusStrandFilter,this.get("checked"));
                         browser.view.redrawTracks();
                     }
                 });

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -89,8 +89,8 @@ return declare( [JBPlugin, HelpMixin],
         // Checking for cookie for determining the color scheme of WebApollo
         if (browser.cookie("Scheme")=="Dark") {
             domClass.add(win.body(), "Dark");
-            LazyLoad.css('plugins/WebApollo/css/maker_darkbackground.css');
         }
+
 
         browser.subscribe('/jbrowse/v1/n/tracks/visibleChanged', dojo.hitch(this,"updateLabels"));
 
@@ -148,7 +148,7 @@ return declare( [JBPlugin, HelpMixin],
                     label: "Light",
                     onClick: function (event) {
                         browser.cookie("Scheme","Light");
-                        window.location.reload();
+                        domClass.remove(win.body(), "Dark");
                     }
                 }
             )
@@ -158,7 +158,7 @@ return declare( [JBPlugin, HelpMixin],
                     label: "Dark",
                     onClick: function (event) {
                         browser.cookie("Scheme","Dark");
-                        window.location.reload();
+                        domClass.add(win.body(), "Dark");
                     }
                 }
             )

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -398,52 +398,71 @@ return declare( [JBPlugin, HelpMixin],
         view.showCoarse();
     },
 
+    plusStrandFilter: function(feature)  {
+        var strand = feature.get('strand');
+        if (strand == 1 || strand == '+' || !strand)  { return true; }
+        else  { return false; }
+    },
+
+    minusStrandFilter: function(feature)  {
+        var strand = feature.get('strand');
+        if (strand == -1 || strand == '-' || !strand)  { return true; }
+        else  { return false; }
+    },
+    passAllFilter: function(feature)  {  return true; },
+    passNoneFilter: function(feature)  { return false; },
+
     addStrandFilterOptions: function()  {
-        var browser=this.browser;
         var thisB = this;
-
-        var strandFilter = function(name,callback,toggle) {
-            if(toggle) {
-                browser.removeFeatureFilter(name);
-            } else {
-                browser.addFeatureFilter(callback,name);
-            }
-        };
-        var minusStrandFilter = function(feature)  {
-            var strand = feature.get('strand');
-            return strand == 1 || strand == '+' || !strand;
-        };
-
-        var plusStrandFilter = function(feature)  {
-            var strand = feature.get('strand');
-            return strand == -1 || strand == '-' || !strand;
-        };
-
+        var browser = this.browser;
         var plus_strand_toggle = new dijitCheckedMenuItem(
                 {
                     label: "Show plus strand",
-                    checked: !(browser.cookie("plusStrandFilter")=="true"),
+                    checked: true,
                     onClick: function(event) {
-                        browser.cookie("plusStrandFilter",this.get("checked")?"true":"false");
-                        strandFilter("plusStrandFilter",plusStrandFilter,this.get("checked"));
-                        browser.view.redrawTracks();
-                    }
-                });
-        var minus_strand_toggle = new dijitCheckedMenuItem(
-                {
-                    label: "Show minus strand",
-                    checked: !(browser.cookie("minusStrandFilter")=="true"),
-                    onClick: function(event) {
-                        browser.cookie("minusStrandFilter",this.get("checked")?"true":"false");
-                        strandFilter("minusStrandFilter",minusStrandFilter,this.get("checked"));
+                        var plus = plus_strand_toggle.checked;
+                        var minus = minus_strand_toggle.checked;
+                        console.log("plus: ", plus, " minus: ", minus);
+                        if (plus && minus)  {
+                            browser.setFeatureFilter(thisB.passAllFilter);
+                        }
+                        else if (plus)  {
+                            browser.setFeatureFilter(thisB.plusStrandFilter);
+                        }
+                        else if (minus)  {
+                            browser.setFeatureFilter(thisB.minusStrandFilter);
+                        }
+                        else  {
+                            browser.setFeatureFilter(thisB.passNoneFilter);
+                        }
                         browser.view.redrawTracks();
                     }
                 });
         browser.addGlobalMenuItem( 'view', plus_strand_toggle );
+        var minus_strand_toggle = new dijitCheckedMenuItem(
+                {
+                    label: "Show minus strand",
+                    checked: true,
+                    onClick: function(event) {
+                        var plus = plus_strand_toggle.checked;
+                        var minus = minus_strand_toggle.checked;
+                        console.log("plus: ", plus, " minus: ", minus);
+                        if (plus && minus)  {
+                            browser.setFeatureFilter(thisB.passAllFilter);
+                        }
+                        else if (plus)  {
+                            browser.setFeatureFilter(thisB.plusStrandFilter);
+                        }
+                        else if (minus)  {
+                            browser.setFeatureFilter(thisB.minusStrandFilter);
+                        }
+                        else  {
+                            browser.setFeatureFilter(thisB.passNoneFilter);
+                        }
+                        browser.view.redrawTracks();
+                        }
+                });
         browser.addGlobalMenuItem( 'view', minus_strand_toggle );
-
-        strandFilter("minusStrandFilter",minusStrandFilter, !(browser.cookie("minusStrandFilter")=="true"));
-        strandFilter("plusStrandFilter",plusStrandFilter, !(browser.cookie("plusStrandFilter")=="true"));
     },
         
     addNavigationOptions: function()  {

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -404,9 +404,9 @@ return declare( [JBPlugin, HelpMixin],
 
         var strandFilter = function(name,callback,toggle) {
             if(toggle||browser.cookie(name)=="true") {
-                browser.addFeatureFilter(callback,name);
-            } else {
                 browser.removeFeatureFilter(name);
+            } else {
+                browser.addFeatureFilter(callback,name);
             }
         };
         var minusStrandFilter = function(feature)  {
@@ -421,7 +421,7 @@ return declare( [JBPlugin, HelpMixin],
 
         var plus_strand_toggle = new dijitCheckedMenuItem(
                 {
-                    label: "Hide plus strand",
+                    label: "Show plus strand",
                     checked: browser.cookie("plusStrandFilter")=="true",
                     onClick: function(event) {
                         browser.cookie("plusStrandFilter",this.get("checked")?"true":"false");
@@ -431,7 +431,7 @@ return declare( [JBPlugin, HelpMixin],
                 });
         var minus_strand_toggle = new dijitCheckedMenuItem(
                 {
-                    label: "Hide minus strand",
+                    label: "Show minus strand",
                     checked: browser.cookie("minusStandFilter")=="true",
                     onClick: function(event) {
                         browser.cookie("minusStrandFilter",this.get("checked")?"true":"false");
@@ -439,8 +439,8 @@ return declare( [JBPlugin, HelpMixin],
                         browser.view.redrawTracks();
                     }
                 });
-        browser.addGlobalMenuItem( 'view', minus_strand_toggle );
         browser.addGlobalMenuItem( 'view', plus_strand_toggle );
+        browser.addGlobalMenuItem( 'view', minus_strand_toggle );
 
         strandFilter("minusStrandFilter",minusStrandFilter);
         strandFilter("plusStrandFilter",plusStrandFilter);

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -176,7 +176,6 @@ return declare( [JBPlugin, HelpMixin],
                 label: "Show track label",
                 checked: (browser.cookie("showTrackLabel")||"true")=="true",
                 onClick: function(event) {
-                    console.log(this);
                     thisB.showLabels(this.get("checked"));
                     browser.cookie("showTrackLabel",this.get("checked")?"true":"false");
                 }
@@ -401,57 +400,53 @@ return declare( [JBPlugin, HelpMixin],
         view.showCoarse();
     },
 
-
     addStrandFilterOptions: function()  {
+        var browser=this.browser;
         var thisB = this;
-        var browser = this.browser;
+
+        var strandFilter = function(name,callback) {
+            if(browser.cookie(name)=="true") {
+                browser.addFeatureFilter(callback,name);
+            } else {
+                browser.removeFeatureFilter(name);
+            }
+        };
+        var minusStrandFilter = function(feature)  {
+            var strand = feature.get('strand');
+            return strand == 1 || strand == '+' || !strand;
+        };
+
+        var plusStrandFilter = function(feature)  {
+            var strand = feature.get('strand');
+            return strand == -1 || strand == '-' || !strand;
+        };
 
         var plus_strand_toggle = new dijitCheckedMenuItem(
                 {
                     label: "Hide plus strand",
-                    checked: (browser.cookie("plusStrandFilter")||"1")=="1",
+                    checked: browser.cookie("plusStrandFilter")=="true",
                     onClick: function(event) {
-                        browser.cookie("plusStrandFilter",this.get("checked")?"1":"0");
-                        thisB.strandFilter("plusStrandFilter",thisB.plusStrandFilter);
+                        browser.cookie("plusStrandFilter",this.get("checked")?"true":"false");
+                        strandFilter("plusStrandFilter",plusStrandFilter);
                         browser.view.redrawTracks();
                     }
                 });
-        browser.addGlobalMenuItem( 'view', plus_strand_toggle );
         var minus_strand_toggle = new dijitCheckedMenuItem(
                 {
                     label: "Hide minus strand",
-                    checked: (browser.cookie("minusStandFilter")||"1")=="1",
+                    checked: browser.cookie("minusStandFilter")=="true",
                     onClick: function(event) {
-                        browser.cookie("minusStrandFilter",this.get("checked")?"1":"0");
-                        thisB.strandFilter("minusStrandFilter",thisB.minusStrandFilter);
+                        browser.cookie("minusStrandFilter",this.get("checked")?"true":"false");
+                        strandFilter("minusStrandFilter",minusStrandFilter);
                         browser.view.redrawTracks();
                     }
                 });
         browser.addGlobalMenuItem( 'view', minus_strand_toggle );
+        browser.addGlobalMenuItem( 'view', plus_strand_toggle );
 
-        this.strandFilter("minusStrandFilter",this.minusStrandFilter);
-        this.strandFilter("plusStrandFilter",this.plusStrandFilter);
+        strandFilter("minusStrandFilter",minusStrandFilter);
+        strandFilter("plusStrandFilter",plusStrandFilter);
     },
-    strandFilter: function(name,callback) {
-        var browser=this.browser;
-        if(browser.cookie(name)=="1") {
-            browser.addFeatureFilter(callback,name)
-        } else {
-            browser.removeFeatureFilter(name);
-        }
-    },
-    minusStrandFilter: function(feature)  {
-        var strand = feature.get('strand');
-        if (strand == 1 || strand == '+')  { return true; }
-        else  { return false; }
-    },
-
-    plusStrandFilter: function(feature)  {
-        var strand = feature.get('strand');
-        if (strand == -1 || strand == '-')  { return true; }
-        else  { return false; }
-    },
-    
         
     addNavigationOptions: function()  {
         var thisB = this;

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -15,6 +15,7 @@ define(
            'dojo/_base/lang',
            'dojo/dom-construct',
            'dojo/dom-class',
+           'dojo/query',
            'dojo/_base/window',
            'dojo/_base/array',
            'dijit/Menu',
@@ -42,6 +43,7 @@ define(
             lang,
             domConstruct,
             domClass,
+            query,
             win,
             array,
             dijitMenu,
@@ -171,19 +173,21 @@ return declare( [JBPlugin, HelpMixin],
         browser.addGlobalMenuItem('view', css_frame_toggle);
 
         this.addStrandFilterOptions();
+
+        this._showLabels=(browser.cookie("showTrackLabel")||"true")=="true"
         var hide_track_label_toggle = new dijitCheckedMenuItem(
             {
                 label: "Show track label",
-                checked: (browser.cookie("showTrackLabel")||"true")=="true",
+                checked: this._showLabels,
                 onClick: function(event) {
-                    thisB.showLabels(this.get("checked"));
+                    thisB._showLabels=this.get("checked");
                     browser.cookie("showTrackLabel",this.get("checked")?"true":"false");
+                    thisB.updateLabels();
                 }
             });
         browser.addGlobalMenuItem( 'view', hide_track_label_toggle);
         browser.addGlobalMenuItem( 'view', new dijitMenuSeparator());
-        this.showLabels(true,true);
-        browser.subscribe('/jbrowse/v1/n/tracks/visibleChanged', dojo.hitch(this,"showLabels",true));
+        browser.subscribe('/jbrowse/v1/n/tracks/visibleChanged', dojo.hitch(this,"updateLabels"));
 
 
             
@@ -240,7 +244,6 @@ return declare( [JBPlugin, HelpMixin],
 
         // put the WebApollo logo in the powered_by place in the main JBrowse bar
         browser.afterMilestone( 'initView', function() {
-            // dojo.connect( browser.browserWidget, "resize", thisB, 'onResize' );
             if (browser.poweredByLink)  {
                 dojo.disconnect(browser.poweredBy_clickHandle);
                 browser.poweredByLink.innerHTML = '<img src=\"plugins/WebApollo/img/ApolloLogo_100x36.png\" height=\"25\" />';
@@ -319,6 +322,7 @@ return declare( [JBPlugin, HelpMixin],
                             }
                         })
                 );
+                thisB.updateLabels();
             }
 
 
@@ -328,20 +332,14 @@ return declare( [JBPlugin, HelpMixin],
 
 
     },
-    showLabels: function(show,updating) {
-        var browser=this.browser;
-        var showLabels;
-        if(updating) {
-            showLabels=(browser.cookie("showTrackLabel")||"true")=="true";
-        }
-        else { showLabels=show; }
-
-        if(!showLabels) {
-            $('.track-label').hide();
+    updateLabels: function() {
+        if(!this._showLabels) {
+            query('.track-label').style('visibility','hidden');
         }
         else {
-            $('.track-label').show();
+            query('.track-label').style('visibility','visible');
         }
+        this.browser.view.updateScroll();
     },
 
     /**

--- a/src/main/webapp/changes.jsp
+++ b/src/main/webapp/changes.jsp
@@ -177,6 +177,7 @@ $(function () {
     });
     </c:forEach>
     cleanup_user_item();
+    cleanup_logo();
 });
 
 function change_status_selected_items(updated_status) {
@@ -449,8 +450,7 @@ function open_user_manager_dialog() {
 <body>
 <div id="header">
     <ul id="menu">
-        <li><a href="http://genomearchitect.org/" target="_blank"><img id="logo" src="images/ApolloLogo_100x36.png"
-                                                                       onload="cleanup_logo()" alt=""/></a></li>
+        <li><a href="http://genomearchitect.org/" target="_blank"><img id="logo" src="images/ApolloLogo_100x36.png" alt=""/></a></li>
         <%--<li><a id="file_item">File</a>--%>
             <%--<ul id="file_menu">--%>
                 <%--<li><a id="export_menu">Export</a>--%>

--- a/src/main/webapp/recentChanges.jsp
+++ b/src/main/webapp/recentChanges.jsp
@@ -181,7 +181,7 @@ if (username != null) {
                 AbstractSingleLocationBioFeature gbolFeature=(AbstractSingleLocationBioFeature)BioObjectUtil.createBioObject(feature, bioObjectConfiguration);
                 ArrayList<String> record = generateFeatureRecord(gbolFeature, track, historyDataStore);
                 for (String s : record) {
-                    out.println("eecent_changes.push(" + s + ");\n");
+                    out.println("recent_changes.push(" + s + ");\n");
                     ++count ;
                 }
             }

--- a/src/main/webapp/recentChanges.jsp
+++ b/src/main/webapp/recentChanges.jsp
@@ -146,7 +146,6 @@ boolean isAdmin = false;
 if (username != null) {
     for (ServerConfiguration.TrackConfiguration track : tracks) {
         Integer permission = permissions.get(track.getName());
-        System.out.println("count ["+count+"] / maximum ["+maximum +"]");
         if (permission == null && count < maximum) {
             permission = 0;
         }
@@ -693,8 +692,6 @@ function open_user_manager_dialog() {
             }
         %>
 
-    </ul>
-    </li>
     <%
 //        }
         if (username != null) {

--- a/src/main/webapp/tracks.jsp
+++ b/src/main/webapp/tracks.jsp
@@ -158,6 +158,7 @@
                 window.open('http://genomearchitect.org/web_apollo_user_guide', '_blank');
             });
             cleanup_user_item();
+            cleanup_logo();
         });
 
         function cleanup_logo() {
@@ -364,8 +365,7 @@
 <body>
 <div id="header">
     <ul id="menu">
-        <li><a href="http://genomearchitect.org/" target="_blank"><img id="logo" src="images/ApolloLogo_100x36.png"
-                                                                       onload="cleanup_logo()" alt=""/></a></li>
+        <li><a href="http://genomearchitect.org/" target="_blank"><img id="logo" src="images/ApolloLogo_100x36.png"/></a></li>
         <li><a id="file_item">File</a>
             <ul id="file_menu">
                 <li><a id="export_menu">Export</a>


### PR DESCRIPTION
This pull-request is sort of a combination of several things aimed at 1.0.4. I can split this into separate pull requests if you want but there is actually overlap between various things (i.e. the (1) also involved considerations for (3))

1) a fix for #155 which tries to automatically resize track height, automatically sets showlabel=false when collapse is turned on, and actually, another idea i had, is when collapse is unselected and showlabels=true beforehand, then reenable showlabels=true. this hopefully makes the collapse features fairly "natural" however testing is needed

2) a  fix for #119 to make user-created annotations track teal when using dark theme. other small adjustments to dark theme includes (a) removing the small white border between tracks (b) making theme change instantaneous (c) making the highlight blue instead of yellow (i thought this looked slightly nicer)

3) reduce dependency on  browser.cookie for enabling the color by cds, collapse features, and hide plus/minus strand features which has problems in browser private mode (especially safari)

cc @deepakunni3 

there is one "casualty" of this refactor which is that the track.config.colorByCds was disabled. this would be something a user could have potentially specified to have the colorByCds "always on" but is probably rarely used. Could be re-enabled if interested.