### PR TITLE
Turn off transactional for read only methods

### DIFF
--- a/grails-app/services/org/bbop/apollo/ExonService.groovy
+++ b/grails-app/services/org/bbop/apollo/ExonService.groovy
@@ -10,7 +10,7 @@ import org.bbop.apollo.sequence.SequenceTranslationHandler
 import org.bbop.apollo.sequence.Strand
 
 //@GrailsCompileStatic
-@Transactional
+@Transactional(readOnly = true)
 class ExonService {
 
 //    CvTermService cvTermService
@@ -27,7 +27,6 @@ class ExonService {
      *
      * @return Transcript that this Exon is associated with
      */
-    @NotTransactional
     public Transcript getTranscript(Exon exon) {
 
         // this could be for any transcript, though
@@ -41,6 +40,7 @@ class ExonService {
      * @param exon2 - Exon to be merged with
      * @throws AnnotationException - If exons don't belong to the same transcript or are in separate strands
      */
+    @Transactional
     public void mergeExons(Exon exon1, Exon exon2) throws AnnotationException {
 //        // both exons must be part of the same transcript
 //        if (!getTranscript(exon1).equals(getTranscript(exon2))) {
@@ -84,6 +84,7 @@ class ExonService {
      * @param transcript - Transcript to have the exon deleted from
      * @param exon - Exon to be deleted from the transcript
      */
+    @Transactional
     public void deleteExon(Transcript transcript, Exon exon) {
         featureRelationshipService.removeFeatureRelationship(transcript,exon)
 
@@ -144,6 +145,7 @@ class ExonService {
     }
 
 
+    @Transactional
     public void setFmin(Exon exon, Integer fmin) {
         exon.getFeatureLocation().setFmin(fmin);
         Transcript transcript = getTranscript(exon)
@@ -152,6 +154,7 @@ class ExonService {
         }
     }
 
+    @Transactional
     public void setFmax(Exon exon, Integer fmax) {
         exon.getFeatureLocation().setFmax(fmax);
         Transcript transcript = getTranscript(exon)
@@ -161,7 +164,7 @@ class ExonService {
     }
 
 
-//    , String splitExonUniqueName
+    @Transactional
     public Exon makeIntron(Exon exon, int genomicPosition, int minimumIntronSize) {
         String sequence = sequenceService.getResiduesFromFeature(exon)
         int exonPosition = featureService.convertSourceCoordinateToLocalCoordinate(exon,genomicPosition);
@@ -208,7 +211,6 @@ class ExonService {
     }
 //
 
-    @NotTransactional
     List<Exon> getSortedExons(Transcript transcript,boolean sortByStrand = true ) {
         List<Exon> sortedExons= new LinkedList<Exon>(transcriptService.getExons(transcript));
         Collections.sort(sortedExons,new FeaturePositionComparator<Exon>(sortByStrand))
@@ -222,6 +224,7 @@ class ExonService {
      * @param fmin - New fmin to be set
      * @param fmax - New fmax to be set
      */
+    @Transactional
     public void setExonBoundaries(Exon exon, int fmin, int fmax) {
 
         Transcript transcript = getTranscript(exon)
@@ -233,6 +236,7 @@ class ExonService {
         featureService.updateGeneBoundaries(transcriptService.getGene(transcript));
     }
 
+    @Transactional
     def setToDownstreamDonor(Exon exon) {
         Transcript transcript = getTranscript(exon)
         Gene gene = transcriptService.getGene(transcript)
@@ -274,6 +278,7 @@ class ExonService {
         }
     }
 
+    @Transactional
     def setToUpstreamDonor(Exon exon) {
         Transcript transcript = getTranscript(exon)
         Gene gene = transcriptService.getGene(transcript)
@@ -302,6 +307,7 @@ class ExonService {
         }
     }
 
+    @Transactional
     def setToUpstreamAcceptor(Exon exon) {
         Transcript transcript = getTranscript(exon);
         Gene gene = transcriptService.getGene(transcript);
@@ -344,6 +350,7 @@ class ExonService {
 
     }
 
+    @Transactional
     def setToDownstreamAcceptor(Exon exon) {
         println "setting downstream acceptor: ${exon}"
         Transcript transcript = getTranscript(exon);
@@ -369,6 +376,7 @@ class ExonService {
 
     }
 
+    @Transactional
     Exon splitExon(Exon exon, int newLeftMax, int newRightMin) {
         Exon leftExon = exon;
         FeatureLocation leftFeatureLocation = leftExon.getFeatureLocation()
@@ -414,7 +422,6 @@ class ExonService {
     }
     
     //added while working on getSequence() on 03.19.15 by D.U.
-    @NotTransactional
     String getCodingSequenceInPhase(Exon exon, boolean removePartialCodons) {
         Transcript transcript = getTranscript(exon)
         CDS cds = transcriptService.getCDS(transcript)

--- a/grails-app/services/org/bbop/apollo/FeaturePropertyService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeaturePropertyService.groovy
@@ -2,7 +2,7 @@ package org.bbop.apollo
 
 import grails.transaction.Transactional
 import grails.transaction.NotTransactional
-@Transactional
+@Transactional(readOnly = true)
 class FeaturePropertyService {
 
 
@@ -13,7 +13,7 @@ class FeaturePropertyService {
  *
  * @return Comments for this feature
  */
-    @NotTransactional
+    @Transactional
     public Collection<Comment> getComments(Feature feature) {
 //        CVTerm commentCvTerm = cvTermService.getTerm(FeatureStringEnum.COMMENT)
 //        Collection<CVTerm> commentCvterms = conf.getCVTermsForClass("Comment");
@@ -41,10 +41,12 @@ class FeaturePropertyService {
         return comments;
     }
 
+    @Transactional
     def addComment(Feature feature, Comment comment) {
         addProperty(feature, comment)
     }
 
+    @Transactional
     def addComment(Feature feature, String commentString) {
         Comment comment = new Comment(
                 feature: feature
@@ -57,6 +59,7 @@ class FeaturePropertyService {
 //        addComment(feature, comment)
     }
 
+    @Transactional
     boolean deleteComment(Feature feature, String commentString) {
 //        CVTerm commentCVTerm = cvTermService.getTerm(FeatureStringEnum.COMMENT.value)
 //        Comment comment =  Comment.findByTypeAndFeatureAndValue(commentCVTerm,feature,commentString)
@@ -69,6 +72,7 @@ class FeaturePropertyService {
         return false
     }
 
+    @Transactional
     def setFeatureProperty(Feature feature,String type,String tag,String value){
 
         for(FeatureProperty featureProperty in feature.featureProperties){
@@ -86,6 +90,7 @@ class FeaturePropertyService {
 
     }
 
+    @Transactional
     def addProperty(Feature feature, FeatureProperty property) {
         int rank = 0;
         println "value of FP to add: ${property.value} ${property.tag}"
@@ -101,6 +106,7 @@ class FeaturePropertyService {
 
     }
 
+    @Transactional
     public boolean deleteProperty(Feature feature, FeatureProperty property) {
         for (FeatureProperty fp : feature.getFeatureProperties()) {
             if (fp.getType().equals(property.getType()) && fp.getValue().equals(property.getValue())) {
@@ -181,7 +187,6 @@ class FeaturePropertyService {
 //    }
 
 
-    @NotTransactional
     def getNonReservedProperties(Feature feature) {
         return FeatureProperty.findAllByFeature(feature).find(){
             return !nonReservedClasses.contains(it.cvTerm)

--- a/grails-app/services/org/bbop/apollo/FeatureRelationshipService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureRelationshipService.groovy
@@ -2,10 +2,9 @@ package org.bbop.apollo
 
 import grails.transaction.Transactional
 import grails.transaction.NotTransactional
-@Transactional
+@Transactional(readOnly = true)
 class FeatureRelationshipService {
 
-    @NotTransactional
     List<Feature> getChildrenForFeatureAndTypes(Feature feature, String... ontologyIds) {
         List<Feature> childFeatures = FeatureRelationship.findAllByParentFeature(feature)*.childFeature
         List<Feature> returnFeatures = new ArrayList<>()
@@ -21,7 +20,6 @@ class FeatureRelationshipService {
     }
 
 
-    @NotTransactional
     Feature getChildForFeature(Feature feature, String ontologyId) {
         List<Feature> featureList = getChildrenForFeatureAndTypes(feature, ontologyId)
 
@@ -37,7 +35,6 @@ class FeatureRelationshipService {
         return featureList.get(0)
     }
 
-    @NotTransactional
     Feature getParentForFeature(Feature feature, String... ontologyId) {
 
         List<Feature> featureList = getParentsForFeature(feature, ontologyId)
@@ -53,7 +50,7 @@ class FeatureRelationshipService {
 
         return featureList.get(0)
     }
-    @NotTransactional
+
     List<Feature> getParentsForFeature(Feature feature, String... ontologyIds) {
         List<String> ontologyIdList = new ArrayList<>()
         ontologyIdList.addAll(ontologyIds)
@@ -62,11 +59,13 @@ class FeatureRelationshipService {
         }.unique()
     }
 
+    @Transactional
     def deleteRelationships(Feature feature, String parentOntologyId, String childOntologyId) {
         deleteChildrenForTypes(feature, childOntologyId)
         deleteParentForTypes(feature, parentOntologyId)
     }
 
+    @Transactional
     def setChildForType(Feature parentFeature, Feature childFeature) {
         List<FeatureRelationship> results = FeatureRelationship.findAllByParentFeature(parentFeature).findAll() {
             it.childFeature.ontologyId == childFeature.ontologyId
@@ -88,6 +87,7 @@ class FeatureRelationshipService {
 
     }
 
+    @Transactional
     def deleteChildrenForTypes(Feature feature, String... ontologyIds) {
         def criteria = FeatureRelationship.createCriteria()
 
@@ -105,6 +105,7 @@ class FeatureRelationshipService {
         }
     }
 
+    @Transactional
     def deleteParentForTypes(Feature feature, String... ontologyIds) {
         // delete transcript -> non canonical 3' splice site child relationship
         def criteria = FeatureRelationship.createCriteria()
@@ -120,6 +121,7 @@ class FeatureRelationshipService {
     }
 
     // based on Transcript.setCDS
+    @Transactional
     def addChildFeature(Feature parent, Feature child, boolean replace = true) {
         
         // replace if of the same type
@@ -158,6 +160,7 @@ class FeatureRelationshipService {
         parent.save(flush: true )
     }
 
+    @Transactional
     public void removeFeatureRelationship(Feature parentFeature, Feature childFeature) {
 
         FeatureRelationship featureRelationship = FeatureRelationship.findByParentFeatureAndChildFeature(parentFeature, childFeature)
@@ -168,11 +171,11 @@ class FeatureRelationshipService {
             childFeature.save(flush: true)
         }
     }
-    @NotTransactional
+
     List<Frameshift> getFeaturePropertyForTypes(Transcript transcript, List<String> strings) {
         return (List<Frameshift>) FeatureProperty.findAllByFeaturesInListAndOntologyIdsInList([transcript], strings)
     }
-    @NotTransactional
+
     List<Feature> getChildren(Feature feature) {
 //        List<Feature> childFeatures = (List<Feature>) Feature.executeQuery("select fr.childFeature from FeatureRelationship fr where fr.parentFeature = :parentFeature",["parentFeature":feature])
 //        return childFeatures
@@ -185,6 +188,7 @@ class FeatureRelationshipService {
      * @param feature
      * @return
      */
+    @Transactional
     def deleteFeatureAndChildren(Feature feature) {
 
 //        Feature.withNewTransaction {

--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -538,7 +538,7 @@ class RequestHandlingService {
         return updateFeatureContainer
     }
 
-    @NotTransactional
+    @Transactional(readOnly = true)
     JSONObject getFeatures(JSONObject inputObject) {
 
 

--- a/grails-app/services/org/bbop/apollo/TranscriptService.groovy
+++ b/grails-app/services/org/bbop/apollo/TranscriptService.groovy
@@ -1,16 +1,12 @@
 package org.bbop.apollo
 
-import org.bbop.apollo.gwt.shared.FeatureStringEnum
-
 import grails.transaction.Transactional
-import grails.transaction.NotTransactional
-import org.codehaus.groovy.grails.web.json.JSONArray
-import org.codehaus.groovy.grails.web.json.JSONObject
+import org.bbop.apollo.gwt.shared.FeatureStringEnum
 
 //import grails.compiler.GrailsCompileStatic
 
 //@GrailsCompileStatic
-@Transactional
+@Transactional(readOnly = true)
 class TranscriptService {
 
     List<String> ontologyIds = [Transcript.ontologyId, SnRNA.ontologyId, MRNA.ontologyId, SnoRNA.ontologyId, MiRNA.ontologyId, TRNA.ontologyId, NcRNA.ontologyId, RRNA.ontologyId]
@@ -30,7 +26,6 @@ class TranscriptService {
      *
      * @return CDS associated with this transcript
      */
-    @NotTransactional
     public CDS getCDS(Transcript transcript) {
         return (CDS) featureRelationshipService.getChildForFeature(transcript, CDS.ontologyId)
 
@@ -42,11 +37,10 @@ class TranscriptService {
      *
      * @return Collection of exons associated with this transcript
      */
-    @NotTransactional
     public Collection<Exon> getExons(Transcript transcript) {
         return (Collection<Exon>) featureRelationshipService.getChildrenForFeatureAndTypes(transcript, Exon.ontologyId)
     }
-    @NotTransactional
+
     public Collection<Exon> getSortedExons(Transcript transcript) {
         Collection<Exon> exons = getExons(transcript)
         List<Exon> sortedExons = new LinkedList<Exon>(exons);
@@ -60,16 +54,14 @@ class TranscriptService {
      *
      * @return Gene that this Transcript is associated with
      */
-    @NotTransactional
     public Gene getGene(Transcript transcript) {
-        return (Gene) featureRelationshipService.getParentForFeature(transcript, Gene.ontologyId,Pseudogene.ontologyId)
+        return (Gene) featureRelationshipService.getParentForFeature(transcript, Gene.ontologyId, Pseudogene.ontologyId)
     }
-    @NotTransactional
+
     public Pseudogene getPseudogene(Transcript transcript) {
         return (Pseudogene) featureRelationshipService.getParentForFeature(transcript, Pseudogene.ontologyId)
     }
 
-    @NotTransactional
     public boolean isProteinCoding(Transcript transcript) {
         return transcript instanceof MRNA
 //        if (getGene(transcript) != null && getGene(transcript) instanceof Pseudogene) {
@@ -78,6 +70,7 @@ class TranscriptService {
 //        return true;
     }
 
+    @Transactional
     CDS createCDS(Transcript transcript) {
         String uniqueName = transcript.getUniqueName() + FeatureStringEnum.CDS_SUFFIX.value;
 
@@ -107,6 +100,7 @@ class TranscriptService {
      *
      * @param transcript - Transcript to be deleted
      */
+    @Transactional
     public void deleteTranscript(Gene gene, Transcript transcript) {
         featureRelationshipService.removeFeatureRelationship(gene, transcript)
 
@@ -136,16 +130,15 @@ class TranscriptService {
      *
      * @return Collection of transcripts associated with this gene
      */
-    @NotTransactional
     public Collection<Transcript> getTranscripts(Gene gene) {
         return (Collection<Transcript>) featureRelationshipService.getChildrenForFeatureAndTypes(gene, ontologyIds as String[])
     }
 
-    @NotTransactional
     List<Transcript> getTranscriptsSortedByFeatureLocation(Gene gene, boolean sortByStrand) {
         return getTranscripts(gene).sort(true, new FeaturePositionComparator<Transcript>(sortByStrand))
     }
 
+    @Transactional
     public void setFmin(Transcript transcript, Integer fmin) {
         transcript.getFeatureLocation().setFmin(fmin);
         Gene gene = getGene(transcript)
@@ -154,6 +147,7 @@ class TranscriptService {
         }
     }
 
+    @Transactional
     public void setFmax(Transcript transcript, Integer fmax) {
         transcript.getFeatureLocation().setFmax(fmax);
         Gene gene = getGene(transcript)
@@ -162,6 +156,7 @@ class TranscriptService {
         }
     }
 
+    @Transactional
     def updateGeneBoundaries(Transcript transcript) {
         Gene gene = getGene(transcript)
         if (gene == null) {
@@ -183,7 +178,7 @@ class TranscriptService {
         // not sure if we want this if not actually saved
 //        gene.setLastUpdated(new Date());
     }
-    @NotTransactional
+
     List<String> getFrameShiftOntologyIds() {
         List<String> intFrameshiftOntologyIds = new ArrayList<>()
 
@@ -195,7 +190,7 @@ class TranscriptService {
 
         return intFrameshiftOntologyIds
     }
-    @NotTransactional
+
     List<Frameshift> getFrameshifts(Transcript transcript) {
         return featureRelationshipService.getFeaturePropertyForTypes(transcript, frameShiftOntologyIds)
     }
@@ -205,6 +200,7 @@ class TranscriptService {
      *
      * @param cds - CDS to be set to this transcript
      */
+    @Transactional
     public void setCDS(Feature feature, CDS cds, boolean replace = true) {
         if (replace) {
             log.debug "replacing CDS on feature"
@@ -232,6 +228,7 @@ class TranscriptService {
         feature.save(flush: true)
     }
 
+    @Transactional
     def addExon(Transcript transcript, Exon exon) {
 
         log.debug "exon feature lcoations ${exon.featureLocation}"
@@ -270,11 +267,12 @@ class TranscriptService {
         updateGeneBoundaries(transcript);  // 6, moved transcript fmin, fmax
         log.debug "post update gene boundaries: ${transcript.parentFeatureRelationships?.size()}"
     }
-    @NotTransactional
+
     Transcript getParentTranscriptForFeature(Feature feature) {
         return (Transcript) featureRelationshipService.getParentForFeature(feature, ontologyIds as String[])
     }
 
+    @Transactional
     Transcript splitTranscript(Transcript transcript, Exon leftExon, Exon rightExon) {
         List<Exon> exons = exonService.getSortedExons(transcript)
         Transcript splitTranscript = (Transcript) transcript.getClass().newInstance()
@@ -337,6 +335,7 @@ class TranscriptService {
      *
      * @param transcript - Transcript to be duplicated
      */
+    @Transactional
     public Transcript duplicateTranscript(Transcript transcript) {
         Transcript duplicate = (Transcript) transcript.generateClone();
         duplicate.name = transcript.name + "-copy"
@@ -369,6 +368,7 @@ class TranscriptService {
         return duplicate
     }
 
+    @Transactional
     def mergeTranscripts(Transcript transcript1, Transcript transcript2) {
         // Merging transcripts basically boils down to moving all exons from one transcript to the other
 
@@ -409,6 +409,7 @@ class TranscriptService {
         featureService.removeExonOverlapsAndAdjacencies(transcript1);
     }
 
+    @Transactional
     Transcript flipTranscriptStrand(Transcript oldTranscript) {
         Gene oldGene = getGene(oldTranscript)
         boolean isPseudogene = oldGene instanceof Pseudogene
@@ -453,7 +454,7 @@ class TranscriptService {
 
         return oldTranscript;
     }
-    @NotTransactional
+
     String getResiduesFromTranscript(Transcript transcript) {
         def exons = exonService.getSortedExons(transcript)
         if (!exons) {
@@ -466,7 +467,7 @@ class TranscriptService {
         }
         return residues.size() > 0 ? residues.toString() : null
     }
-    @NotTransactional
+
     Transcript getTranscript(CDS cds) {
         return (Transcript) featureRelationshipService.getParentForFeature(cds, ontologyIds as String[])
     }


### PR DESCRIPTION
This is request to turn off transactional reads and so it is a more lightweight optimization (compared to #460). This leads to some speedups

In a scaffold with 400 features, previously it would take 180 seconds. Now it takes 40 seconds. That is still not optimal but it is better because the nontransactional tag prevents the data from being re-fetched every time. 

Further optimizations will require doing some better querying, this change did not change any querying, only the tagging of methods as nontransactional

Note: I could not set @Transaction(readOnly=true) because having both @Transaction was set globally and the @Transaction(readOnly=true) set on a specific method produced the error "transactionManager is declared in a dynamic context, but you tried to access it from a static 

Note 2: problem with the locking is fixed too, but it is necessarily doing a slower fetch for parent/child features as a result