### PR TITLE
moved the webapollo to apollo in the readhtedocs guide

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -108,7 +108,7 @@ Bugfixes
 
 Features
 
-+ Added a PDF version of documentation to [readthedocs](http://webapollo.readthedocs.org).
++ Added a PDF version of documentation to [readthedocs](http://apollo.readthedocs.org).
 + Added a button to generate a public link to the genome browser for a particular organism.
 + Added ability to manage statuses, custom comments, and feature types using the "Admin panel".
 + Added a feature to logout all instances of webapollo from different windows if one window is logged out (#409).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For general information on Web Apollo, go to:
 [http://genomearchitect.org/](http://genomearchitect.org/)
 
 Complete Web Apollo installation and configuration instructions are available at:
-[http://webapollo.readthedocs.org](http://webapollo.readthedocs.org)
+[http://apollo.readthedocs.org](http://apollo.readthedocs.org)
 
 The Web Apollo client is implemented as a plugin for JBrowse, for more information on JBrowse, please visit:
 [http://jbrowse.org](http://jbrowse.org)

--- a/client/apollo/js/View/Dialog/Help.js
+++ b/client/apollo/js/View/Dialog/Help.js
@@ -47,7 +47,7 @@ return declare( null, {
                 + '<div style="float: left; width: 49%;"><dt>Web Apollo links</dt>'
                 + '<dd><ul>'
                 + '<li><a href="http://genomearchitect.org/web_apollo_user_guide" target="_blank">Web Apollo User Guide</a></li>'
-                + '<li><a href="http://webapollo.readthedocs.org" target="_blank">Web Apollo Configuration and Installation Guide</a></li>'
+                + '<li><a href="http://apollo.readthedocs.org" target="_blank">Apollo Configuration and Installation Guide</a></li>'
                 + '</ul></dd>'
                 + '</div>'
                 + '<div style="float: right; width:49%; margin-top: 10px;"><a href="http://genomearchitect.org" target="_blank"><img src="plugins/WebApollo/img/ApolloLogo_100x36.png"/></a></div>'

--- a/docs/TestScript.md
+++ b/docs/TestScript.md
@@ -20,7 +20,7 @@ http://www.slideshare.net/MonicaMunozTorres/
 - Web Apollo at GMOD page: 
 http://www.gmod.org/wiki/WebApollo 
 - Web Apollo installation and configuration guide
-http://webapollo.readthedocs.org/en/latest/
+http://apollo.readthedocs.org/en/latest/
 
 If testing the Web Apollo demo, go to: http://genomearchitect.org/WebApolloDemo/ 
 Login|Password : demo|demo

--- a/docs/apollo-stress-tests/suite2/jmeter-dev-stress-test-notes.md
+++ b/docs/apollo-stress-tests/suite2/jmeter-dev-stress-test-notes.md
@@ -14,7 +14,7 @@ Datasets:
 1. [*A. mellifera* reference genome](http://hymenopteragenome.org/beebase/sites/hymenopteragenome.org.beebase/files/data/Amel_4.5_scaffolds.fa.gz)
 2. [*A. mellifera* Official Gene Set v3.2](http://hymenopteragenome.org/beebase/sites/hymenopteragenome.org.beebase/files/data/consortium_data/amel_OGSv3.2.gff3.gz)
 
-The datasets can be processed as described [here](http://webapollo.readthedocs.org/en/latest/Data_loading.html#data-generation-pipeline).
+The datasets can be processed as described [here](http://apollo.readthedocs.org/en/latest/Data_loading.html#data-generation-pipeline).
 
 ### jmeter-dev-stress-test-2.jmx
 
@@ -29,7 +29,7 @@ Datasets:
 1. [*Bos taurus* reference genome](http://128.206.12.216/drupal/sites/bovinegenome.org/files/data/umd3.1/UMD3.1_chromosomes.fa.gz)
 2. [*Bos taurus* RefSeq Annotations for protein coding genes](http://128.206.12.216/drupal/sites/bovinegenome.org/files/data/umd3.1/RefSeq_UMD3.1.1_protein_coding.gff3.gz)
 
-The datasets can be processed as described [here](http://webapollo.readthedocs.org/en/latest/Data_loading.html#data-generation-pipeline).
+The datasets can be processed as described [here](http://apollo.readthedocs.org/en/latest/Data_loading.html#data-generation-pipeline).
 
 ###Users
 Each of the test script utilizes several user profiles. To add the same user profiles as described in the script, make use of ```add_users.groovy``` with ```example-users-for-stress-test.csv``` as input.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -197,8 +197,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'WebApollo.tex', u'Web Apollo Documentation',
-   u'Web Apollo', 'manual'),
+  ('index', 'Apollo.tex', u'Apollo Documentation',
+   u'Apollo', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,12 +15,12 @@ For more information on JBrowse, please visit:
 .. image:: https://travis-ci.org/GMOD/Apollo.png?branch=master
 
 Note: This documentation covers release versions 2.x of Apollo. For the 1.x installation please refer to
-`http://webapollo.readthedocs.org/en/1.0/ <http://webapollo.readthedocs.org/en/1.0/>`__
+`http://apollo.readthedocs.org/en/1.0/ <http://apollo.readthedocs.org/en/1.0/>`__
 
 
 A PDF version of this documentation is also available for download.
 
-Link `https://media.readthedocs.org/pdf/webapollo/latest/webapollo.pdf <https://media.readthedocs.org/pdf/webapollo/latest/webapollo.pdf>`__
+Link `https://media.readthedocs.org/pdf/apollo/latest/apollo.pdf <https://media.readthedocs.org/pdf/apollo/latest/apollo.pdf>`__
 
 
 

--- a/grails-app/services/org/bbop/apollo/TranscriptService.groovy
+++ b/grails-app/services/org/bbop/apollo/TranscriptService.groovy
@@ -396,7 +396,7 @@ class TranscriptService {
         if (gene1 && gene2) {
             if (gene1 != gene2) {
                 List<Transcript> gene2Transcripts = getTranscripts(gene2)
-                for (Transcript transcript : gene2Transcripts) {
+                for (Transcript transcript : geneTranscripts) {
                     if (transcript != transcript2) {
                         deleteTranscript(gene2, transcript)
                         featureService.addTranscriptToGene(gene1, transcript)


### PR DESCRIPTION
noted that we can't actually change the URL:

http://read-the-docs.readthedocs.org/en/latest/faq.html

so reverting, but changing the root url back