### PR TITLE
Remove the blue/grey alternating lines from the default flatfile-to-json loaded tracks

### DIFF
--- a/client/apollo/css/maker_styles.css
+++ b/client/apollo/css/maker_styles.css
@@ -431,11 +431,13 @@
 .Apollo .feature {
     height: 16px;
     background-color: transparent;
+    background-image: none;
 }
  
 .Apollo .generic_parent {
     height: 16px;
     background-color: transparent;
+    background-image: none;
 }
 
 


### PR DESCRIPTION
By default Apollo picked up this weird feature style from jbrowse which had these blue/grey alternating lines.


The blue/grey alternating lines was from a background-image in CSS, and this pull request simply removes that


Before
![screenshot-localhost 8080 2016-01-19 16-15-03](https://cloud.githubusercontent.com/assets/6511937/12433963/87d3829e-bec9-11e5-967f-a696d94992fd.png)


After
![screenshot-localhost 8080 2016-01-19 16-28-09](https://cloud.githubusercontent.com/assets/6511937/12433996/ad7bd816-bec9-11e5-912e-b276c462f534.png)
