### PR TITLE
Fixed Apollo styles for features loaded with maker2jbrowse

### DIFF
--- a/client/apollo/css/main.css
+++ b/client/apollo/css/main.css
@@ -6,6 +6,7 @@
 @import url("search_sequence.css");
 @import url("get_history.css");
 @import url("export.css");
+@import url("maker_styles.css");
 /* for now, maker.css is not loaded by default
    to use maker.css without modifying this file, just add 
            "css": "plugins/WebApollo/css/maker.css"

--- a/client/apollo/css/maker_styles.css
+++ b/client/apollo/css/maker_styles.css
@@ -1,0 +1,444 @@
+/*MAKER CSS with colors for common features*/
+
+/*SNAP*/
+.snap-exon,
+.plus-snap-exon,
+.minus-snap-exon,
+.snap-five_prime_UTR,
+.plus-snap-five_prime_UTR,
+.minus-snap-five_prime_UTR,
+.snap-three_prime_UTR,
+.plus-snap-three_prime_UTR,
+.minus-snap-three_prime_UTR {
+    position: absolute;
+    height: 7px;
+    background-color: #99FFCC;
+    border-style: solid;
+    border-color: #D88;
+    border-width: 2px 0px 2px 0px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+.Apollo .snap-exon,
+.Apollo .plus-snap-exon,
+.Apollo .minus-snap-exon,
+.Apollo .snap-five_prime_UTR,
+.Apollo .plus-snap-five_prime_UTR,
+.Apollo .minus-snap-five_prime_UTR,
+.Apollo .snap-three_prime_UTR,
+.Apollo .plus-snap-three_prime_UTR,
+.Apollo .minus-snap-three_prime_UTR {
+    position: absolute;
+    height: 80%;
+    top: 10%;
+    background-color: #99DDCC;
+    border: 0px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+/*Augustus*/
+.augustus-exon,
+.plus-augustus-exon,
+.minus-augustus-exon,
+.augustus-five_prime_UTR,
+.plus-augustus-five_prime_UTR,
+.minus-augustus-five_prime_UTR,
+.augustus-three_prime_UTR,
+.plus-augustus-three_prime_UTR,
+.minus-augustus-three_prime_UTR {
+    position: absolute;
+    height: 7px;
+    background-color: #FFCCFF;
+    border-style: solid;
+    border-color: #D88;
+    border-width: 2px 0px 2px 0px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+
+
+.Apollo .augustus-exon,
+.Apollo .plus-augustus-exon,
+.Apollo .minus-augustus-exon,
+.Apollo .augustus-five_prime_UTR,
+.Apollo .plus-augustus-five_prime_UTR,
+.Apollo .minus-augustus-five_prime_UTR,
+.Apollo .augustus-three_prime_UTR,
+.Apollo .plus-augustus-three_prime_UTR,
+.Apollo .minus-augustus-three_prime_UTR {
+    position: absolute;
+    height: 80%;
+    top: 10%;
+    background-color: #FFCCFF;
+    border-style: solid;
+    border-color: #D88;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+/*GeneMark*/
+.Apollo .genemark-exon,
+.Apollo .plus-genemark-exon,
+.Apollo .minus-genemark-exon,
+.Apollo .genemark-five_prime_UTR,
+.Apollo .plus-genemark-five_prime_UTR,
+.Apollo .minus-genemark-five_prime_UTR,
+.Apollo .genemark-three_prime_UTR,
+.Apollo .plus-genemark-three_prime_UTR,
+.Apollo .minus-genemark-three_prime_UTR {
+    position: absolute;
+    height: 80%;
+    top: 10%;
+    background-color: #679B68;
+    border-style: solid;
+    border-color: #D88;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+
+/*GeneMark*/
+.genemark-exon,
+.plus-genemark-exon,
+.minus-genemark-exon,
+.genemark-five_prime_UTR,
+.plus-genemark-five_prime_UTR,
+.minus-genemark-five_prime_UTR,
+.genemark-three_prime_UTR,
+.plus-genemark-three_prime_UTR,
+.minus-genemark-three_prime_UTR {
+    position: absolute;
+    height: 7px;
+    background-color: #679B68;
+    border-style: solid;
+    border-color: #D88;
+    border-width: 2px 0px 2px 0px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+/*FGENESH*/
+.Apollo .fgenesh-exon,
+.Apollo .plus-fgenesh-exon,
+.Apollo .minus-fgenesh-exon,
+.Apollo .fgenesh-five_prime_UTR,
+.Apollo .plus-fgenesh-five_prime_UTR,
+.Apollo .minus-fgenesh-five_prime_UTR,
+.Apollo .fgenesh-three_prime_UTR,
+.Apollo .plus-fgenesh-three_prime_UTR,
+.Apollo .minus-fgenesh-three_prime_UTR {
+    position: absolute;
+    height: 7px;
+    background-color: #FF99FF;
+    border-style: solid;
+    border-color: #D88;
+    border-width: 2px 0px 2px 0px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+
+
+/*FGENESH*/
+.fgenesh-exon,
+.plus-fgenesh-exon,
+.minus-fgenesh-exon,
+.fgenesh-five_prime_UTR,
+.plus-fgenesh-five_prime_UTR,
+.minus-fgenesh-five_prime_UTR,
+.fgenesh-three_prime_UTR,
+.plus-fgenesh-three_prime_UTR,
+.minus-fgenesh-three_prime_UTR {
+    position: absolute;
+    height: 7px;
+    background-color: #FF99FF;
+    border-style: solid;
+    border-color: #D88;
+    border-width: 2px 0px 2px 0px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+/*protein2genome*/
+.Apollo .protein2genome_part,
+.Apollo .plus-protein2genome_part,
+.Apollo .minus-protein2genome_part {
+    position: absolute;
+    height: 60%;
+    margin-top: 0px;
+    top: 20%;
+    background-color: #FFFF00;
+    border-style: solid;
+    border-color: #6E6E6E;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+/*protein2genome*/
+.protein2genome_part,
+.plus-protein2genome_part,
+.minus-protein2genome_part {
+    position: absolute;
+    height: 4px;
+    margin-top: -2px;
+    background-color: #FFFF00;
+    border-style: solid;
+    border-color: #6E6E6E;
+    border-width: 1px 1px 1px 1px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+/*BLASTN*/
+.blastn_part,
+.plus-blastn_part,
+.minus-blastn_part {
+    position: absolute;
+    height: 4px;
+    margin-top: -2px;
+    background-color: #66CC00;
+    border-style: solid;
+    border-color: #6E6E6E;
+    border-width: 1px 1px 1px 1px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+/*BLASTN*/
+.Apollo .blastn_part,
+.Apollo .plus-blastn_part,
+.Apollo .minus-blastn_part {
+    position: absolute;
+    height: 60%;
+    margin-top: 0px;
+    top: 20%;
+    background-color: #66CC00;
+    border-style: solid;
+    border-color: #6E6E6E;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+/*BLASTX*/
+.blastx_part,
+.plus-blastx_part,
+.minus-blastx_part {
+    position: absolute;
+    height: 4px;
+    margin-top: -2px;
+    background-color: #FF00FF;
+    border-style: solid;
+    border-color: #6E6E6E;
+    border-width: 1px 1px 1px 1px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+/*BLASTX*/
+.Apollo .blastx_part,
+.Apollo .plus-blastx_part,
+.Apollo .minus-blastx_part {
+    position: absolute;
+    height: 60%;
+    margin-top: 0;
+    top: 20%;
+    background-color: #FF00FF;
+    border-style: solid;
+    border-color: #6E6E6E;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+
+
+/*TBLASTX*/
+.tblastx_part,
+.plus-tblastx_part,
+.minus-tblastx_part {
+    position: absolute;
+    height: 4px;
+    margin-top: -2px;
+    background-color: #663366;
+    border-style: solid;
+    border-color: #6E6E6E;
+    border-width: 1px 1px 1px 1px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+/*TBLASTX*/
+.Apollo .tblastx_part,
+.Apollo .plus-tblastx_part,
+.Apollo .minus-tblastx_part {
+    position: absolute;
+    height: 60%;
+    margin-top: 0px;
+    top: 20%;
+    background-color: #663366;
+    border-style: solid;
+    border-color: #6E6E6E;
+    border-width: 1px 1px 1px 1px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+/*est2genome*/
+.est2genome_part,
+.plus-est2genome_part,
+.minus-est2genome_part {
+    position: absolute;
+    height: 4px;
+    margin-top: -2px;
+    background-color: #FAFAD2;
+    border-style: solid;
+    border-color: #6E6E6E;
+    border-width: 1px 1px 1px 1px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+
+/*est2genome*/
+.Apollo .est2genome_part,
+.Apollo .plus-est2genome_part,
+.Apollo .minus-est2genome_part {
+    position: absolute;
+    height: 60%;
+    top: 20%;
+    margin-top: 0px;
+    background-color: #FAFAD2;
+    border-style: solid;
+    border-color: #6E6E6E;
+    z-index: 8;
+    min-width: 1px;
+}
+
+/*repeat*/
+.repeat_part,
+.plus-repeat_part,
+.minus-repeat_part {
+    position: absolute;
+    height: 4px;
+    margin-top: -2px;
+    background-color: #FF0000;
+    border-style: solid;
+    border-color: #6E6E6E;
+    border-width: 1px 1px 1px 1px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+/*repeat*/
+.Apollo .repeat_part,
+.Apollo .plus-repeat_part,
+.Apollo .minus-repeat_part {
+    position: absolute;
+    height: 60%;
+    top: 20%;
+    margin-top: 0px;
+    background-color: #FF0000;
+    border-style: solid;
+    border-color: #6E6E6E;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+
+/*cdna2genome*/
+.cdna2genome_part,
+.plus-cdna2genome_part,
+.minus-cdna2genome_part {
+    position: absolute;
+    height: 4px;
+    margin-top: -2px;
+    background-color: #8C468C;
+    border-style: solid;
+    border-color: #6E6E6E;
+    border-width: 1px 1px 1px 1px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+
+
+/*cdna2genome*/
+.Apollo .cdna2genome_part,
+.Apollo .plus-cdna2genome_part,
+.Apollo .minus-cdna2genome_part {
+    position: absolute;
+    height: 60%;
+    margin-top: 0px;
+    top: 20%;
+    background-color: #8C468C;
+    border-style: solid;
+    border-color: #6E6E6E;
+    border-width: 1px 1px 1px 1px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+
+
+
+/*cdna2genome*/
+.Apollo .exon,
+.Apollo .minus-exon,
+.Apollo .plus-exon {
+    position: absolute;
+    height: 60%;
+    margin-top: 0px;
+    top: 20%;
+    background-color: #6C468C;
+    border: 0px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+
+/*cdna2genome*/
+.Apollo .CDS {
+    position: absolute;
+    height: 80%;
+    margin-top: 0px;
+    top: 10%;
+    background-color: #8C468C;
+    border: 0px;
+    z-index: 8;
+    min-width: 1px;
+    cursor: pointer;
+}
+
+
+.Apollo .feature {
+    height: 16px;
+    background-color: transparent;
+}
+ 
+.Apollo .generic_parent {
+    height: 16px;
+    background-color: transparent;
+}
+
+
+.Apollo .transcript, .plus-transcript, .minus-transcript {
+    background: white;
+}

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -98,6 +98,7 @@ return declare( [JBPlugin, HelpMixin],
         if (browser.cookie("colorCdsByFrame")=="true") {
             domClass.add(win.body(), "colorCds");
         }
+        domClass.add(win.body(), "Apollo");
         if (browser.config.favicon) {
             // this.setFavicon("plugins/WebApollo/img/webapollo_favicon.ico");
             this.setFavicon(browser.config.favicon);


### PR DESCRIPTION
The maker2jbrowse script uses jbrowse specific track styles (which are based on pixel heights) and Apollo uses percentage heights

This adds an "apollo specific" style set that helps style the features loaded with maker2jbrowse

Before
![screenshot-localhost 8080 2016-01-15 16-14-14](https://cloud.githubusercontent.com/assets/6511937/12368756/42822bb0-bba3-11e5-9813-d9b5c55a41aa.png)



After
![screenshot-localhost 8080 2016-01-15 16-05-29](https://cloud.githubusercontent.com/assets/6511937/12368695/9ca10fcc-bba2-11e5-9d75-df7b6966c9a1.png)

