### PR TITLE
#464 - fixed IOService controller to no longer user file paths

### DIFF
--- a/src/groovy/org/bbop/apollo/sequence/DownloadFile.groovy
+++ b/src/groovy/org/bbop/apollo/sequence/DownloadFile.groovy
@@ -1,0 +1,10 @@
+package org.bbop.apollo.sequence
+
+/**
+ * Created by nathandunn on 7/7/15.
+ */
+class DownloadFile {
+    String uuid
+    String path
+    String fileName
+}


### PR DESCRIPTION
For #464   

@cmdcolin  Can you make sure that this feels more secure.  

I'm only handing around a UUID right now that has reference to the file paths.  Once downloaded the UUID is removed.  