### PR TITLE
Add sequence names to the recent changes page

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/FeatureEventController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/FeatureEventController.groovy
@@ -38,7 +38,13 @@ class FeatureEventController {
             if(params.sort=="owners") {
                 owners {
                     order('username', params.order)
-
+                }
+            }
+            if(params.sort=="sequencename") {
+                featureLocations {
+                    sequence {
+                        order('name', params.order)
+                    }
                 }
             }
             else if(params.sort=="name") {

--- a/grails-app/views/featureEvent/changes.gsp
+++ b/grails-app/views/featureEvent/changes.gsp
@@ -33,6 +33,7 @@
         <tr>
             <g:sortableColumn property="lastUpdated" title="Last updated"/>
             <g:sortableColumn property="organism" title="Organism"/>
+            <g:sortableColumn property="sequencename" title="Sequence name"/>
             <g:sortableColumn property="name" title="Name"/>
             <g:sortableColumn property="owners" title="Owner"/>
             <g:sortableColumn property="cvTerm" title="Feature type"/>
@@ -46,6 +47,9 @@
                 </td>
                 <td>
                     ${feature.featureLocation.sequence.organism.commonName}
+                </td>
+                <td>
+                    ${feature.featureLocation.sequence.name}
                 </td>
                 <td>
                     <g:link target="_blank" controller="annotator" action="loadLink" params="[loc: feature.featureLocation.sequence.name+':'+feature.featureLocation.fmin+'..'+feature.featureLocation.fmax, organism: feature.featureLocation.sequence.organism.id]">


### PR DESCRIPTION
This adds a sequence column to the recent changes page

We have planned more additions to the recent changes page (bulk operations) but this is the most basic implementation of such a feature!