### PR TITLE
#148 - made urls more configurable for GOLR

### DIFF
--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -2816,9 +2816,9 @@ define([
                                                     }
                                                 }
                                             });
-                                            var original = 'http://golr.berkeleybop.org/solr/';
-                                            //var gserv = 'http://golr.geneontology.org/solr/';
+                                            var original = 'http://golr.geneontology.org/';
                                             //var original = 'http://golr.geneontology.org/solr/';
+                                            //var original = 'http://golr.berkeleybop.org/solr/';
                                             var encoded_original = encodeURI(original);
                                             encoded_original = encoded_original.replace(/:/g,"%3A");
                                             encoded_original = encoded_original.replace(/\//g,"%2F");

--- a/grails-app/conf/BootStrap.groovy
+++ b/grails-app/conf/BootStrap.groovy
@@ -19,38 +19,14 @@ class BootStrap {
     def configWrapperService
     def grailsApplication
     def featureTypeService
+    def domainMarshallerService
+    def proxyService
 
 
     def init = { servletContext ->
 
-        JSON.registerObjectMarshaller(User) {
-            def returnArray = [:]
-            returnArray['userId'] = it.id
-            returnArray['username'] = it.username
-            returnArray['firstName'] = it.firstName
-            returnArray['lastName'] = it.lastName
-            return returnArray
-        }
-
-        JSON.registerObjectMarshaller(Organism) {
-            def returnArray = [:]
-            returnArray['id'] = it.id
-            returnArray['commonName'] = it.commonName
-            returnArray['genus'] = it?.genus
-            returnArray['species'] = it?.species
-            returnArray['directory'] = it.directory
-            return returnArray
-        }
-
-        JSON.registerObjectMarshaller(Sequence) {
-            def returnArray = [:]
-            returnArray['id'] = it.id
-            returnArray['name'] = it.name
-            returnArray['length'] = it?.length
-            returnArray['start'] = it?.start
-            returnArray['end'] = it.end
-            return returnArray
-        }
+        domainMarshallerService.registerObjects()
+        proxyService.initProxies()
 
         SequenceTranslationHandler.spliceDonorSites.addAll(configWrapperService.spliceDonorSites)
         SequenceTranslationHandler.spliceAcceptorSites.addAll(configWrapperService.spliceAcceptorSites)
@@ -68,8 +44,6 @@ class BootStrap {
             def adminRole = new Role(name: UserService.ADMIN).save()
             adminRole.addToPermissions("*:*")
         }
-
-
 
         if (grailsApplication.config.apollo.bootstrap || Environment.current == Environment.TEST) {
             log.debug "attempting to bootstrap the data "

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -208,6 +208,31 @@ apollo {
     translation_table = "/config/translation_tables/ncbi_1_translation_table.txt"
     is_partial_translation_allowed = false // unused so far
     get_translation_code = 1
+    proxies = [
+            [
+                    referenceUrl: 'http://golr.geneontology.org/select',
+                    targetUrl   : 'http://golr.geneontology.org/select',
+                    active      : true,
+                    fallbackOrder: 0,
+                    replace: false
+            ]
+            ,
+            [
+                    referenceUrl: 'http://golr.geneontology.org/select',
+                    targetUrl   : 'http://golr.berkeleybop.org/select',
+                    active      : false,
+                    fallbackOrder: 1,
+                    replace: false
+            ]
+            ,
+            [
+                    referenceUrl: 'http://golr.geneontology.org/select',
+                    targetUrl   : 'http://golr.berkeleybop.org/solr/select',
+                    active      : false,
+                    fallbackOrder: 2,
+                    replace: false
+            ]
+    ]
     sequence_search_tools = [
         blat_nuc: [
             search_exe: "/usr/local/bin/blat",
@@ -290,7 +315,7 @@ apollo {
 
     // customize new tabs on the annotator panel with these links
     customPanel = [
-        //['name':'GenSas2','link':'http://localhost/gensas2']
+            //['name':'GenSas2','link':'http://localhost/gensas2']
     ]
 
     // comment out if you don't want this to be reported
@@ -301,15 +326,6 @@ apollo {
 grails.plugin.databasemigration.updateOnStart = true
 //grails.plugin.databasemigration.updateOnStartFileNames = ['changelog-2.0.0.groovy','changelog-2.0.1.groovy']
 grails.plugin.databasemigration.updateOnStartFileNames = ['changelog-2.0.1.groovy']
-
-
-//grails.plugins.restapidoc.basePath = "http://localhost:8080/apollo"
-//grails.plugins.restapidoc.layout = "restapidoc_layout"
-//grails.plugins.restapidoc.layout = "main"
-
-
-//grails.plugins.twitterbootstrap.defaultBundle = false
-//grails.views.javascript.library="jquery"
 
 // from: http://grails.org/plugin/audit-logging
 auditLog {

--- a/grails-app/controllers/org/bbop/apollo/ProxyController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/ProxyController.groovy
@@ -49,21 +49,17 @@ class ProxyController {
 
 
         if(!proxy){
-            proxy = proxyService.findDefaultProxy(referenceUrl)
-        }
-        if(!proxy){
             log.error "Proxy not found for ${referenceUrl}.  Please add a proxy (see the config guide)."
             render status: NOT_FOUND
             return
         }
-
-
 
         log.info "using proxy ${proxy?.targetUrl}"
 
         String targetUrl = proxy ? proxy.targetUrl : referenceUrl
 
         targetUrl += "?"+request.queryString
+        println "target url: ${targetUrl}"
         URL returnUrl = new URL(targetUrl)
 
         log.debug "input URI ${request.requestURI}"

--- a/grails-app/services/org/bbop/apollo/DomainMarshallerService.groovy
+++ b/grails-app/services/org/bbop/apollo/DomainMarshallerService.groovy
@@ -1,0 +1,40 @@
+package org.bbop.apollo
+
+import grails.converters.JSON
+import grails.transaction.Transactional
+
+@Transactional
+class DomainMarshallerService {
+
+    def registerObjects() {
+
+        JSON.registerObjectMarshaller(User) {
+            def returnArray = [:]
+            returnArray['userId'] = it.id
+            returnArray['username'] = it.username
+            returnArray['firstName'] = it.firstName
+            returnArray['lastName'] = it.lastName
+            return returnArray
+        }
+
+        JSON.registerObjectMarshaller(Organism) {
+            def returnArray = [:]
+            returnArray['id'] = it.id
+            returnArray['commonName'] = it.commonName
+            returnArray['genus'] = it?.genus
+            returnArray['species'] = it?.species
+            returnArray['directory'] = it.directory
+            return returnArray
+        }
+
+        JSON.registerObjectMarshaller(Sequence) {
+            def returnArray = [:]
+            returnArray['id'] = it.id
+            returnArray['name'] = it.name
+            returnArray['length'] = it?.length
+            returnArray['start'] = it?.start
+            returnArray['end'] = it.end
+            return returnArray
+        }
+    }
+}

--- a/grails-app/views/proxy/_form.gsp
+++ b/grails-app/views/proxy/_form.gsp
@@ -38,21 +38,4 @@
 
 </div>
 
-<div class="fieldcontain ${hasErrors(bean: proxyInstance, field: 'lastSuccess', 'error')} ">
-	<label for="lastSuccess">
-		<g:message code="proxy.lastSuccess.label" default="Last Success" />
-		
-	</label>
-	<g:datePicker name="lastSuccess" precision="day"  value="${proxyInstance?.lastSuccess}" default="none" noSelection="['': '']" />
-
-</div>
-
-<div class="fieldcontain ${hasErrors(bean: proxyInstance, field: 'lastFail', 'error')} ">
-	<label for="lastFail">
-		<g:message code="proxy.lastFail.label" default="Last Fail" />
-		
-	</label>
-	<g:datePicker name="lastFail" precision="day"  value="${proxyInstance?.lastFail}" default="none" noSelection="['': '']" />
-
-</div>
-
+<br/>

--- a/grails-app/views/proxy/show.gsp
+++ b/grails-app/views/proxy/show.gsp
@@ -43,31 +43,31 @@
 
 				</li>
 
-				<g:if test="${proxyInstance?.fallbackOrder}">
+				%{--<g:if test="${proxyInstance?.fallbackOrder}">--}%
 				<li class="fieldcontain">
 					<span id="fallbackOrder-label" class="property-label"><g:message code="proxy.fallbackOrder.label" default="Fallback Order" /></span>
 						<span class="property-value" aria-labelledby="fallbackOrder-label"><g:fieldValue bean="${proxyInstance}" field="fallbackOrder"/></span>
 					
 				</li>
-				</g:if>
+				%{--</g:if>--}%
 			
-				<g:if test="${proxyInstance?.lastSuccess}">
-				<li class="fieldcontain">
-					<span id="lastSuccess-label" class="property-label"><g:message code="proxy.lastSuccess.label" default="Last Success" /></span>
-					
-						<span class="property-value" aria-labelledby="lastSuccess-label"><g:formatDate date="${proxyInstance?.lastSuccess}" /></span>
-					
-				</li>
-				</g:if>
+				%{--<g:if test="${proxyInstance?.lastSuccess}">--}%
+				%{--<li class="fieldcontain">--}%
+					%{--<span id="lastSuccess-label" class="property-label"><g:message code="proxy.lastSuccess.label" default="Last Success" /></span>--}%
+					%{----}%
+						%{--<span class="property-value" aria-labelledby="lastSuccess-label"><g:formatDate date="${proxyInstance?.lastSuccess}" /></span>--}%
+					%{----}%
+				%{--</li>--}%
+				%{--</g:if>--}%
 			
-				<g:if test="${proxyInstance?.lastFail}">
-				<li class="fieldcontain">
-					<span id="lastFail-label" class="property-label"><g:message code="proxy.lastFail.label" default="Last Fail" /></span>
-					
-						<span class="property-value" aria-labelledby="lastFail-label"><g:formatDate date="${proxyInstance?.lastFail}" /></span>
-					
-				</li>
-				</g:if>
+				%{--<g:if test="${proxyInstance?.lastFail}">--}%
+				%{--<li class="fieldcontain">--}%
+					%{--<span id="lastFail-label" class="property-label"><g:message code="proxy.lastFail.label" default="Last Fail" /></span>--}%
+					%{----}%
+						%{--<span class="property-value" aria-labelledby="lastFail-label"><g:formatDate date="${proxyInstance?.lastFail}" /></span>--}%
+					%{----}%
+				%{--</li>--}%
+				%{--</g:if>--}%
 			
 
 			</ol>


### PR DESCRIPTION
For #148  . . . 

From the issue itself:

>http://golr.geneontology.org/select?q=*:*
>http://golr.berkeleybop.org/select?q=*:*
>http://golr.berkeleybop.org/solr/select?q=*:*

>The first two are "forever" URLs, with the first being the "production"
>one and the second being a special use one (failback, some experiments,
>etc.). The last one there is functional for the time being, but is on
>notice--it should be replaced in all code going forward with the first
>(this has been harmonized with production, so we should be good in the
>future during outages and the like). At a future date, the third should
>be purged at version EOL



This code allows a "fallback" if the other one goes off-line that can be affected without a redeploy, though  this has to be set manually right now. 

At some point we could have a more formal / automated process for this, but not for this year.