### PR TITLE
Add annotation count to the refseq panel

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
@@ -192,7 +192,7 @@ class SequenceController {
                     results = results.reverse()
                 }
             }
-            render results[start..start+length] as JSON
+            render results[start..Math.min(start+length-1,results.size()-1)] as JSON
         }
         catch(PermissionException e) {
             def error=[error: "Error: "+e]

--- a/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
@@ -192,7 +192,7 @@ class SequenceController {
                     results = results.reverse()
                 }
             }
-            render results as JSON
+            render results[start..start+length] as JSON
         }
         catch(PermissionException e) {
             def error=[error: "Error: "+e]

--- a/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
@@ -9,7 +9,6 @@ import org.bbop.apollo.gwt.shared.PermissionEnum
 import org.bbop.apollo.report.SequenceSummary
 import org.codehaus.groovy.grails.web.json.JSONArray
 import org.codehaus.groovy.grails.web.json.JSONObject
-
 import static org.springframework.http.HttpStatus.*
 
 @Transactional(readOnly = true)
@@ -20,6 +19,7 @@ class SequenceController {
 
     def sequenceService
     def featureService
+    def requestHandlingService
     def transcriptService
     def permissionService
     def preferenceService
@@ -93,7 +93,6 @@ class SequenceController {
 
     @Transactional
     def loadSequences(Organism organism) {
-        println "Loading sequences ${organism.commonName}"
         if (!organism.sequences) {
             sequenceService.loadRefSeqs(organism)
         }
@@ -171,18 +170,29 @@ class SequenceController {
     def getSequences(String name, Integer start, Integer length, String sort, Boolean asc, Integer minFeatureLength, Integer maxFeatureLength) {
         try {
             Organism organism = preferenceService.getCurrentOrganismForCurrentUser()
-            minFeatureLength = minFeatureLength ?: 0
-            maxFeatureLength = maxFeatureLength ?: Integer.MAX_VALUE
-            List<Sequence> sequences
-            def sequenceCount = Sequence.countByOrganismAndNameIlikeAndLengthGreaterThanEqualsAndLengthLessThanEquals(organism, "%${name}%", minFeatureLength, maxFeatureLength )
-            sequences = Sequence.findAllByOrganismAndNameIlikeAndLengthGreaterThanEqualsAndLengthLessThanEquals(organism, "%${name}%", minFeatureLength, maxFeatureLength, [offset: start, max: length, sort: sort, order: asc ? "asc" : "desc"])
-            JSONArray returnSequences = JSON.parse( (sequences as JSON).toString()) as JSONArray
-
-            for(int i = 0 ; i < returnSequences.size() ; i++){
-                returnSequences.getJSONObject(i).put("sequenceCount",sequenceCount)
+            def sequences = Sequence.createCriteria().list() {
+                eq('organism',organism)
+                gt('length',minFeatureLength ?: 0)
+                lt('length',maxFeatureLength ?: Integer.MAX_VALUE)
+                if(sort=="length") {
+                    order('length',asc?"asc":"desc")
+                }
             }
-
-            render returnSequences as JSON
+            def sequenceCounts = Feature.executeQuery("select fl.sequence.name, count(fl.sequence.id) from Feature f join f.featureLocations fl where fl.sequence.organism = :organism and fl.sequence.length < :maxFeatureLength and fl.sequence.length > :minFeatureLength and f.class in :viewableAnnotationList group by fl.sequence.name", [minFeatureLength: minFeatureLength ?: 0, maxFeatureLength: maxFeatureLength ?: Integer.MAX_VALUE, viewableAnnotationList: requestHandlingService.viewableAnnotationList, organism: organism])
+            def map = [:]
+            sequenceCounts.each {
+                map[it[0]] = it[1]
+            }
+            def results = sequences.collect { s ->
+                [id: s.id, length: s.length, start: s.start, end: s.end, count: map[s.name]?:0, name: s.name, sequenceCount: sequences.size()]
+            } 
+            if(sort=="count") {
+                results = results.sort { it.count }
+                if(!asc) {
+                    results = results.reverse()
+                }
+            }
+            render results as JSON
         }
         catch(PermissionException e) {
             def error=[error: "Error: "+e]
@@ -204,7 +214,6 @@ class SequenceController {
         sequences.each {
             sequenceInstanceList.add(reportService.generateSequenceSummary(it))
         }
-        println "sequence summary list size: ${sequenceInstanceList.size()}"
 
         int sequenceInstanceCount = Sequence.countByOrganism(organism)
         render view:"report", model:[sequenceInstanceList:sequenceInstanceList,organism:organism,sequenceInstanceCount:sequenceInstanceCount]

--- a/src/gwt/org/bbop/apollo/gwt/client/SequencePanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/SequencePanel.java
@@ -109,10 +109,18 @@ public class SequencePanel extends Composite {
         lengthColumn.setDefaultSortAscending(false);
         lengthColumn.setSortable(true);
 
+        Column<SequenceInfo, Number> annotationCount = new Column<SequenceInfo, Number>(new NumberCell()) {
+            @Override
+            public Integer getValue(SequenceInfo object) {
+                return object.getCount();
+            }
+        };
 
+        annotationCount.setSortable(true);
         dataGrid.addColumn(nameColumn, "Name");
         dataGrid.addColumn(lengthColumn, "Length");
         dataGrid.setColumnWidth(1, "100px");
+        dataGrid.addColumn(annotationCount, "Annotations");
 
         dataGrid.setSelectionModel(multiSelectionModel);
         multiSelectionModel.addSelectionChangeHandler(new SelectionChangeEvent.Handler() {

--- a/src/gwt/org/bbop/apollo/gwt/client/SequencePanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/SequencePanel.java
@@ -168,7 +168,7 @@ public class SequencePanel extends Composite {
                 if (nameSortInfo.getColumn().isSortable()) {
                     Column<SequenceInfo, ?> sortColumn = (Column<SequenceInfo, ?>) sortList.get(0).getColumn();
                     Integer columnIndex = dataGrid.getColumnIndex(sortColumn);
-                    String searchColumnString = columnIndex == 0 ? "name" : "length";
+                    String searchColumnString = columnIndex == 0 ? "name" : columnIndex == 1 ? "length" : "count";
                     Boolean sortNameAscending = nameSortInfo.isAscending();
                     SequenceRestService.getSequenceForOffsetAndMax(requestCallback, nameSearchBox.getText(), start, length, searchColumnString, sortNameAscending, minFeatureLength.getText(), maxFeatureLength.getText());
                 }

--- a/src/gwt/org/bbop/apollo/gwt/client/dto/SequenceInfo.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/dto/SequenceInfo.java
@@ -17,9 +17,17 @@ public class SequenceInfo implements Comparable<SequenceInfo>,HasJSON{
     private Integer length ;
     private Integer start ;
     private Integer end ;
+    private Integer count ;
     private Boolean selected = false ;
     private Boolean aDefault = false ;
 
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
     public String getName() {
         return name;
     }
@@ -92,6 +100,7 @@ public class SequenceInfo implements Comparable<SequenceInfo>,HasJSON{
         jsonObject.put("id", new JSONNumber(id));
         jsonObject.put("name", new JSONString(name));
         jsonObject.put("start", new JSONNumber(start));
+        if(count != null) jsonObject.put("count", new JSONNumber(count));
         jsonObject.put("end", new JSONNumber(end));
         jsonObject.put("length", new JSONNumber(length));
         return jsonObject;

--- a/src/gwt/org/bbop/apollo/gwt/client/dto/SequenceInfoConverter.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/dto/SequenceInfoConverter.java
@@ -19,6 +19,7 @@ public class SequenceInfoConverter {
         sequenceInfo.setEnd((int) object.get("end").isNumber().doubleValue());
         sequenceInfo.setLength((int) object.get("length").isNumber().doubleValue());
         sequenceInfo.setSelected(object.get("selected") != null && object.get("selected").isBoolean().booleanValue());
+        if(object.get("count") != null) sequenceInfo.setCount((int) object.get("count").isNumber().doubleValue());
         sequenceInfo.setDefault(object.get("aDefault") != null && object.get("aDefault").isBoolean().booleanValue());
         return sequenceInfo ;
     }


### PR DESCRIPTION
Here is an example of adding annotation counts to the refseq panel

Address #803 

This doesn't have sorting on the annotation column yet, but I just wanted to put this pull request in place for review


![screenshot-localhost 8080 2016-01-21 15-03-21 png resize](https://cloud.githubusercontent.com/assets/6511937/12494515/31b3d7e6-c050-11e5-82a3-5070a4b4d9b0.png)


