### PR TITLE
Automatically create users and grant default permissions

### DIFF
--- a/sample_config.xml
+++ b/sample_config.xml
@@ -132,6 +132,7 @@
                 <read />
                 <publish />
             </auto_grant>
+        </default_permissions>
         -->
 
 	</tracks>

--- a/sample_config.xml
+++ b/sample_config.xml
@@ -54,6 +54,8 @@
 		<authentication_class>org.bbop.apollo.web.user.encryptedlocaldb.EncryptedLocalDbUserAuthentication</authentication_class>
 		<!-- If the database is unencrypted (older default).  -->
 		<!--<authentication_class>org.bbop.apollo.web.user.localdb.LocalDbUserAuthentication</authentication_class>-->
+        <!-- If using an upstream authentication method (OAuth, BrowserID, etc...), automatically add users to the database on first login -->
+        <!--<auto_add_users>true</auto_add_users>-->
 
 	</user>
 
@@ -93,6 +95,45 @@
 			<acceptor_site>AG</acceptor_site>
 		</splice_sites>
 
+
+        <!-- Authentication methods which use upstream authentication servers
+             (e.g. OAuth, BrowserID, RemoteUser) may define a list of default
+             permissions to be granted on first login to users.
+
+             These are only relevant if
+
+                 <auto_add_users>true</auto_add_users>
+
+            is set above in the <user/> section. Authentication "groups" may be
+            configured to apply batch permissions to users or domains.
+
+            Users should contain one or more <user> block with a username/email
+            as is appropriate for the selected authentication method.
+
+            Domains should contain one or more <domain> block. Will only be
+            functional if usernames have an @ in them.
+
+            Permissions can be granted by adding the xml tags:
+
+              - <read/>
+              - <write/>
+              - <publish/>
+             -->
+        <!--
+        <default_permissions>
+            <auto_grant>
+                <users>
+                    <user>username@fqdn.edu</user>
+                    <user>username2@fqdn.edu</user>
+                </users>
+                <domains>
+                    <domain>university.edu</domain>
+                </domains>
+                <read />
+                <publish />
+            </auto_grant>
+        -->
+
 	</tracks>
 
 	<!-- path to file containing canned comments XML -->
@@ -120,7 +161,7 @@
 				<status_flag>Needs review</status_flag>
 			</status>
 			-->
-			
+
 			<!-- display generic attributes section -->
 			<attributes />
 
@@ -239,7 +280,7 @@
 
 				<!-- class for data adapter plugin -->
 				<class>org.bbop.apollo.web.dataadapter.fasta.FastaDataAdapter</class>
-				
+
 				<!-- required permission for using data adapter
 				available options are: read, write, publish -->
 				<permission>read</permission>
@@ -259,7 +300,7 @@
 
 				<!-- class for data adapter plugin -->
 				<class>org.bbop.apollo.web.dataadapter.fasta.FastaDataAdapter</class>
-				
+
 				<!-- required permission for using data adapter
 				available options are: read, write, publish -->
 				<permission>read</permission>
@@ -279,7 +320,7 @@
 
 				<!-- class for data adapter plugin -->
 				<class>org.bbop.apollo.web.dataadapter.fasta.FastaDataAdapter</class>
-				
+
 				<!-- required permission for using data adapter
 				available options are: read, write, publish -->
 				<permission>read</permission>

--- a/src/main/java/org/bbop/apollo/web/config/ServerConfiguration.java
+++ b/src/main/java/org/bbop/apollo/web/config/ServerConfiguration.java
@@ -386,7 +386,6 @@ public class ServerConfiguration {
                     }else{
                         trackPermissions = new HashSet<TrackAutoPermissionsGroup>();
                     }
-                    System.out.println("Track permissions " + trackPermissions.size());
 
                     Node spliceSitesNode = tracksNode.getElementsByTagName("splice_sites").item(0);
                     Set<String> spliceDonorSites = parseSpliceDonorSites((Element)spliceSitesNode);
@@ -426,7 +425,6 @@ public class ServerConfiguration {
             } else {
                 trackPermissions = new HashSet<TrackAutoPermissionsGroup>();
             }
