### PR TITLE
Fixup non canon

### DIFF
--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -2216,7 +2216,6 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         log.debug "convertSourceToModifiedLocalCoordinate"
         List<SequenceAlteration> alterations = new ArrayList<>()
         alterations.addAll(getAllSequenceAlterationsForFeature(feature))
-        log.debug "ALTERATIONS ${alterations} ${alterations[0].fmin}"
 
         if (alterations.size() == 0) {
             log.debug "alterations.size() == 0"
@@ -2235,6 +2234,14 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         for (SequenceAlteration alteration : alterations) {
             int alterationResidueLength = alteration.alterationResidue.length()
             int coordinateInContext = convertSourceCoordinateToLocalCoordinate(feature, alteration.fmin);
+
+
+            //getAllSequenceAlterationsForFeature returns alterations over entire scaffold?!
+            if(alteration.fmin<=feature.fmin || alteration.fmax> feature.fmax) {
+                log.debug "SKIPPING ${coordinateInContext}"
+                continue
+            }
+
             if (feature.strand == Strand.NEGATIVE.value) {
                 if (coordinateInContext <= localCoordinate && alteration instanceof Deletion) {
                     log.debug "Processing negative deletion"

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -2,11 +2,12 @@ package org.bbop.apollo
 
 import grails.converters.JSON
 import org.bbop.apollo.gwt.shared.FeatureStringEnum
-
+import org.bbop.apollo.Feature
 import grails.transaction.Transactional
 import org.bbop.apollo.filter.Cds3Filter
 import org.bbop.apollo.filter.StopCodonFilter
 import org.bbop.apollo.sequence.SequenceTranslationHandler
+import org.bbop.apollo.sequence.Strand
 import org.bbop.apollo.sequence.Strand
 import org.bbop.apollo.alteration.SequenceAlterationInContext
 import org.bbop.apollo.sequence.TranslationTable
@@ -1956,6 +1957,8 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         return sequenceAlterations
     }
 
+
+
     public List<SequenceAlterationInContext> getSequenceAlterationsInContext(Feature feature, Collection<SequenceAlteration> sequenceAlterations) {
         List<SequenceAlterationInContext> sequenceAlterationInContextList = new ArrayList<>()
         if (!(feature instanceof CDS) && !(feature instanceof Transcript)) {
@@ -2211,15 +2214,16 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
 
     public int convertSourceToModifiedLocalCoordinate(Feature feature, Integer localCoordinate) {
         log.debug "convertSourceToModifiedLocalCoordinate"
-        List<SequenceAlterationInContext> alterations = new ArrayList<>()
-        alterations.addAll(getSequenceAlterationsInContext(feature, getAllSequenceAlterationsForFeature(feature)))
+        List<SequenceAlteration> alterations = new ArrayList<>()
+        alterations.addAll(getAllSequenceAlterationsForFeature(feature))
+
         if (alterations.size() == 0) {
             log.debug "alterations.size() == 0"
             return localCoordinate
         }
 
 
-        Collections.sort(alterations, new SequenceAlterationInContextPositionComparator<SequenceAlterationInContext>());
+        Collections.sort(alterations, new FeaturePositionComparator<SequenceAlteration>());
         if (feature.getFeatureLocation().getStrand() == -1) {
             Collections.reverse(alterations);
         }
@@ -2227,7 +2231,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         int deletionOffset = 0
         int insertionOffset = 0
 
-        for (SequenceAlterationInContext alteration : alterations) {
+        for (SequenceAlteration alteration : alterations) {
             int alterationResidueLength = alteration.alterationResidue.length()
             int coordinateInContext = convertSourceCoordinateToLocalCoordinate(feature, alteration.fmin);
             if (feature.strand == Strand.NEGATIVE.value) {

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -1589,7 +1589,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         }
         List<SequenceAlteration> orderedSequenceAlterationList = new ArrayList<>(sequenceAlterationsInContext)
         Collections.sort(orderedSequenceAlterationList, new FeaturePositionComparator<SequenceAlteration>());
-        if (!feature.getStrand().equals(Strand.NEGATIVE.value)) {
+        if (!feature.getFeatureLocation().getStrand().equals(orderedSequenceAlterationList.get(0).getFeatureLocation().getStrand())) {
             Collections.reverse(orderedSequenceAlterationList);
         }
 

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -2218,7 +2218,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         alterations.addAll(getAllSequenceAlterationsForFeature(feature))
 
         if (alterations.size() == 0) {
-            log.debug "alterations.size() == 0"
+            log.debug "No alterations returning ${localCoordinate}"
             return localCoordinate
         }
 
@@ -2243,24 +2243,26 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
             }
 
             if (feature.strand == Strand.NEGATIVE.value) {
+                coordinateInContext=feature.featureLocation.calculateLength()-coordinateInContext
+                log.debug "Checking negative insertion ${coordinateInContext} ${localCoordinate} ${(coordinateInContext - alterationResidueLength) - 1}"
                 if (coordinateInContext <= localCoordinate && alteration instanceof Deletion) {
                     log.debug "Processing negative deletion"
                     deletionOffset += alterationResidueLength
                 }
                 if ((coordinateInContext - alterationResidueLength) - 1 <= localCoordinate && alteration instanceof Insertion) {
-                    log.debug "Processing negative insertion"
-                    insertionOffset -= alterationResidueLength
+                    log.debug "Processing negative insertion ${coordinateInContext} ${localCoordinate} ${(coordinateInContext - alterationResidueLength) - 1}"
+                    insertionOffset += alterationResidueLength
                 }
                 if ((localCoordinate - coordinateInContext) - 1 < alterationResidueLength && (localCoordinate - coordinateInContext) >= 0 && alteration instanceof Insertion) {
                     log.debug "Processing negative insertion pt 2"
-                    insertionOffset += (alterationResidueLength - (localCoordinate - coordinateInContext - 1))
+                    insertionOffset -= (alterationResidueLength - (localCoordinate - coordinateInContext - 1))
 
                 }
 
             } else {
                 if (coordinateInContext < localCoordinate && alteration instanceof Deletion) {
                     log.debug "Processing positive deletion"
-                    deletionOffset -= alterationResidueLength
+                    deletionOffset += alterationResidueLength
                 }
                 if ((coordinateInContext + alterationResidueLength) <= localCoordinate && alteration instanceof Insertion) {
                     log.debug "Processing positive insertion"

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -2216,6 +2216,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         log.debug "convertSourceToModifiedLocalCoordinate"
         List<SequenceAlteration> alterations = new ArrayList<>()
         alterations.addAll(getAllSequenceAlterationsForFeature(feature))
+        log.debug "ALTERATIONS ${alterations} ${alterations[0].fmin}"
 
         if (alterations.size() == 0) {
             log.debug "alterations.size() == 0"
@@ -2235,32 +2236,32 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
             int alterationResidueLength = alteration.alterationResidue.length()
             int coordinateInContext = convertSourceCoordinateToLocalCoordinate(feature, alteration.fmin);
             if (feature.strand == Strand.NEGATIVE.value) {
-                if (coordinateInContext <= localCoordinate && alteration.instanceOf == Deletion.canonicalName) {
+                if (coordinateInContext <= localCoordinate && alteration instanceof Deletion) {
                     log.debug "Processing negative deletion"
                     deletionOffset += alterationResidueLength
                 }
-                if ((coordinateInContext - alterationResidueLength) - 1 <= localCoordinate && alteration.instanceOf == Insertion.canonicalName) {
+                if ((coordinateInContext - alterationResidueLength) - 1 <= localCoordinate && alteration instanceof Insertion) {
                     log.debug "Processing negative insertion"
                     insertionOffset -= alterationResidueLength
                 }
-                if ((localCoordinate - coordinateInContext) - 1 < alterationResidueLength && (localCoordinate - coordinateInContext) >= 0 && alteration.instanceOf == Insertion.canonicalName) {
+                if ((localCoordinate - coordinateInContext) - 1 < alterationResidueLength && (localCoordinate - coordinateInContext) >= 0 && alteration instanceof Insertion) {
                     log.debug "Processing negative insertion pt 2"
                     insertionOffset += (alterationResidueLength - (localCoordinate - coordinateInContext - 1))
 
                 }
 
             } else {
-                if (coordinateInContext < localCoordinate && alteration.instanceOf == Deletion.canonicalName) {
+                if (coordinateInContext < localCoordinate && alteration instanceof Deletion) {
                     log.debug "Processing positive deletion"
                     deletionOffset -= alterationResidueLength
                 }
-                if ((coordinateInContext + alterationResidueLength) <= localCoordinate && alteration.instanceOf == Insertion.canonicalName) {
+                if ((coordinateInContext + alterationResidueLength) <= localCoordinate && alteration instanceof Insertion) {
                     log.debug "Processing positive insertion"
                     insertionOffset += alterationResidueLength
                 }
-                if ((localCoordinate - coordinateInContext) < alterationResidueLength && (localCoordinate - coordinateInContext) >= 0 && alteration.instanceOf == Insertion.canonicalName) {
+                if ((localCoordinate - coordinateInContext) < alterationResidueLength && (localCoordinate - coordinateInContext) >= 0 && alteration instanceof Insertion) {
                     log.debug "Processing positive insertion pt 2"
-                    insertionOffset -= localCoordinate - coordinateInContext
+                    insertionOffset += localCoordinate - coordinateInContext
                 }
             }
 

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -1464,259 +1464,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         }
     }
 
-//    String getResiduesWithAlterations(Feature feature,
-//                                      Collection<SequenceAlteration> sequenceAlterations = new ArrayList<>()) {
-//        String residueString = null
-//
-//        if (feature instanceof Transcript) {
-//            residueString = transcriptService.getResiduesFromTranscript((Transcript) feature)
-//            // sequence from exons with UTRs too
-//        } else if (feature instanceof CDS) {
-//            residueString = cdsService.getResiduesFromCDS((CDS) feature)
-//            // sequence from exons without UTRs (if any)
-//        } else {
-//            residueString = sequenceService.getResiduesFromFeature(feature)
-//            // sequence from feature, as is.
-//        }
-//        if (sequenceAlterations.size() == 0) {
-//            return residueString
-//        }
-//        StringBuilder residues = new StringBuilder(residueString);
-//        FeatureLocation featureLoc = feature.getFeatureLocation();
-////        List<SequenceAlteration> orderedSequenceAlterationList = BioObjectUtil.createSortedFeatureListByLocation(sequenceAlterations);
-//
-//        List<SequenceAlteration> orderedSequenceAlterationList = new ArrayList<>(sequenceAlterations)
-//        Collections.sort(orderedSequenceAlterationList, new FeaturePositionComparator<SequenceAlteration>());
-//        if (!feature.getFeatureLocation().getStrand().equals(orderedSequenceAlterationList.get(0).getFeatureLocation().getStrand())) {
-//            Collections.reverse(orderedSequenceAlterationList);
-//        }
-//        int currentOffset = 0;
-//        for (SequenceAlteration sequenceAlteration : orderedSequenceAlterationList) {
-//            if (!overlapperService.overlaps(feature, sequenceAlteration, false)) {
-//                continue
-//            }
-////            if (!feature.overlaps(sequenceAlteration, false)) {
-////                continue;
-////            }
-//            FeatureLocation sequenceAlterationLoc = sequenceAlteration.getFeatureLocation();
-//            if (sequenceAlterationLoc.sequence == featureLoc.sequence) {
-//
-//                int localCoordinate
-//                if(feature instanceof Transcript){
-//                    localCoordinate = convertSourceCoordinateToLocalCoordinateForTranscript(feature, sequenceAlterationLoc.getFmin());
-//                }
-//                else {
-//                    localCoordinate = convertSourceCoordinateToLocalCoordinate(feature, sequenceAlterationLoc.getFmin());
-//                }
-////                int localCoordinate = convertModifiedLocalCoordinateToSourceCoordinate(feature, sequenceAlterationLoc.getFmin());
-////                String sequenceAlterationResidues = sequenceAlteration.getResidues();
-//
-//                // TODO: is this correct?
-//                String sequenceAlterationResidues = sequenceAlteration.alterationResidue
-//                if (feature.getFeatureLocation().getStrand() == -1) {
-//                    sequenceAlterationResidues = SequenceTranslationHandler.reverseComplementSequence(sequenceAlterationResidues);
-//                }
-//                // Insertions
-//                if (sequenceAlteration instanceof Insertion) {
-//                    if (feature.getFeatureLocation().getStrand() == -1) {
-//                        ++localCoordinate;
-//                    }
-//                    residues.insert(localCoordinate + currentOffset, sequenceAlterationResidues);
-//                    currentOffset += sequenceAlterationResidues.length();
-//                }
-//                // Deletions
-//                else if (sequenceAlteration instanceof Deletion) {
-//                    if (feature.getFeatureLocation().getStrand() == -1) {
-//                        residues.delete(localCoordinate + currentOffset - sequenceAlteration.getLength() + 1,
-//                                localCoordinate + currentOffset + 1);
-//                    } else {
-//                        residues.delete(localCoordinate + currentOffset,
-//                                localCoordinate + currentOffset + sequenceAlteration.getLength());
-//                    }
-//                    currentOffset -= sequenceAlterationResidues.length();
-//                }
-//                // Substitions
-//                else if (sequenceAlteration instanceof Substitution) {
-//                    int start = feature.getStrand() == -1 ? localCoordinate - (sequenceAlteration.getLength() - 1) : localCoordinate;
-//                    residues.replace(start + currentOffset,
-//                            start + currentOffset + sequenceAlteration.getLength(),
-//                            sequenceAlterationResidues);
-//                }
-//            }
-//        }
-//        return residues.toString();
-//    }
 
-//    def getSequenceAlterationsInContext(Feature feature, Collection<SequenceAlteration> sequenceAlterations) {
-//        List<Exon> exonList = exonService.getSortedExons(feature, true)
-//        List<SequenceAlteration> sequenceAlterationsInContext = new ArrayList<>()
-//        for (SequenceAlteration eachSequenceAlteration : sequenceAlterations) {
-//            for (Exon exon : exonList) {
-//                if (overlapperService.overlaps(exon, eachSequenceAlteration, false)) {
-//                    // alteration overlaps with exon and is overlapping with the CDS
-//                    sequenceAlterationsInContext.add(eachSequenceAlteration)
-//                }
-//            }
-//        }
-//        return sequenceAlterationsInContext
-//    }
-
-//    def isSequenceAlterationInContext(Feature feature, SequenceAlteration sequenceAlteration) {
-//        List<Exon> exonList = exonService.getSortedExons(feature, true)
-//        for (Exon exon : exonList) {
-//            if (overlapperService.overlaps(exon, sequenceAlteration, false)) {
-//                // alteration overlaps with exon and is overlapping with the CDS
-//                return true
-//            }
-//        }
-//        return false
-//    }
-
-    /* convert an input local coordinate to a local coordinate that incorporates sequence alterations */
-
-    Integer getFeatureModifiedCoord(Feature feature, Integer inputCoord, Collection<SequenceAlteration> sequenceAlterations = new ArrayList<>()) {
-
-        List<SequenceAlteration> sequenceAlterationsInContext = new ArrayList<>()
-
-        // sequence from feature, as is
-        for (SequenceAlteration eachSequenceAlteration : sequenceAlterations) {
-            if (overlapperService.overlaps(eachSequenceAlteration, feature, false)) {
-                sequenceAlterationsInContext.add(eachSequenceAlteration)
-            }
-        }
-        if (sequenceAlterations.size() == 0 || sequenceAlterationsInContext.size() == 0) {
-            return inputCoord
-        }
-        List<SequenceAlteration> orderedSequenceAlterationList = new ArrayList<>(sequenceAlterationsInContext)
-        Collections.sort(orderedSequenceAlterationList, new FeaturePositionComparator<SequenceAlteration>());
-        if (!feature.getFeatureLocation().getStrand().equals(orderedSequenceAlterationList.get(0).getFeatureLocation().getStrand())) {
-            Collections.reverse(orderedSequenceAlterationList);
-        }
-
-        int currentOffset = 0
-        for (SequenceAlteration sequenceAlteration : orderedSequenceAlterationList) {
-            int localCoordinate
-            int localCoordinateMax
-            localCoordinate = convertSourceCoordinateToLocalCoordinate(feature, sequenceAlteration.fmin);
-            localCoordinateMax = convertSourceCoordinateToLocalCoordinate(feature, sequenceAlteration.fmax);
-
-            // Insertions
-            if (sequenceAlteration instanceof Insertion) {
-                if (localCoordinate < inputCoord) {
-                    currentOffset += sequenceAlteration.alterationResidue.length()
-                    if(feature.strand==-1) {
-                        currentOffset += 1
-                    }
-                }
-                else {
-                    break
-                }
-            }
-            // Deletions
-            else if (sequenceAlteration instanceof Deletion) {
-                if(localCoordinate<inputCoord) {
-                    if(localCoordinateMax>=inputCoord) {
-                        currentOffset-=sequenceAlteration.alterationResidue.length()
-                        if(feature.strand==-1) {
-                            currentOffset += 1
-                        }
-                    }
-                    else {
-                        currentOffset-=localCoordinate-localCoordinateMax-inputCoord
-                        if(feature.strand==-1) {
-                            currentOffset += 1
-                        }
-                    }
-                }
-                else {
-                    break
-                }
-            }
-        }
-        return inputCoord+currentOffset;
-
-    }
-
-//    String getResiduesWithAlterationsNew (Feature feature, Collection<SequenceAlteration> sequenceAlterations = new ArrayList<>()) {
-//        String residueString = null
-//        List<SequenceAlteration> sequenceAlterationsInContext = new ArrayList<>()
-//        if (feature instanceof Transcript) {
-//            residueString = transcriptService.getResiduesFromTranscript((Transcript) feature)
-//            // sequence from exons, with UTRs too
-//            sequenceAlterationsInContext = getSequenceAlterationsInContext(feature, sequenceAlterations)
-//        } else if (feature instanceof CDS) {
-//            residueString = cdsService.getResiduesFromCDS((CDS) feature)
-//            // sequence from exons without UTRs
-//            sequenceAlterationsInContext = getSequenceAlterationsInContext(transcriptService.getTranscript(feature), sequenceAlterations)
-//        } else {
-//            // sequence from feature, as is
-//            residueString = sequenceService.getResiduesFromFeature(feature)
-//            for (SequenceAlteration eachSequenceAlteration : sequenceAlterations) {
-//                if (overlapperService.overlaps(eachSequenceAlteration, feature, false)) {
-//                    sequenceAlterationsInContext.add(eachSequenceAlteration)
-//                }
-//            }
-//        }
-//        if (sequenceAlterations.size() == 0 || sequenceAlterationsInContext.size() == 0) {
-//            return residueString
-//        }
-//
-//        StringBuilder residues = new StringBuilder(residueString);
-//        List<SequenceAlteration> orderedSequenceAlterationList = new ArrayList<>(sequenceAlterationsInContext)
-//        Collections.sort(orderedSequenceAlterationList, new FeaturePositionComparator<SequenceAlteration>());
-//        if (!feature.getFeatureLocation().getStrand().equals(orderedSequenceAlterationList.get(0).getFeatureLocation().getStrand())) {
-//            Collections.reverse(orderedSequenceAlterationList);
-//        }
-//
-//        int currentOffset = 0;
-//        for (SequenceAlteration sequenceAlteration : orderedSequenceAlterationList) {
-//            int localCoordinate
-//            if(feature instanceof Transcript) {
-//                localCoordinate = convertSourceCoordinateToLocalCoordinateForTranscript(feature, sequenceAlteration.featureLocation.fmin);
-//            } else if (feature instanceof CDS){
-//                if (! overlapperService.overlaps(feature, sequenceAlteration, false)) {
-//                    // a check to verify if alteration is part of the CDS
-//                    continue
-//                }
-//                //localCoordinate = convertSourceCoordinateToLocalCoordinateForTranscript(transcriptService.getTranscript(feature), sequenceAlteration.featureLocation.fmin);
-//                localCoordinate = convertSourceCoordinateToLocalCoordinateForCDS(transcriptService.getTranscript(feature), sequenceAlteration.featureLocation.fmin)
-//            }
-//            else {
-//                localCoordinate = convertSourceCoordinateToLocalCoordinate(feature, sequenceAlteration.featureLocation.fmin);
-//            }
-//            String sequenceAlterationResidues = sequenceAlteration.alterationResidue
-//            if (feature.getFeatureLocation().getStrand() == -1) {
-//                sequenceAlterationResidues = SequenceTranslationHandler.reverseComplementSequence(sequenceAlterationResidues);
-//            }
-//            // Insertions
-//            if (sequenceAlteration instanceof Insertion) {
-//                if (feature.getFeatureLocation().getStrand() == -1) {
-//                    ++localCoordinate;
-//                }
-//                residues.insert(localCoordinate + currentOffset, sequenceAlterationResidues);
-//                currentOffset += sequenceAlterationResidues.length();
-//            }
-//            // Deletions
-//            else if (sequenceAlteration instanceof Deletion) {
-//                if (feature.getFeatureLocation().getStrand() == -1) {
-//                    residues.delete(localCoordinate + currentOffset - sequenceAlteration.getLength() + 1,
-//                            localCoordinate + currentOffset + 1);
-//                } else {
-//                    residues.delete(localCoordinate + currentOffset,
-//                            localCoordinate + currentOffset + sequenceAlteration.getLength());
-//                }
-//                currentOffset -= sequenceAlterationResidues.length();
-//            }
-//            // Substitions
-//            else if (sequenceAlteration instanceof Substitution) {
-//                int start = feature.getStrand() == -1 ? localCoordinate - (sequenceAlteration.getLength() - 1) : localCoordinate;
-//                residues.replace(start + currentOffset,
-//                        start + currentOffset + sequenceAlteration.getLength(),
-//                        sequenceAlterationResidues);
-//            }
-//        }
-//        return residues.toString();
-//    }
 
     public void removeFeatureRelationship(Transcript transcript, Feature feature) {
 
@@ -2053,14 +1801,14 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         }
     }
 
-/**
- * From https://github.com/GMOD/Apollo/issues/73
- * Need to add another call after other calculations are done to verify that we verify that we have not left our current isoform siblings or that we have just joined some and we should merge genes (always taking the one on the left).
- 1 - using OrfOverlapper, find other isoforms
- 2 - for each isoform, confirm that they belong to the same gene (if not, we merge genes)
- 3 - confirm that no other non-overlapping isoforms have the same gene (if not, we create a new gene)
- * @param transcript
- */
+    /**
+     * From https://github.com/GMOD/Apollo/issues/73
+     * Need to add another call after other calculations are done to verify that we verify that we have not left our current isoform siblings or that we have just joined some and we should merge genes (always taking the one on the left).
+     1 - using OrfOverlapper, find other isoforms
+     2 - for each isoform, confirm that they belong to the same gene (if not, we merge genes)
+     3 - confirm that no other non-overlapping isoforms have the same gene (if not, we create a new gene)
+     * @param transcript
+     */
     @Transactional
     def handleIsoformOverlap(Transcript transcript) {
         Gene originalGene = transcriptService.getGene(transcript)
@@ -2455,5 +2203,67 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
             // calling convertLocalCoordinateToSourceCoordinate for all other feature types
             return convertLocalCoordinateToSourceCoordinate(feature, localCoordinate)
         }
+    }
+
+
+
+    /* convert an input local coordinate to a local coordinate that incorporates sequence alterations */
+
+    public int convertSourceToModifiedLocalCoordinate(Feature feature, Integer localCoordinate) {
+        log.debug "convertSourceToModifiedLocalCoordinate"
+        List<SequenceAlterationInContext> alterations = new ArrayList<>()
+        alterations.addAll(getSequenceAlterationsInContext(feature, getAllSequenceAlterationsForFeature(feature)))
+        if (alterations.size() == 0) {
+            log.debug "alterations.size() == 0"
+            return localCoordinate
+        }
+
+
+        Collections.sort(alterations, new SequenceAlterationInContextPositionComparator<SequenceAlterationInContext>());
+        if (feature.getFeatureLocation().getStrand() == -1) {
+            Collections.reverse(alterations);
+        }
+
+        int deletionOffset = 0
+        int insertionOffset = 0
+
+        for (SequenceAlterationInContext alteration : alterations) {
+            int alterationResidueLength = alteration.alterationResidue.length()
+            int coordinateInContext = convertSourceCoordinateToLocalCoordinate(feature, alteration.fmin);
+            if (feature.strand == Strand.NEGATIVE.value) {
+                if (coordinateInContext <= localCoordinate && alteration.instanceOf == Deletion.canonicalName) {
+                    log.debug "Processing negative deletion"
+                    deletionOffset += alterationResidueLength
+                }
+                if ((coordinateInContext - alterationResidueLength) - 1 <= localCoordinate && alteration.instanceOf == Insertion.canonicalName) {
+                    log.debug "Processing negative insertion"
+                    insertionOffset -= alterationResidueLength
+                }
+                if ((localCoordinate - coordinateInContext) - 1 < alterationResidueLength && (localCoordinate - coordinateInContext) >= 0 && alteration.instanceOf == Insertion.canonicalName) {
+                    log.debug "Processing negative insertion pt 2"
+                    insertionOffset += (alterationResidueLength - (localCoordinate - coordinateInContext - 1))
+
+                }
+
+            } else {
+                if (coordinateInContext < localCoordinate && alteration.instanceOf == Deletion.canonicalName) {
+                    log.debug "Processing positive deletion"
+                    deletionOffset -= alterationResidueLength
+                }
+                if ((coordinateInContext + alterationResidueLength) <= localCoordinate && alteration.instanceOf == Insertion.canonicalName) {
+                    log.debug "Processing positive insertion"
+                    insertionOffset += alterationResidueLength
+                }
+                if ((localCoordinate - coordinateInContext) < alterationResidueLength && (localCoordinate - coordinateInContext) >= 0 && alteration.instanceOf == Insertion.canonicalName) {
+                    log.debug "Processing positive insertion pt 2"
+                    insertionOffset -= localCoordinate - coordinateInContext
+                }
+            }
+
+        }
+
+        log.debug "Returning ${localCoordinate-deletionOffset+insertionOffset}"
+        return localCoordinate-deletionOffset+insertionOffset
+
     }
 }

--- a/grails-app/services/org/bbop/apollo/NonCanonicalSplitSiteService.groovy
+++ b/grails-app/services/org/bbop/apollo/NonCanonicalSplitSiteService.groovy
@@ -142,7 +142,7 @@ class NonCanonicalSplitSiteService {
         Strand strand=transcript.getFeatureLocation().strand==-1?Strand.NEGATIVE:Strand.POSITIVE
 
         String residues = sequenceService.getGenomicResiduesFromSequenceWithAlterations(sequence,fmin,fmax,strand);
-//        if(transcript.getStrand()==-1)residues=residues.reverse()
+        if(transcript.getStrand()==-1)residues=residues.reverse()
 
         for (Exon exon : exons) {
             int fivePrimeSpliceSitePosition = -1;
@@ -163,14 +163,14 @@ class NonCanonicalSplitSiteService {
                     int local4=featureService.getFeatureModifiedCoord(transcript,local44,alts)
 
 
-//                    if (exon.featureLocation.getStrand() == -1) {
-//                        int tmp1=local1
-//                        int tmp2=local2
-//                        local1=local3
-//                        local2=local4
-//                        local3=tmp1
-//                        local4=tmp2
-//                    }
+                    if (exon.featureLocation.getStrand() == -1) {
+                        int tmp1=local1
+                        int tmp2=local2
+                        local1=local3
+                        local2=local4
+                        local3=tmp1
+                        local4=tmp2
+                    }
                     if(local1>=0&&local2 < residues.length()) {
                         String acceptorSpliceSiteSequence = residues.substring(local1,local2)
                         acceptorSpliceSiteSequence=transcript.getStrand()==-1?acceptorSpliceSiteSequence.reverse():acceptorSpliceSiteSequence

--- a/grails-app/services/org/bbop/apollo/NonCanonicalSplitSiteService.groovy
+++ b/grails-app/services/org/bbop/apollo/NonCanonicalSplitSiteService.groovy
@@ -155,12 +155,11 @@ class NonCanonicalSplitSiteService {
                     int local22=exon.fmin-transcript.fmin
                     int local33=exon.fmax-transcript.fmin
                     int local44=exon.fmax+donor.length()-transcript.fmin
-                    List<SequenceAlteration> alts=featureService.getAllSequenceAlterationsForFeature(transcript)
 
-                    int local1=featureService.getFeatureModifiedCoord(transcript,local11,alts)
-                    int local2=featureService.getFeatureModifiedCoord(transcript,local22,alts)
-                    int local3=featureService.getFeatureModifiedCoord(transcript,local33,alts)
-                    int local4=featureService.getFeatureModifiedCoord(transcript,local44,alts)
+                    int local1=featureService.convertSourceToModifiedLocalCoordinate(transcript,local11)
+                    int local2=featureService.convertSourceToModifiedLocalCoordinate(transcript,local22)
+                    int local3=featureService.convertSourceToModifiedLocalCoordinate(transcript,local33)
+                    int local4=featureService.convertSourceToModifiedLocalCoordinate(transcript,local44)
 
 
                     if (exon.featureLocation.getStrand() == -1) {

--- a/grails-app/services/org/bbop/apollo/OverlapperService.groovy
+++ b/grails-app/services/org/bbop/apollo/OverlapperService.groovy
@@ -14,6 +14,7 @@ class OverlapperService implements Overlapper{
 
     @Override
     boolean overlaps(Transcript transcript, Gene gene) {
+        log.debug("overlaps(Transcript transcript, Gene gene) ")
         String overlapperName = configWrapperService.overlapper.class.name
         if(overlapperName.contains("Orf")){
             return overlapsOrf(transcript,gene)
@@ -23,6 +24,7 @@ class OverlapperService implements Overlapper{
 
     @Override
     boolean overlaps(Transcript transcript1, Transcript transcript2) {
+        log.debug("overlaps(Transcript transcript1, Transcript transcript2) ")
         String overlapperName = configWrapperService.overlapper.class.name
         if(overlapperName.contains("Orf")){
             return overlapsOrf(transcript1,transcript2)
@@ -32,6 +34,7 @@ class OverlapperService implements Overlapper{
 
 
     boolean overlapsOrf(Transcript transcript, Gene gene) {
+        log.debug("overlapsOrf(Transcript transcript, Gene gene) ")
 
         for (Transcript geneTranscript : transcriptService.getTranscripts(gene)) {
             if (overlapsOrf(transcript, geneTranscript)) {
@@ -42,6 +45,7 @@ class OverlapperService implements Overlapper{
     }
 
     boolean overlapsOrf(Transcript transcript1, Transcript transcript2) {
+        log.debug("overlapsOrf(Transcript transcript1, Transcript transcript2) ")
         if ((transcriptService.isProteinCoding(transcript1) && transcriptService.isProteinCoding(transcript2))
                 && ((transcriptService.getGene(transcript1) == null || transcriptService.getGene(transcript2) == null) || (!(transcriptService.getGene(transcript1) instanceof Pseudogene) && !(transcriptService.getGene(transcript2) instanceof Pseudogene)))) {
 
@@ -57,6 +61,7 @@ class OverlapperService implements Overlapper{
     }
 
     private boolean exonsOverlap(List<Exon> exons1, List<Exon> exons2, boolean checkStrand) {
+        log.debug("boolean exonsOverlap(List<Exon> exons1, List<Exon> exons2, boolean checkStrand) ")
         int i = 0;
         int j = 0;
         while (i < exons1.size() && j < exons2.size()) {
@@ -98,10 +103,12 @@ class OverlapperService implements Overlapper{
     }
 
     boolean overlaps(Feature leftFeature, Feature rightFeature, boolean compareStrands = true) {
+        log.debug("overlaps(Feature leftFeature, Feature rightFeature, boolean compareStrands)")
         return overlaps(leftFeature.featureLocation, rightFeature.featureLocation, compareStrands)
     }
 
     boolean overlaps(FeatureLocation leftFeatureLocation, FeatureLocation rightFeatureLocation, boolean compareStrands = true) {
+        log.debug("overlaps(FeatureLocation leftFeatureLocation, FeatureLocation rightFeatureLocation, boolean compareStrands)")
         if (leftFeatureLocation.sequence != rightFeatureLocation.sequence) {
             return false;
         }

--- a/grails-app/services/org/bbop/apollo/OverlapperService.groovy
+++ b/grails-app/services/org/bbop/apollo/OverlapperService.groovy
@@ -14,7 +14,7 @@ class OverlapperService implements Overlapper{
 
     @Override
     boolean overlaps(Transcript transcript, Gene gene) {
-        log.debug("overlaps(Transcript transcript, Gene gene) ")
+        //log.debug("overlaps(Transcript transcript, Gene gene) ")
         String overlapperName = configWrapperService.overlapper.class.name
         if(overlapperName.contains("Orf")){
             return overlapsOrf(transcript,gene)
@@ -24,7 +24,7 @@ class OverlapperService implements Overlapper{
 
     @Override
     boolean overlaps(Transcript transcript1, Transcript transcript2) {
-        log.debug("overlaps(Transcript transcript1, Transcript transcript2) ")
+        //log.debug("overlaps(Transcript transcript1, Transcript transcript2) ")
         String overlapperName = configWrapperService.overlapper.class.name
         if(overlapperName.contains("Orf")){
             return overlapsOrf(transcript1,transcript2)
@@ -34,7 +34,7 @@ class OverlapperService implements Overlapper{
 
 
     boolean overlapsOrf(Transcript transcript, Gene gene) {
-        log.debug("overlapsOrf(Transcript transcript, Gene gene) ")
+        //log.debug("overlapsOrf(Transcript transcript, Gene gene) ")
 
         for (Transcript geneTranscript : transcriptService.getTranscripts(gene)) {
             if (overlapsOrf(transcript, geneTranscript)) {
@@ -45,7 +45,7 @@ class OverlapperService implements Overlapper{
     }
 
     boolean overlapsOrf(Transcript transcript1, Transcript transcript2) {
-        log.debug("overlapsOrf(Transcript transcript1, Transcript transcript2) ")
+        //log.debug("overlapsOrf(Transcript transcript1, Transcript transcript2) ")
         if ((transcriptService.isProteinCoding(transcript1) && transcriptService.isProteinCoding(transcript2))
                 && ((transcriptService.getGene(transcript1) == null || transcriptService.getGene(transcript2) == null) || (!(transcriptService.getGene(transcript1) instanceof Pseudogene) && !(transcriptService.getGene(transcript2) instanceof Pseudogene)))) {
 
@@ -61,7 +61,7 @@ class OverlapperService implements Overlapper{
     }
 
     private boolean exonsOverlap(List<Exon> exons1, List<Exon> exons2, boolean checkStrand) {
-        log.debug("boolean exonsOverlap(List<Exon> exons1, List<Exon> exons2, boolean checkStrand) ")
+        //log.debug("boolean exonsOverlap(List<Exon> exons1, List<Exon> exons2, boolean checkStrand) ")
         int i = 0;
         int j = 0;
         while (i < exons1.size() && j < exons2.size()) {
@@ -103,12 +103,12 @@ class OverlapperService implements Overlapper{
     }
 
     boolean overlaps(Feature leftFeature, Feature rightFeature, boolean compareStrands = true) {
-        log.debug("overlaps(Feature leftFeature, Feature rightFeature, boolean compareStrands)")
+        //log.debug("overlaps(Feature leftFeature, Feature rightFeature, boolean compareStrands)")
         return overlaps(leftFeature.featureLocation, rightFeature.featureLocation, compareStrands)
     }
 
     boolean overlaps(FeatureLocation leftFeatureLocation, FeatureLocation rightFeatureLocation, boolean compareStrands = true) {
-        log.debug("overlaps(FeatureLocation leftFeatureLocation, FeatureLocation rightFeatureLocation, boolean compareStrands)")
+        //log.debug("overlaps(FeatureLocation leftFeatureLocation, FeatureLocation rightFeatureLocation, boolean compareStrands)")
         if (leftFeatureLocation.sequence != rightFeatureLocation.sequence) {
             return false;
         }


### PR DESCRIPTION
Here is an initial fix for #531 
It does fix (in test cases that I had) the issues with sequence alterations miscalculating non-canon splice sites on the negative strand


Here are some remaining issues that are I think not big problems, but just notable.

- Haven't really tested deletions very much but seems to work if it's in an intron (doens't affect non canon splice site flags, a good thing)
- Insertions larger than 2 bp inside a splice site cause a string out of bounds exception (I am probably just overlooking something here)
- Non-canon splice sites exclamation marks are slightly off center in the plus strand features but they do seem to be calculated appropriately otherwise?

I just wanted to get this available for review ASAP, please test and comment :+1: 


