### PR TITLE
Add ability to set organism by common name in URL

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -57,7 +57,7 @@ class JbrowseController {
                 organism = Organism.findById(params.organism.toInteger())
             }
             if(!organism) {
-                forward(controller: "organism", action: "chooseOrganismForJbrowse",params:[urlString:urlString,error:"Unable to find organism"])
+                forward(controller: "organism", action: "chooseOrganismForJbrowse",params:[urlString:urlString,error:"Unable to find organism '${params.organism}'"])
             }
 
 

--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -50,7 +50,16 @@ class JbrowseController {
             log.debug "organism ID specified: ${params.organism}"
 
             // set the organism
-            Organism organism = Organism.findById(params.organism)
+
+
+            Organism organism = Organism.findByCommonName(params.organism)
+            if(!organism) organism = Organism.findById(params.organism)
+            if(!organism) {
+                render "Organism not found!"
+                return
+            }
+
+
             def session = request.getSession(true)
             session.setAttribute(FeatureStringEnum.ORGANISM_JBROWSE_DIRECTORY.value,organism.directory)
             session.setAttribute(FeatureStringEnum.ORGANISM_ID.value,organism.id)

--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -53,7 +53,9 @@ class JbrowseController {
 
 
             Organism organism = Organism.findByCommonName(params.organism)
-            if(!organism) organism = Organism.findById(params.organism)
+            if(!organism&&params.organism.isInteger()) {
+                organism = Organism.findById(params.organism.toInteger())
+            }
             if(!organism) {
                 response.status = 404
                 render "Organism not found!"

--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -55,6 +55,7 @@ class JbrowseController {
             Organism organism = Organism.findByCommonName(params.organism)
             if(!organism) organism = Organism.findById(params.organism)
             if(!organism) {
+                response.status = 404
                 render "Organism not found!"
                 return
             }

--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -57,9 +57,7 @@ class JbrowseController {
                 organism = Organism.findById(params.organism.toInteger())
             }
             if(!organism) {
-                response.status = 404
-                render "Organism not found!"
-                return
+                forward(controller: "organism", action: "chooseOrganismForJbrowse",params:[urlString:urlString,error:"Unable to find organism"])
             }
 
 

--- a/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
@@ -33,7 +33,7 @@ class OrganismController {
     def reportService
 
     def chooseOrganismForJbrowse() {
-        [organisms: Organism.findAllByPublicMode(true, [sort: 'commonName', order: 'desc']), urlString: params.urlString]
+        [organisms: Organism.findAllByPublicMode(true, [sort: 'commonName', order: 'desc']), urlString: params.urlString, flash: [message: params.error]]
     }
 
     @RestApiMethod(description = "Remove an organism", path = "/organism/deleteOrganism", verb = RestApiVerb.POST)

--- a/grails-app/views/organism/chooseOrganismForJbrowse.gsp
+++ b/grails-app/views/organism/chooseOrganismForJbrowse.gsp
@@ -24,6 +24,11 @@
     </ul>
 </div>
 
+<g:if test="${flash.message}">
+    <div class="message" role="status">${flash.message}</div>
+</g:if>
+
+
 <div style="margin-left: 20px;">
     <h3>
         Choose Organism to View


### PR DESCRIPTION
Currently for jbrowse links we have to specify the organism ID which is not easy to memorize

This pull request makes us allowed to use the name of the organism for this purpose

So instead of just 
http://mysite.cool/Apollo2/jbrowse/index.html?organism=1351345

Which is impossible to memorize, we can now also have

http://mysite.cool/Apollo2/jbrowse/index.html?organism=Honeybee


Note that our command line tools have allowed using name instead of organism ID for awhile now, so at least conceptually this is not new.

This was kind of discussed in #618