### PR TITLE
Annotator panel optimization

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
@@ -260,6 +260,7 @@ class AnnotatorController {
             }
 
             long start = System.currentTimeMillis()
+            log.debug "${sort} ${sortorder}"
 
             //use two step query. step 1 gets genes in a page
             def pagination = Feature.createCriteria().list(max: max, offset: offset) {
@@ -291,6 +292,22 @@ class AnnotatorController {
             //step 2 does a distinct query with extra attributes added in
             def features = Feature.createCriteria().listDistinct {
                 'in'('id', pagination.collect { it.id })
+                featureLocations {
+                    if(sort=="length") {
+                        order('length', sortorder)
+                    }
+                    sequence {
+                        if(sort=="sequence") {
+                            order('name',sortorder)
+                        }
+                    }
+                }
+                if(sort=="name") {
+                    order('name', sortorder)
+                }
+                if(sort=="date") {
+                    order('lastUpdated', sortorder)
+                }
                 fetchMode 'owners', FetchMode.JOIN
                 fetchMode 'featureLocations', FetchMode.JOIN
                 fetchMode 'featureLocations.sequence', FetchMode.JOIN

--- a/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
@@ -17,6 +17,7 @@ import org.restapidoc.annotation.RestApiParams
 import org.restapidoc.pojo.RestApiParamType
 import org.restapidoc.pojo.RestApiVerb
 import org.springframework.http.HttpStatus
+import org.hibernate.FetchMode
 
 /**
  * This is server-side code supporting the high-level functionality of the GWT AnnotatorPanel class.
@@ -175,7 +176,6 @@ class AnnotatorController {
         feature.save(flush: true, failOnError: true)
 
         // need to grant the parent feature to force a redraw
-//        Feature parentFeature = feature.childFeatureRelationships*.parentFeature.first()
         Feature parentFeature = featureRelationshipService.getParentForFeature(feature)
 
         JSONObject jsonFeature = featureService.convertFeatureToJSON(parentFeature, false)
@@ -214,11 +214,11 @@ class AnnotatorController {
      * @param user
      * @param offset
      * @param max
-     * @param order
+     * @param sortorder
      * @param sort
      * @return
      */
-    def findAnnotationsForSequence(String sequenceName, String request, String annotationName, String type, String user, Integer offset, Integer max, String order, String sort) {
+    def findAnnotationsForSequence(String sequenceName, String request, String annotationName, String type, String user, Integer offset, Integer max, String sortorder, String sort) {
         try {
             JSONObject returnObject = createJSONFeatureContainer()
             if (sequenceName && !Sequence.countByName(sequenceName)) return
@@ -227,21 +227,15 @@ class AnnotatorController {
                 returnObject.track = sequenceName
             }
 
-            Sequence sequence
+            Sequence sequenceObj
             Organism organism
             if (returnObject.has("track")) {
-                sequence = permissionService.checkPermissions(returnObject, PermissionEnum.READ)
-                organism = sequence.organism
+                sequenceObj = permissionService.checkPermissions(returnObject, PermissionEnum.READ)
+                organism = sequenceObj.organism
             } else {
                 organism = permissionService.checkPermissionsForOrganism(returnObject, PermissionEnum.READ)
             }
-            // find all features for current organism
-
             Integer index = Integer.parseInt(request)
-
-            // TODO: should only be returning the top-level features
-            List<Feature> allFeatures
-            Integer annotationCount = 0
 
             List<String> viewableTypes
 
@@ -265,62 +259,52 @@ class AnnotatorController {
                 viewableTypes = requestHandlingService.viewableAnnotationList
             }
 
-            String sortString
-
-            if (sort) {
-                sortString = " order by "
-                switch (sort) {
-                    case "name": sortString += " f.name "
-                        break
-                    case "sequence":
-                            sortString += " s.name "
-                        break
-                    case "length": sortString += " abs(fl.fmax-fl.fmin) "
-                        break
-                    case "date": sortString += " f.lastUpdated "
-                }
-                sortString += " ${order} "
-
-
-            }
-
-            if (organism) {
-                if (!sequence) {
-                    try {
-                        final long start = System.currentTimeMillis();
-                        allFeatures = Feature.executeQuery("select distinct f, abs(fl.fmax-fl.fmin) as seqLength, s from Feature f join f.owners own left join f.parentFeatureRelationships pfr  join f.featureLocations fl join fl.sequence s join s.organism o  where f.childFeatureRelationships is empty and o = :organism and f.class in (:viewableTypes) and upper(f.name) like :annotationName and own.username like :username " + sortString, [organism: organism, viewableTypes: viewableTypes, offset: offset, max: max, annotationName: '%' + annotationName.toUpperCase() + "%", username: '%' + user + '%']).collect {
-                            it[0]
-                        }
-                        annotationCount = (Integer) Feature.executeQuery("select count(distinct f) from Feature f join f.owners own left join f.parentFeatureRelationships pfr  join f.featureLocations fl join fl.sequence s join s.organism o  where f.childFeatureRelationships is empty and o = :organism and f.class in (:viewableTypes)  and upper(f.name) like :annotationName and own.username like :username ", [organism: organism, viewableTypes: viewableTypes, annotationName: '%' + annotationName.toUpperCase() + '%', username: '%' + user + '%']).iterator().next()
-                        final long durationInMilliseconds = System.currentTimeMillis() - start;
-
-                        log.debug "selecting features all ${durationInMilliseconds}"
-                    } catch (e) {
-                        allFeatures = new ArrayList<>()
-                        log.error(e)
+            long start = System.currentTimeMillis()
+            def features = Feature.createCriteria().list(max: max, offset: offset) {
+                featureLocations {
+                    if(sequenceName) {
+                        eq('sequence',sequenceObj)
                     }
-                } else {
-                    final long start = System.currentTimeMillis();
-                    allFeatures = Feature.executeQuery("select distinct f, abs(fl.fmax-fl.fmin) as seqLength, s from Feature f join f.owners own left join f.parentFeatureRelationships pfr join f.featureLocations fl join fl.sequence s join s.organism o where s.name = :sequenceName and f.childFeatureRelationships is empty  and upper(f.name) like :annotationName and o = :organism  and f.class in (:viewableTypes)  and own.username like :username " + sortString, [sequenceName: sequenceName, organism: organism, viewableTypes: viewableTypes, offset: offset, max: max, annotationName: '%' + annotationName.toUpperCase() + "%", username: '%' + user + '%']).collect { it[0]}
-                    annotationCount = (Integer) Feature.executeQuery("select count(distinct f) from Feature f  join f.owners own left join f.parentFeatureRelationships pfr join f.featureLocations fl join fl.sequence s join s.organism o where s.name = :sequenceName and f.childFeatureRelationships is empty and upper(f.name) like :annotationName and o = :organism  and f.class in (:viewableTypes)  and own.username like :username ", [sequenceName: sequenceName, organism: organism, viewableTypes: viewableTypes, annotationName: '%' + annotationName.toUpperCase() + "%", username: '%' + user + '%']).iterator().next()
-                    final long durationInMilliseconds = System.currentTimeMillis() - start;
-
-                    log.debug "selecting features ${durationInMilliseconds}"
+                    sequence {
+                        if(sort=="sequence") {
+                            order('name',sortorder)
+                        }
+                        eq('organism', organism)
+                    }
                 }
-                final long start = System.currentTimeMillis();
-                for (Feature feature in allFeatures) {
-                    JSONObject featureObject = featureService.convertFeatureToJSON(feature, false)
-                    returnObject.getJSONArray(FeatureStringEnum.FEATURES.value).put(featureObject)
+                if(sort=="name") {
+                    order('name', sortorder)
                 }
-                final long durationInMilliseconds = System.currentTimeMillis() - start;
+                if(sort=="date") {
+                    order('lastUpdated', sortorder)
+                }
+                if(annotationName) {
+                    ilike('name','%'+annotationName+'%')
+                }
+                fetchMode 'owners', FetchMode.JOIN
+                fetchMode 'parentFeatureRelationships', FetchMode.JOIN
+                fetchMode 'parentFeatureRelationships.childFeature', FetchMode.JOIN
+                fetchMode 'parentFeatureRelationships.childFeature.childFeatureRelationships', FetchMode.JOIN
+                fetchMode 'parentFeatureRelationships.childFeature.featureLocations', FetchMode.JOIN
+                fetchMode 'parentFeatureRelationships.childFeature.featureLocations.sequence', FetchMode.JOIN
+                fetchMode 'parentFeatureRelationships.childFeature.owners', FetchMode.JOIN
 
-                log.debug "convert to json ${durationInMilliseconds}"
+                'in'('class', viewableTypes)
             }
+            long durationInMilliseconds = System.currentTimeMillis() - start;
+            log.debug "criteria query ${durationInMilliseconds}"
+
+            start = System.currentTimeMillis();
+            for (Feature feature in features) {
+                JSONObject featureObject = featureService.convertFeatureToJSONLite(feature, false, 0)
+                returnObject.getJSONArray(FeatureStringEnum.FEATURES.value).put(featureObject)
+            }
+            durationInMilliseconds = System.currentTimeMillis() - start;
+            log.debug "convert to json ${durationInMilliseconds}"
 
             returnObject.put(FeatureStringEnum.REQUEST_INDEX.getValue(), index + 1)
-            returnObject.put(FeatureStringEnum.ANNOTATION_COUNT.value, annotationCount)
+            returnObject.put(FeatureStringEnum.ANNOTATION_COUNT.value, features.totalCount)
 
-            // TODO: do checks here
             render returnObject
         }
         catch(PermissionException e) {

--- a/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
@@ -267,6 +267,9 @@ class AnnotatorController {
                     if(sequenceName) {
                         eq('sequence',sequenceObj)
                     }
+                    if(sort=="length") {
+                        order('length', sortorder)
+                    }
                     sequence {
                         if(sort=="sequence") {
                             order('name',sortorder)

--- a/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
@@ -260,7 +260,7 @@ class AnnotatorController {
             }
 
             long start = System.currentTimeMillis()
-            def features = Feature.createCriteria().list(max: max, offset: offset) {
+            def features = Gene.createCriteria().list(max: max, offset: offset) {
                 featureLocations {
                     if(sequenceName) {
                         eq('sequence',sequenceObj)
@@ -284,10 +284,7 @@ class AnnotatorController {
                 fetchMode 'owners', FetchMode.JOIN
                 fetchMode 'parentFeatureRelationships', FetchMode.JOIN
                 fetchMode 'parentFeatureRelationships.childFeature', FetchMode.JOIN
-                fetchMode 'parentFeatureRelationships.childFeature.childFeatureRelationships', FetchMode.JOIN
-                fetchMode 'parentFeatureRelationships.childFeature.featureLocations', FetchMode.JOIN
-                fetchMode 'parentFeatureRelationships.childFeature.featureLocations.sequence', FetchMode.JOIN
-                fetchMode 'parentFeatureRelationships.childFeature.owners', FetchMode.JOIN
+                fetchMode 'parentFeatureRelationships.childFeature.parentFeatureRelationships', FetchMode.SELECT
 
                 'in'('class', viewableTypes)
             }

--- a/grails-app/domain/org/bbop/apollo/FeatureLocation.groovy
+++ b/grails-app/domain/org/bbop/apollo/FeatureLocation.groovy
@@ -9,8 +9,7 @@ class FeatureLocation {
         fmin nullable: false
         fmax nullable: false
         sequence nullable: false
-
-
+        length nullable: true
         isFminPartial nullable: true
         isFmaxPartial nullable: true
         strand nullable: true
@@ -18,7 +17,6 @@ class FeatureLocation {
         residueInfo nullable: true
         locgroup nullable: true
         rank nullable: true
-
     }
 
     Feature feature

--- a/grails-app/domain/org/bbop/apollo/FeatureLocation.groovy
+++ b/grails-app/domain/org/bbop/apollo/FeatureLocation.groovy
@@ -1,7 +1,9 @@
 package org.bbop.apollo
 
 class FeatureLocation {
-
+    static mapping = {
+        length formula: 'FMAX-FMIN'
+    }
     static constraints = {
         feature nullable: false
         fmin nullable: false
@@ -19,16 +21,17 @@ class FeatureLocation {
 
     }
 
-    Feature feature;
-    Integer fmin;
-    boolean isFminPartial;
-    Integer fmax;
-    boolean isFmaxPartial;
-    Integer strand;
-    Integer phase;
-    String residueInfo;
-    int locgroup;
-    int rank;
+    Feature feature
+    Integer fmin
+    Integer length
+    boolean isFminPartial
+    Integer fmax
+    boolean isFmaxPartial
+    Integer strand
+    Integer phase
+    String residueInfo
+    int locgroup
+    int rank
     Sequence sequence
 
     static belongsTo = [Feature]
@@ -63,6 +66,9 @@ class FeatureLocation {
         return fmax-fmin
     }
 
+    public Integer getFeatureLength(){
+        return fmax-fmin
+    }
     public FeatureLocation generateClone() {
         FeatureLocation cloned = new FeatureLocation();
         cloned.sequence = this.sequence;

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -1476,18 +1476,20 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         }
         long start = System.currentTimeMillis();
         String finalOwnerString = ""
-        if (gsolFeature.owners) {
-            String ownerString = ""
-            for (owner in gsolFeature.owners) {
-                ownerString += gsolFeature.owner.username + " "
+        if(depth<=1) {
+            if (gsolFeature.owners) {
+                String ownerString = ""
+                for (owner in gsolFeature.owners) {
+                    ownerString += gsolFeature.owner.username + " "
+                }
+                finalOwnerString = ownerString?.trim()
+            } else if (gsolFeature.owner) {
+                finalOwnerString = gsolFeature?.owner?.username
+            } else {
+                finalOwnerString = "None"
             }
-            finalOwnerString = ownerString?.trim()
-        } else if (gsolFeature.owner) {
-            finalOwnerString = gsolFeature?.owner?.username
-        } else {
-            finalOwnerString = "None"
+            jsonFeature.put(FeatureStringEnum.OWNER.value.toLowerCase(), finalOwnerString);
         }
-        jsonFeature.put(FeatureStringEnum.OWNER.value.toLowerCase(), finalOwnerString);
 
         if (gsolFeature.featureLocation) {
             jsonFeature.put(FeatureStringEnum.SEQUENCE.value, gsolFeature.featureLocation.sequence.name);
@@ -1496,7 +1498,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
 
 
         List<Feature> childFeatures = featureRelationshipService.getChildrenForFeatureAndTypes(gsolFeature)
-        if (childFeatures && depth==0) {
+        if (childFeatures && depth<=1) {
             JSONArray children = new JSONArray();
             jsonFeature.put(FeatureStringEnum.CHILDREN.value, children);
             for (Feature f : childFeatures) {

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -1497,13 +1497,15 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         }
 
 
-        List<Feature> childFeatures = featureRelationshipService.getChildrenForFeatureAndTypes(gsolFeature)
-        if (childFeatures && depth<=1) {
-            JSONArray children = new JSONArray();
-            jsonFeature.put(FeatureStringEnum.CHILDREN.value, children);
-            for (Feature f : childFeatures) {
-                Feature childFeature = f
-                children.put(convertFeatureToJSONLite(childFeature, includeSequence,1));
+        if (depth<=1) {
+            List<Feature> childFeatures = featureRelationshipService.getChildrenForFeatureAndTypes(gsolFeature)
+            if(childFeatures) {
+                JSONArray children = new JSONArray();
+                jsonFeature.put(FeatureStringEnum.CHILDREN.value, children);
+                for (Feature f : childFeatures) {
+                    Feature childFeature = f
+                    children.put(convertFeatureToJSONLite(childFeature, includeSequence,depth+1));
+                }
             }
         }
 

--- a/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
+++ b/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
@@ -286,7 +286,6 @@ public class Gff3HandlerService {
         if (feature.getName() != null && !isBlank(feature.getName()) && writeObject.attributesToExport.contains(FeatureStringEnum.NAME.value)) {
             attributes.put(FeatureStringEnum.EXPORT_NAME.value, encodeString(feature.getName()));
         }
-        log.debug "${feature}"
         if (!(feature.class.name in requestHandlingService.viewableAnnotationList+requestHandlingService.viewableAlterations)) {
             def parent= featureRelationshipService.getParentForFeature(feature)
             attributes.put(FeatureStringEnum.EXPORT_PARENT.value, encodeString(parent.uniqueName));

--- a/src/gwt/org/bbop/apollo/gwt/client/AnnotatorPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/AnnotatorPanel.java
@@ -178,7 +178,7 @@ public class AnnotatorPanel extends Composite {
                         break;
                 }
                 Boolean sortNameAscending = nameSortInfo.isAscending();
-                url += "&order=" + (sortNameAscending ? "asc" : "desc");
+                url += "&sortorder=" + (sortNameAscending ? "asc" : "desc");
                 url += "&sort=" + searchColumnString;
 
                 RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, URL.encode(url));


### PR DESCRIPTION
This is a special query that optimizes the annotator panel for #820

It does a two step query

1. Get the genes in a specific range for the sidebar
2. Get the details about the genes in that specific range

This blog nicely summarizes that issue http://floledermann.blogspot.com/2007/10/solving-hibernate-criterias-distinct.html (briefly, the first step doesn't use select distinct() and the second one does)

We also have a "convertFeatureToJSONLite" for the purpose that avoids getting extraneous feature info, but even if we did want to display that info, we would still do well by using this strategy

I get about ~300ms for selecting new pages (mean 311ms, stddev 14ms) with database that is bulkloaded with over 10000 genes

Same database on  current master (mean 4528ms, stddev 775ms), so it's quite improved