-            System.out.println("Track permissions " + trackPermissions.size());
 //            if (refSeqsNode != null && annotationTrackNameNode != null && organismNode != null && sequenceTypeNode != null) {
                 Set<String> spliceDonorSites = parseSpliceDonorSites((Element)spliceSitesNode);
                 Set<String> spliceAcceptorSites = parseSpliceAcceptorSites((Element)spliceSitesNode);
@@ -679,12 +677,9 @@ public class ServerConfiguration {
     }
 
     private Set<TrackAutoPermissionsGroup> parsePermissions(NodeList permissionGroupList) {
-        System.out.println("parsePermissions()");
         Set<TrackAutoPermissionsGroup> trackPermissions = new HashSet<TrackAutoPermissionsGroup>();
         if (permissionGroupList != null) {
-            System.out.println("(has)permissionGroupList");
             for (int j = 0; j < permissionGroupList.getLength(); ++j) {
-                System.out.println("(" + j + ")");
                 Element grantNode = (Element)permissionGroupList.item(j);
 
                 NodeList usersList = grantNode.getElementsByTagName("users");
@@ -692,7 +687,6 @@ public class ServerConfiguration {
                 if (usersList != null) {
                     for (int k = 0; k < usersList.getLength(); ++k) {
                         users.add(usersList.item(k).getTextContent().trim());
-                        System.out.println("(pP)user: " + usersList.item(k).getTextContent().trim());
                     }
                 }
 
@@ -701,7 +695,6 @@ public class ServerConfiguration {
                 if (domainsList != null) {
                     for (int k = 0; k < domainsList.getLength(); ++k) {
                         domains.add(domainsList.item(k).getTextContent().trim());
-                        System.out.println("(pP)domain: " + domainsList.item(k).getTextContent().trim());
                     }
                 }
 
@@ -718,7 +711,6 @@ public class ServerConfiguration {
                 if (grantNode.getElementsByTagName("publish").getLength() > 0){
                     publish = true;
                 }
-                System.out.println(read +" " + write +" " + publish);
 
                 trackPermissions.add(new TrackAutoPermissionsGroup(users, domains, read, write, publish));
             }

--- a/src/main/java/org/bbop/apollo/web/user/UserAuthentication.java
+++ b/src/main/java/org/bbop/apollo/web/user/UserAuthentication.java
@@ -8,10 +8,10 @@ import javax.servlet.http.HttpServletResponse;
 public interface UserAuthentication {
 
 //    public void generateUserLoginPage(HttpServlet servlet, HttpServletRequest request, HttpServletResponse response) throws ServletException;
-    
+
     public String validateUser(HttpServletRequest request, HttpServletResponse response) throws UserAuthenticationException;
-    
+
     public String getUserLoginPageURL();
-    
+
     public String getAddUserURL();
 }

--- a/src/main/java/org/bbop/apollo/web/user/UserManager.java
+++ b/src/main/java/org/bbop/apollo/web/user/UserManager.java
@@ -12,6 +12,10 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.bbop.apollo.web.config.ServerConfiguration.TrackConfiguration;
+import org.bbop.apollo.web.config.ServerConfiguration.TrackAutoPermissionsGroup;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import net.crackstation.PasswordHash;
 
@@ -21,7 +25,8 @@ public class UserManager {
     private String databaseURL;
     private String databaseUserName;
     private String databasePassword;
-    
+    private final Logger logger = LogManager.getLogger(LogManager.ROOT_LOGGER_NAME);
+
     private UserManager() {
     }
 
@@ -35,11 +40,11 @@ public class UserManager {
     public String getDatabaseURL() {
         return databaseURL;
     }
-    
+
     public void setDatabaseURL(String dbURL) {
         this.databaseURL = dbURL;
     }
-    
+
     public String getDatabaseUserName() {
         return databaseUserName;
     }
@@ -59,11 +64,11 @@ public class UserManager {
     public boolean isInitialized() {
         return databaseURL != null;
     }
-    
+
     public void initialize(String dbDriver, String dbURL) throws ClassNotFoundException {
         initialize(dbDriver, dbURL, null, null);
     }
-    
+
     public void initialize(String dbDriver, String dbURL, String userName, String password) throws ClassNotFoundException {
         Class.forName(dbDriver);
         setDatabaseURL(dbURL);
@@ -85,7 +90,7 @@ public class UserManager {
         return permission;
 
     }
-    
+
     public Map<String, Integer> getPermissionsForUser(String username) throws SQLException {
         Map<String, Integer> permissions = new HashMap<String, Integer>();
         Connection conn = getConnection();
@@ -98,7 +103,7 @@ public class UserManager {
         conn.close();
         return permissions;
     }
-    
+
     public Set<String> getTrackNames() throws SQLException {
         Connection conn = getConnection();
         Set<String> trackNames = getTrackNamesWithPrimaryKey(conn).keySet();
@@ -115,14 +120,14 @@ public class UserManager {
         conn.close();
         return valid;
     }
-    
+
     public Set<String> getUserNames() throws SQLException {
         Connection conn = getConnection();
         Set<String> userNames = getUserNamesWithPrimaryKey(conn).keySet();
         conn.close();
         return userNames;
     }
-    
+
     public void updateAllTrackPermissionForUsers(Map<String, Integer> permissions) throws SQLException {
         Connection conn = getConnection();
         conn.setAutoCommit(false);
@@ -136,6 +141,7 @@ public class UserManager {
             PreparedStatement stmt = conn.prepareStatement("INSERT INTO permissions VALUES(?, ?, ?)");
             for (Map.Entry<String, Integer> track : tracks.entrySet()) {
                 int trackId = track.getValue();
+                // If the user doesn't have pre-existing permissions on this track, insert them
                 if (!permissionsForUser.containsKey(track.getKey())) {
                     stmt.setInt(1, trackId);
                     stmt.setInt(2, userId);
@@ -152,8 +158,53 @@ public class UserManager {
         conn.commit();
         conn.close();
     }
-    
+
+    /**
+     * Written to be a track specific version of updateAllTrackPermissionForUsers.
+     * There seems to be hints of work towards more configurable track specific permissions
+     *
+     * @param permissions a username to permission map
+     * @param track_name track name
+     *
+     */
+    public void updateTrackSpecificPermissionForUsers(Map<String, Integer> permissions, String track_name) throws SQLException {
+        Connection conn = getConnection();
+        conn.setAutoCommit(false);
+        logger.debug("Updating permissions for " + track_name);
+        Map<String, Integer> tracks = getTrackNamesWithPrimaryKey(conn);
+        Map<String, Integer> users = getUserNamesWithPrimaryKey(conn);
+        for (Map.Entry<String, Integer> permissionsEntrySet : permissions.entrySet()) {
+            String username = permissionsEntrySet.getKey();
+            int userId = users.get(username);
+            int permission = permissionsEntrySet.getValue();
+            Map<String, Integer> permissionsForUser = UserManager.getInstance().getPermissionsForUser(username);
+            PreparedStatement stmt = conn.prepareStatement("INSERT INTO permissions VALUES(?, ?, ?)");
+            int trackId = tracks.get(track_name);
+            // If the user doesn't have pre-existing permissions on this track, insert them
+            if (!permissionsForUser.containsKey(track_name)) {
+                stmt.setInt(1, trackId);
+                stmt.setInt(2, userId);
+                stmt.setInt(3, permission);
+                stmt.addBatch();
+            }
+            stmt.executeBatch();
+            stmt = conn.prepareStatement("UPDATE permissions SET permission=? WHERE user_id=?");
+            stmt.setInt(1, permission);
+            stmt.setInt(2, userId);
+            stmt.executeUpdate();
+        }
+        conn.commit();
+        conn.close();
+    }
+
+    /**
+     * Add user to Apollo user database.
+     *
+     * @param username New username for the user.
+     * @param password password for the user which will automatically be encrypted.
+     */
     public void addUser(String username, String password) throws SQLException {
+        logger.debug("Adding user " + username);
         String encrypted = null;
         try {
             encrypted = PasswordHash.createHash(password);
@@ -169,7 +220,49 @@ public class UserManager {
         stmt.executeUpdate();
         conn.close();
     }
-    
+
+    /**
+     * Set track specific default permissions for specific user.
+     * Only applicable to auth methods with upstream authentication sources (e.g. RemoteUser/OAuth/BrowserID).
+     * Only applicable when auto-creation of users is on
+     *
+     * @param username Username to apply automatic permissions to
+     * @param tracks Map of track name/track configurations which hold default permission data.
+     *
+     **/
+    public void setDefaultUserTrackPermissions(String username, Map<String, TrackConfiguration> tracks) throws SQLException {
+        System.out.println("Applying default track permissions for " + username);
+        Map<String, Integer> new_permissions = new HashMap<String, Integer>();
+        // Loop across all known tracks
+        for (Map.Entry<String, TrackConfiguration> trackEntry : tracks.entrySet()) {
+            // There are multiple permission groups per track e.g.:
+            //  - one listing read/write users,
+            //  - one listing read-only users
+            new_permissions.clear();
+            TrackConfiguration track = trackEntry.getValue();
+            System.out.println("Track " + track.getName());
+            for (TrackAutoPermissionsGroup trackPermissions : track.getAutoPermissions()) {
+                // If this trackPermissions applies to username
+                //
+                // Precedence from first read from config file; exit early as
+                // soon as we have a match
+                if (trackPermissions.validateUser(username)) {
+                    System.out.println("Applying permissions " + trackPermissions.getPermissionValue() + " for " + username +" to " + track.getName());
+                    new_permissions.put(username, trackPermissions.getPermissionValue());
+                    break;
+                }
+            }
+            updateTrackSpecificPermissionForUsers(new_permissions, track.getName());
+        }
+    }
+
+    /**
+     * Add a user without a password.
+     * Some authentication methods are passwordless, especially those storing
+     * passwords "upstream", e.g. OAuth/BrowserID/RemoteUser
+     *
+     * @param username username for the new user
+     **/
     public void addUser(String username) throws SQLException {
         Connection conn = getConnection();
         PreparedStatement stmt = conn.prepareStatement("INSERT INTO users(username) VALUES(?)");
@@ -177,7 +270,12 @@ public class UserManager {
         stmt.executeUpdate();
         conn.close();
     }
-    
+
+    /**
+     * Remove user.
+     *
+     * @param username username of the user to be deleted.
+     */
     public void deleteUser(String username) throws SQLException {
         Connection conn = getConnection();
         PreparedStatement stmt = conn.prepareStatement("DELETE FROM permissions WHERE user_id=(SELECT user_id FROM users where username=?)");
@@ -188,7 +286,7 @@ public class UserManager {
         stmt.executeUpdate();
         conn.close();
     }
-    
+
     private Map<String, Integer> getUserNamesWithPrimaryKey(Connection conn) throws SQLException {
         PreparedStatement stmt = conn.prepareStatement("SELECT username, user_id FROM users");
         ResultSet rs = stmt.executeQuery();
@@ -198,7 +296,7 @@ public class UserManager {
         }
         return userNames;
     }
-    
+
     private Map<String, Integer> getTrackNamesWithPrimaryKey(Connection conn) throws SQLException {
         Map<String, Integer> trackNames = new HashMap<String, Integer>();
         PreparedStatement stmt = conn.prepareStatement("SELECT track_name, track_id FROM tracks");
@@ -208,7 +306,7 @@ public class UserManager {
         }
         return trackNames;
     }
-    
+
     public Connection getConnection() throws SQLException {
         if (getDatabaseUserName() != null) {
             return DriverManager.getConnection(databaseURL, getDatabaseUserName(), getDatabasePassword());

--- a/src/main/java/org/bbop/apollo/web/user/encryptedlocaldb/EncryptedLocalDbUserAuthentication.java
+++ b/src/main/java/org/bbop/apollo/web/user/encryptedlocaldb/EncryptedLocalDbUserAuthentication.java
@@ -21,11 +21,18 @@ import net.crackstation.PasswordHash;
 import org.bbop.apollo.web.user.UserAuthenticationException;
 import org.bbop.apollo.web.user.UserAuthentication;
 import org.bbop.apollo.web.user.UserManager;
+import org.bbop.apollo.web.config.ServerConfiguration;
 import org.bbop.apollo.web.util.JSONUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class EncryptedLocalDbUserAuthentication implements UserAuthentication {
+
+    private ServerConfiguration serverConfig;
+
+    public EncryptedLocalDbUserAuthentication(ServerConfiguration serverConfig) {
+        this.serverConfig = serverConfig;
+    }
 
 //    @Override
 //    public void generateUserLoginPage(HttpServlet servlet, HttpServletRequest request,

--- a/src/main/java/org/bbop/apollo/web/user/localdb/LocalDbUserAuthentication.java
+++ b/src/main/java/org/bbop/apollo/web/user/localdb/LocalDbUserAuthentication.java
@@ -19,12 +19,18 @@ import javax.servlet.http.HttpServletResponse;
 import org.bbop.apollo.web.user.UserAuthenticationException;
 import org.bbop.apollo.web.user.UserAuthentication;
 import org.bbop.apollo.web.user.UserManager;
+import org.bbop.apollo.web.config.ServerConfiguration;
 import org.bbop.apollo.web.util.JSONUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class LocalDbUserAuthentication implements UserAuthentication {
 
+    private ServerConfiguration serverConfig;
+
+    public LocalDbUserAuthentication(ServerConfiguration serverConfig) {
+        this.serverConfig = serverConfig;
+    }
 //    @Override
 //    public void generateUserLoginPage(HttpServlet servlet, HttpServletRequest request,
 //            HttpServletResponse response) throws ServletException {

--- a/src/main/java/org/bbop/apollo/web/user/oauth/OauthUserAuthentication.java
+++ b/src/main/java/org/bbop/apollo/web/user/oauth/OauthUserAuthentication.java
@@ -22,6 +22,8 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.bbop.apollo.web.user.UserAuthenticationException;
 import org.bbop.apollo.web.user.UserAuthentication;
+import org.bbop.apollo.web.user.UserManager;
+import org.bbop.apollo.web.config.ServerConfiguration;
 import org.bbop.apollo.web.util.JSONUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -31,6 +33,8 @@ import org.xml.sax.SAXException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.sql.SQLException;
+import java.util.Set;
 
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 import com.google.api.client.auth.oauth2.AuthorizationCodeTokenRequest;
@@ -50,13 +54,14 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import org.bbop.apollo.web.config.ServerConfiguration;
 
 /**
  * NOTE: not yet working
  */
 public class OauthUserAuthentication implements UserAuthentication {
-    
-    // These values are set in the Oauth.xml configuration file 
+
+    // These values are set in the Oauth.xml configuration file
     private String providerName = null;
     private String clientID = null;
     private String clientSecret = null;
@@ -65,8 +70,10 @@ public class OauthUserAuthentication implements UserAuthentication {
     private String profileUrl = null;
     private String unameField = null;
     private final Logger logger = LogManager.getLogger(LogManager.ROOT_LOGGER_NAME);
-    
-    public OauthUserAuthentication() {
+    private ServerConfiguration serverConfig;
+
+    public OauthUserAuthentication(ServerConfiguration serverConfig) {
+        this.serverConfig = serverConfig;
         try {
             File currentDirectory= new File(".");
             String[] extensions = new String[]{"xml"};
@@ -88,7 +95,7 @@ public class OauthUserAuthentication implements UserAuthentication {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             DocumentBuilder db = dbf.newDocumentBuilder();
             Document doc = db.parse(fstream);
-            
+
             providerName = doc.getElementsByTagName("provider_name").item(0).getFirstChild().getNodeValue();
             clientID = doc.getElementsByTagName("client_id").item(0).getFirstChild().getNodeValue();
             clientSecret = doc.getElementsByTagName("client_secret").item(0).getFirstChild().getNodeValue();
@@ -96,8 +103,8 @@ public class OauthUserAuthentication implements UserAuthentication {
             tokenURL = doc.getElementsByTagName("token_url").item(0).getFirstChild().getNodeValue();
             profileUrl = doc.getElementsByTagName("profile_url").item(0).getFirstChild().getNodeValue();
             unameField = doc.getElementsByTagName("uname_field").item(0).getFirstChild().getNodeValue();
-            
-        } 
+
+        }
         catch (FileNotFoundException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
@@ -106,11 +113,11 @@ public class OauthUserAuthentication implements UserAuthentication {
         catch (ParserConfigurationException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } 
+        }
         catch (SAXException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } 
+        }
         catch (IOException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
@@ -136,22 +143,22 @@ public class OauthUserAuthentication implements UserAuthentication {
     @Override
     public String validateUser(HttpServletRequest request,
             HttpServletResponse response) throws UserAuthenticationException {
-        
+
         // The WebApollo user name
         String username = null;
         try {
             // ---------------
-            // Step1: first, WebApollo redirects the user to the provider 
-            // authentication site to log in and approve access for WebApollo. If 
-            // we are here, it is because the provider has responded with an 
-            // authorization code.  The link that directs the user to the remote 
+            // Step1: first, WebApollo redirects the user to the provider
+            // authentication site to log in and approve access for WebApollo. If
+            // we are here, it is because the provider has responded with an
+            // authorization code.  The link that directs the user to the remote
             // provider is constructed in the WebContent/user_interfaces/oauth/login.jsp file
-            
+
             // get the authorization code
             String authCode = request.getParameter("code");
             String error = request.getParameter("error");
             String state = request.getParameter("state");
-            
+
             // we have an error and should not continue.  return a message for the
             // user.  If the provider provides an "error_description" then include
             // that in the error message
@@ -161,9 +168,9 @@ public class OauthUserAuthentication implements UserAuthentication {
             }
 
             // ---------------
-            // Step 2: now that we have an authorization code, we must use it to 
+            // Step 2: now that we have an authorization code, we must use it to
             // request the access token. There are several types of authentication
-            // available by the Oauth2 protocal:  Authentication Code Flow, 
+            // available by the Oauth2 protocal:  Authentication Code Flow,
             // Implicit Flow, Resource Owner Password Flow, and Client Credentials.
             // We will use Authentication code Flow. Therefore, we begin by
             // creating an AuthroizationCodeFlow object
@@ -178,22 +185,22 @@ public class OauthUserAuthentication implements UserAuthentication {
                     tokenURL
             );
             AuthorizationCodeFlow codeFlow = acfb.setScopes(Arrays.asList(unameField)).build();
-            
+
             // Next we need to construct a token request object to request the access token
             String redirectUri = "http://localhost:8080/apollo/Login?operation=login";
             AuthorizationCodeTokenRequest actr = codeFlow.newTokenRequest(authCode);
             actr.setRedirectUri(redirectUri);
             actr.setScopes(Arrays.asList(unameField));
-            
+
             // The executeUnparsed() function of the token request object causes
-            // WebApollo to request the access token from the oauth provider. 
+            // WebApollo to request the access token from the oauth provider.
             // The Google oauth2 library has an execute() function that will
             // automatically parse the return JSON array but not all providers
             // return values in ways that the Google parser likes, so we must
             // manually parse the response.
             HttpResponse tokenUnparsed = actr.executeUnparsed();
             if (tokenUnparsed.getContentEncoding() == "gzip") {
-                
+
             }
 
             // Parse the response into a TokenResponse object.
@@ -202,7 +209,7 @@ public class OauthUserAuthentication implements UserAuthentication {
             InputStream tokenIs = tokenUnparsed.getContent();
             JSONObject tokenJson = JSONUtil.convertInputStreamToJSON(tokenIs);
             String accessToken = tokenJson.getString("access_token");
-            
+
             // store the details in a TokenResponse object
             TokenResponse tokenResponse = new TokenResponse();
             tokenResponse.setExpiresInSeconds(tokenJson.getLong("expires_in"));
@@ -211,24 +218,24 @@ public class OauthUserAuthentication implements UserAuthentication {
             tokenResponse.setTokenType(tokenJson.getString("token_type"));
             //tokenResponse.setRefreshToken(tokenJson.getString("refresh_token"));
             tokenResponse.setFactory(jsonFactory);
-            
+
             // ---------------
             // Step 3: now that we have the access token, we can request the profile
             // information which should include the username
             HttpClient httpClient = new DefaultHttpClient();
             System.out.println(profileUrl);
             HttpPost httpPost = new HttpPost(profileUrl);
-            
+
             List <NameValuePair> nvps = new ArrayList <NameValuePair>();
             nvps.add(new BasicNameValuePair("access_token", accessToken));
             nvps.add(new BasicNameValuePair("scope", "openid email profile"));
             httpPost.setEntity(new UrlEncodedFormEntity(nvps));
-            
+
             org.apache.http.HttpResponse post_response = httpClient.execute(httpPost);
             String postJson = EntityUtils.toString(post_response.getEntity());
             System.out.println(postJson);
             JSONObject postObj = new JSONObject(postJson);
-            
+
             if (postObj.has("error")) {
                 String errorDescription = "";
                 if (postObj.has("error_description")) {
@@ -236,14 +243,14 @@ public class OauthUserAuthentication implements UserAuthentication {
                 }
                 throw new UserAuthenticationException("OAuth error: " + error + ". " + errorDescription + ". ");
             }
-            
+
             //Object obj = token_response.get("id_token");
-            
+
             //TokenResponse token_response = actr.execute();
             IdToken idToken = IdToken.parse(jsonFactory, tokenResponse.get("id_token").toString());
             username = idToken.getPayload().get(unameField).toString();
             System.out.println("Oauth returned");
-        } 
+        }
         catch (java.lang.IllegalArgumentException e){
             String error = e.getMessage();
             throw new UserAuthenticationException("OAuth error: Illegal Argument " + error);
@@ -255,10 +262,24 @@ public class OauthUserAuthentication implements UserAuthentication {
         catch (IOException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } 
+        }
         catch (JSONException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
+        }
+
+        if (username != null) {
+            // Autocreate users if enabled
+            UserManager umi = UserManager.getInstance();
+            try {
+                Set<String> users = umi.getUserNames();
+                if(serverConfig.getAutoCreateUsers() && !users.contains(username) ){
+                    umi.addUser(username);
+                    umi.setDefaultUserTrackPermissions(username, serverConfig.getTracks());
+                }
+            } catch(SQLException sqle) {
+                // Handle this?
+            }
         }
         return username;
     }

--- a/src/main/java/org/bbop/apollo/web/user/remoteuser/RemoteUserAuthentication.java
+++ b/src/main/java/org/bbop/apollo/web/user/remoteuser/RemoteUserAuthentication.java
@@ -10,6 +10,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Set;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -25,30 +26,26 @@ import org.json.JSONObject;
 
 public class RemoteUserAuthentication implements UserAuthentication {
 
-//    @Override
-//    public void generateUserLoginPage(HttpServlet servlet, HttpServletRequest request,
-//            HttpServletResponse response) throws ServletException {
-//        InputStream in = servlet.getServletContext().getResourceAsStream("/user_interfaces/remoteuser/login.html");
-//        BufferedReader reader = new BufferedReader(new InputStreamReader(in));
-//        String line;
-//        try {
-//            while ((line = reader.readLine()) != null) {
-//                response.getOutputStream().println(line);
-//            }
-//            in.close();
-//        } catch (IOException e) {
-//            throw new ServletException(e);
-//        }
-//    }
-
     @Override
     public String validateUser(HttpServletRequest request,
             HttpServletResponse response) throws UserAuthenticationException {
         String username = request.getHeader("REMOTE_USER");
         if(username == null){
+            // If the header isn't provided, it's actually a server
+            // configuration error
             throw new UserAuthenticationException("Invalid login");
+        } else {
+            UserManager umi = UserManager.getInstance();
+            try {
+                Set<String> users = umi.getUserNames();
+                if(!users.contains(username)){
+                    umi.addUser(username);
+                }
+            } catch(SQLException sqle) {
+                // Handle this?
+            }
+            return username;
         }
-        return username;
     }
 
 

--- a/src/main/java/org/bbop/apollo/web/user/remoteuser/RemoteUserAuthentication.java
+++ b/src/main/java/org/bbop/apollo/web/user/remoteuser/RemoteUserAuthentication.java
@@ -11,6 +11,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Set;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -21,10 +22,18 @@ import org.bbop.apollo.web.user.UserAuthenticationException;
 import org.bbop.apollo.web.user.UserAuthentication;
 import org.bbop.apollo.web.user.UserManager;
 import org.bbop.apollo.web.util.JSONUtil;
+import org.bbop.apollo.web.config.ServerConfiguration;
+import org.bbop.apollo.web.config.ServerConfiguration.TrackConfiguration;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class RemoteUserAuthentication implements UserAuthentication {
+
+    private ServerConfiguration serverConfig;
+
+    public RemoteUserAuthentication(ServerConfiguration serverConfig) {
+        this.serverConfig = serverConfig;
+    }
 
     @Override
     public String validateUser(HttpServletRequest request,
@@ -38,8 +47,9 @@ public class RemoteUserAuthentication implements UserAuthentication {
             UserManager umi = UserManager.getInstance();
             try {
                 Set<String> users = umi.getUserNames();
-                if(!users.contains(username)){
+                if(!users.contains(username) && serverConfig.getAutoCreateUsers()){
                     umi.addUser(username);
+                    umi.setDefaultUserTrackPermissions(username, serverConfig.getTracks());
                 }
             } catch(SQLException sqle) {
                 // Handle this?

--- a/src/main/java/org/bbop/apollo/web/user/remoteuser/RemoteUserAuthentication.java
+++ b/src/main/java/org/bbop/apollo/web/user/remoteuser/RemoteUserAuthentication.java
@@ -11,7 +11,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Set;
-import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -23,7 +22,6 @@ import org.bbop.apollo.web.user.UserAuthentication;
 import org.bbop.apollo.web.user.UserManager;
 import org.bbop.apollo.web.util.JSONUtil;
 import org.bbop.apollo.web.config.ServerConfiguration;
-import org.bbop.apollo.web.config.ServerConfiguration.TrackConfiguration;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -47,7 +45,7 @@ public class RemoteUserAuthentication implements UserAuthentication {
             UserManager umi = UserManager.getInstance();
             try {
                 Set<String> users = umi.getUserNames();
-                if(!users.contains(username) && serverConfig.getAutoCreateUsers()){
+                if(serverConfig.getAutoCreateUsers() && !users.contains(username) ){
                     umi.addUser(username);
                     umi.setDefaultUserTrackPermissions(username, serverConfig.getTracks());
                 }


### PR DESCRIPTION
I know it's considered incredibly poor practice to submit PRs that adjust whitespace alongside those that modify code, but I hope y'all will overlook it once. If requested, I can go back and put in trailing spaces.

## Auto-creation of users

This PR implements the ability to automatically create users in the user database for authentication methods which rely on upstream user databases, so:

- OAuth
- RemoteUser
- BrowserID
- Drupal

If enabled, as soon as the first time a user logs in successfully, they'll be created in the database if they don't exist yet. Additionally, automatic permissions will possibly be granted to them.

## Auto-permissions

Having users automatically created is one thing, but it wasn't *that* much good until they were automatically granted permissions on first log-in. These are track specific permissions, and can enable 

- read
- write 
- publish

permissions. This is pretty easy to enable and allows whitelisting of users and domains:

```xml
<default_permissions>
     <auto_grant>
        <users>
            <user>username@fqdn.edu</user>        
            <user>username2@fqdn.edu</user>
        </users>
        <domains>
            <domain>university.edu</domain>
         </domains>
         <read />
         <publish />
   </auto_grant>
</default_permissions>
```
Additionally, since it's impossible to determine "new" users, there's no way to automatically add permissions to localdb/encryptedlocaldb users.

This fixes #203 