### PR TITLE
Delete features from organism

### DIFF
--- a/docs/Apollo2Build.md
+++ b/docs/Apollo2Build.md
@@ -12,8 +12,8 @@ the "production mode" setup.
 
 ### Grails
 
-Installing grails is made easier by using [SDKMAN](http://sdkman.io/) (formerly GVM) which can automatically setup grails for you. We
-will use grails 2.4.5 for Web Apollo.
+Installing grails is made easier by using [SDKMAN](http://sdkman.io/) (formerly GVM) which can automatically setup
+grails for you. We will use grails 2.4.5 for Web Apollo.
 
 1. curl -s http://get.sdkman.io | bash
 2. gvm install grails 2.4.5

--- a/docs/Apollo2Build.md
+++ b/docs/Apollo2Build.md
@@ -15,8 +15,14 @@ the "production mode" setup.
 Installing grails is made easier by using [SDKMAN](http://sdkman.io/) (formerly GVM) which can automatically setup
 grails for you. We will use grails 2.4.5 for Web Apollo.
 
-1. curl -s http://get.sdkman.io | bash
-2. gvm install grails 2.4.5
+1. `curl -s http://get.sdkman.io | bash`
+2. `gvm install grails 2.4.5`
+
+### Groovy
+
+It is not required but you can also install the groovy command line
+
+`gvm install groovy`
 
 
 ### Get the code

--- a/grails-app/domain/org/bbop/apollo/Feature.groovy
+++ b/grails-app/domain/org/bbop/apollo/Feature.groovy
@@ -57,7 +57,7 @@ class Feature implements Ontological{
     static mapping = {
             childFeatureRelationships cascade: 'all-delete-orphan'
             parentFeatureRelationships cascade: 'all-delete-orphan'
-            featureLocations cascade: 'all-delete-orphan', fetch: "join" // lazy: false  since most / all feature locations have a single element join is more efficient
+            featureLocations cascade: 'all-delete-orphan' // lazy: false  since most / all feature locations have a single element join is more efficient
             name type: 'text'
             description type: 'text'
     }

--- a/grails-app/services/org/bbop/apollo/OrganismService.groovy
+++ b/grails-app/services/org/bbop/apollo/OrganismService.groovy
@@ -6,16 +6,8 @@ import org.hibernate.Session
 
 @Transactional
 class OrganismService {
-
-    def sessionFactory
     def featureService
 
-    /**
-     * A good example of executing bulk operations from hibernate
-     * http://mrhaki.blogspot.com/2014/03/grails-goodness-using-hibernate-native.html
-     * @param organism
-     * @return
-     */
     def deleteAllFeaturesForOrganism(Organism organism) {
 
         // the very slow way
@@ -31,8 +23,25 @@ class OrganismService {
             }
         }
 
+
+        def uniqueNames=list.collect {
+            it.uniqueName
+        }
+
+
+
         list.each {
             it.delete();
+        }
+
+
+        def events=FeatureEvent.withCriteria() {
+            'in'("uniqueName",uniqueNames)
+        }
+
+
+        events.each {
+            it.delete()
         }
 
 

--- a/grails-app/services/org/bbop/apollo/OrganismService.groovy
+++ b/grails-app/services/org/bbop/apollo/OrganismService.groovy
@@ -21,31 +21,20 @@ class OrganismService {
         // the very slow way
 
         int count = 0
-        final Session session = sessionFactory.currentSession
+        //final Session session = sessionFactory.currentSession
 
+        def list=Feature.withCriteria() {
+            featureLocations {
+                sequence {
+                    eq("organism",organism)
+                }
+            }
+        }
 
-        // there are a few missing here
-        println "deleted owners " + session.createSQLQuery("delete from feature_grails_user where EXISTS (select 'x' from feature_grails_user fgu JOIN feature f ON fgu.feature_owners_id=f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
+        list.each {
+            it.delete();
+        }
 
-        println "deleted genotypes " + session.createSQLQuery("delete from feature_genotype where EXISTS (select 'x' from feature_genotype fgu JOIN feature f ON fgu.feature_id=f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-        println "deleted synonyms " + session.createSQLQuery("delete from feature_synonym where EXISTS (select 'x' from feature_synonym fgu JOIN feature f ON fgu.feature_id=f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-
-        println "deleted publication " + session.createSQLQuery("delete from feature_publication where EXISTS (select 'x' from feature_publication fgu JOIN feature f ON fgu.feature_feature_publications_id=f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-        println "deleted phenotypes " + session.createSQLQuery("delete from feature_feature_phenotypes where EXISTS (select 'x' from feature_feature_phenotypes fgu JOIN feature f ON fgu.feature_id=f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-        println "deleted synonyms " + session.createSQLQuery("delete from feature_synonym where EXISTS (select 'x' from feature_synonym fgu JOIN feature f ON fgu.feature_id=f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-
-
-        println "deleted dbxrefs " + session.createSQLQuery("delete from feature_dbxref where EXISTS (select 'x' from feature_dbxref fgu JOIN feature f ON fgu.feature_featuredbxrefs_id=f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-        println "deleted property " + session.createSQLQuery("delete from feature_property where EXISTS (select 'x' from feature_property fgu JOIN feature f ON fgu.feature_id =f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-        println "deleted child relationship " + session.createSQLQuery("delete from feature_relationship where EXISTS (select 'x' from feature_relationship fgu JOIN feature f ON fgu.child_feature_id =f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-        println "deleted parent relationship " + session.createSQLQuery("delete from feature_relationship where EXISTS (select 'x' from feature_relationship fgu JOIN feature f ON fgu.parent_feature_id =f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-
-        // get all of the parent features
-
-
-        println "deleted location " + session.createSQLQuery("delete from feature_location where EXISTS (select 'x' from feature_location fl join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-        println "deleted feature " + session.createSQLQuery("delete from feature where not EXISTS (select 'x' from feature f join feature_location fl on fl.feature_id=f.id)").executeUpdate()
-        println "deleted feature_event " + session.createSQLQuery("delete from feature_event where not exists (select 'x' from feature f, feature_event fe where f.unique_name=f.name) ").executeUpdate()
 
         organism.save(flush: true )
         return count

--- a/grails-app/services/org/bbop/apollo/OrganismService.groovy
+++ b/grails-app/services/org/bbop/apollo/OrganismService.groovy
@@ -23,7 +23,8 @@ class OrganismService {
         int count = 0
         final Session session = sessionFactory.currentSession
 
-        // there are a few missing heere
+
+        // there are a few missing here
         println "deleted owners " + session.createSQLQuery("delete from feature_grails_user where EXISTS (select 'x' from feature_grails_user fgu JOIN feature f ON fgu.feature_owners_id=f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
 
         println "deleted genotypes " + session.createSQLQuery("delete from feature_genotype where EXISTS (select 'x' from feature_genotype fgu JOIN feature f ON fgu.feature_id=f.id join feature_location fl on fl.feature_id=f.id join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
@@ -43,9 +44,7 @@ class OrganismService {
 
 
         println "deleted location " + session.createSQLQuery("delete from feature_location where EXISTS (select 'x' from feature_location fl join sequence s on s.id = fl.sequence_id join organism o ON o.id = s.organism_id where o.id = ${organism.id})").executeUpdate()
-
         println "deleted feature " + session.createSQLQuery("delete from feature where not EXISTS (select 'x' from feature f join feature_location fl on fl.feature_id=f.id)").executeUpdate()
-
         println "deleted feature_event " + session.createSQLQuery("delete from feature_event where not exists (select 'x' from feature f, feature_event fe where f.unique_name=f.name) ").executeUpdate()
 
         organism.save(flush: true )


### PR DESCRIPTION
See #636

This commit takes a different approach towards deleting features from an organism


It selects features from an organism using criteria queries, and then simply uses hibernate functions instead of raw SQL, which I think is much more elegant.



It also does away with the fetchMode join in Feature.groovy. We have talked about fetchMode fairly frequently but I think it breaks the Feature objects stability




