### PR TITLE
Fix permissions

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -122,7 +122,11 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         JSONObject inputObject = (JSONObject) JSON.parse(params.data)
         inputObject.put(FeatureStringEnum.USERNAME.value, SecurityUtils.subject.principal)
         JSONArray featuresArray = inputObject.getJSONArray(FeatureStringEnum.FEATURES.value)
-        permissionService.checkPermissions(inputObject, PermissionEnum.READ)
+        if(!permissionService.checkPermissions(inputObject, PermissionEnum.READ)) {
+            def error=[error: "not authorized"]
+            render error as JSON
+            return
+        }
 
         JSONObject historyContainer = createJSONFeatureContainer();
         DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
@@ -456,8 +460,13 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
     def getFeatures() {
         JSONObject returnObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
         try {
-            permissionService.checkPermissions(returnObject, PermissionEnum.READ)
-            render requestHandlingService.getFeatures(returnObject)
+            if(!permissionService.checkPermissions(returnObject, PermissionEnum.READ)) {
+                def error=[error: "not authorized"]
+                render error as JSON
+            }
+            else {
+                render requestHandlingService.getFeatures(returnObject)
+            }
         } catch (e) {
             def error = [error: 'problem getting features: ' + e.fillInStackTrace()]
             render error as JSON

--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -105,6 +105,8 @@ class RequestHandlingService {
             )
             fireAnnotationEvent(annotationEvent)
         }
+
+        return new JSONObject()
     }
 
     JSONObject setDescription(JSONObject inputObject) {

--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -86,7 +86,9 @@ class RequestHandlingService {
             Feature feature = Feature.findByUniqueName(uniqueName)
             String symbolString = jsonFeature.getString(FeatureStringEnum.SYMBOL.value);
             if (!sequence) sequence = feature.getFeatureLocation().getSequence()
-            permissionService.checkPermissions(inputObject, sequence.organism, PermissionEnum.WRITE)
+            if(!permissionService.checkPermissions(inputObject, sequence.organism, PermissionEnum.WRITE)) {
+                throw new Exception("Not authorized")
+            }
 
             feature.symbol = symbolString
             feature.save(flush: true, failOnError: true)
@@ -116,7 +118,9 @@ class RequestHandlingService {
             Feature feature = Feature.findByUniqueName(uniqueName)
             String descriptionString = jsonFeature.getString(FeatureStringEnum.DESCRIPTION.value);
             if (!sequence) sequence = feature.getFeatureLocation().getSequence()
-            permissionService.checkPermissions(inputObject, sequence.organism, PermissionEnum.WRITE)
+            if(!permissionService.checkPermissions(inputObject, sequence.organism, PermissionEnum.WRITE)) {
+                throw new Exception("not authorized")
+            }
 
 
             feature.description = descriptionString
@@ -2306,7 +2310,9 @@ class RequestHandlingService {
     @Timed
     def undo(JSONObject inputObject) {
         JSONArray featuresArray = inputObject.getJSONArray(FeatureStringEnum.FEATURES.value)
-        permissionService.checkPermissions(inputObject, PermissionEnum.WRITE)
+        if(!permissionService.checkPermissions(inputObject, PermissionEnum.WRITE)) {
+            throw new Exception("not authorized")
+        }
         permissionService.getCurrentUser(inputObject)
 
         for (int i = 0; i < featuresArray.size(); ++i) {
@@ -2322,7 +2328,9 @@ class RequestHandlingService {
     @Timed
     def redo(JSONObject inputObject) {
         JSONArray featuresArray = inputObject.getJSONArray(FeatureStringEnum.FEATURES.value)
-        permissionService.checkPermissions(inputObject, PermissionEnum.WRITE)
+        if(!permissionService.checkPermissions(inputObject, PermissionEnum.WRITE)) {
+            throw new Exception("not authorized")
+        }
         permissionService.getCurrentUser(inputObject)
 
         for (int i = 0; i < featuresArray.size(); ++i) {


### PR DESCRIPTION
There is an issue with the use of the function Boolean checkPermissions

It seems to be assumed that the function will throw an exception if it cannot authenticate the user, but instead it does not throw the error

Web services affected

setStatus
getHistoryForFeatures
getFeatures
setDescription
undo
redo


If you look at the git blame for the permissions service, you can see that this doesn't appear to be a new bug

https://github.com/GMOD/Apollo/blame/master/grails-app/services/org/bbop/apollo/PermissionService.groovy


Note that the commit 4ec5fe756788c17e1 showed a particular example of this affecting the updateOrganism webservice.

