### PR TITLE
Add repeat region/transposable element/seq alterations to the gff3 output

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/IOServiceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/IOServiceController.groovy
@@ -87,7 +87,7 @@ class IOServiceController extends AbstractApolloController {
             // caputures 3 level indirection, joins feature locations only. joining other things slows it down
             def genes = Gene.executeQuery("select distinct f from Gene f join fetch f.featureLocations fl join fetch f.parentFeatureRelationships pr join fetch pr.childFeature child join fetch child.featureLocations join fetch child.childFeatureRelationships join fetch child.parentFeatureRelationships cpr join fetch cpr.childFeature subchild join fetch subchild.featureLocations join fetch subchild.childFeatureRelationships left join fetch subchild.parentFeatureRelationships where fl.sequence.organism = :organism and f.class in (:viewableAnnotationList)" + (sequences? " and fl.sequence.name in (:sequences)":""), queryParams)
             // captures repeat regions, transposable elements
-            queryParams.viewableAnnotationList = requestHandlingService.viewableAnnotationFeatureList
+            queryParams.viewableAnnotationList = requestHandlingService.viewableAlterations+requestHandlingService.viewableAnnotationFeatureList
             def otherFeats = Feature.executeQuery("select distinct f from Feature f join fetch f.featureLocations fl where fl.sequence.organism = :organism and f.class in (:viewableAnnotationList)" + (sequences? " and fl.sequence.name in (:sequences)":""), queryParams)
             def features = genes+otherFeats
 

--- a/grails-app/controllers/org/bbop/apollo/IOServiceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/IOServiceController.groovy
@@ -87,6 +87,7 @@ class IOServiceController extends AbstractApolloController {
             // caputures 3 level indirection, joins feature locations only. joining other things slows it down
             def genes = Gene.executeQuery("select distinct f from Gene f join fetch f.featureLocations fl join fetch f.parentFeatureRelationships pr join fetch pr.childFeature child join fetch child.featureLocations join fetch child.childFeatureRelationships join fetch child.parentFeatureRelationships cpr join fetch cpr.childFeature subchild join fetch subchild.featureLocations join fetch subchild.childFeatureRelationships left join fetch subchild.parentFeatureRelationships where fl.sequence.organism = :organism and f.class in (:viewableAnnotationList)" + (sequences? " and fl.sequence.name in (:sequences)":""), queryParams)
             // captures repeat regions, transposable elements
+            queryParams.viewableAnnotationList = requestHandlingService.viewableAnnotationFeatureList
             def otherFeats = Feature.executeQuery("select distinct f from Feature f join fetch f.featureLocations fl where fl.sequence.organism = :organism and f.class in (:viewableAnnotationList)" + (sequences? " and fl.sequence.name in (:sequences)":""), queryParams)
             def features = genes+otherFeats
 

--- a/grails-app/controllers/org/bbop/apollo/IOServiceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/IOServiceController.groovy
@@ -84,7 +84,11 @@ class IOServiceController extends AbstractApolloController {
             def st=System.currentTimeMillis()
             def queryParams = [viewableAnnotationList: requestHandlingService.viewableAnnotationList, organism: organism]
             if(sequences) queryParams.sequences = sequences
-            def features = Gene.executeQuery("select distinct f from Gene f join fetch f.featureLocations fl join fetch f.parentFeatureRelationships pr join fetch pr.childFeature child join fetch child.featureLocations join fetch child.childFeatureRelationships join fetch child.parentFeatureRelationships cpr join fetch cpr.childFeature subchild join fetch subchild.featureLocations join fetch subchild.childFeatureRelationships left join fetch subchild.parentFeatureRelationships where fl.sequence.organism = :organism and f.class in (:viewableAnnotationList)" + (sequences? " and fl.sequence.name in (:sequences)":""), queryParams)
+            // caputures 3 level indirection, joins feature locations only. joining other things slows it down
+            def genes = Gene.executeQuery("select distinct f from Gene f join fetch f.featureLocations fl join fetch f.parentFeatureRelationships pr join fetch pr.childFeature child join fetch child.featureLocations join fetch child.childFeatureRelationships join fetch child.parentFeatureRelationships cpr join fetch cpr.childFeature subchild join fetch subchild.featureLocations join fetch subchild.childFeatureRelationships left join fetch subchild.parentFeatureRelationships where fl.sequence.organism = :organism and f.class in (:viewableAnnotationList)" + (sequences? " and fl.sequence.name in (:sequences)":""), queryParams)
+            // captures repeat regions, transposable elements
+            def otherFeats = Feature.executeQuery("select distinct f from Feature f join fetch f.featureLocations fl where fl.sequence.organism = :organism and f.class in (:viewableAnnotationList)" + (sequences? " and fl.sequence.name in (:sequences)":""), queryParams)
+            def features = genes+otherFeats
 
             log.debug "GFF3 feature query: ${System.currentTimeMillis()-st}ms"
            

--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -64,9 +64,9 @@ class RequestHandlingService {
     ]
 
     public static final List<String> viewableAlterations = [
-        Deletion.class.name,
-        Insertion.class.name,
-        Substitution.class.name
+            Deletion.class.name,
+            Insertion.class.name,
+            Substitution.class.name
     ]
 
     public static final List<String> viewableAnnotationList = viewableAnnotationFeatureList + viewableAnnotationTranscriptParentList

--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -43,16 +43,16 @@ class RequestHandlingService {
     def brokerMessagingTemplate
 
 
-    public static List<String> viewableAnnotationFeatureList = [
+    public static final List<String> viewableAnnotationFeatureList = [
             RepeatRegion.class.name,
             TransposableElement.class.name
     ]
-    public static List<String> viewableAnnotationTranscriptParentList = [
+    public static final List<String> viewableAnnotationTranscriptParentList = [
             Gene.class.name,
             Pseudogene.class.name
     ]
 
-    public static List<String> viewableAnnotationTranscriptList = [
+    public static final List<String> viewableAnnotationTranscriptList = [
             Transcript.class.name,
             MRNA.class.name,
             TRNA.class.name,
@@ -63,9 +63,13 @@ class RequestHandlingService {
             MiRNA.class.name,
     ]
 
-    public static List<String> viewableAlterations = [Deletion.class.name,Insertion.class.name,Substitution.class.name]
+    public static final List<String> viewableAlterations = [
+        Deletion.class.name,
+        Insertion.class.name,
+        Substitution.class.name
+    ]
 
-    public static List<String> viewableAnnotationList = viewableAnnotationFeatureList + viewableAnnotationTranscriptParentList
+    public static final List<String> viewableAnnotationList = viewableAnnotationFeatureList + viewableAnnotationTranscriptParentList
 
     private String underscoreToCamelCase(String underscore) {
         if (!underscore || underscore.isAllWhitespace()) {

--- a/test/integration/org/bbop/apollo/Gff3HandlerServiceIntegrationSpec.groovy
+++ b/test/integration/org/bbop/apollo/Gff3HandlerServiceIntegrationSpec.groovy
@@ -32,11 +32,13 @@ class Gff3HandlerServiceIntegrationSpec extends IntegrationSpec {
         String json=' { "track": "Group1.10", "features": [{"location":{"fmin":1216824,"fmax":1235616,"strand":1},"type":{"cv":{"name":"sequence"},"name":"mRNA"},"name":"GB40856-RA","children":[{"location":{"fmin":1235534,"fmax":1235616,"strand":1},"type":{"cv":{"name":"sequence"},"name":"exon"}},{"location":{"fmin":1216824,"fmax":1216850,"strand":1},"type":{"cv":{"name":"sequence"},"name":"exon"}},{"location":{"fmin":1224676,"fmax":1224823,"strand":1},"type":{"cv":{"name":"sequence"},"name":"exon"}},{"location":{"fmin":1228682,"fmax":1228825,"strand":1},"type":{"cv":{"name":"sequence"},"name":"exon"}},{"location":{"fmin":1235237,"fmax":1235396,"strand":1},"type":{"cv":{"name":"sequence"},"name":"exon"}},{"location":{"fmin":1235487,"fmax":1235616,"strand":1},"type":{"cv":{"name":"sequence"},"name":"exon"}},{"location":{"fmin":1216824,"fmax":1235534,"strand":1},"type":{"cv":{"name":"sequence"},"name":"CDS"}}]}], "operation": "add_transcript" }'
         String addInsertionString = '{"operation":"add_sequence_alteration","username":"deepak.unni3@gmail.com","features":[{"non_reserved_properties": [{"tag": "justification", "value":"Sanger sequencing"}], "residues":"GGG","location":{"fmin":208499,"strand":1,"fmax":208499},"type":{"name":"insertion","cv":{"name":"sequence"}}}],"track":"Group1.10"}'
         String pseudogene = '{ "track": "Group1.10", "features": [{"location":{"fmin":433518,"fmax":437436,"strand":1},"type":{"cv":{"name":"sequence"},"name":"pseudogene"},"children":[{"location":{"fmin":433518,"fmax":437436,"strand":1},"type":{"cv":{"name":"sequence"},"name":"transcript"},"name":"GB40815-RA","children":[{"location":{"fmin":433518,"fmax":433570,"strand":1},"type":{"cv":{"name":"sequence"},"name":"exon"}},{"location":{"fmin":436576,"fmax":436641,"strand":1},"type":{"cv":{"name":"sequence"},"name":"exon"}},{"location":{"fmin":437424,"fmax":437436,"strand":1},"type":{"cv":{"name":"sequence"},"name":"exon"}},{"location":{"fmin":433518,"fmax":437436,"strand":1},"type":{"cv":{"name":"sequence"},"name":"CDS"}}]}]}], "operation": "add_feature", "username": "colin.diesh@gmail.com" }'
+        String repeat_region = '{ "track": "Group1.10", "features": [{"location":{"fmin":414369,"fmax":414600,"strand":0},"type":{"cv":{"name":"sequence"},"name":"repeat_region"},"name":"GB40814-RA"}], "operation": "add_feature", "username": "colin.diesh@gmail.com" }'
        
         when: "we parse the json"
         requestHandlingService.addTranscript(JSON.parse(json))
         requestHandlingService.addSequenceAlteration(JSON.parse(addInsertionString))
         requestHandlingService.addFeature(JSON.parse(pseudogene))
+        requestHandlingService.addFeature(JSON.parse(repeat_region))
         
 
         then: "We should have at least one new gene"
@@ -44,6 +46,7 @@ class Gff3HandlerServiceIntegrationSpec extends IntegrationSpec {
         log.debug "${Gene.findAll()}"
         assert Gene.count == 2
         assert MRNA.count == 1
+        assert RepeatRegion.count == 1
         assert Pseudogene.count == 1
         assert Exon.count == 8
         assert CDS.count == 2

--- a/test/integration/org/bbop/apollo/Gff3HandlerServiceIntegrationSpec.groovy
+++ b/test/integration/org/bbop/apollo/Gff3HandlerServiceIntegrationSpec.groovy
@@ -56,7 +56,7 @@ class Gff3HandlerServiceIntegrationSpec extends IntegrationSpec {
         File tempFile = File.createTempFile("output", ".gff3")
         tempFile.deleteOnExit()
         log.debug "${tempFile.absolutePath}"
-        def featuresToWrite = Gene.findAll()+SequenceAlteration.findAll()
+        def featuresToWrite = Gene.findAll()+SequenceAlteration.findAll()+RepeatRegion.findAll()
         gff3HandlerService.writeFeaturesToText(tempFile.absolutePath,featuresToWrite,".")
         String tempFileText = tempFile.text
 
@@ -70,6 +70,8 @@ class Gff3HandlerServiceIntegrationSpec extends IntegrationSpec {
         assert lines[15].split("\t")[2]=="pseudogene"
         assert lines[21].split("\t")[2]=="insertion"
         assert lines[21].split("\t")[8].indexOf("justification=Sanger sequencing")!=-1
+        assert lines[23].split("\t")[2]=="repeat_region"
+
         assert tempFileText.length() > 0
     }
 }


### PR DESCRIPTION
This fixes an oversight pointed out in #836 and adds back repeat regions/transposable elements in a separate query (it is separate because the single features dont need complex parent/child relationships to be located)

I also added a integration test for this case as well and check for a repeat region in gff3 output



