### PR TITLE
Add filters parameter to the recent changes page. See #824

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/FeatureEventController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/FeatureEventController.groovy
@@ -90,7 +90,7 @@ class FeatureEventController {
 
         def filters = [organismName: params.organismName, featureType: params.featureType, ownerName: params.ownerName]
 
-        render view: "changes", model: [features: list, featureCount: list.totalCount, organismName: params.organismName, featureType: params.featureType, ownerName: params.ownerName, filters: filters]
+        render view: "changes", model: [features: list, featureCount: list.totalCount, organismName: params.organismName, featureType: params.featureType, ownerName: params.ownerName, filters: filters, sort: params.sort]
     }
 
     def index(Integer max) {

--- a/grails-app/controllers/org/bbop/apollo/FeatureEventController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/FeatureEventController.groovy
@@ -88,8 +88,9 @@ class FeatureEventController {
             'in'('class',requestHandlingService.viewableAnnotationList)
         }
 
+        def filters = [organismName: params.organismName, featureType: params.featureType, ownerName: params.ownerName]
 
-        render view: "changes", model: [features: list, featureCount: list.totalCount, organismName: params.organismName, featureType: params.featureType, ownerName: params.ownerName]
+        render view: "changes", model: [features: list, featureCount: list.totalCount, organismName: params.organismName, featureType: params.featureType, ownerName: params.ownerName, filters: filters]
     }
 
     def index(Integer max) {

--- a/grails-app/views/featureEvent/changes.gsp
+++ b/grails-app/views/featureEvent/changes.gsp
@@ -16,14 +16,15 @@
         <div class="message" role="status">${flash.message}</div>
     </g:if>
 
-    <g:form id="customform" name="myForm" url="[action:'changes',controller:'featureEvent']" params="${params}">
+    <g:form id="customform" name="myForm" url="[action:'changes',controller:'featureEvent']">
         <label for="ownerName">Owner:</label>
         <g:textField name="ownerName" maxlength="50" value="${ownerName}"/><br />
         <label for="featureType">Feature type:</label>
         <g:textField name="featureType" maxlength="50" value="${featureType}"/> <br />
         <label for="organismName">Organism:</label>
         <g:textField name="organismName" maxlength="50" value="${organismName}"/><br />
-
+        <g:hiddenField name="sort" value="${params.sort}"/>
+        <g:hiddenField name="order" value="${params.order}"/>
         <input type="submit" value="Submit" />
     </g:form>
 

--- a/grails-app/views/featureEvent/changes.gsp
+++ b/grails-app/views/featureEvent/changes.gsp
@@ -16,7 +16,7 @@
         <div class="message" role="status">${flash.message}</div>
     </g:if>
 
-    <g:form id="customform" name="myForm" url="[action:'changes',controller:'featureEvent']">
+    <g:form id="customform" name="myForm" url="[action:'changes',controller:'featureEvent']" params="${params}">
         <label for="ownerName">Owner:</label>
         <g:textField name="ownerName" maxlength="50" value="${ownerName}"/><br />
         <label for="featureType">Feature type:</label>
@@ -31,12 +31,12 @@
     <table>
         <thead>
         <tr>
-            <g:sortableColumn property="lastUpdated" title="Last updated"/>
-            <g:sortableColumn property="organism" title="Organism"/>
-            <g:sortableColumn property="sequencename" title="Sequence name"/>
-            <g:sortableColumn property="name" title="Name"/>
-            <g:sortableColumn property="owners" title="Owner"/>
-            <g:sortableColumn property="cvTerm" title="Feature type"/>
+            <g:sortableColumn property="lastUpdated" title="Last updated"  params="${filters}"/>
+            <g:sortableColumn property="organism" title="Organism"  params="${filters}"/>
+            <g:sortableColumn property="sequencename" title="Sequence name"  params="${filters}"/>
+            <g:sortableColumn property="name" title="Name"  params="${filters}"/>
+            <g:sortableColumn property="owners" title="Owner"  params="${filters}"/>
+            <g:sortableColumn property="cvTerm" title="Feature type"  params="${filters}"/>
         </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
This applies a fix to keep track of the filter parameters during sorting so that it remembers the filters after applying a sort on the columns of the table