### PR TITLE
Expose non primary dbx refs

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -719,7 +719,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
             ,@RestApiParam(name="password", type="password", paramType = RestApiParamType.QUERY)
             ,@RestApiParam(name="sequence", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Sequence name")
             ,@RestApiParam(name="organism", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Organism ID or common name")
-            ,@RestApiParam(name="features", type="JSONArray", paramType = RestApiParamType.QUERY,description = "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ")
+            ,@RestApiParam(name="features", type="JSONArray", paramType = RestApiParamType.QUERY,description = "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.")
     ] )
     def updateAttribute() {
         JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
@@ -753,7 +753,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
             ,@RestApiParam(name="password", type="password", paramType = RestApiParamType.QUERY)
             ,@RestApiParam(name="sequence", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Sequence name")
             ,@RestApiParam(name="organism", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Organism ID or common name")
-            ,@RestApiParam(name="features", type="JSONArray", paramType = RestApiParamType.QUERY,description = "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.")
+            ,@RestApiParam(name="features", type="JSONArray", paramType = RestApiParamType.QUERY,description = "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.")
     ] )
     def updateDbxref() {
         JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject

--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -741,7 +741,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
     def addDbxref() {
         JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
         if (permissionService.hasPermissions(inputObject, PermissionEnum.WRITE)) {
-            render requestHandlingService.addNonPrimaryDbxRefs(inputObject)
+            render requestHandlingService.addNonPrimaryDbxrefs(inputObject)
         } else {
             render status: HttpStatus.UNAUTHORIZED
         }
@@ -758,7 +758,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
     def updateDbxref() {
         JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
         if (permissionService.hasPermissions(inputObject, PermissionEnum.WRITE)) {
-            render requestHandlingService.updateNonPrimaryDbxRefs(inputObject)
+            render requestHandlingService.updateNonPrimaryDbxrefs(inputObject)
         } else {
             render status: HttpStatus.UNAUTHORIZED
         }
@@ -775,7 +775,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
     def deleteDbxref() {
         JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
         if (permissionService.hasPermissions(inputObject, PermissionEnum.WRITE)) {
-            render requestHandlingService.deleteNonPrimaryDbxRefs(inputObject)
+            render requestHandlingService.deleteNonPrimaryDbxrefs(inputObject)
         } else {
             render status: HttpStatus.UNAUTHORIZED
         }

--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -688,10 +688,26 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
             ,@RestApiParam(name="features", type="JSONArray", paramType = RestApiParamType.QUERY,description = "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ")
     ] )
     def addAttribute() {
-        println("PARAMS: " + params.data)
         JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
         if (permissionService.hasPermissions(inputObject, PermissionEnum.WRITE)) {
             render requestHandlingService.addNonReservedProperties(inputObject)
+        } else {
+            render status: HttpStatus.UNAUTHORIZED
+        }
+    }
+
+    @RestApiMethod(description="Add dbxref (db,id pair) to feature" ,path="/annotationEditor/addDbxref",verb = RestApiVerb.POST )
+    @RestApiParams(params=[
+            @RestApiParam(name="username", type="email", paramType = RestApiParamType.QUERY)
+            ,@RestApiParam(name="password", type="password", paramType = RestApiParamType.QUERY)
+            ,@RestApiParam(name="sequence", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Sequence name")
+            ,@RestApiParam(name="organism", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Organism ID or common name")
+            ,@RestApiParam(name="features", type="JSONArray", paramType = RestApiParamType.QUERY,description = "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.")
+    ] )
+    def addDbxref() {
+        JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
+        if (permissionService.hasPermissions(inputObject, PermissionEnum.WRITE)) {
+            render requestHandlingService.addNonPrimaryDbxRefs(inputObject)
         } else {
             render status: HttpStatus.UNAUTHORIZED
         }

--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -696,6 +696,40 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         }
     }
 
+    @RestApiMethod(description="Delete attribute (key,value pair) for feature" ,path="/annotationEditor/deleteAttribute",verb = RestApiVerb.POST )
+    @RestApiParams(params=[
+            @RestApiParam(name="username", type="email", paramType = RestApiParamType.QUERY)
+            ,@RestApiParam(name="password", type="password", paramType = RestApiParamType.QUERY)
+            ,@RestApiParam(name="sequence", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Sequence name")
+            ,@RestApiParam(name="organism", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Organism ID or common name")
+            ,@RestApiParam(name="features", type="JSONArray", paramType = RestApiParamType.QUERY,description = "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ")
+    ] )
+    def deleteAttribute() {
+        JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
+        if (permissionService.hasPermissions(inputObject, PermissionEnum.WRITE)) {
+            render requestHandlingService.deleteNonReservedProperties(inputObject)
+        } else {
+            render status: HttpStatus.UNAUTHORIZED
+        }
+    }
+
+    @RestApiMethod(description="Update attribute (key,value pair) for feature" ,path="/annotationEditor/updateAttribute",verb = RestApiVerb.POST )
+    @RestApiParams(params=[
+            @RestApiParam(name="username", type="email", paramType = RestApiParamType.QUERY)
+            ,@RestApiParam(name="password", type="password", paramType = RestApiParamType.QUERY)
+            ,@RestApiParam(name="sequence", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Sequence name")
+            ,@RestApiParam(name="organism", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Organism ID or common name")
+            ,@RestApiParam(name="features", type="JSONArray", paramType = RestApiParamType.QUERY,description = "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ")
+    ] )
+    def updateAttribute() {
+        JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
+        if (permissionService.hasPermissions(inputObject, PermissionEnum.WRITE)) {
+            render requestHandlingService.updateNonReservedProperties(inputObject)
+        } else {
+            render status: HttpStatus.UNAUTHORIZED
+        }
+    }
+
     @RestApiMethod(description="Add dbxref (db,id pair) to feature" ,path="/annotationEditor/addDbxref",verb = RestApiVerb.POST )
     @RestApiParams(params=[
             @RestApiParam(name="username", type="email", paramType = RestApiParamType.QUERY)
@@ -708,6 +742,40 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
         if (permissionService.hasPermissions(inputObject, PermissionEnum.WRITE)) {
             render requestHandlingService.addNonPrimaryDbxRefs(inputObject)
+        } else {
+            render status: HttpStatus.UNAUTHORIZED
+        }
+    }
+
+    @RestApiMethod(description="Update dbxrefs (db,id pairs) for a feature" ,path="/annotationEditor/updateDbxref",verb = RestApiVerb.POST )
+    @RestApiParams(params=[
+            @RestApiParam(name="username", type="email", paramType = RestApiParamType.QUERY)
+            ,@RestApiParam(name="password", type="password", paramType = RestApiParamType.QUERY)
+            ,@RestApiParam(name="sequence", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Sequence name")
+            ,@RestApiParam(name="organism", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Organism ID or common name")
+            ,@RestApiParam(name="features", type="JSONArray", paramType = RestApiParamType.QUERY,description = "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.")
+    ] )
+    def updateDbxref() {
+        JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
+        if (permissionService.hasPermissions(inputObject, PermissionEnum.WRITE)) {
+            render requestHandlingService.updateNonPrimaryDbxRefs(inputObject)
+        } else {
+            render status: HttpStatus.UNAUTHORIZED
+        }
+    }
+
+    @RestApiMethod(description="Delete dbxrefs (db,id pairs) for a feature" ,path="/annotationEditor/deleteDbxref",verb = RestApiVerb.POST )
+    @RestApiParams(params=[
+            @RestApiParam(name="username", type="email", paramType = RestApiParamType.QUERY)
+            ,@RestApiParam(name="password", type="password", paramType = RestApiParamType.QUERY)
+            ,@RestApiParam(name="sequence", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Sequence name")
+            ,@RestApiParam(name="organism", type="string", paramType = RestApiParamType.QUERY,description = "(optional) Organism ID or common name")
+            ,@RestApiParam(name="features", type="JSONArray", paramType = RestApiParamType.QUERY,description = "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.")
+    ] )
+    def deleteDbxref() {
+        JSONObject inputObject = (request.JSON ?: JSON.parse(params.data)) as JSONObject
+        if (permissionService.hasPermissions(inputObject, PermissionEnum.WRITE)) {
+            render requestHandlingService.deleteNonPrimaryDbxRefs(inputObject)
         } else {
             render status: HttpStatus.UNAUTHORIZED
         }

--- a/restapidoc.json
+++ b/restapidoc.json
@@ -2,14 +2,14 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
-         "jsondocId": "943812e0-1df4-4998-8a94-7a34ddefbc74",
+         "jsondocId": "152b995a-d83b-4f9e-8816-ad7a0f53fcde",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f87ca3c2-60ac-49f0-8d2e-3d61284428b1",
+                     "jsondocId": "16be2c5a-5139-49aa-bd1d-0e9e98164627",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -18,7 +18,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b56bb463-572a-4c5e-bb0b-d8aaf65b43f6",
+                     "jsondocId": "ef6390ae-ccd3-4b8c-a208-2bfe5bf83e0f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -27,7 +27,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2745554d-299e-4fea-b79a-8e8a1c7391ac",
+                     "jsondocId": "1c2a3d27-5429-4c75-9fd0-618959fc3451",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -36,7 +36,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b8373274-624c-455c-bf82-8d0ecbd912de",
+                     "jsondocId": "da6d8c58-b7c6-4e82-92bf-5a92b3460c1a",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -45,7 +45,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "43411da1-e010-44f2-89e7-ee9a76b06776",
+                     "jsondocId": "64c1206f-bda4-4899-9e83-fe25191b8b7b",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -57,9 +57,9 @@
                "verb": "POST",
                "description": "Add attribute (key,value pair) to feature",
                "methodName": "addAttribute",
-               "jsondocId": "4b7a650f-6556-4dff-858c-6dca85e6c872",
+               "jsondocId": "ebe64737-2fec-4bbc-ac9f-4ef80b4583dd",
                "bodyobject": {
-                  "jsondocId": "428ee311-1955-48cb-9585-fbb9373153de",
+                  "jsondocId": "b3069616-8a76-4960-b277-ce5d085bcf0e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -69,7 +69,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addAttribute",
                "response": {
-                  "jsondocId": "3272b695-dbc6-4d0f-8f4d-c54b8c816890",
+                  "jsondocId": "410bf0ed-4b32-45bd-9014-fb04e5cb817e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -82,7 +82,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2c4e61eb-d5a0-4138-8d8f-9bb9790d1bf0",
+                     "jsondocId": "23978c33-3d65-4601-9d53-51b043b9dbf2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -91,7 +91,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14ea9d68-517d-45fd-9d88-f1366285a791",
+                     "jsondocId": "b0410779-cbed-4ded-88a2-8bda45a553b8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -100,7 +100,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1822fa92-f998-4226-83d3-d36e30c0b8c3",
+                     "jsondocId": "3fa76d71-0b3b-49bb-85e3-24d66af44453",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -109,7 +109,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1b3527f-e69b-4ecb-8b1f-c718cc7aedc9",
+                     "jsondocId": "ac326788-a7f3-44a5-8c26-ebb6668a141e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -118,1567 +118,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f76df25d-ff12-4076-bad9-7ec501a9b2a5",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set symbol of a feature",
-               "methodName": "setSymbol",
-               "jsondocId": "98f67387-5d43-4a70-a851-1212f3084c42",
-               "bodyobject": {
-                  "jsondocId": "a5e2656d-7a47-41e0-838f-5d2f6cfeded7",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setSymbol",
-               "response": {
-                  "jsondocId": "31c4b7a5-4e35-40ca-8029-a2ff644f85af",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "d0970b25-52ed-4900-a130-0654b6a1ccb9",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a3c34869-50d2-43c5-9bee-fd359d193d62",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "82310e30-a340-44e6-8f3b-47034de5db1b",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4677f884-d8d1-42a1-bdfb-7fc2a5137c54",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7545e99e-bb59-4962-9846-df3c0d9b5feb",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set description for a feature",
-               "methodName": "setDescription",
-               "jsondocId": "f24e3124-b9b0-4f57-ab00-537de8f26176",
-               "bodyobject": {
-                  "jsondocId": "5652ac12-b054-49ec-8630-7c6d958aa8d6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setDescription",
-               "response": {
-                  "jsondocId": "1815f478-22ff-4b31-b8a6-da1d6fd0489d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "18407be7-0194-4693-9a1c-1ae8175da54c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "445b9ae0-20b1-4a48-8873-980200841dc7",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2f428058-2025-4b19-add7-5ae6bf1ce58e",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9781f64c-4a83-4fee-946b-7206f29d0575",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get sequence alterations for a given sequence",
-               "methodName": "getSequenceAlterations",
-               "jsondocId": "5bacc7bd-6873-4b8b-afe4-ee9e0189eb93",
-               "bodyobject": {
-                  "jsondocId": "125ddb6c-548d-47ea-9d5f-d95e1379e46f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getSequenceAlterations",
-               "response": {
-                  "jsondocId": "cfcbaedd-def1-4613-a967-d1fbf9821bd4",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "d20d4181-289f-4a18-8fd0-0a1c03c284fa",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "18ab4437-a8cd-4fa0-98aa-bc8fe6aa2979",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d253a13f-0753-4a3b-a321-083e9561c6ba",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bd2dbf9b-5fab-45f5-b418-2f875faaf3ae",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c55f9f56-4568-48bd-9639-82e210d445d9",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete attribute (key,value pair) for feature",
-               "methodName": "deleteAttribute",
-               "jsondocId": "d2502171-5bf3-41e3-af25-940c0a437d85",
-               "bodyobject": {
-                  "jsondocId": "4df49905-a6ae-4c9a-8937-0177a1ccc942",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/deleteAttribute",
-               "response": {
-                  "jsondocId": "69a01455-1390-41af-95d7-be62a3069af8",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "b40e0de2-7d2c-4e57-ada2-e6063569fb75",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0f2288d4-88d0-4f28-afbb-8039535d9d8e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5470609b-c318-4c32-b2fd-4e083604020b",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a5948218-6de3-4040-b578-6e78b23114c9",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c51cfa96-1a2c-47f2-82b4-2f66d95f0d0d",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update attribute (key,value pair) for feature",
-               "methodName": "updateAttribute",
-               "jsondocId": "0c707c5b-c6d4-4202-a402-5532bca29663",
-               "bodyobject": {
-                  "jsondocId": "e76a65b8-1d58-4708-bdc6-ee1e81ea73ad",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/updateAttribute",
-               "response": {
-                  "jsondocId": "55bd81c9-00cd-4310-870b-038a23b37f67",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "0ccf7126-412d-4900-a31c-8e207f19df1a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5443faec-ff86-4fdb-920d-f654119d7820",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c8327bfc-8a74-4d94-af7b-79f75a5472e9",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0f1d4343-26c8-48be-88fe-f137b7fb8fe4",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "36da50ab-f71d-4e42-939c-222594eccaf4",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add dbxref (db,id pair) to feature",
-               "methodName": "addDbxref",
-               "jsondocId": "09ccaa4a-3918-462f-ab01-ea3736241468",
-               "bodyobject": {
-                  "jsondocId": "e34d9605-81bb-49f3-8357-75abdd8245fb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addDbxref",
-               "response": {
-                  "jsondocId": "ad8a2bc3-815c-4a27-8c59-bc1a181bbb8d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "8953a556-6392-4c1c-a6c2-1b4f3d85d7c0",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "82eaed76-4852-4a9f-ab76-17f4a06d2463",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "791c896c-1a02-49eb-830b-9b10cd51bb53",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "72164104-7462-4364-a507-cba7ba4af2b5",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a339b642-1cfa-4306-850e-d1e05185c304",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update dbxrefs (db,id pairs) for a feature",
-               "methodName": "updateDbxref",
-               "jsondocId": "37fa5144-1b10-44b1-b318-eba2affc694e",
-               "bodyobject": {
-                  "jsondocId": "a46a2f8f-88a0-4442-87bf-b9c9bc9d998b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/updateDbxref",
-               "response": {
-                  "jsondocId": "bb6fc441-e846-4d7e-9fa3-063f0732b84d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "bc77b0be-8aaf-4541-bfc0-b1eb43db8128",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f3d00a7c-16f1-4361-b7c5-f2dca1cc21ce",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "09245605-bee9-4bbe-9010-6cbbcb89d17d",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a79a8fe3-ef86-4bff-8747-91c6087eebfc",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cf59ec92-7d55-481c-86d6-2a2fdab89349",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete dbxrefs (db,id pairs) for a feature",
-               "methodName": "deleteDbxref",
-               "jsondocId": "7e17ed23-4bb5-494e-bf7f-0c1f02524cab",
-               "bodyobject": {
-                  "jsondocId": "0fbfa22b-81d9-4d65-a1a9-d1e4cf6b0224",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/deleteDbxref",
-               "response": {
-                  "jsondocId": "4cf82b41-4c77-41b8-97f3-8963b21aaf24",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "501e0f27-d5d9-4bd7-a297-78bb40dcfe53",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0365026c-bf7d-4796-9f0c-a6e92def2857",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get canned comments",
-               "methodName": "getCannedComments",
-               "jsondocId": "fd49744d-cca8-4056-8dca-f35a58a1539c",
-               "bodyobject": {
-                  "jsondocId": "e2f20dcc-1dd2-4338-ab2a-61840e850798",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getCannedComments",
-               "response": {
-                  "jsondocId": "e6db4646-eb8a-4da7-bfbd-f4af845187eb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "66f6da07-de26-4e37-bdcb-d36f0cabaf53",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c27b357b-0681-48f3-b5d6-231f231cf85e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bafe2278-8c30-48f4-94ff-e0909a2754a0",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get gff3",
-               "methodName": "getGff3",
-               "jsondocId": "3583c54b-f395-4036-9765-4da82fb56b79",
-               "bodyobject": {
-                  "jsondocId": "64d2b0fd-f8f9-458f-915a-317258ba2c39",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getGff3",
-               "response": {
-                  "jsondocId": "d039f13d-c8e0-488e-9d5a-98cda01b234a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "705602dc-be24-49c8-9c41-1bb2e7a3ec53",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "36811ed8-3b2d-4eef-9abd-ebd441f9d81a",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b171c5bb-b69d-4953-8ba0-9b6d315b2d00",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cfabffc5-eced-4466-8817-80fee95f3179",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "91e89e19-4c7f-41a9-a6f4-41b3892b85d2",
-                     "name": "suppressHistory",
-                     "format": "",
-                     "description": "Suppress the history of this operation",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "88d9267d-7170-42c1-baec-f564521ab616",
-                     "name": "suppressEvents",
-                     "format": "",
-                     "description": "Suppress instant update of the user interface",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3c9b95ce-7bff-4b10-812c-9799e27dfdf4",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add an exon",
-               "methodName": "addExon",
-               "jsondocId": "f7d9f8fa-a5dd-4532-abbf-c859f73f5e0f",
-               "bodyobject": {
-                  "jsondocId": "fb7c9fa0-ce92-470f-bbb1-682958d9c8d5",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addExon",
-               "response": {
-                  "jsondocId": "1b808f61-2055-4f5d-bab7-1441adaa3eae",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "d0443d73-3652-4d7f-8487-f74f8fb92431",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "01da0ee2-80b9-46b8-b8b4-42a7797f2a7b",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7e1cb326-a9b2-44db-afcf-5c7200e02ae1",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4315d42d-ea83-4a0c-ad7b-8e85740be4e2",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9d82cb69-b265-4260-8ab0-ee27c1adda9e",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Split transcript",
-               "methodName": "splitTranscript",
-               "jsondocId": "dfb0ce3a-b863-4c02-9413-df031dcc5bcc",
-               "bodyobject": {
-                  "jsondocId": "e99b5ac2-9c5c-4356-80ae-6f6f23ff14e6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/splitTranscript",
-               "response": {
-                  "jsondocId": "071aad84-be5f-4bc8-8d77-9a29836a11de",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "2e7e99f6-d6ad-4e96-a15d-3bad79c530d1",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3401ded8-fe75-47ac-9064-ffb5bd4be40e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7a5c79b2-582a-4081-85d5-bfcc0cfa5137",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e28f6cc2-c6d4-41c4-b778-cbff6eb336c1",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6aa767b7-c096-4aed-9962-80f9e86b1f4a",
-                     "name": "suppressHistory",
-                     "format": "",
-                     "description": "Suppress the history of this operation",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "83073396-5acb-4a18-a5cb-a7014657f707",
-                     "name": "suppressEvents",
-                     "format": "",
-                     "description": "Suppress instant update of the user interface",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "fe4e3682-7332-4fb9-a728-f7721df4c3a9",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Duplicate transcript",
-               "methodName": "duplicateTranscript",
-               "jsondocId": "b9310e92-b966-4bfc-b080-0f7c297c0e57",
-               "bodyobject": {
-                  "jsondocId": "41908a04-b4ad-4c3a-b04f-b18d7605cc06",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/duplicateTranscript",
-               "response": {
-                  "jsondocId": "27be38cf-90d5-44b9-8c3d-34e9dcb3387b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "ec3a6f67-b449-404f-8898-fce5f0ea2220",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bc2e0181-921e-4b71-abda-5b9ecc88177e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7d519fe9-e24a-4391-bcbe-31b37edf453c",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2384ee87-fc49-44f7-82aa-5b73279f8392",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9922cc85-d057-4fb0-b0c6-3ecc551e74bc",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Merge transcripts",
-               "methodName": "mergeTranscripts",
-               "jsondocId": "fbbdc154-5483-4f75-bd45-6f8049dcb0ea",
-               "bodyobject": {
-                  "jsondocId": "65675156-82e2-4a97-84d7-e6478777733b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/mergeTranscripts",
-               "response": {
-                  "jsondocId": "d1db733d-71b0-41e0-a880-76f1e55a26bc",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "656f2681-c17a-4021-81a1-b17ed4a09c1c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2898dc72-f5f8-4d41-be93-e81fad5dcc36",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4712d8ff-a558-4fb6-8fe1-dd90bb32dcaf",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2a318cc4-bf60-4cb9-a8a9-da723bc45439",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3eb163f6-fa8c-4ba3-9615-afc5c4497a62",
-                     "name": "suppressHistory",
-                     "format": "",
-                     "description": "Suppress the history of this operation",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5183a62f-0edb-4af9-a40d-982ad993884f",
-                     "name": "suppressEvents",
-                     "format": "",
-                     "description": "Suppress instant update of the user interface",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "169168db-6811-4593-9d9d-5d05261329ab",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add non-coding genomic feature",
-               "methodName": "addFeature",
-               "jsondocId": "67f86c90-8afe-4ae9-9038-11580c0a4de2",
-               "bodyobject": {
-                  "jsondocId": "dbebc07c-9f73-470e-a51c-178276eb3b35",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addFeature",
-               "response": {
-                  "jsondocId": "13817fcc-ab17-4ca7-88be-b9c1f293d0f2",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "e894ae43-9a26-4aa9-909e-b7df7e763b98",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f0ff666c-94e8-48c6-b3d7-8a1a5925bcd9",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3b371199-7d6c-461a-b151-1233bc1beb13",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cbbeeabe-2f4b-4e78-84e9-83419bf384e4",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2b5b634f-7f0c-4726-a492-679cb5ee9b21",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set translation start",
-               "methodName": "setTranslationStart",
-               "jsondocId": "76360508-bd82-40b7-8bf3-6393943c7f98",
-               "bodyobject": {
-                  "jsondocId": "6a912590-e645-488f-8494-eb49198e64b6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setTranslationStart",
-               "response": {
-                  "jsondocId": "a6e45f87-e8d1-451d-8cda-953b5baaa529",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "e2a5240c-f0d5-42e8-a033-4c27177523ed",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "887e72bc-1931-48dc-a8ee-e2ee61e20d73",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5678e46a-cf27-468f-96c8-ea681185a84b",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b3487854-51dd-478e-bada-ff58ef686dcf",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "621c823e-efd5-4e84-b289-da1732fb7980",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set translation end",
-               "methodName": "setTranslationEnd",
-               "jsondocId": "3a94eb21-1df9-49d7-9f49-6e975196d53b",
-               "bodyobject": {
-                  "jsondocId": "ff755e1f-453c-4ba2-a429-ff36a82940dd",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setTranslationEnd",
-               "response": {
-                  "jsondocId": "a1662b29-a4b3-4405-b035-ec04c811f8f9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "4149ce5a-7f7b-417f-b772-3bcd9053fe4f",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "66aeb029-538a-42d0-b67e-7083952ea114",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3d3216c2-5855-4d2a-99cb-98d8557503c7",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cf8c16cf-0cec-4157-b2fb-bd9809f5a591",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c8c0b10d-510e-4440-9398-c64e9d3f0465",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete feature",
-               "methodName": "deleteFeature",
-               "jsondocId": "a60317de-6dda-437a-9dda-cbd5264da3a4",
-               "bodyobject": {
-                  "jsondocId": "204b3dd2-6585-42bb-93ef-d0e55bd5f727",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/deleteFeature",
-               "response": {
-                  "jsondocId": "a043897d-a409-4ee3-839d-648893cd157a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "7bf74c55-e270-4771-b30b-d2a34344867f",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "526c8f1c-5c49-47b1-84c0-dcc438a3f8a0",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "527630c8-3831-4f32-99d3-0b09cbbb7333",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a72b44ec-ca21-43a6-9686-855745386ad6",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "35e37339-1e28-4c1c-bd84-aae92fdec695",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Flip strand",
-               "methodName": "flipStrand",
-               "jsondocId": "ae548ff3-0e51-4cb7-a6e9-e37081881360",
-               "bodyobject": {
-                  "jsondocId": "372abcd5-325e-48d0-a617-d7c8f0994cd8",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/flipStrand",
-               "response": {
-                  "jsondocId": "ec3a8c36-8ec4-4ee4-800e-f49c0f661875",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "c20d0639-9987-466f-ad81-d24e07db839c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "88e3e7c4-4fb1-4c41-8185-1acd4c469f7d",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "208704e4-05bf-4dd4-92f9-97935ca8f4bc",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f7d547ae-41f7-4142-b827-bd5d126f2e5d",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "08443bf7-6470-4e22-8482-7fac8311a6d0",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Merge exons",
-               "methodName": "mergeExons",
-               "jsondocId": "9063b482-5b52-4fe4-a8b7-13913a3a0c87",
-               "bodyobject": {
-                  "jsondocId": "231197c3-c423-43aa-a024-10defaeb540a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/mergeExons",
-               "response": {
-                  "jsondocId": "87a41f7c-d826-408e-aea6-dd846fbcfb6f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [],
-               "verb": "POST",
-               "description": "Returns a translation table as JSON",
-               "methodName": "getTranslationTable",
-               "jsondocId": "676515b8-9224-43f3-bffb-7d2848914864",
-               "bodyobject": {
-                  "jsondocId": "a720f5e4-9393-4fcb-b784-82ecf12e068b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getTranslationTable",
-               "response": {
-                  "jsondocId": "cca10c1d-de2c-4e00-ad45-b163f50adea9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "6c610e99-6911-4057-82a0-7d253091f1a6",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ece1c90f-a003-476f-98fa-bf71010bd671",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "acfa9eab-fc1e-44e2-bc06-a3e254a8983d",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4008ab74-6960-4947-bc1b-c866eb6a790d",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3d136a42-9256-4bc2-b5c6-1493b37f786b",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete exons",
-               "methodName": "deleteExon",
-               "jsondocId": "78be04e9-58d8-4350-884c-e1a11461e7c0",
-               "bodyobject": {
-                  "jsondocId": "08285085-2c6c-47c0-887f-0fb25fa470d1",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/deleteExon",
-               "response": {
-                  "jsondocId": "d0b88faa-9bb4-429e-a21e-abbe8a9516ab",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "9b5160aa-1a6f-4018-8351-fe72443a5fec",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2d455143-36eb-4e15-8b84-6bfa880d66ad",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6ef9521e-0d52-45e1-b734-d2959f0ade02",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e55da443-3782-4d3a-ad16-935347af4fbc",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "40413b42-f3b5-4bfc-90b4-77c85a37f7e0",
+                     "jsondocId": "c916391e-81d3-4a46-9fb3-5ce3cf96a506",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -1690,9 +130,9 @@
                "verb": "POST",
                "description": "Get sequences for features",
                "methodName": "getSequence",
-               "jsondocId": "b65ba100-e6b8-4dd5-b16d-fbd039130d51",
+               "jsondocId": "44e93880-429b-4ac1-986a-ffc5031f4ae4",
                "bodyobject": {
-                  "jsondocId": "5efd27ca-a94c-40e3-8597-4272ee656155",
+                  "jsondocId": "ab62f25b-bc5f-465d-b0a2-6425d912be17",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1702,7 +142,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequences",
                "response": {
-                  "jsondocId": "ec9a2324-e306-45d7-9d71-e64409f737fd",
+                  "jsondocId": "b7afdbbc-e1c1-4d7a-a54c-bad052ffdf59",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1715,7 +155,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8b41704e-bde4-45fa-bc6b-294618c5347c",
+                     "jsondocId": "ad008b6d-c68a-4ad0-9d08-30cfcf69a884",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1724,7 +164,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8adfaa8a-97f8-473d-875f-574efd7025a1",
+                     "jsondocId": "fcc7678b-747a-41f5-aed3-c1048948086c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1733,7 +173,1065 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e834623-c6f6-47d7-b4d6-827f9c2030f3",
+                     "jsondocId": "7ba11312-36a9-46e1-b195-c61b7602cd80",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "455f643c-76c3-4c13-8ec5-5f011ba7c90d",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f1d8054e-8cea-4925-bd07-33eeea3a351c",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set symbol of a feature",
+               "methodName": "setSymbol",
+               "jsondocId": "f2600665-f1d5-403c-b169-6e663d4c8df0",
+               "bodyobject": {
+                  "jsondocId": "434d1d33-678a-4f99-8bd5-a4b96263b4c6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setSymbol",
+               "response": {
+                  "jsondocId": "d490becf-4564-4542-b70a-5491bdb2cf26",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4a87ad2d-62e6-4f5b-9fc5-08e32eee94c8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dbc5ce42-2c2f-44c7-b5d2-90295eb3b17e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5e1d71d8-09a6-43df-939b-0a93f2fce926",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "64fafefe-059a-4248-b183-5e74ef256f5a",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e2da8993-ed5b-4190-9b44-2f10949c9290",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add comments",
+               "methodName": "addComments",
+               "jsondocId": "27559249-0637-4905-8f34-9c2b7ab857c0",
+               "bodyobject": {
+                  "jsondocId": "3502c52f-ae99-4061-baba-e0936eadba6c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addComments",
+               "response": {
+                  "jsondocId": "ec08705e-6d58-46e6-8993-2b963cf68833",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "b1102ecf-c137-4fba-9eca-c6ad3ed82ad0",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6bf305c2-3420-40a7-94f3-cbb1f3f9fd32",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "332176c6-f281-46da-bdbe-efdf824ccbe3",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "67839e95-4321-4667-9c64-b3ce3ab9e6ac",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "13cc572e-62e9-4f80-9860-10918840ab75",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete comments",
+               "methodName": "deleteComments",
+               "jsondocId": "10ca80d2-c5af-49b0-bfb3-0c49944fb3ae",
+               "bodyobject": {
+                  "jsondocId": "ba3d660a-d640-4a97-ae8f-e898e4beea8b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteComments",
+               "response": {
+                  "jsondocId": "cd749147-e249-4586-8047-c055aae51611",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "d9b7be1c-124d-403a-b7ea-2de6c8bb8789",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7446843e-505c-45c1-a6e9-2659e760faf0",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d7b34971-6776-4eb6-871d-27c8726edf97",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bc4222ec-26b5-41a0-86f9-81511de7be70",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "831fca32-1b32-422b-a5e5-cbf1e9121d06",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update comments",
+               "methodName": "updateComments",
+               "jsondocId": "0c67b640-df05-488c-bd11-6bfe491c713c",
+               "bodyobject": {
+                  "jsondocId": "21eb7926-44b8-4783-a06a-96d3eace3e6c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateComments",
+               "response": {
+                  "jsondocId": "b111ef8c-235e-4c5a-b801-46eeca228c0d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "29aaf750-986b-4e47-ad4b-c520dafce7ee",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d1ed621d-80e2-438d-9aa8-be6e30795f7c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8f2cb998-d796-4c99-a859-0495c5326dfa",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "662b15b2-3d38-4021-b70f-42d82da9bf0a",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3d52044a-d837-40b8-8137-335ac5fa185d",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fd233fd2-97ea-4142-ab82-692892b4c5da",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5ed15d84-fd88-4a6f-9783-ab8202e0628c",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add transcript",
+               "methodName": "addTranscript",
+               "jsondocId": "d345097d-e629-443a-ae2c-968ed86ac434",
+               "bodyobject": {
+                  "jsondocId": "8d1672f2-2da8-458a-bcbc-9c5dcf2d1ea9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addTranscript",
+               "response": {
+                  "jsondocId": "8172eb73-3637-448c-a5cd-f56de421457c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6ff71a63-c7a1-4c86-b871-c2fd14711755",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "eee7d887-2907-439e-9ff7-41cd690e8101",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d8a7ef6d-a1cf-46da-a8be-c6fbceca0411",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "eae96bb2-849e-4cb7-b502-4cfb35ecd7eb",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "468cf2a1-120e-4cff-93e6-a724aded1aa6",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set readthrough stop codon",
+               "methodName": "setReadthroughStopCodon",
+               "jsondocId": "6a9b7dfb-e5ee-4ab7-937b-e37e073d5c0a",
+               "bodyobject": {
+                  "jsondocId": "29944b0e-5f7f-490d-ab16-2e9134dec32c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setReadthroughStopCodon",
+               "response": {
+                  "jsondocId": "f54eff1d-d0dd-4f59-8784-2f89ad743dbf",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5a38afd4-c739-4c37-b06a-f09eaef86419",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "05aabba8-efdd-47f7-ad39-7ac62acb15f4",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ef407077-747b-4c72-96ba-6dc263c830e9",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "74d189ff-9bf0-4cd6-85ac-b04f3082fddb",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "36c8a183-888a-4925-93cc-87ceef7c6417",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set longest ORF",
+               "methodName": "setLongestOrf",
+               "jsondocId": "dfc00ef5-acff-4dde-aad6-6b62b737b504",
+               "bodyobject": {
+                  "jsondocId": "d79ab383-8414-4fbd-9b27-4588adfe055c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setLongestOrf",
+               "response": {
+                  "jsondocId": "0851a86f-1bd4-4614-9b56-d648486f719d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c6d26a1b-ff83-47a3-930c-0cf412b0c80d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7b154b7f-911a-4edc-8b96-7055ae8d35f2",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e142a84a-d312-4ac2-907e-f37d9f836165",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1a374294-d6e8-4776-805b-1257ce1bcdd3",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bdec675a-9ed3-4edd-b1f0-c3b3f24abfa6",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c082c90c-7b73-474e-a5dc-c68bb33bc1e2",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0f16b3e8-19d8-4ba9-8730-df427af5c48c",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set exon feature boundaries",
+               "methodName": "setExonBoundaries",
+               "jsondocId": "4a643b60-cc0b-43c2-a922-fb7fcfb82fc0",
+               "bodyobject": {
+                  "jsondocId": "97470549-905e-4a73-b9aa-6252b0be4dd0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setExonBoundaries",
+               "response": {
+                  "jsondocId": "476e48d0-20d9-4821-8ac9-4ed508d537e0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "dd668445-4b53-4440-a8f0-4c4aebfa1b76",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0527df89-3366-470c-b995-ea560e24c7fe",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "339f3553-ca9b-4881-985c-527f7efce339",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "95989063-b639-4287-b3d8-0dc0bf52c143",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ac767af4-46d8-4833-ab17-e8cfe20de902",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set boundaries of genomic feature",
+               "methodName": "setBoundaries",
+               "jsondocId": "039917ee-421f-47e4-9aaa-ac29a3aacdf9",
+               "bodyobject": {
+                  "jsondocId": "b39031d0-c18a-47bd-a7b0-32dedc9fd787",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setBoundaries",
+               "response": {
+                  "jsondocId": "ec7f17f1-9d96-499e-8276-4a3b74fb25ca",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "22a47f09-27aa-4b87-9687-36bfb264ca34",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e668f2f2-51b2-47ec-92d1-ba1776a37691",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "352de19a-7e5b-499f-8347-098cb5a8ca50",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fb97cea5-e411-4541-aed0-62e5f0d9a999",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0287ff06-c8df-4497-b72d-38c081e15325",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete sequence alteration",
+               "methodName": "deleteSequenceAlteration",
+               "jsondocId": "90b4d514-768e-46cc-b94f-d213d1665657",
+               "bodyobject": {
+                  "jsondocId": "13cbbd2a-52e3-4831-b512-efc56b65ece1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteSequenceAlteration",
+               "response": {
+                  "jsondocId": "37257afb-ce8a-4d9e-bb41-2e3512888966",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "12ed7a38-3669-4c4f-a951-cb50a09b357f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b8a2627b-61a5-42f7-9674-9a908ca2070c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "814d2f6a-d7be-4a08-841f-551a6c590e27",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0e806c25-90db-4ca4-a0f4-e6c495e3ab5b",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "76fde1b9-cf39-4c42-bd9d-32102fc81380",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add sequence alteration",
+               "methodName": "addSequenceAlteration",
+               "jsondocId": "4a00ddf5-be35-4229-a2a4-f47f9690f4be",
+               "bodyobject": {
+                  "jsondocId": "f717ba34-2d81-43dc-a092-069e88ebefdc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addSequenceAlteration",
+               "response": {
+                  "jsondocId": "85bbbf1e-47c1-4d2b-a33e-c02a797e9e29",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "f623a49b-75a3-4367-b540-f60762707744",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8b507044-cc1d-4f79-abf0-a0c6ca2ee5cf",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4b9a86da-9fbe-4f02-b70f-ea78ca04ebc6",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "46023a1f-9d94-4a2c-a740-44375ba8bccd",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "36aa6019-ed77-4176-8e48-f9f3f0bf7214",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Split exons",
+               "methodName": "splitExon",
+               "jsondocId": "30478185-8723-4c5e-a567-0b42be8895ed",
+               "bodyobject": {
+                  "jsondocId": "c1061acc-89ec-4be7-bc53-7d468a1eac97",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/splitExon",
+               "response": {
+                  "jsondocId": "5ea712fe-1e99-4375-9c86-0459af520f16",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "bd642db9-5c68-4e6d-8a4e-5a56664b20ed",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "213dc5c2-4b30-4557-8f45-6e3d0cc59936",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "51914cbd-0463-49d1-8f66-312335a6f973",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e9b382d1-050c-4a9b-abf9-93f67050502a",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8e876756-543e-4e77-bdaa-09fb02db0703",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Merge exons",
+               "methodName": "mergeExons",
+               "jsondocId": "0f05806c-2e37-42ff-88c4-20a0b67a2b95",
+               "bodyobject": {
+                  "jsondocId": "34f47294-1846-4a19-8556-981ca33494e6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/mergeExons",
+               "response": {
+                  "jsondocId": "096e7d50-f329-4bc1-ac78-02ff6130dfd6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "66de7c4e-a0b2-4c03-b4fc-2e8efb7fbdbb",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a14c4bf8-62ee-40ce-9a35-bacbf62b8b2b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f6ab7720-227c-4ea9-a624-a8eaf9e32895",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e7e2d06b-9774-4550-bc39-49c87b423387",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "24c343a7-6845-4ad5-a1e4-7215cd24ece2",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete exons",
+               "methodName": "deleteExon",
+               "jsondocId": "6607c659-0930-4beb-956e-2e9df6c20bf8",
+               "bodyobject": {
+                  "jsondocId": "b59b6d57-3813-4543-bc9a-2dc59ff28b67",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteExon",
+               "response": {
+                  "jsondocId": "c2590fa9-a2f3-47c9-8fe1-8a22a990c793",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "40e7b2cc-b6ff-4025-9a26-189f2cf3eb5e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9e5fbf9b-49ec-47ff-8281-8157c8a1625b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "92eaaa35-d4f6-4766-848f-9771af4de27d",
                      "name": "search",
                      "format": "",
                      "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
@@ -1745,9 +1243,9 @@
                "verb": "POST",
                "description": "Search sequences",
                "methodName": "searchSequence",
-               "jsondocId": "2a7ed7f3-3ad7-418f-880e-9f305279d493",
+               "jsondocId": "25c358ce-441a-4cdc-9615-d37036b2cf47",
                "bodyobject": {
-                  "jsondocId": "79f3d080-dc6f-4814-afd7-e319a6f29ab1",
+                  "jsondocId": "ee0a5ccc-c5da-409c-a635-849db0824a37",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1757,7 +1255,7 @@
                "apierrors": [],
                "path": "/annotationEditor/searchSequences",
                "response": {
-                  "jsondocId": "b1d75633-2934-4af5-a34f-f7977688abbc",
+                  "jsondocId": "5b3d8825-f58f-4ecd-bcd4-471e15d53508",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1766,7 +1264,7 @@
                "consumes": ["application/json"]
             },
             {
-               "jsondocId": "cc27b6e6-6912-4295-a53f-1b7d47719aeb",
+               "jsondocId": "f377bae0-20c1-4eba-b744-e1e86a76d1a7",
                "bodyobject": null,
                "apierrors": [],
                "path": "/annotationEditor/getSequenceSearchTools",
@@ -1774,7 +1272,7 @@
                "pathparameters": [],
                "queryparameters": [],
                "response": {
-                  "jsondocId": "88c560fd-49c2-48a9-aea4-84bcd44a3dcc",
+                  "jsondocId": "bf2af60b-a74a-4c7a-9a13-3a14cdccb708",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1789,7 +1287,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0beb1b82-f799-4d54-b67c-83b2d535480c",
+                     "jsondocId": "4855a670-bd5b-4bb4-8d65-bab2990c1863",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1798,7 +1296,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6297966b-4260-4b45-a244-e8e57bd297b3",
+                     "jsondocId": "d2a9c278-a104-4ba2-908a-911aae0172a8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1807,7 +1305,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "56727fa6-4b31-43c6-86c8-8eacf62bd14d",
+                     "jsondocId": "91130e2a-522a-4f14-b23a-e983ffc8240d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1816,7 +1314,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "58ba1a86-5d29-4897-8dab-114e84d6ef56",
+                     "jsondocId": "af43fa66-a046-426d-b5a0-f2c0d536465b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1825,21 +1323,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ffb57e81-148c-4529-8275-f9174ee631df",
+                     "jsondocId": "e4d2ee3e-6005-4890-939a-7b59931c2d9b",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Set status of a feature",
-               "methodName": "setStatus",
-               "jsondocId": "01afe7e5-3a5d-4824-9126-25f57957f96c",
+               "description": "Set description for a feature",
+               "methodName": "setDescription",
+               "jsondocId": "94371b9a-1096-4e09-a56c-090c256ac0d6",
                "bodyobject": {
-                  "jsondocId": "97cf649d-788c-467f-9d84-41caa843d8f6",
+                  "jsondocId": "30d386a6-13a5-44c1-b619-fe6c3d02b43e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1847,9 +1345,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setStatus",
+               "path": "/annotationEditor/setDescription",
                "response": {
-                  "jsondocId": "837d8d3b-f517-4b00-ad3e-7d984869c8e5",
+                  "jsondocId": "c80701c0-c625-410c-9473-f3061d84ebbb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1862,7 +1360,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7dd9eb25-4187-4b19-978d-ad4e306ea3f4",
+                     "jsondocId": "27839a59-eb58-455e-a802-49ecaee7e28d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1871,7 +1369,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44c4fa31-cb23-46a3-88e3-99e9207cf8b2",
+                     "jsondocId": "1824bf6a-dfa7-490c-936e-b911476af035",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1880,7 +1378,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6bafcd3f-01a9-4ad0-afd8-d983a2c9c2d8",
+                     "jsondocId": "9c65e0d9-84c7-4a72-a3da-c428b3a7ae34",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1889,7 +1387,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5425c33c-ec62-4014-9e20-a931d8de52ad",
+                     "jsondocId": "ba1d6795-d966-44be-8ec6-59fb2aba5836",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1898,21 +1396,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "480ccd6a-c9a1-4d60-bb23-2e475d9dcf10",
+                     "jsondocId": "70e495cd-7b14-4d37-a4c1-68e2fba7e351",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Get comments",
-               "methodName": "getComments",
-               "jsondocId": "fad6817c-dc00-4c2f-8883-3009b90f31ac",
+               "description": "Delete feature",
+               "methodName": "deleteFeature",
+               "jsondocId": "e972acf1-ca20-443d-9b01-aedd22cadc34",
                "bodyobject": {
-                  "jsondocId": "122a4d58-9bfe-46ab-a2ba-092b649b9ae2",
+                  "jsondocId": "f80f194c-4c9a-4b02-89cc-6352736c20ab",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1920,9 +1418,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/getComments",
+               "path": "/annotationEditor/deleteFeature",
                "response": {
-                  "jsondocId": "b077bc15-8ec7-45c1-b664-faddaec362f7",
+                  "jsondocId": "0d9c29ba-1c09-4fa4-92a9-aace9068586d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1935,7 +1433,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c030b77e-33c6-4655-849e-964bb70a8baf",
+                     "jsondocId": "bbb545b1-0562-44cc-877f-538bf0f2594e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1944,7 +1442,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0056a2c8-29f4-4318-9b05-fc4af79f7bee",
+                     "jsondocId": "1d2b59c4-66f6-40ed-b9ce-469b992b6c51",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1953,7 +1451,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "947c90dd-cba4-4db9-82c6-d9dac4cc6b67",
+                     "jsondocId": "cc2456c2-d240-43db-802a-b4d19dae8b99",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1962,7 +1460,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5438bbf5-4774-4a96-9675-b4eac838f4f8",
+                     "jsondocId": "48fb0005-1019-4848-be96-6ff973fbb7dc",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1971,21 +1469,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7c6b9f05-5ba1-443f-9d4f-e1da95824ebc",
+                     "jsondocId": "98865481-60ca-4153-8396-536be1fa81df",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Add comments",
-               "methodName": "addComments",
-               "jsondocId": "cc7bb121-0bb0-468d-890e-a88c295f998e",
+               "description": "Flip strand",
+               "methodName": "flipStrand",
+               "jsondocId": "5b5a9a6e-91b6-4ec3-a8c3-427f95d08ce6",
                "bodyobject": {
-                  "jsondocId": "efac1622-d4ff-4849-8b1c-a24e338b5c7b",
+                  "jsondocId": "c8c7134c-9ad3-4d1c-9e77-cda7a14f85e6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1993,9 +1491,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/addComments",
+               "path": "/annotationEditor/flipStrand",
                "response": {
-                  "jsondocId": "0387464c-2e37-4ddd-8e2e-7164549061b3",
+                  "jsondocId": "592ddf9e-ad38-42a5-81d3-110ad7fa8d17",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2008,7 +1506,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c5238fe5-a998-4862-83bd-f47961b13ed8",
+                     "jsondocId": "8d0e5021-f4f6-4f57-bf54-44325a808015",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2017,7 +1515,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0fd3ac13-ca0c-4a6b-acb3-d91d9ab4eb50",
+                     "jsondocId": "380348af-4985-4c60-bcd3-71d6cd1c9faa",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2026,16 +1524,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2101c3c2-98e6-4d90-ab76-595a0a6db5da",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "dd8d55b5-4669-4d87-a5ee-e581cc22bebc",
+                     "jsondocId": "af1d8b9b-c70a-4c33-a5cd-b123bdc0dbfa",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2044,62 +1533,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7febd8d1-7cde-4d71-9ca9-fd6ec7101679",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete comments",
-               "methodName": "deleteComments",
-               "jsondocId": "7f3eb9b6-5702-4ee4-98f9-46eb0c934b5f",
-               "bodyobject": {
-                  "jsondocId": "edc54441-31fe-40ce-94a5-a68002cf696e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/deleteComments",
-               "response": {
-                  "jsondocId": "b6ff0bc3-79ef-4bd8-9686-37f12a846ae7",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "81473e74-3148-44f8-b9e3-454b8a0a15af",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "31b34919-7644-4067-9c9d-9b23665db616",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ffa9b7ee-1d56-4854-b2c2-818b7204cac2",
+                     "jsondocId": "659ddb4e-767e-4a8d-b639-511a0d45c906",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2108,153 +1542,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fa396dcb-1998-44d2-8b72-09c58beed75e",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bc2fd1e8-2136-4edd-9e08-ba76e8b0f989",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update comments",
-               "methodName": "updateComments",
-               "jsondocId": "65193204-a834-40d3-8c2d-dd9ea6edd974",
-               "bodyobject": {
-                  "jsondocId": "e87a1535-14be-40b1-8e13-788954ee05fc",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/updateComments",
-               "response": {
-                  "jsondocId": "a7e0dec0-7300-44a9-877a-d6a8eb5f358a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "7f25d57b-999b-4932-82c9-37a4f9c9c29a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "dca9a809-786c-4bff-8e3a-de3b2f5802cf",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9b7da06f-5a92-4299-83e8-590dc77fe6e2",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ba1057e5-5087-4c6b-8976-85a9029161e8",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get all annotated features for a sequence",
-               "methodName": "getFeatures",
-               "jsondocId": "967db250-0b13-4652-923d-d60f8677d337",
-               "bodyobject": {
-                  "jsondocId": "8a4ebe46-6af4-4e1e-8a83-4ac44e0f05e2",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getFeatures",
-               "response": {
-                  "jsondocId": "77579bd1-3cf2-4d20-ab47-6aba75c5e311",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "24805605-9d02-4a14-b2df-f4d414eb27a1",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "06fc4323-ccb5-484b-862e-27891e051aaf",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7025716f-1cf9-491c-8c5e-85344223f86d",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cd3738a0-26b4-4cd8-af1a-9f6350e9a942",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "41bda46e-553e-4159-88ba-1da739428f0a",
+                     "jsondocId": "54001dbf-e389-4dc5-a178-5cd747d7bffc",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -2263,7 +1551,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5dc54d78-af86-463a-afb1-13d41ae810ea",
+                     "jsondocId": "adefaa0b-f281-49f2-85dc-5653b7c151b3",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -2272,7 +1560,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7af738bb-2173-48e4-b8cc-a1d46ec8b31e",
+                     "jsondocId": "7cd9517c-bca1-4662-bf38-ea96cd770950",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -2282,11 +1570,11 @@
                   }
                ],
                "verb": "POST",
-               "description": "Add transcript",
-               "methodName": "addTranscript",
-               "jsondocId": "a98ce8a5-78f2-4437-ba42-25094d830abe",
+               "description": "Add an exon",
+               "methodName": "addExon",
+               "jsondocId": "f881528d-9cb9-4841-b183-87c104c064aa",
                "bodyobject": {
-                  "jsondocId": "44018e69-58a0-4bce-8c35-545b0c9773e2",
+                  "jsondocId": "c712a7fa-4cb4-4c70-8d92-1187ae409b47",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2294,9 +1582,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/addTranscript",
+               "path": "/annotationEditor/addExon",
                "response": {
-                  "jsondocId": "111e21e5-21df-4842-aa9d-463ca59b58b2",
+                  "jsondocId": "891bc3cf-d8a2-4ccb-8f64-f6ec5c15e9ae",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2309,7 +1597,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "740c646a-0087-483a-9cf4-eb7f1d08593e",
+                     "jsondocId": "0f66aa36-66c8-411a-9f6e-bbdd81b08c2f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2318,7 +1606,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "647049c4-2db6-4029-858d-4b61bfe56c59",
+                     "jsondocId": "cbdc1707-d7e5-430b-8c64-bc508d31b68d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2327,7 +1615,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ec6143b8-f0c7-48ee-86ed-ddd07c570648",
+                     "jsondocId": "004cd6ca-b776-436a-a4a2-302004c66c33",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2336,7 +1624,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b8b50a18-ab3a-4dab-ab9f-6ecacc3aee83",
+                     "jsondocId": "5964c3df-e34a-4921-a744-2d3415bd00ea",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2345,21 +1633,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2d95ebdc-437c-4133-b927-c67fff33d214",
+                     "jsondocId": "5779ae4f-c373-4173-90f8-71ea5551f10d",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
+                     "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Set readthrough stop codon",
-               "methodName": "setReadthroughStopCodon",
-               "jsondocId": "e54515e8-82c1-4c03-861b-e75998ba7907",
+               "description": "Split transcript",
+               "methodName": "splitTranscript",
+               "jsondocId": "ffa6cea1-acf3-4afe-8237-8039c87b162f",
                "bodyobject": {
-                  "jsondocId": "d8200e56-de85-44ca-b410-06e3251f1463",
+                  "jsondocId": "2af0c486-f616-4778-b299-8c98055bea32",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2367,9 +1655,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setReadthroughStopCodon",
+               "path": "/annotationEditor/splitTranscript",
                "response": {
-                  "jsondocId": "4c5afae7-0706-48c2-8388-1fa6e906c5fe",
+                  "jsondocId": "96412b91-d2c2-4ea0-8164-cc46c9a20580",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2382,7 +1670,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "338025fa-8771-414a-8233-517266cff259",
+                     "jsondocId": "bbe576ae-fef7-46e1-9139-cfed5201c468",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2391,7 +1679,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c90abcc1-7909-4624-9f7a-5b684fb22cf0",
+                     "jsondocId": "fcd0bb9d-4b94-442a-a8b0-5d0507dc7aed",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2400,7 +1688,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cfe1a113-bca5-493b-931a-31286c67f4ba",
+                     "jsondocId": "dc1cf2e1-d076-4f6d-9f8c-cefe881492bd",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2409,7 +1697,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "528a5805-60c0-49ae-8138-de8f57782a34",
+                     "jsondocId": "8ffbb050-a454-42bf-ac9c-ad17c8910900",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2418,80 +1706,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b2ee6ccc-e089-40c2-ba9a-bf6c46857320",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set longest ORF",
-               "methodName": "setLongestOrf",
-               "jsondocId": "d45f3cad-0b57-4bcd-a5d9-909f3785b271",
-               "bodyobject": {
-                  "jsondocId": "49f3e478-35a7-49d4-b8ce-1296b4167e9a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setLongestOrf",
-               "response": {
-                  "jsondocId": "4f3572f7-7c38-483e-9c37-f32db43dff04",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "7204981a-6b85-4c88-8397-d8ca46fb509a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4404a240-b383-45da-ac34-fdfc55dedd30",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f5004891-5cc9-4a8f-8ec8-2b33aa9e706d",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5ad8232e-ff81-46ab-915a-dc6e4d1725d9",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9efdc313-bf0f-4e16-91a0-78b30957b38d",
+                     "jsondocId": "3e92c0c0-ff5b-4ae7-ab5c-b093bc1b1bcc",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -2500,7 +1715,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "de93163d-4c8a-4364-a739-22e8d9d5f5ae",
+                     "jsondocId": "fc524633-2292-41ee-8f07-de9020655c36",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -2509,7 +1724,171 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "072c2707-c32d-405c-9b44-c89b659d350a",
+                     "jsondocId": "1f0a9804-9a3b-456c-b096-e763aee058bc",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Duplicate transcript",
+               "methodName": "duplicateTranscript",
+               "jsondocId": "4ebc5dd9-0270-41a6-9687-6c40c5009bca",
+               "bodyobject": {
+                  "jsondocId": "21de2d9b-760d-4c11-b959-e09e8ba0cbe9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/duplicateTranscript",
+               "response": {
+                  "jsondocId": "3bb76ad5-c5a9-45c6-9cd0-9936664be4fa",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "a84b12e2-7ba8-4de2-b48b-ec3bc3e4bd4d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6f2d2f84-923b-4e59-8cf1-1a0e6429eecd",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a3f56af1-8a49-49b1-96a0-64c4ece58b83",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a27ee2db-c9b2-4ad5-a902-f988dba1495b",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f9abf687-5666-476e-afd2-da076cb81955",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Merge transcripts",
+               "methodName": "mergeTranscripts",
+               "jsondocId": "1623590b-0321-4309-b20e-89e3715293dc",
+               "bodyobject": {
+                  "jsondocId": "4cc16dfc-cc64-4d9a-bf74-6f38f5ecb8df",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/mergeTranscripts",
+               "response": {
+                  "jsondocId": "4467035d-86bb-4bf1-93cd-eac04f0b6e0e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4da7cd05-9035-4d3b-99f2-db17757181d3",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b8472396-9f58-4b69-b741-21f67feca219",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "59e4f460-4bcd-4901-90b0-a637a1084d7b",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fdcd856d-71ff-4e58-aca5-a085093991b6",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "53d65fe3-f790-4ecf-bd37-932a92ee2c44",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7eb4cbcb-6fae-4973-b950-380ea3c0874d",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fa909ae0-0708-4441-ae8d-97cc4fe84a2a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -2519,11 +1898,11 @@
                   }
                ],
                "verb": "POST",
-               "description": "Set exon feature boundaries",
-               "methodName": "setExonBoundaries",
-               "jsondocId": "88f268a6-a399-4747-a19d-824330275267",
+               "description": "Add non-coding genomic feature",
+               "methodName": "addFeature",
+               "jsondocId": "a652d435-6cb2-4eca-acb9-5f70bdb7bb5b",
                "bodyobject": {
-                  "jsondocId": "5d388432-438f-48e4-b53e-f4629f8c4042",
+                  "jsondocId": "c18a4943-bca2-41c4-9171-12dcbc9b7a31",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2531,9 +1910,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setExonBoundaries",
+               "path": "/annotationEditor/addFeature",
                "response": {
-                  "jsondocId": "66b4296c-e463-48c6-814a-b5a3d59df0a0",
+                  "jsondocId": "c7ce9727-ebc9-4152-99a8-e3d7a752f364",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2546,7 +1925,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "dad0ae62-7c59-4dd3-ab73-ce3841f3978c",
+                     "jsondocId": "adbd9fb0-f97b-4ba9-8dcb-d18d1c57f6bd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2555,7 +1934,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1360de8a-cae8-4fcc-86e2-2727b294d9a1",
+                     "jsondocId": "71d27cd9-23bd-4e0a-acd6-9825774a07f1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2564,7 +1943,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "664e3546-a4e7-47e9-ab27-01395ae3fd7e",
+                     "jsondocId": "07a05265-43e8-4331-a2c8-8abe0ea77311",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2573,7 +1952,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e14042f9-8a30-4b11-b2e2-5566506e9e88",
+                     "jsondocId": "75eca336-0c34-4b72-877f-42fb2cd51c9d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2582,21 +1961,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3e33aa82-e59d-4d60-8e77-0109ec5194ae",
+                     "jsondocId": "c7ee4fba-081e-4d1d-8af4-7df2e47c2733",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Set boundaries of genomic feature",
-               "methodName": "setBoundaries",
-               "jsondocId": "d09144a0-0196-4060-a399-637d64957130",
+               "description": "Set translation start",
+               "methodName": "setTranslationStart",
+               "jsondocId": "975669d1-6971-4a00-8935-01f268de2ba0",
                "bodyobject": {
-                  "jsondocId": "013fab9d-28f6-4bac-8757-02b363552e81",
+                  "jsondocId": "955e9118-26b4-41fd-b2fb-95588283f30f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2604,9 +1983,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setBoundaries",
+               "path": "/annotationEditor/setTranslationStart",
                "response": {
-                  "jsondocId": "673f9211-90b4-4697-a1ac-bd3aceb5187f",
+                  "jsondocId": "f7830fb4-c973-4d92-9d2d-f294cfcced08",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2619,7 +1998,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "210cb334-9b83-43d2-a397-acb0ed8b3cc4",
+                     "jsondocId": "27e2b011-933b-446f-ad4d-7ebbf57a9308",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2628,7 +2007,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4b233720-e301-4c85-a5e8-2e0a03383528",
+                     "jsondocId": "5f81d738-0309-4605-bb6a-057867bd657d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2637,7 +2016,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d76afa14-5f84-41ac-b0c9-86bfe2066429",
+                     "jsondocId": "a3f7d0fa-c977-40ed-8710-769b336b1c5c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2646,7 +2025,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d34625ff-593b-4ca0-af18-af10a0af29c4",
+                     "jsondocId": "b4b40411-b70b-42e6-9082-61616c5a0626",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2655,21 +2034,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66942182-312a-4fa5-8255-71791c01576e",
+                     "jsondocId": "12e4badb-dede-45be-b755-4d32011c9729",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Delete sequence alteration",
-               "methodName": "deleteSequenceAlteration",
-               "jsondocId": "4d869c00-aa74-4a0b-bfe4-78db579bcee9",
+               "description": "Set translation end",
+               "methodName": "setTranslationEnd",
+               "jsondocId": "49eff872-0d5e-4e95-9942-a2619de734e9",
                "bodyobject": {
-                  "jsondocId": "d498cb9f-8a5e-49ae-b110-87234d4471ec",
+                  "jsondocId": "1aa26570-74d4-409e-b181-6c01dd06bf35",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2677,9 +2056,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/deleteSequenceAlteration",
+               "path": "/annotationEditor/setTranslationEnd",
                "response": {
-                  "jsondocId": "fdcc851a-7fb7-48e3-92a2-adf5d7098016",
+                  "jsondocId": "b069a4a0-dab8-4ba2-b14e-61fb4aee0523",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2692,7 +2071,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "254e21a8-ea1e-49e2-b2bc-47c4f53cd207",
+                     "jsondocId": "41cc8aaf-5153-40ca-ad6f-d0b53ba317a2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2701,7 +2080,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "07ae5207-b565-478e-888a-e26e5f47aed1",
+                     "jsondocId": "92c410d9-76cf-4338-b808-96ace1e4d578",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2710,7 +2089,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c072bf9c-2057-410b-ae16-a547b27931f9",
+                     "jsondocId": "67239c9d-e77b-45cc-b830-4780b6f9ebcc",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2719,7 +2098,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d4b0835-7ead-4ac3-8f5c-72e6dce86b1b",
+                     "jsondocId": "34b842bc-bd0a-4eff-bd7b-0295212ba2b9",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2728,153 +2107,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "981066fe-95a8-4f2c-ac97-82bb4459e605",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add sequence alteration",
-               "methodName": "addSequenceAlteration",
-               "jsondocId": "fda05842-82ba-4e32-bdac-f588238c31d4",
-               "bodyobject": {
-                  "jsondocId": "fedcb979-6a13-44cb-b254-5981eed7ebb0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addSequenceAlteration",
-               "response": {
-                  "jsondocId": "9d094546-2a5d-4da7-83a6-7d157b2ce5b0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "513f1dcd-1cab-4e94-b902-13057fb5aa10",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0a2a47e1-085f-4bae-ab7a-4a0cb3793108",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e0f8069c-5982-4a8d-976b-023f74a71f94",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "00e3e366-ad1f-4047-9933-857492f7e193",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9f6ae822-bb5f-412e-9a5f-2194bedc5d3a",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Split exons",
-               "methodName": "splitExon",
-               "jsondocId": "98e93aed-7bdd-4204-8e4c-a6edb30565a9",
-               "bodyobject": {
-                  "jsondocId": "f760ab53-2e28-4693-966d-dc1b4771c260",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/splitExon",
-               "response": {
-                  "jsondocId": "9172a61c-a841-463a-9f71-61090dec74ad",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "5e3d058c-b862-41fa-99a4-22b6dad1dd9c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e3cda6cf-e6ed-4b68-80f0-49b6c15642a7",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f86fa15a-74dc-44f9-8f38-e5a1fe54bc52",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ec876415-db29-4f25-9358-34d83f1a80ed",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ad4bf7da-985b-48ac-ad67-0e3e93316640",
+                     "jsondocId": "13f74896-2a63-46b9-9841-07e6691bfc48",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -2886,9 +2119,9 @@
                "verb": "POST",
                "description": "Make intron",
                "methodName": "makeIntron",
-               "jsondocId": "32760480-1856-4b3a-bfc4-aa9aae8eb1ad",
+               "jsondocId": "5098fdfe-19e7-43bc-badb-1fb71659b2b1",
                "bodyobject": {
-                  "jsondocId": "fc6db65a-ba57-4efd-87cf-172001d7ddff",
+                  "jsondocId": "21103ce5-dcbb-4416-8a69-f9c15d7d1b06",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2898,7 +2131,7 @@
                "apierrors": [],
                "path": "/annotationEditor/makeIntron",
                "response": {
-                  "jsondocId": "1ed0c1d6-2b74-4184-a8a8-10469db812db",
+                  "jsondocId": "2de2d09e-47ab-49c1-b5fe-3b72ab149497",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2911,7 +2144,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1a5046a9-f29a-475c-8cda-f0c3fae8f0d7",
+                     "jsondocId": "3a90f7ef-4100-4421-9f3e-245e7f435e07",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2920,7 +2153,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5f1174e3-ded4-457d-b2b7-08f44fe51794",
+                     "jsondocId": "e81ee5d5-2f2f-4978-a43c-0487e29c96ff",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2929,7 +2162,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "572fc769-a417-4d60-8516-d7c50038854a",
+                     "jsondocId": "65825207-28d0-4212-a825-1c9b6f2623a5",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2938,7 +2171,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4aad307f-60e2-41f0-8a63-05b1fabb0971",
+                     "jsondocId": "6234ab3f-4a2e-4c3e-b122-292be1c7c271",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2947,7 +2180,774 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d3e39b3-cd57-4639-94aa-b7bbf1f5f9ee",
+                     "jsondocId": "57d7e330-fc1e-442c-9b3f-8a0250105aa9",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add dbxref (db,id pair) to feature",
+               "methodName": "addDbxref",
+               "jsondocId": "21cb3c8b-c915-4584-bc9c-79c7abd21935",
+               "bodyobject": {
+                  "jsondocId": "95cc0cb4-e84f-4297-85a8-33f02631f575",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addDbxref",
+               "response": {
+                  "jsondocId": "a975f781-7f70-446c-a4d5-d3f357685ce4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c22e48a9-53f3-49ca-a3a1-c124f330326d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c8fc3ae1-1b49-458d-b670-e0ed99f8690e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ba8c3a0f-b4bd-4f26-b5c2-64feacdbe2cc",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "342a39b9-56e3-483b-a24f-fb4579575c59",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7b31ae15-58c0-48d6-949c-21039b4350e4",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update dbxrefs (db,id pairs) for a feature",
+               "methodName": "updateDbxref",
+               "jsondocId": "7601c37f-33b8-4a9f-a4f3-e2d7e6cf976e",
+               "bodyobject": {
+                  "jsondocId": "2aa51cf8-828e-4705-b549-137a9f760228",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateDbxref",
+               "response": {
+                  "jsondocId": "9d634114-882c-4e7a-bb3e-7cdd59c17c1f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "a12bbe91-2afb-4d3f-a5d4-b031422fca9e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0ceb80c6-8c3c-4f65-83b2-84fb39539eed",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7c51fe56-0a30-42ec-afc2-08ec05cd1a82",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "691525c4-e50b-439c-ac20-d0346861c0fd",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2443656b-7958-4f25-8b8f-80282550182f",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete dbxrefs (db,id pairs) for a feature",
+               "methodName": "deleteDbxref",
+               "jsondocId": "812c24ce-5dc4-49c7-9564-43df4c2f8f89",
+               "bodyobject": {
+                  "jsondocId": "66f16112-99ee-4a4c-ab89-5599d249c810",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteDbxref",
+               "response": {
+                  "jsondocId": "9e9edb7f-9ee4-4553-bb4b-f35414d61121",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "3de03328-facd-4e08-ac67-94e537a0a341",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f62e6017-e371-4b66-9014-7696e2af2c11",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get canned comments",
+               "methodName": "getCannedComments",
+               "jsondocId": "ed2db6fc-1a0f-4ac4-b3d6-df6b3ed7d417",
+               "bodyobject": {
+                  "jsondocId": "57f67adf-207d-45ef-b6f8-f60c39f953e2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getCannedComments",
+               "response": {
+                  "jsondocId": "7bf70f44-a3d9-49e1-9799-1d8ac462e0a1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "69f9d1ed-202b-4ffb-9d85-3b4ce7ed2595",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cb6efc04-ac2d-4c6c-bb33-003a8f9225a8",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "11a2ce14-ec71-4537-8228-32dfb23e3f2e",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get gff3",
+               "methodName": "getGff3",
+               "jsondocId": "9d1cf0bb-7a17-4a0c-bc1f-4ae70a30e4ec",
+               "bodyobject": {
+                  "jsondocId": "e83b3d30-08b0-48f6-9150-61e409f5d5cb",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getGff3",
+               "response": {
+                  "jsondocId": "5ee5d86b-919f-400b-83e6-72f7b928ecb9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "57a40421-67d9-41bb-8b70-7acf86f3c971",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5901ad27-30f7-4ec6-bc28-4e647d82c1a5",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dabe27aa-6cb2-43a1-80a0-27aa2dd77582",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "78eabb7a-801b-47ab-a459-c08cc69c4d70",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get sequence alterations for a given sequence",
+               "methodName": "getSequenceAlterations",
+               "jsondocId": "a2ef266a-fd4c-418e-b443-2ef1f9d4a821",
+               "bodyobject": {
+                  "jsondocId": "c1768212-a9ab-46cf-aee1-1ae2d3cd1c1e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getSequenceAlterations",
+               "response": {
+                  "jsondocId": "2233e0da-4ece-43f8-9d70-c64e596885b6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "9559d5b7-5c9d-4509-94be-82509f741f0d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "94d022e7-6427-4c36-a056-d23c220a054d",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b5d84e4e-50ca-42c8-b2e1-868adcc31341",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4cf79222-e764-4953-b83d-8e4bdf76285a",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "09706b6a-0a99-44d3-a560-e2a33a130556",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete attribute (key,value pair) for feature",
+               "methodName": "deleteAttribute",
+               "jsondocId": "859a3bce-375d-47ca-9042-86550d945a4d",
+               "bodyobject": {
+                  "jsondocId": "c22f77da-a108-468e-a881-8211e694fa52",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteAttribute",
+               "response": {
+                  "jsondocId": "a56b1b26-9c7b-4a9c-a722-76bc3dc10397",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "8f2ef10e-fdfc-4fdb-94d1-18f73f550a29",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "186fe2a0-e435-46e4-8a1e-2246c925cbd4",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3ca8ec68-6d96-445c-b1bb-9f337e00b8ce",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5f4317bd-29bd-4588-b976-716979afe8b4",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9fda2dcc-35c4-429f-846f-ad905110cb77",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update attribute (key,value pair) for feature",
+               "methodName": "updateAttribute",
+               "jsondocId": "bec5f181-feb7-4de7-9eb2-a26e44a258e1",
+               "bodyobject": {
+                  "jsondocId": "efd1fe67-fc2a-4431-8c85-eba806f426d8",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateAttribute",
+               "response": {
+                  "jsondocId": "2b2e046d-6109-40d8-ab72-d7db01c31eec",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6694bff2-13f1-46fe-8417-fbf673be689d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "76439c47-dd36-4e0b-8ab1-212df779138c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1829afb2-527e-43b5-a079-3fe35ea25d94",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b4552fc1-3d7e-4a57-88d0-5f143686a60e",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3b51ee06-bef1-4277-9232-ae2d3b41321d",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set status of a feature",
+               "methodName": "setStatus",
+               "jsondocId": "963fcd80-d2bc-4446-85d9-a60c0b1bbd5a",
+               "bodyobject": {
+                  "jsondocId": "689ed61c-b9cc-4af6-9d5b-4521c5be5185",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setStatus",
+               "response": {
+                  "jsondocId": "7a40d49e-6539-41a8-ab7c-68cf2c281c37",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "96f204d8-2719-461e-a426-ab94cd1d60bd",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "91616daa-9d5c-40b7-aec9-5ef6774b03cc",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e1dae084-a86e-4eb0-b263-8655a534d782",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dff84480-8db2-40b0-9448-601f2bcb55a5",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "87baff9d-5ef3-415c-955b-d81cf4e700bc",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get comments",
+               "methodName": "getComments",
+               "jsondocId": "0c6f0d9c-ac8d-450d-bfa5-e779a7b0320e",
+               "bodyobject": {
+                  "jsondocId": "a16e001e-4381-47f7-8235-e2b171173614",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getComments",
+               "response": {
+                  "jsondocId": "e9efb14f-a3d6-47fa-ac45-d8a275c94bfa",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [],
+               "verb": "POST",
+               "description": "Returns a translation table as JSON",
+               "methodName": "getTranslationTable",
+               "jsondocId": "6afb6809-01c2-4375-acfc-593eb6a5effb",
+               "bodyobject": {
+                  "jsondocId": "36f3dd41-23dd-4001-a8e6-4d990338cf93",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getTranslationTable",
+               "response": {
+                  "jsondocId": "ae343ebd-f9ee-48cf-a9ac-135033cf11b0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "08633fc4-5036-480a-b226-540a38087737",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4a1fd45c-00ba-415d-a03a-66bd8089ec29",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4a002632-9f04-4245-84f3-16ac669fbf07",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "abb7126c-1c0f-494a-9d19-5540b905fc04",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get all annotated features for a sequence",
+               "methodName": "getFeatures",
+               "jsondocId": "8c69361d-f52b-46c7-82a0-fad2a4ad50e8",
+               "bodyobject": {
+                  "jsondocId": "4a9f1d03-9326-4989-8b1d-a7c549c6b1e6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getFeatures",
+               "response": {
+                  "jsondocId": "c9ae45cc-f4c8-4b23-b30b-8aa5d2ea3ab9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "abc0e82d-1ee7-4e4d-97b5-a7cba6e158af",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "db93f056-9394-4b8b-823d-b10ddffff4e5",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "931000c2-be47-4e0b-98ff-1c14657f42ef",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dd7b3050-0378-4ce3-bd81-64ed2030d656",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "15d0685c-ec83-4111-943d-472b4465b556",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
@@ -2959,9 +2959,9 @@
                "verb": "POST",
                "description": "Set name of a feature",
                "methodName": "setName",
-               "jsondocId": "114890b5-5f30-4811-8a21-4b7ee1437b55",
+               "jsondocId": "5c48d901-06fb-4256-a806-2769f3bf863d",
                "bodyobject": {
-                  "jsondocId": "25b03de4-58ca-48d8-946d-fc4fdd404932",
+                  "jsondocId": "b9c6b40a-e4b8-452b-b2b6-9d2c020c9c10",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2971,7 +2971,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setName",
                "response": {
-                  "jsondocId": "07323518-240d-4e80-ae98-a2cebc9fea6d",
+                  "jsondocId": "75cf580b-af58-4830-a646-d6747e63c222",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2984,14 +2984,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "7c441dd0-e31b-4b5f-86fa-dda48cdc42ea",
+         "jsondocId": "5fba0155-6018-46f4-af89-3016a1d4b33d",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7d15067a-0573-48fc-ba27-70131da98bf5",
+                     "jsondocId": "a05eff40-7d59-4263-a83a-eac6c5b294c9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3000,7 +3000,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b0cb6847-75e0-46e1-b655-53d56213ff4e",
+                     "jsondocId": "18b4f703-b000-4e55-b9f2-cfaafef9ec74",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3009,7 +3009,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3747883b-efda-4a66-921b-ef37acd7fc6f",
+                     "jsondocId": "546a61ce-b629-4430-b0e9-22d4c37e6a8a",
                      "name": "name",
                      "format": "",
                      "description": "Group name to add",
@@ -3021,9 +3021,9 @@
                "verb": "POST",
                "description": "Create group",
                "methodName": "createGroup",
-               "jsondocId": "87df70cc-6053-4ef1-b622-61b455fa1fa3",
+               "jsondocId": "47beb054-a9fd-40b1-962d-69680ba7b2c9",
                "bodyobject": {
-                  "jsondocId": "5b482365-90ed-4e6b-87dc-5c84a1c4ae47",
+                  "jsondocId": "9d95cd5e-26b3-415e-aee4-adcafc34f4d0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3033,7 +3033,7 @@
                "apierrors": [],
                "path": "/group/createGroup",
                "response": {
-                  "jsondocId": "81737ca6-0184-4e5b-96a1-b6af010bcbd1",
+                  "jsondocId": "ce7ebb6b-3d7c-41ae-841c-d4b0ce299445",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3046,7 +3046,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "34b68097-60a9-4804-a074-3df938408e09",
+                     "jsondocId": "1496d539-13cb-47e8-8115-a1b026c0209a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3055,7 +3055,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66b92494-0ab3-4638-98a7-ddceaec73377",
+                     "jsondocId": "528e54ef-6776-42c9-a139-1a10fd6cc2f9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3064,116 +3064,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "60722889-e2b5-41be-869c-38ae65c44500",
-                     "name": "groupId",
-                     "format": "",
-                     "description": "Group ID to modify permissions for",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e9f39345-deba-4c84-9c30-fd5a2bc04d4b",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name to modify permissions for",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4bb1d07f-0e4a-4e8a-961b-591c8eaa22cb",
-                     "name": "organism",
-                     "format": "",
-                     "description": "Organism common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "251d2ae8-f957-4e82-b739-956587be4ffd",
-                     "name": "administrate",
-                     "format": "",
-                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "272ec8f3-4acb-4a20-857c-b6f86a1a6b34",
-                     "name": "write",
-                     "format": "",
-                     "description": "Indicate if user has write privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "af5188d8-fbf7-4f2d-b4c4-61d5cf6971b6",
-                     "name": "export",
-                     "format": "",
-                     "description": "Indicate if user has export privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bbcbc7ee-43a3-443d-a1a5-12ad3a8aa02f",
-                     "name": "read",
-                     "format": "",
-                     "description": "Indicate if user has read privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update organism permission",
-               "methodName": "updateOrganismPermission",
-               "jsondocId": "e31f80e3-ead1-4dde-87e1-77aeeaf4cdb4",
-               "bodyobject": {
-                  "jsondocId": "4cdd4456-e243-4c70-9c90-c2efaad1acae",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/updateOrganismPermission",
-               "response": {
-                  "jsondocId": "999a331a-b0fa-4629-bd14-2b015f698074",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "ee3afaeb-58e9-4be1-bfcb-70c5941418e6",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7e867e98-5f60-4941-937b-55b99cbad710",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d3c17bd6-9bde-4a1c-8774-7d519ce08e42",
+                     "jsondocId": "d474715d-cb1d-4f0d-a1f6-df7061e0674a",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -3182,7 +3073,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44878288-404a-4476-943f-66446d50cff8",
+                     "jsondocId": "fcc305e5-a0b4-4556-8d23-e6b36a92a8d7",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -3194,9 +3085,9 @@
                "verb": "POST",
                "description": "Get organism permissions for group",
                "methodName": "getOrganismPermissionsForGroup",
-               "jsondocId": "a861dcdc-7dd2-44da-b200-36a50cfe1aee",
+               "jsondocId": "08c62e5a-b971-4adc-a3cb-d763ce7a5d07",
                "bodyobject": {
-                  "jsondocId": "89384e81-da87-488a-b339-a0aa1e00fe00",
+                  "jsondocId": "1e107223-bf18-4058-816d-9611651e923f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3206,7 +3097,7 @@
                "apierrors": [],
                "path": "/group/getOrganismPermissionsForGroup",
                "response": {
-                  "jsondocId": "fb061119-8d23-4adb-b02b-708b49b47c5e",
+                  "jsondocId": "8654afba-6c5e-49b1-b4ca-b83ccac5f25b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3219,7 +3110,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "30821be1-dde2-4d76-bc1c-1a4c04732094",
+                     "jsondocId": "0c480dd4-783b-4f00-8116-6145b90da7da",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3228,7 +3119,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2fefba03-5f72-43d4-888d-59036e382c1c",
+                     "jsondocId": "da83fd9b-13ab-40a1-b600-b254e88e0383",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3237,7 +3128,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49c38a75-0576-4776-990a-1413a19b2c55",
+                     "jsondocId": "a8d05cc2-74e6-41b0-ae1c-64294cd1f112",
                      "name": "groupId",
                      "format": "",
                      "description": "Optional only load a specific groupId",
@@ -3249,9 +3140,9 @@
                "verb": "POST",
                "description": "Load all groups",
                "methodName": "loadGroups",
-               "jsondocId": "8a8b2c34-bd54-4ec9-8fff-b369147da79c",
+               "jsondocId": "cbcec83d-a721-4205-8244-c22e7d089540",
                "bodyobject": {
-                  "jsondocId": "0309a289-5e8f-4329-b201-67d8c676d932",
+                  "jsondocId": "4acf6608-6c7d-4589-8251-7f7a43edd234",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3261,7 +3152,7 @@
                "apierrors": [],
                "path": "/group/loadGroups",
                "response": {
-                  "jsondocId": "3782c771-121b-4ce1-aa9e-88520aa8b64e",
+                  "jsondocId": "2eb17b5d-2561-4ad1-b3a0-c6b0d0ae76a4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3274,7 +3165,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f4e48909-23e1-452a-b404-11607cbb55f4",
+                     "jsondocId": "b35adcbf-6405-42d0-807d-1a4c9d024f95",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3283,7 +3174,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8add6e23-1203-4d0e-b944-50cfaca898a8",
+                     "jsondocId": "6f0159e4-d957-4e7c-b618-8c3099806f57",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3292,7 +3183,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f0d7a0de-95ec-4fc2-91bc-695bd1ea4508",
+                     "jsondocId": "0dd46541-b0e7-4df1-89a3-9aa71e4f17a4",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to remove (or specify the name)",
@@ -3301,7 +3192,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "663976f7-b46a-45dc-89e8-998b8befd973",
+                     "jsondocId": "5f4c71cb-325a-4674-b0d4-53c52cc03a9c",
                      "name": "name",
                      "format": "",
                      "description": "Group name to remove",
@@ -3313,9 +3204,9 @@
                "verb": "POST",
                "description": "Delete a group",
                "methodName": "deleteGroup",
-               "jsondocId": "13c85a26-628f-45ad-ae78-186676f79f37",
+               "jsondocId": "c28a7516-3bba-4472-84e2-38d4110f64b0",
                "bodyobject": {
-                  "jsondocId": "0f2e1317-c9d4-4788-b0f0-e9a4febb500a",
+                  "jsondocId": "7dcbb6c8-2d3a-4d05-8027-67bb5aba61da",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3325,7 +3216,7 @@
                "apierrors": [],
                "path": "/group/deleteGroup",
                "response": {
-                  "jsondocId": "b5e60b03-42d9-4811-a671-82a86f15574e",
+                  "jsondocId": "e7ef9ddb-7e49-441c-a118-d3df59ba4803",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3338,7 +3229,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ddb5c53b-6390-4bda-9f8d-8104239c6241",
+                     "jsondocId": "fff40571-63f3-495f-b863-37faccbdcd25",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3347,7 +3238,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3f93c4f5-58f7-457c-a6cf-4ea827cf4126",
+                     "jsondocId": "65842105-75e3-46c7-8846-51c71fe413a6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3356,7 +3247,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "329f3221-a05d-434d-a887-114da70e609b",
+                     "jsondocId": "fe6c77e4-dd32-4052-9f03-443974bd9a92",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to update",
@@ -3365,7 +3256,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a83b3d5c-894e-48f2-ae0d-5ea2963e4f8a",
+                     "jsondocId": "21652465-9870-49c4-adec-1c454290e2e4",
                      "name": "name",
                      "format": "",
                      "description": "Group name to change to (the only editable optoin)",
@@ -3377,9 +3268,9 @@
                "verb": "POST",
                "description": "Update group",
                "methodName": "updateGroup",
-               "jsondocId": "719ba585-9a3c-4bec-9fe0-9d0ba0560845",
+               "jsondocId": "64ef7de6-f6ff-47e3-b4c9-d23423dec5cd",
                "bodyobject": {
-                  "jsondocId": "9c44fe27-23fb-4179-877f-4891b5cbf326",
+                  "jsondocId": "5d9fd750-c54c-4a89-9da4-ff2dfc625b50",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3389,7 +3280,7 @@
                "apierrors": [],
                "path": "/group/updateGroup",
                "response": {
-                  "jsondocId": "b94b3faa-472b-4c91-a13c-66d24ad95868",
+                  "jsondocId": "f16c2198-d674-4846-b7bf-b62ad27d6dae",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3402,7 +3293,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fff3d2db-f5da-4ab0-b47b-fe779c834775",
+                     "jsondocId": "72aa9420-3da6-4ef1-ac2e-cd50a7fb1e25",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3411,7 +3302,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "673bd991-48be-41c6-939c-1818e962a81d",
+                     "jsondocId": "60c7db30-20a0-47f3-85b5-cef4d4831aea",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3420,7 +3311,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dcd844c2-3343-4695-a1da-f3a9c56e934c",
+                     "jsondocId": "cdb7c96e-3851-4aec-860d-305a60e1b10c",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -3429,7 +3320,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "70e9494c-1994-4a18-a6c5-ec87bfc5f7c2",
+                     "jsondocId": "082ca98d-dd72-475b-bfa4-b7597d245f91",
                      "name": "user",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -3441,9 +3332,9 @@
                "verb": "POST",
                "description": "Update group membership",
                "methodName": "updateMembership",
-               "jsondocId": "540fb3b8-4622-4ea1-94bd-fac971e80a21",
+               "jsondocId": "7e177af1-04d6-4094-b2c8-14e8df832eb1",
                "bodyobject": {
-                  "jsondocId": "7f2d222e-09ff-4d44-9aa6-fb9d42c91d51",
+                  "jsondocId": "fbac1471-bafe-477c-81ee-a15a0c728f5c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3453,7 +3344,116 @@
                "apierrors": [],
                "path": "/group/updateMembership",
                "response": {
-                  "jsondocId": "eef9c2bc-9b95-46df-a502-1ad1fe1e66b1",
+                  "jsondocId": "317ac0d3-27e7-4690-91dc-56040f146e71",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5ac2b023-673b-479b-b71b-4566ec94b8f8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "da54d668-4661-44eb-bbf4-2da133c05be8",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6c760a5f-b5cb-4202-a85f-1f452786139e",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Group ID to modify permissions for",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b7248882-b30e-4aa2-946d-d8f9eb50c4f0",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to modify permissions for",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7bafd6ae-f730-4d4c-9a18-6cc3e683a8b8",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Organism common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "13e96d43-7f71-4e58-be74-5dc82eb9043d",
+                     "name": "administrate",
+                     "format": "",
+                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3ec90e8c-0b5b-446d-bc77-028e229a89e6",
+                     "name": "write",
+                     "format": "",
+                     "description": "Indicate if user has write privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "de8a1949-ae14-49fd-9904-89777b7354e4",
+                     "name": "export",
+                     "format": "",
+                     "description": "Indicate if user has export privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "854ae240-39d3-4fbd-a3b1-8ee85fe5d672",
+                     "name": "read",
+                     "format": "",
+                     "description": "Indicate if user has read privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update organism permission",
+               "methodName": "updateOrganismPermission",
+               "jsondocId": "44715be7-2b16-4932-98dc-432c497d6f3a",
+               "bodyobject": {
+                  "jsondocId": "3d2a3a17-2ef4-428c-863b-e9854da70277",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/updateOrganismPermission",
+               "response": {
+                  "jsondocId": "d3237b91-8e02-4ccd-91b2-2282c8dd3c62",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3466,14 +3466,14 @@
          "description": "Methods for managing groups"
       },
       {
-         "jsondocId": "948213fd-b7da-4cd4-a2f4-aa1537c98d0b",
+         "jsondocId": "2485a575-ceb0-441d-af79-7622d52f4a43",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7871157c-8af1-4228-8d40-37446f86cf23",
+                     "jsondocId": "73601cac-65b4-41de-80f8-a90e8d0f1f4b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3482,7 +3482,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "658d86e5-ab63-46eb-8199-8587b2173d22",
+                     "jsondocId": "0bac49ab-2291-4129-bbfc-c043c1aa44e9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3491,7 +3491,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a3de3794-5808-4e7a-b4a4-8ee080c167d9",
+                     "jsondocId": "67b61d7e-022a-4267-9c0e-4e48e64358ad",
                      "name": "uuid",
                      "format": "",
                      "description": "UUID that holds the key to the stored download.",
@@ -3500,7 +3500,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3564bbd3-19e7-47a8-aecc-8ce0e8c7627d",
+                     "jsondocId": "bdbff313-4397-4077-bf04-a235e964a8cf",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -3512,9 +3512,9 @@
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
                "methodName": "download",
-               "jsondocId": "a2d0f350-42ca-401d-b7aa-0925a929314f",
+               "jsondocId": "6ba72458-1020-4ef0-bd8c-0c606a18dc9a",
                "bodyobject": {
-                  "jsondocId": "4e9001ca-a3b1-47ec-81cd-dbac5314c318",
+                  "jsondocId": "ec4718a5-a683-4dcc-b605-369b0a6314b2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3524,7 +3524,7 @@
                "apierrors": [],
                "path": "/ioService/download",
                "response": {
-                  "jsondocId": "0aa163b3-85dc-4e9b-ac63-70a75d0ef3ee",
+                  "jsondocId": "765572ea-0f0c-440a-9144-2be3e0e3ca63",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -3537,7 +3537,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "14881869-f128-4a23-9d0a-996971cf4b07",
+                     "jsondocId": "4763738c-9fca-42ac-a7e5-10887678d7e1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3546,7 +3546,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d456d3b-b936-458c-afaa-00096c189ccf",
+                     "jsondocId": "5b70fc05-237c-438b-bc57-16889ea9852b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3555,7 +3555,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2e3e3931-57a9-4c8f-ae00-5e0e6fdc839b",
+                     "jsondocId": "88c77e6e-05ea-4fb2-a509-d574dba72085",
                      "name": "type",
                      "format": "",
                      "description": "Type of export 'FASTA','GFF3'",
@@ -3564,7 +3564,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14bf337c-2ba0-43ab-b4dc-3c7a5617a3da",
+                     "jsondocId": "38b94bc0-c0cf-4573-91b3-93d9b6919a95",
                      "name": "seqType",
                      "format": "",
                      "description": "Type of output sequence 'peptide','cds','cdna','genomic'",
@@ -3573,7 +3573,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1994c0d3-cb53-4cc8-a81f-dc9a81516e98",
+                     "jsondocId": "95a3abaf-fcc5-46fc-80a3-e8e4e4b14754",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -3582,7 +3582,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cd13622c-0f77-4f5b-a589-d5db0a93868e",
+                     "jsondocId": "bd01d53c-4144-45a6-8310-7a415a33584c",
                      "name": "sequences",
                      "format": "",
                      "description": "Names of references sequences to add.",
@@ -3591,7 +3591,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1a67350c-f5b0-498a-9cd3-e1c03009f049",
+                     "jsondocId": "ba78095f-c8d2-4fd2-a717-2dff6b390a21",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism that sequences belong to.",
@@ -3600,7 +3600,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4a7ead99-10bf-4eec-bc65-51177e6a9f28",
+                     "jsondocId": "6e7c8b62-20d3-44d4-ab34-d2638f35a947",
                      "name": "output",
                      "format": "",
                      "description": "Output method 'file','text'",
@@ -3609,7 +3609,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7003bada-eea5-402d-b7c3-cc783e574a7a",
+                     "jsondocId": "5b0e21b7-d376-4da9-b3ba-efb89d42fe75",
                      "name": "exportAllSequences",
                      "format": "",
                      "description": "Export all sequences for an organism (over-rides 'sequences')",
@@ -3618,7 +3618,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a5179a7f-1dc5-413b-a2e2-520c04aadd0e",
+                     "jsondocId": "446e77d2-3766-4dea-9200-17bc41b2dbc6",
                      "name": "exportGff3Fasta",
                      "format": "",
                      "description": "Export sequences when exporting gff3",
@@ -3630,9 +3630,9 @@
                "verb": "POST",
                "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "methodName": "write",
-               "jsondocId": "3be6065c-0aae-42ae-aa09-bf1f88a4328f",
+               "jsondocId": "05962c36-3ac2-4b33-9c94-518a54b01012",
                "bodyobject": {
-                  "jsondocId": "d6df77c0-076c-4c12-8285-8eb8c2e335a1",
+                  "jsondocId": "82837b96-2c5a-48e0-a844-da922e5becdd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3642,7 +3642,7 @@
                "apierrors": [],
                "path": "/ioService/write",
                "response": {
-                  "jsondocId": "b19402da-776c-4c9a-b04e-82d96171784a",
+                  "jsondocId": "cd0ad3a3-fbb8-4625-a5de-c01a8304a29b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -3655,14 +3655,14 @@
          "description": "Methods for bulk importing and exporting sequence data"
       },
       {
-         "jsondocId": "89ef57c5-ea63-42dd-ba12-4dd32e328ce9",
+         "jsondocId": "269d81cd-df01-4a52-896d-d909f5a3a791",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c095d811-085b-491c-9b4e-58a43055580e",
+                     "jsondocId": "4cf36881-ac78-405e-819b-01746c40efef",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3671,7 +3671,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "21e80e06-cb83-4954-b7b7-664d7a9492d7",
+                     "jsondocId": "d610a160-ec85-4011-a4d4-9c5da70a3885",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3680,7 +3680,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fe7dc85e-f84f-4029-a828-ea157f17e5b7",
+                     "jsondocId": "dc3c4337-c476-492f-a6c6-c782433659e6",
                      "name": "organism",
                      "format": "",
                      "description": "Pass an Organism JSON object with an 'id' that corresponds to the id to delete",
@@ -3692,9 +3692,9 @@
                "verb": "POST",
                "description": "Remove an organism",
                "methodName": "deleteOrganism",
-               "jsondocId": "a4cda158-bcee-4c7b-bdc8-ef9efdac4fce",
+               "jsondocId": "571220fe-2dae-4592-9607-7bb8638e82ad",
                "bodyobject": {
-                  "jsondocId": "058869f9-01b1-4260-9b20-06d9ec249ddc",
+                  "jsondocId": "821496ef-e20c-4d46-bdeb-cae1de9d4c09",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3704,7 +3704,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganism",
                "response": {
-                  "jsondocId": "ab2098f9-05f0-4dc3-801d-b9171672bc9d",
+                  "jsondocId": "bdfc35f7-4c7d-463b-a9ab-f2e2b65d8020",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -3717,7 +3717,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e6c12161-cf67-4d19-b759-7ec6a98d955f",
+                     "jsondocId": "974997b1-ea44-486e-97d5-33042305e8f3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3726,7 +3726,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ec504b1a-52e9-45c8-b083-2d61479f23d7",
+                     "jsondocId": "c24f8147-e01d-4185-9685-439e524b3401",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3735,7 +3735,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fb2ce7cc-2388-4df8-8464-f5fbb4a9307b",
+                     "jsondocId": "6f531825-6488-4595-a7d7-b6a96e13d485",
                      "name": "organism",
                      "format": "",
                      "description": "An organism json object that has an 'id' or 'commonName' parameter that corresponds to an organism.",
@@ -3747,9 +3747,9 @@
                "verb": "POST",
                "description": "Remove features from an organism",
                "methodName": "deleteOrganismFeatures",
-               "jsondocId": "4548af2e-c87a-4659-8dcd-d65a70d5500f",
+               "jsondocId": "249fbbe9-9c32-462e-822d-d0d0016d5dbf",
                "bodyobject": {
-                  "jsondocId": "440119a1-d468-449a-a87e-da1c97945d3d",
+                  "jsondocId": "e7eaadca-fdf8-4329-9905-b29e73203fd0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3759,7 +3759,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
                "response": {
-                  "jsondocId": "ca2c071b-5a6e-4653-b379-5524c75d7f67",
+                  "jsondocId": "435e54c6-5deb-4100-906f-c123fd29cd5c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -3772,7 +3772,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e5f12fad-f754-4c29-a7ef-114d5ac891f3",
+                     "jsondocId": "8e2b68a2-4a8d-40db-bf73-fe17ad973ef3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3781,7 +3781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "deb38f92-fcb3-4033-b147-99d9219266a7",
+                     "jsondocId": "8ffb468f-85e7-49db-8a24-acf7e141fb36",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3790,7 +3790,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1eca5cd9-2253-47bd-867c-afdfa4103628",
+                     "jsondocId": "dcb788b9-766e-4237-bd73-f2caacd885d8",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -3799,7 +3799,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d2e555d9-294e-42e5-b727-6e15ba5800bc",
+                     "jsondocId": "21697d6f-8c78-4579-afc0-8c9e1895d610",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -3808,7 +3808,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c41ff996-2ca3-4651-93a9-1f2793ba473a",
+                     "jsondocId": "afc0fecb-0479-4323-97a5-5883cc9ed470",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -3817,7 +3817,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "017da2bd-34fe-43d0-8bc0-268ee61d76fe",
+                     "jsondocId": "058851d4-99f6-4d80-96aa-9c597cf5478f",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -3826,7 +3826,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "16290516-95fc-4005-b329-a1846eec78ab",
+                     "jsondocId": "15095eb9-2ab3-4375-8f4a-f82382c6260d",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -3835,7 +3835,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c052837f-94b2-4caf-8114-019e8007b62b",
+                     "jsondocId": "fa854cc8-7690-41ba-b270-8f895d736415",
                      "name": "commonName",
                      "format": "",
                      "description": "a name used for the organism",
@@ -3847,9 +3847,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganism",
-               "jsondocId": "19f2dde7-92ba-4ab7-b4d3-8b8e2f706b53",
+               "jsondocId": "f7f73fd2-4ffb-4854-b2cf-be7a7e23acb0",
                "bodyobject": {
-                  "jsondocId": "881746b0-0447-48a5-857a-7b99ab1b81e3",
+                  "jsondocId": "f97964bc-3522-411f-9e79-f43fd6da7a5a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3859,7 +3859,7 @@
                "apierrors": [],
                "path": "/organism/addOrganism",
                "response": {
-                  "jsondocId": "08f4bf6a-984f-42da-8461-9272facc4d21",
+                  "jsondocId": "321de043-e3f8-4c21-99cb-dc62aec620aa",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -3872,7 +3872,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "20be3cea-2093-4dee-912a-d86ddf2a7689",
+                     "jsondocId": "ea729eb6-c7b9-4121-8653-f946878f770e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3881,7 +3881,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "871393f1-f818-4435-a879-82203e127eac",
+                     "jsondocId": "3a53a8af-c097-41ab-a5b7-af0cc661f3ea",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3890,7 +3890,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "936f69af-d482-4e98-a727-d4ae5e66ca14",
+                     "jsondocId": "56914841-9a82-4804-9514-528e30b00be3",
                      "name": "organism",
                      "format": "",
                      "description": "Common name or ID for the organism",
@@ -3902,9 +3902,9 @@
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
                "methodName": "getSequencesForOrganism",
-               "jsondocId": "1e2a1677-edad-405b-96f5-b06f448ae1a3",
+               "jsondocId": "ed86ddd4-f13d-4abf-b119-99f53546d174",
                "bodyobject": {
-                  "jsondocId": "6e5f5772-4a3c-44a3-bd1d-93a11da3dcd4",
+                  "jsondocId": "0c664fc6-6b01-4a03-a14f-deeead81782e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3914,7 +3914,7 @@
                "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
                "response": {
-                  "jsondocId": "f112bcd7-ea79-43cc-97a9-55d7c2160cfc",
+                  "jsondocId": "047c12e7-a2b0-40a7-b518-3a470ece13a7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -3927,7 +3927,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9f3f1879-d45e-48e1-a3de-0eb1b3e83d87",
+                     "jsondocId": "4af5a416-1af9-489a-a78c-e45dcd4959a4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3936,7 +3936,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7a7d0e6a-26c9-47cd-9dc0-bc654b2fa61b",
+                     "jsondocId": "1762a76a-cf67-4fe2-8f06-fa2c0c91e2ca",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3945,7 +3945,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "efa5ef97-466a-4588-9fa9-6558377ccb11",
+                     "jsondocId": "5cbe69c8-a2c3-40df-94a3-eb6b895356ee",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -3954,7 +3954,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e83dc3dd-2242-48d9-93af-3269c1edbd4d",
+                     "jsondocId": "70daf934-8320-429b-9c2d-b4946003ffe7",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -3963,7 +3963,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "858b7faf-02bd-4753-be53-5a5df49a95d0",
+                     "jsondocId": "6c420b43-bb88-46c7-8a1f-0dfca09f3f63",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -3972,7 +3972,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "75183079-4aed-45ab-ab9e-b22cd9a1e6e5",
+                     "jsondocId": "988231d0-304f-4ff3-a142-7a282e90d9ea",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -3981,7 +3981,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1cc8f4a-fe75-4478-93f3-b34f87082d7d",
+                     "jsondocId": "b376c5b3-ea86-42c7-804e-4b02f5f257e6",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -3990,7 +3990,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9fb5aab1-6ba0-46bf-b294-ab2391c9912d",
+                     "jsondocId": "b4503b95-7732-4f09-b27d-ab878a566bd1",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -3999,7 +3999,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "458ecfb6-d6c0-46d1-a0ff-f02250cb6207",
+                     "jsondocId": "738ab3ba-87ae-43fd-98e3-0e934cbfa82f",
                      "name": "name",
                      "format": "",
                      "description": "a common name used for the organism",
@@ -4011,9 +4011,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "updateOrganismInfo",
-               "jsondocId": "5bc90bcc-8f73-480a-8b0e-0730aa097015",
+               "jsondocId": "13c13b6e-82b6-4218-8d53-31af9c5c33e0",
                "bodyobject": {
-                  "jsondocId": "8306d222-bf65-49dd-b777-8b895834ae35",
+                  "jsondocId": "d7d08780-8401-4841-9607-4c46e5984a5d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4023,7 +4023,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismInfo",
                "response": {
-                  "jsondocId": "6e8ae37a-9af7-4834-9491-0a9736737008",
+                  "jsondocId": "acfb4315-35d9-45de-b9be-99d071ed475e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4036,7 +4036,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0ea1ad20-5737-42ab-932b-40d79ff16b9d",
+                     "jsondocId": "afc05988-f61c-4b06-bb33-f08656e0d659",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4045,7 +4045,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3cbfdd3f-b993-46cd-bad6-b09629fa0b76",
+                     "jsondocId": "8174fabb-20e6-44f0-b553-83b24b126829",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4054,7 +4054,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44d9c329-5dd2-4953-920b-3f929c1f046f",
+                     "jsondocId": "ec096a96-9e71-48b5-85be-c545862e5d69",
                      "name": "organism",
                      "format": "",
                      "description": "",
@@ -4066,9 +4066,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "methodName": "findAllOrganisms",
-               "jsondocId": "b90c3ebf-baec-4242-ad6d-e2877cdfe0ad",
+               "jsondocId": "82c23f66-55a1-45fe-86c1-cae79d402d76",
                "bodyobject": {
-                  "jsondocId": "ff470acf-23f2-4ad5-87e9-2ffa5d0af06b",
+                  "jsondocId": "a4c90a88-d1fb-4bd6-94bd-3b885e7c1061",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4078,7 +4078,7 @@
                "apierrors": [],
                "path": "/organism/findAllOrganisms",
                "response": {
-                  "jsondocId": "43c0e9f0-1f85-4fa2-ac61-0af44d835dd9",
+                  "jsondocId": "c6b6c7d4-4d4c-4c58-9bcf-a4d22756187d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4091,14 +4091,14 @@
          "description": "Methods for managing users"
       },
       {
-         "jsondocId": "199aab01-21bf-4bea-9192-7ff6fdac9544",
+         "jsondocId": "85ad0c8a-e5ed-428b-83be-4486c1864cc2",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "703756fc-666e-4b3b-b22d-f5344648070b",
+                     "jsondocId": "ac8e5f2c-d97a-4bc5-b538-fb7fc5bab272",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4107,7 +4107,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f1401f9-f266-4018-856f-2e7a532adbf4",
+                     "jsondocId": "5daebf05-d3a2-4538-abab-80aac0c69063",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4116,563 +4116,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e0ba2315-ce7c-426c-beee-8ea9f988c222",
-                     "name": "userId",
-                     "format": "",
-                     "description": "Optionally only user a specific userId",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Load all users",
-               "methodName": "loadUsers",
-               "jsondocId": "d94dc1d1-3352-445e-9e4d-88654c837a84",
-               "bodyobject": {
-                  "jsondocId": "3b920df7-4a96-4f01-bb6c-acc796362de0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/loadUsers",
-               "response": {
-                  "jsondocId": "fcf8ce10-8661-435e-94d1-3c220f70e486",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "5695a3a0-45a4-4b2f-97ca-d51299e18d5a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2d13185e-7b4f-495c-9331-34c0f1a7cb6c",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f14a0fbd-e1d4-4a25-ad3d-67be51678f0c",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "850ca007-6d34-4153-8101-7455e827eda0",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "78c25987-8b7d-4efa-b5a7-9c202121b4b6",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add user to group",
-               "methodName": "addUserToGroup",
-               "jsondocId": "d679660e-a7f3-4714-a3a1-177e78e699e0",
-               "bodyobject": {
-                  "jsondocId": "f68073d9-cd03-440d-bbc9-144b528a0ae7",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/addUserToGroup",
-               "response": {
-                  "jsondocId": "b1fa1dea-49b6-4de2-83df-959867963421",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "2aeea3a3-d8ac-4c4d-b5c7-351e7af68ec8",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "75917c4f-bdfb-4347-ad8c-f04504de4d0d",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5815b25b-5450-480b-b1b3-9c60903371b5",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "84676c1a-5235-469c-a16e-62a6917f1710",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "29148575-da2c-4f5d-9b15-546ab84f4e02",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Remove user from group",
-               "methodName": "removeUserFromGroup",
-               "jsondocId": "54fcc40e-d441-4b53-8247-a738730848d3",
-               "bodyobject": {
-                  "jsondocId": "2b1c0a7e-a96b-493a-8da4-bbac4c47bdcc",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/removeUserFromGroup",
-               "response": {
-                  "jsondocId": "175b3ca8-c17d-4c06-b0fa-fe30e99c667e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "e91c9be6-4549-4d32-be31-2a98cb0d90cb",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ec4261a2-bb45-4d71-a098-e4b2a5dd60c7",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "372a777a-2e4e-42d0-9e30-61270d261a5c",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to add",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e597957e-9923-47b5-8b29-09be952aa7d6",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "aac9efc2-d189-45a0-a82e-f4fe8abfca84",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1e22482a-d0ef-436c-891f-67c5bca60e98",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create user",
-               "methodName": "createUser",
-               "jsondocId": "bc9ef75e-bfd9-49da-b6d1-2b5eaa9bf00a",
-               "bodyobject": {
-                  "jsondocId": "6429f2bd-e80a-4f82-b602-0a7182f6f05b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/createUser",
-               "response": {
-                  "jsondocId": "5b9c3bab-167f-4ba8-8a37-e1173ce66c1e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "b814e9f0-d3c8-49e2-bb4a-07f3f4dc14c2",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4973a319-de82-4332-ab0d-d4a63019f8fb",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "31b62e33-b42c-45e5-aa9e-00b606456394",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to delete",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "50d1f757-09b1-4a8e-b88e-ab1d86f80608",
-                     "name": "userToDelete",
-                     "format": "",
-                     "description": "Username (email) to delete",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete user",
-               "methodName": "deleteUser",
-               "jsondocId": "6a21c6d9-da0a-457e-b77a-ee740510017f",
-               "bodyobject": {
-                  "jsondocId": "6e0bf224-30b8-46d7-9bae-36a6d8a7971b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/deleteUser",
-               "response": {
-                  "jsondocId": "974e12c0-18f7-4806-be6f-bf1f52e899b2",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "d5676b94-b4b0-488c-b8aa-12902d0a4190",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "30283417-2364-4d60-a5b9-9828fdef6d67",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3d4d16f4-c731-4401-8789-9dad69991f52",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to update",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "73d8f2ca-3491-4518-8f06-a3212af1604b",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to update",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6cbb5bf5-2c8e-48e9-bc1d-f42559ee61f9",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "36ca9cba-c2ac-4145-af9d-8f98f57956a9",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "193b8e13-a756-4337-badf-70e7ae0a3996",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update user",
-               "methodName": "updateUser",
-               "jsondocId": "1d43778f-ab33-4a5f-b4ff-2ab53ef3141b",
-               "bodyobject": {
-                  "jsondocId": "b2f2b24d-0c7c-4397-a278-6e40cbffe248",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/updateUser",
-               "response": {
-                  "jsondocId": "1424eabb-25a8-4301-926e-77bfa7a18a55",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "a85043d0-b7ac-46cc-94a2-7847f38342d4",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d5f863de-148b-4cc3-bf96-e13b0e0e67c1",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "481cfd51-2332-4883-ad09-d831c51431be",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to modify permissions for",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "8a5b5e2b-a0af-4a6c-a60b-060822f264b0",
-                     "name": "user",
-                     "format": "",
-                     "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0d09e8e9-cc6e-48b3-91fb-9582990d7966",
-                     "name": "organism",
-                     "format": "",
-                     "description": "Name of organism to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "90302d31-44e4-4064-92b3-f21855beb77f",
-                     "name": "id",
-                     "format": "",
-                     "description": "Permission ID to update (can get from userId/organism instead)",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b683455c-34f2-4108-948c-89842e9ffa30",
-                     "name": "administrate",
-                     "format": "",
-                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "88ac35c5-12a9-42eb-948e-6ac08db54527",
-                     "name": "write",
-                     "format": "",
-                     "description": "Indicate if user has write privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f01a6554-53d2-4491-86bb-8346f9b30ae0",
-                     "name": "export",
-                     "format": "",
-                     "description": "Indicate if user has export privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9bb0a052-977c-40ca-b992-2f2a6c51ec54",
-                     "name": "read",
-                     "format": "",
-                     "description": "Indicate if user has read privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update organism permissions",
-               "methodName": "updateOrganismPermission",
-               "jsondocId": "b76779f9-aaf5-463e-a660-ca6a63a9668a",
-               "bodyobject": {
-                  "jsondocId": "9399a6b8-6552-4db6-bbb5-55bf82b022d4",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/updateOrganismPermission",
-               "response": {
-                  "jsondocId": "5b0a37b0-6a26-478b-8006-ab85b70b6448",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "3e185fa8-edf9-40a9-afb4-969e41dbed09",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a426dc5a-b54c-4163-938c-c4c669f7e56d",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4d00b18b-c14e-4a30-88e6-dcc63a5f6f34",
+                     "jsondocId": "e7ab3af1-138a-49f3-9d21-c327d6051aab",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to fetch",
@@ -4684,9 +4128,9 @@
                "verb": "POST",
                "description": "Get organism permissions for user, returns an array of permission objects",
                "methodName": "getOrganismPermissionsForUser",
-               "jsondocId": "965e6a95-86e3-41ed-86b6-f19447918100",
+               "jsondocId": "a4b347f9-f4e7-478b-8b2b-78aca6c2be8d",
                "bodyobject": {
-                  "jsondocId": "cf4ef688-ac65-419e-bd71-a0207634ea74",
+                  "jsondocId": "264768f2-3f26-451d-b1af-bda394e21daa",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4696,7 +4140,563 @@
                "apierrors": [],
                "path": "/user/getOrganismPermissionsForUser",
                "response": {
-                  "jsondocId": "266122d3-f421-4297-86cd-d95ab623ce86",
+                  "jsondocId": "da1c0370-021c-4bd4-b282-4b4e609df7a1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "cb887363-6fe9-4d31-89fe-5b5bf2c8c38f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "56cab4f4-fdc5-49a6-8adf-151dbfa0d421",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dc26d46d-4009-4ae6-8ed7-0c31397bc1c4",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "28132b2e-a07e-47f3-ae3e-dc9d42a72ff2",
+                     "name": "userToDelete",
+                     "format": "",
+                     "description": "Username (email) to delete",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete user",
+               "methodName": "deleteUser",
+               "jsondocId": "d77e64b2-735a-4a86-a60f-aea6c1bdf4b9",
+               "bodyobject": {
+                  "jsondocId": "6a5fbc96-8831-409b-9ca8-a09c67a30345",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/deleteUser",
+               "response": {
+                  "jsondocId": "224fc808-b009-47e3-92a8-575636811545",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c11c55f7-86b1-406b-8642-343472b5c136",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "15a87b35-1061-46ba-8714-a63c7b5fe08b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "68c7e309-b23b-4bbc-8eba-f1766194a17a",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to update",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3240268f-2697-4d3e-bd12-d2f8dab2b86b",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to update",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ccd46408-7b2b-4b8a-b074-7650fa8b38ce",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4bff59da-d29a-47d0-9747-4ad9701f2aa2",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8d0d86c9-e2b0-4096-9e2a-89519350b911",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update user",
+               "methodName": "updateUser",
+               "jsondocId": "078e9b30-8e10-4d31-bb58-e5612ed85f2f",
+               "bodyobject": {
+                  "jsondocId": "5f28c119-1f1c-4e60-9b7b-ef7ca1a1e9f2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateUser",
+               "response": {
+                  "jsondocId": "a3af3774-b56b-427b-8a19-6ac67c2c43ae",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4f6dd91f-02fb-4e57-93d4-10abce15d5bf",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5f93a542-74bc-4e2e-8ea4-e3f6ec98266b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "70829d03-2ae6-4bb9-b854-94cfe5f703b8",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to modify permissions for",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1a068683-2b07-4a7f-b6ed-2cf4f76e21c5",
+                     "name": "user",
+                     "format": "",
+                     "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "13eb755a-2b5d-48db-9898-48496207c6ef",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Name of organism to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9d8b06e7-73a6-461e-8d50-6a66666651a0",
+                     "name": "id",
+                     "format": "",
+                     "description": "Permission ID to update (can get from userId/organism instead)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0f563b84-866b-48be-8b5e-deda69b769b4",
+                     "name": "administrate",
+                     "format": "",
+                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1ca1d026-4bdd-484a-ab10-05a3b37431b2",
+                     "name": "write",
+                     "format": "",
+                     "description": "Indicate if user has write privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c9ce150e-c8c9-41ea-b368-1ef930a6dead",
+                     "name": "export",
+                     "format": "",
+                     "description": "Indicate if user has export privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "27c3af50-9e49-45a0-b0dd-9d848ddee7e7",
+                     "name": "read",
+                     "format": "",
+                     "description": "Indicate if user has read privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update organism permissions",
+               "methodName": "updateOrganismPermission",
+               "jsondocId": "fdaaaf77-6351-4887-abcb-45e720f048a8",
+               "bodyobject": {
+                  "jsondocId": "736f1be7-3dc8-4f39-be2d-4130a9024b44",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateOrganismPermission",
+               "response": {
+                  "jsondocId": "affa0433-dae3-47e9-bf82-2d70df0bff9a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "52f35d6d-a145-4b7f-b75d-a820de696307",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9f23566e-f7cd-4908-9443-9514bf4f52d5",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c29a58cb-d678-4620-bc2f-3f75d95967bd",
+                     "name": "userId",
+                     "format": "",
+                     "description": "Optionally only user a specific userId",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Load all users",
+               "methodName": "loadUsers",
+               "jsondocId": "1f1b5801-4fba-41a1-ad7d-b41eeeb7c3c3",
+               "bodyobject": {
+                  "jsondocId": "ed17d510-2eaa-47e3-81bf-df6942419d29",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/loadUsers",
+               "response": {
+                  "jsondocId": "02fedb17-6ec9-4ffd-ad52-f8eade10b41a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "57085219-540a-46ce-9a51-192e709df7ca",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dabefaf8-11a9-40fd-aec2-ff207fed7235",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9f8201c9-9b8e-416e-b6b5-f605f9e4e3c0",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3600f7f5-f7d1-42da-b6cc-0a1234b0e56e",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "91e42e5c-1895-48b7-8979-be6e854a7185",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add user to group",
+               "methodName": "addUserToGroup",
+               "jsondocId": "add2a7a5-0990-4746-9a2f-76d515f063a2",
+               "bodyobject": {
+                  "jsondocId": "afabbeca-de13-47ad-89c9-f2f986a22d00",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/addUserToGroup",
+               "response": {
+                  "jsondocId": "0994c67a-45da-4ee0-b3f6-dcd86e76b9fa",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "02e2bc40-3fd0-4723-a558-3038929d2a4d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "81a4e7f9-6def-4447-8e57-3ddea6bb8fec",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "aa8a3f67-e1a2-48b2-85c6-24aa707cca73",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ac2d3bfd-5102-4f5c-9903-0714c2ebf6d9",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9aede555-e165-45bb-bb6f-3377c9c948ea",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Remove user from group",
+               "methodName": "removeUserFromGroup",
+               "jsondocId": "3dffcc3a-7d91-4adf-a1e1-2a7146be8f89",
+               "bodyobject": {
+                  "jsondocId": "15a05131-4376-4937-8dbd-763108660a7f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/removeUserFromGroup",
+               "response": {
+                  "jsondocId": "0fe67bb7-043d-4eb1-a04e-b6defa28c1e1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4709c032-a88b-4420-bd21-36a876418815",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c5aee476-65f0-4800-9e68-005ac323e622",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "599c767b-b67b-4b63-b635-81b1086a04c9",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to add",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3fa936b7-f57d-464c-aa39-2a935ad35c4f",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7d0e6146-5ce9-4038-9964-59dd65e38f4d",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "130120c5-b76b-4838-a312-4b66e6f44df2",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create user",
+               "methodName": "createUser",
+               "jsondocId": "6beafd9f-955b-46c5-876b-c46e66d15593",
+               "bodyobject": {
+                  "jsondocId": "03b24ebb-ff99-4025-ad44-65e71ab4734f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/createUser",
+               "response": {
+                  "jsondocId": "f8a9936e-d2cb-41ad-a3df-43d8c91fd5e0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"

--- a/restapidoc.json
+++ b/restapidoc.json
@@ -2,4346 +2,4711 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
+         "jsondocId": "943812e0-1df4-4998-8a94-7a34ddefbc74",
          "methods": [
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3ffcfc58-6a17-4c22-a289-473c4fbaf165",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "cc41df60-a79e-4087-b78b-b288a21364d5",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "129fc91d-86e1-4506-9015-26f10c446bd1",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set name of a feature",
                "queryparameters": [
                   {
-                     "jsondocId": "49fac469-c488-49f5-9141-36609bfabb09",
-                     "description": "",
+                     "jsondocId": "f87ca3c2-60ac-49f0-8d2e-3d61284428b1",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "0567cb5d-334e-48af-aa78-fe6893091308",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b56bb463-572a-4c5e-bb0b-d8aaf65b43f6",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "67190862-5051-4ab3-a80d-b0373bff7c9b",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "2745554d-299e-4fea-b79a-8e8a1c7391ac",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eeb49166-6989-4328-87dd-e26d6507e5a5",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "b8373274-624c-455c-bf82-8d0ecbd912de",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a5b3b5b6-877b-4e75-b337-f5128187f842",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
+                     "jsondocId": "43411da1-e010-44f2-89e7-ee9a76b06776",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/setName",
-               "produces": ["application/json"],
-               "methodName": "setName"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "525df69c-207a-48d2-8c2d-a0a54a1532fa",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "fd6f48df-53b7-48ad-8b67-0afe47892cfe",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e5b9f9f2-920c-4f9e-ae71-b3ea2e84c64d",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set description for a feature",
-               "queryparameters": [
-                  {
-                     "jsondocId": "cd53f728-aada-4fbe-af12-c7c8d9210d29",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "51b51c59-85ea-4d74-8b80-5ed376890422",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "9967960f-126c-4192-9387-0fdf258d6584",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "9aea06a3-2b22-4259-a7af-82d318963c7f",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "22ff9711-733c-44da-8a0b-024e1e0770ab",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setDescription",
-               "produces": ["application/json"],
-               "methodName": "setDescription"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ef8743a1-500f-4802-ae6e-117030881311",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "c2668cc2-46f1-4b45-8b03-58bc98610978",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "b72d0b51-f1b9-4c9b-968f-9c9c672a9196",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set status of a feature",
-               "queryparameters": [
-                  {
-                     "jsondocId": "1b849e4d-4eb8-4102-a8a7-f250426f5f7a",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "db432e20-c83e-448c-8f1c-d5e080d9a627",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "f592d1c6-c5a6-4d82-9b03-d5cf0cd16457",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "982da2dc-f6e6-435b-b95e-ac9565333e64",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "6f297584-f416-465c-bd6f-833dbf923020",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setStatus",
-               "produces": ["application/json"],
-               "methodName": "setStatus"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "4019684a-6d2f-452f-b858-4c682aee7143",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "b44a934c-ed44-4fb9-9f1c-6bdec007400a",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "1cd1717e-a268-46f5-ad8f-e05dfa0debb6",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get comments",
-               "queryparameters": [
-                  {
-                     "jsondocId": "5c3458bf-2470-46d7-be0d-372984c84bc2",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "a61cbe74-ddac-47b7-8fa2-dfe72f53d63d",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "cf178d4f-2a77-43e4-99ef-c70e20d41489",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "f9292b78-50f2-4256-b344-a15cc51cf4b2",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "6c106ea6-26d5-4755-814e-d70ceec9bd42",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/getComments",
-               "produces": ["application/json"],
-               "methodName": "getComments"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "23233c2d-7b0f-45de-b875-2195e54620b0",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "e93c358e-6e8a-42a9-8060-9e9aed41d1de",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "34ad49e3-5bca-4d1e-88e4-f1945c3ed174",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "Add attribute (key,value pair) to feature",
-               "queryparameters": [
-                  {
-                     "jsondocId": "1a8c978e-7056-4ac9-89c3-8178b52a7272",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "2555e280-0dd9-4667-82f6-293f28860776",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "9e6e29a5-f833-4624-aba6-0a2ac1e99811",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "e356c06d-f86b-4e7b-bf29-cb985b7a2500",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "13d19baa-a323-4e7c-bc68-42a95f3f5883",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
+               "methodName": "addAttribute",
+               "jsondocId": "4b7a650f-6556-4dff-858c-6dca85e6c872",
+               "bodyobject": {
+                  "jsondocId": "428ee311-1955-48cb-9585-fbb9373153de",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
                "path": "/annotationEditor/addAttribute",
+               "response": {
+                  "jsondocId": "3272b695-dbc6-4d0f-8f4d-c54b8c816890",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "addAttribute"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0d4aee9f-d9f2-4345-be24-4cd20ff9fc88",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "163eca75-da9c-4533-9a1f-cc26185e559d",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "60068d4a-bee3-4e48-aca4-396375e1c58e",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "2c4e61eb-d5a0-4138-8d8f-9bb9790d1bf0",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "14ea9d68-517d-45fd-9d88-f1366285a791",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1822fa92-f998-4226-83d3-d36e30c0b8c3",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d1b3527f-e69b-4ecb-8b1f-c718cc7aedc9",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f76df25d-ff12-4076-bad9-7ec501a9b2a5",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Set symbol of a feature",
-               "queryparameters": [
-                  {
-                     "jsondocId": "4b3e774a-2d7f-46cc-ab35-5ec92a8ad445",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "96d64ad1-7552-4cd4-a4ca-c337d13c1238",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "af0b7d37-1cf2-489f-89b3-f99c48b00922",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "ba790d8e-0398-4bf5-8b8a-007c07bce233",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "2fd9de8e-0ceb-44c0-9a0c-187dbfc507dc",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
+               "methodName": "setSymbol",
+               "jsondocId": "98f67387-5d43-4a70-a851-1212f3084c42",
+               "bodyobject": {
+                  "jsondocId": "a5e2656d-7a47-41e0-838f-5d2f6cfeded7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
                "path": "/annotationEditor/setSymbol",
+               "response": {
+                  "jsondocId": "31c4b7a5-4e35-40ca-8029-a2ff644f85af",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "setSymbol"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "6089370c-3c9f-4475-8fb3-bee618da02ca",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "2c793aed-65ce-4c68-9dc2-ac521bbffb44",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0a669de8-eb83-4655-ad45-5c7fa3b5abf1",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Returns a translation table as JSON",
-               "queryparameters": [],
-               "path": "/annotationEditor/getTranslationTable",
-               "produces": ["application/json"],
-               "methodName": "getTranslationTable"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e183b897-743c-49a2-8c10-ebc0b093001c",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "cea87572-9ff4-4cc6-af4c-b66678913705",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d7a50351-1a0b-44cf-87fc-941d59b7e4b4",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Add non-coding genomic feature",
                "queryparameters": [
                   {
-                     "jsondocId": "5c64d771-2c3d-4667-91d1-4f9e70441b92",
-                     "description": "",
+                     "jsondocId": "d0970b25-52ed-4900-a130-0654b6a1ccb9",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "83e800af-6861-40e0-961a-c3fa8a383e44",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a3c34869-50d2-43c5-9bee-fd359d193d62",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5f288b02-38f8-4ea0-9f76-895e73e4d70c",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "19379459-be47-4a21-9105-a9da79e81157",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "82310e30-a340-44e6-8f3b-47034de5db1b",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e878a14-100c-4905-85cd-7dd74b51f481",
-                     "description": "Suppress the history of this operation",
-                     "name": "suppressHistory",
-                     "allowedvalues": [],
+                     "jsondocId": "4677f884-d8d1-42a1-bdfb-7fc2a5137c54",
+                     "name": "organism",
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "boolean"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ab8db453-ce6d-4d70-83eb-d894b8871875",
-                     "description": "Suppress instant update of the user interface",
-                     "name": "suppressEvents",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "85f72b49-c978-4c4b-983a-79ce63b1167b",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "jsondocId": "7545e99e-bb59-4962-9846-df3c0d9b5feb",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/addFeature",
+               "verb": "POST",
+               "description": "Set description for a feature",
+               "methodName": "setDescription",
+               "jsondocId": "f24e3124-b9b0-4f57-ab00-537de8f26176",
+               "bodyobject": {
+                  "jsondocId": "5652ac12-b054-49ec-8630-7c6d958aa8d6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setDescription",
+               "response": {
+                  "jsondocId": "1815f478-22ff-4b31-b8a6-da1d6fd0489d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "addFeature"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0817316b-171c-4d0a-8a3b-b4eca7bb2a25",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "a9ddce83-f4ae-444c-828a-a76d143d62b6",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "154eb593-d731-41ac-94d6-2e888d03b005",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set exon feature boundaries",
                "queryparameters": [
                   {
-                     "jsondocId": "c5110bb8-0baf-4dfa-ae84-072a90a1db34",
-                     "description": "",
+                     "jsondocId": "18407be7-0194-4693-9a1c-1ae8175da54c",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "57bf1d78-73b5-4208-aa66-364e8866e524",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "445b9ae0-20b1-4a48-8873-980200841dc7",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ecc6fb43-b203-4ab1-a2b1-07c448f503bd",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "4564d54a-23eb-4310-a0a0-5d865a0f4722",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "2f428058-2025-4b19-add7-5ae6bf1ce58e",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3abeaf67-6228-4a09-9a7f-2a234c4cbe0d",
-                     "description": "Suppress the history of this operation",
-                     "name": "suppressHistory",
-                     "allowedvalues": [],
+                     "jsondocId": "9781f64c-4a83-4fee-946b-7206f29d0575",
+                     "name": "organism",
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "8e3a2e77-bd8f-4584-9974-760f12f7ea5f",
-                     "description": "Suppress instant update of the user interface",
-                     "name": "suppressEvents",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "c94defd7-ebdd-4f6e-8a6e-9cc71f6fa933",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/setExonBoundaries",
-               "produces": ["application/json"],
-               "methodName": "setExonBoundaries"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3319485c-b6af-4106-aab7-a8c186fc2bf0",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "797270be-7040-4433-8618-6e979827062e",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d68d3f4b-0dcc-4ae8-bd56-0eaf92ed2748",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Add an exon",
-               "queryparameters": [
-                  {
-                     "jsondocId": "609c79ef-04e6-4591-8f74-a0068532b226",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "b1877fe0-2c24-4665-b1a8-489832813898",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "30e0dc43-55e5-46ad-bd53-e6799d86c324",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "7a41ce19-d755-4800-b573-9c9af5003c6c",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "0ef6beba-028e-4696-9baf-bb7d961e1628",
-                     "description": "Suppress the history of this operation",
-                     "name": "suppressHistory",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "b9927569-9b62-4996-bb26-2fa061816100",
-                     "description": "Suppress instant update of the user interface",
-                     "name": "suppressEvents",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "804d9c91-ce57-4c74-a134-34e525851446",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/addExon",
-               "produces": ["application/json"],
-               "methodName": "addExon"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "b2e6251d-3572-4657-bf87-477db499fe15",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "dc11eb6b-45d7-45f7-83cb-7f02c1150f2d",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f01f9a1b-ea06-42eb-944d-febb4ed4e8c1",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Add comments",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d68d5f61-5898-462c-a25f-ea1580cadfd7",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "93ca1d88-4834-4fa1-8b1e-20d0c663f8f5",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "32220e64-60b8-4c72-a834-b7eebcdb9b6b",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "85cd3ef2-0f6b-43d8-9a4b-fbfe565463ed",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "42ee67ad-9064-4f21-a6f9-e5b8fff66fd6",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/addComments",
-               "produces": ["application/json"],
-               "methodName": "addComments"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "69b0d8ed-37fb-415e-9448-daa2367396f4",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "0d424e21-0a2c-4a0d-8b30-3293e2707bf0",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ef4e5435-e532-4e78-af2a-736e3398aa67",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Delete comments",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d49b548b-e2df-4e95-ad56-00548cff4d1c",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "e39db73b-5697-4b6e-913f-490d9952d758",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "be588b4c-a005-40ee-b977-e6311b456b8a",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "cfa7cb2b-85b6-4615-ac7b-92184590064f",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "dc4ce9d8-37e4-4ca4-96e7-e18669e723bc",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/deleteComments",
-               "produces": ["application/json"],
-               "methodName": "deleteComments"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "9213d2f1-c764-42df-bc0d-07c897593f83",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "423a7d33-beb2-4c7c-a111-d964e51f40c7",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "69a74123-2b4e-45f6-9d0a-d27b4ee60ffe",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Update comments",
-               "queryparameters": [
-                  {
-                     "jsondocId": "a392cac7-acdc-40ab-86af-a0f25de03b85",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "fe6fd67d-3f57-434e-838b-8977d63579f3",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "f98b04bb-10f2-47e2-affa-83caaa4f1e54",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "5a568093-c834-460f-bb3d-ed2e2708752d",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "2cc488ba-0797-499a-9487-d249c0745d32",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/updateComments",
-               "produces": ["application/json"],
-               "methodName": "updateComments"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "c8c6433c-97c4-47e9-a0d3-af79f90f859a",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "b7ba871e-62c0-4366-afe6-7ecd8c76f4a3",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "9356a390-3497-4739-9929-711f84f81b18",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Add transcript",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d14aa1fa-7cc8-438a-adac-b36b7f28906b",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "2bad314b-9c4e-4738-b569-3cbd62be2f48",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "ad203bb7-93e1-48e1-bc33-595ef637a4da",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "a7489929-487a-44e2-9243-9686039c3a26",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "ba1cb720-2db6-4763-b1ac-73d60c73be90",
-                     "description": "Suppress the history of this operation",
-                     "name": "suppressHistory",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "ed9db572-f6f1-4f74-9a86-229879f207ce",
-                     "description": "Suppress instant update of the user interface",
-                     "name": "suppressEvents",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "2685dae0-dc4e-4c04-baa6-b7d335e3892e",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/addTranscript",
-               "produces": ["application/json"],
-               "methodName": "addTranscript"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "750b4e7d-700e-4139-a779-6716c7b649ba",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "e2cb5851-5235-4fa2-b75a-8860e0857068",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "caa90556-7cd6-4bd4-9a41-0252b32d022b",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Duplicate transcript",
-               "queryparameters": [
-                  {
-                     "jsondocId": "b9f0ed80-cc44-4964-aa11-d2874465c055",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "4ece74a7-d781-497a-936a-d98393c19cbe",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "35dc39d9-3927-4f30-82a3-00f573539dcd",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "59cc367b-12d3-4e13-8c16-b431b0b308f8",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "01f4ad0c-1f09-485d-9625-a0033bf9f0c7",
-                     "description": "Suppress the history of this operation",
-                     "name": "suppressHistory",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "3ee134bd-17e5-4bae-9230-9d30a283b4e4",
-                     "description": "Suppress instant update of the user interface",
-                     "name": "suppressEvents",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "095a78b9-9087-4232-9660-1e9b45d2bd90",
-                     "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/duplicateTranscript",
-               "produces": ["application/json"],
-               "methodName": "duplicateTranscript"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "1928b906-443c-4d3a-b130-8d15cb5b7b92",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "3e9c5137-318e-4897-9310-2708e7a6756e",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "7eac8847-8204-4c97-9657-72b2a9d9cc40",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set translation start",
-               "queryparameters": [
-                  {
-                     "jsondocId": "b995cf69-a586-40bc-8fad-b49efd6c8885",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "480b0afd-a5c2-4f17-9443-1b7101b533ec",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "fcdbca81-7389-49a4-8472-883b5d50728c",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "8ea0e20a-5cde-4cb4-8113-13e2c509d6c7",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "a42950ab-c1df-484e-944c-ec89f47d0730",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setTranslationStart",
-               "produces": ["application/json"],
-               "methodName": "setTranslationStart"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "48acb6d6-1cd9-440d-b5c7-a209374729ae",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "991d10f1-5dd1-4fa0-b31d-07fcffcc18b7",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "28abd423-6fac-47f8-a29f-f8dcf19bb301",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set translation end",
-               "queryparameters": [
-                  {
-                     "jsondocId": "19982b4a-2363-4727-bb16-fda67b4be6ce",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "3362a031-15a2-4e48-963a-3b92f6531a44",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "865f97fb-b343-4813-ba63-8e761d446d36",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "f44db66b-7d58-4b88-ab59-f7675964ca25",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "a4f4480e-60c0-49a6-8da0-3d86e1fafd5f",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setTranslationEnd",
-               "produces": ["application/json"],
-               "methodName": "setTranslationEnd"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "b53f35bb-c8d9-4634-8098-34bb2fc5c4ea",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "6c85d609-ab45-4bc5-a968-b7278d6e36fd",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f257a9a9-d2fa-4166-a68a-259edc70cb51",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set longest ORF",
-               "queryparameters": [
-                  {
-                     "jsondocId": "adc697b6-1f93-4801-ae22-c8bf2adcdcc0",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "7c664ee3-368f-4596-aebd-614f33bdc7d3",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "333ddfd8-8c5e-44a0-af83-ae757203320b",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "398e81ea-4c08-41fe-b4ef-90aede701f1a",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "c7d18970-e849-480c-969d-7b9983fc6b02",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setLongestOrf",
-               "produces": ["application/json"],
-               "methodName": "setLongestOrf"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "42259241-cb42-468f-ba57-e4d5c44b3ac0",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "d8789e66-5a1b-46e3-8c9b-d6a6102dcc8d",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "db80ffa3-8de0-459c-b74e-514fed7b784b",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set boundaries of genomic feature",
-               "queryparameters": [
-                  {
-                     "jsondocId": "3e291a0b-755c-4cd2-a812-8f9f6c7b312d",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "c7195577-69c2-4a69-b284-eb6acb9d27e2",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "45b17ab0-66fd-49e2-ad24-fdb7bae40394",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "045ebb86-47e0-477d-9c8d-c049ea3650e7",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "c9dbe502-47f3-4983-aedd-6dadbd7a8842",
-                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setBoundaries",
-               "produces": ["application/json"],
-               "methodName": "setBoundaries"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d9d4af83-c0f9-4299-8673-aa3e927a717b",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "22f7b1ac-e97f-4c10-ad4e-6acd734c4ff3",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "4d8c68e3-abe0-466a-8619-d071f531f7b7",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get all annotated features for a sequence",
-               "queryparameters": [
-                  {
-                     "jsondocId": "345ae529-7da9-4897-a305-9c2442b028f0",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "8ef755cf-4cc3-424e-b66c-9f71730f12ed",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "5ef3d65d-bb64-4b44-8f1e-1da4ed273662",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "12c0316a-243a-45b4-b449-ec4df1c6a61b",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
-               "path": "/annotationEditor/getFeatures",
-               "produces": ["application/json"],
-               "methodName": "getFeatures"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ac826575-7e00-4ef8-8a6b-4224d391dcbc",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "02dd3d8a-59d9-4f98-b0c3-bfa23aff03b5",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e274cdf4-e4c0-4869-8017-8040ed37abba",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "Get sequence alterations for a given sequence",
-               "queryparameters": [
-                  {
-                     "jsondocId": "6cfe713a-950d-4ee9-881a-aac1b83512fa",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "862e8abc-204d-4735-b56f-1e7caaf77172",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "a180cd64-d6b5-4c02-aa4f-fa00abc8f220",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "f09911cb-fef5-4162-a9ab-8bd75a0d4edc",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "getSequenceAlterations",
+               "jsondocId": "5bacc7bd-6873-4b8b-afe4-ee9e0189eb93",
+               "bodyobject": {
+                  "jsondocId": "125ddb6c-548d-47ea-9d5f-d95e1379e46f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
                "path": "/annotationEditor/getSequenceAlterations",
+               "response": {
+                  "jsondocId": "cfcbaedd-def1-4613-a967-d1fbf9821bd4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "getSequenceAlterations"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "82ed35c1-0838-44e7-8637-d3620cea239d",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "fae2d393-da0a-4151-a858-961897736277",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "26147ae2-a275-496d-b3b9-02ae86366eac",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set readthrough stop codon",
                "queryparameters": [
                   {
-                     "jsondocId": "5568a342-5fcf-4bf8-8bb8-cf14a88054f7",
-                     "description": "",
+                     "jsondocId": "d20d4181-289f-4a18-8fd0-0a1c03c284fa",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "a3d9c6e5-4ec9-4c90-819b-fda25dbdf82b",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "18ab4437-a8cd-4fa0-98aa-bc8fe6aa2979",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e0fc7d71-b31d-4d68-b420-1f27995a0e3a",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "d253a13f-0753-4a3b-a321-083e9561c6ba",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "779fd421-388d-432c-ac14-a5e038110b09",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "bd2dbf9b-5fab-45f5-b418-2f875faaf3ae",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ea328022-16f2-43ae-88b2-a4058242f48c",
-                     "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
+                     "jsondocId": "c55f9f56-4568-48bd-9639-82e210d445d9",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/setReadthroughStopCodon",
+               "verb": "POST",
+               "description": "Delete attribute (key,value pair) for feature",
+               "methodName": "deleteAttribute",
+               "jsondocId": "d2502171-5bf3-41e3-af25-940c0a437d85",
+               "bodyobject": {
+                  "jsondocId": "4df49905-a6ae-4c9a-8937-0177a1ccc942",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteAttribute",
+               "response": {
+                  "jsondocId": "69a01455-1390-41af-95d7-be62a3069af8",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "setReadthroughStopCodon"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "7e3b23ca-9ac9-49d6-9eca-a70d241e3425",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "323ab141-a1f6-44a4-9b68-173f48cc9d4e",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "cec8a3cf-d14a-4d2f-af5c-7e443785cb8c",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Add sequence alteration",
                "queryparameters": [
                   {
-                     "jsondocId": "12c98459-4a93-4b8b-9761-61d918ee3735",
-                     "description": "",
+                     "jsondocId": "b40e0de2-7d2c-4e57-ada2-e6063569fb75",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "ee6aeccd-7947-4bbc-8321-c2bfcd0fd237",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0f2288d4-88d0-4f28-afbb-8039535d9d8e",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "067c562c-0982-4e6f-b4a0-f49a1644b843",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "5470609b-c318-4c32-b2fd-4e083604020b",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "387fb311-ef39-4350-887d-9db0f369f37b",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "a5948218-6de3-4040-b578-6e78b23114c9",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c98d259f-daa0-4206-9c75-1a0e252292e2",
-                     "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
+                     "jsondocId": "c51cfa96-1a2c-47f2-82b4-2f66d95f0d0d",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/addSequenceAlteration",
+               "verb": "POST",
+               "description": "Update attribute (key,value pair) for feature",
+               "methodName": "updateAttribute",
+               "jsondocId": "0c707c5b-c6d4-4202-a402-5532bca29663",
+               "bodyobject": {
+                  "jsondocId": "e76a65b8-1d58-4708-bdc6-ee1e81ea73ad",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateAttribute",
+               "response": {
+                  "jsondocId": "55bd81c9-00cd-4310-870b-038a23b37f67",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "addSequenceAlteration"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "99f6c7c6-d6d6-4317-ad7c-89604a0339c5",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "dfff7454-a5ed-44d3-aae6-311e2182b801",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "bee5b243-ffb1-4846-9fe5-4f7e10da4424",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Delete sequence alteration",
                "queryparameters": [
                   {
-                     "jsondocId": "82bc6104-2f99-4b32-92e3-54161b6c22f9",
-                     "description": "",
+                     "jsondocId": "0ccf7126-412d-4900-a31c-8e207f19df1a",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "484a0551-7c67-4f26-a885-5246b680398a",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5443faec-ff86-4fdb-920d-f654119d7820",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a859d332-146e-4179-b49d-7fa8d8078266",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "c8327bfc-8a74-4d94-af7b-79f75a5472e9",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "301d388c-6611-44dc-98aa-258fca4a3354",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "0f1d4343-26c8-48be-88fe-f137b7fb8fe4",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "37105ffa-9f6f-4fae-9c86-3b49d0459146",
-                     "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
+                     "jsondocId": "36da50ab-f71d-4e42-939c-222594eccaf4",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/deleteSequenceAlteration",
+               "verb": "POST",
+               "description": "Add dbxref (db,id pair) to feature",
+               "methodName": "addDbxref",
+               "jsondocId": "09ccaa4a-3918-462f-ab01-ea3736241468",
+               "bodyobject": {
+                  "jsondocId": "e34d9605-81bb-49f3-8357-75abdd8245fb",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addDbxref",
+               "response": {
+                  "jsondocId": "ad8a2bc3-815c-4a27-8c59-bc1a181bbb8d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteSequenceAlteration"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "5bd14c20-7238-471b-af0e-03a5d1faf749",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "b5318dce-92d1-4238-b07e-a164f683a537",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3df47f19-32d5-40a3-bffd-d1b8d1334da4",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Flip strand",
                "queryparameters": [
                   {
-                     "jsondocId": "503a0cf9-801a-4c88-bdaf-eb4134dcbacd",
-                     "description": "",
+                     "jsondocId": "8953a556-6392-4c1c-a6c2-1b4f3d85d7c0",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "e31e4b9a-e6a2-40e5-bab5-86ba9514e467",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "82eaed76-4852-4a9f-ab76-17f4a06d2463",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9b7ce44a-4a01-4a0c-9f33-58b5ab0eb19d",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "791c896c-1a02-49eb-830b-9b10cd51bb53",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9e75a06f-4cec-44fd-9eac-12e307b2ef37",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "72164104-7462-4364-a507-cba7ba4af2b5",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "46d517d8-0382-4147-8691-06b71454f50c",
-                     "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
+                     "jsondocId": "a339b642-1cfa-4306-850e-d1e05185c304",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/flipStrand",
+               "verb": "POST",
+               "description": "Update dbxrefs (db,id pairs) for a feature",
+               "methodName": "updateDbxref",
+               "jsondocId": "37fa5144-1b10-44b1-b318-eba2affc694e",
+               "bodyobject": {
+                  "jsondocId": "a46a2f8f-88a0-4442-87bf-b9c9bc9d998b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateDbxref",
+               "response": {
+                  "jsondocId": "bb6fc441-e846-4d7e-9fa3-063f0732b84d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "flipStrand"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "52ef834c-db90-45d8-8f55-c877a2f1a3b4",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "141f9d76-348c-4ba8-b091-688e169b8f07",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "7babf1e3-40ae-41e1-858e-ccbfd048853c",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Merge exons",
                "queryparameters": [
                   {
-                     "jsondocId": "6f3856fb-9e45-4359-ac6a-8f40d0075765",
-                     "description": "",
+                     "jsondocId": "bc77b0be-8aaf-4541-bfc0-b1eb43db8128",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "0525a073-330e-4f75-9c0b-56ec008b3176",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f3d00a7c-16f1-4361-b7c5-f2dca1cc21ce",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3bd85bba-fc5a-4940-a01e-03b9dd98f9b3",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "09245605-bee9-4bbe-9010-6cbbcb89d17d",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "22aafb90-80ed-49dc-ae38-f9969ad0de29",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "a79a8fe3-ef86-4bff-8747-91c6087eebfc",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "16727144-80b4-4dc8-b5a0-4ec11714cc88",
-                     "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
+                     "jsondocId": "cf59ec92-7d55-481c-86d6-2a2fdab89349",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/mergeExons",
+               "verb": "POST",
+               "description": "Delete dbxrefs (db,id pairs) for a feature",
+               "methodName": "deleteDbxref",
+               "jsondocId": "7e17ed23-4bb5-494e-bf7f-0c1f02524cab",
+               "bodyobject": {
+                  "jsondocId": "0fbfa22b-81d9-4d65-a1a9-d1e4cf6b0224",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteDbxref",
+               "response": {
+                  "jsondocId": "4cf82b41-4c77-41b8-97f3-8963b21aaf24",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "mergeExons"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "61513a45-61e7-4452-838d-c213c0c0f487",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "b618c86d-0a78-47f1-8c61-8feec73caa54",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "2ba591dc-df0e-457c-b02c-22c39a77ab93",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Split exons",
                "queryparameters": [
                   {
-                     "jsondocId": "56a2b09c-607c-449a-a1cf-6a914fc222b9",
-                     "description": "",
+                     "jsondocId": "501e0f27-d5d9-4bd7-a297-78bb40dcfe53",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "f024868a-5e46-4564-a277-9cd05dd5be70",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0365026c-bf7d-4796-9f0c-a6e92def2857",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "06f95054-fb31-4632-92a5-7aaea5f54c24",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "c80b57c1-eb72-4990-9284-2653cfcbd377",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "60595e68-bcfa-4199-8a41-2e9ed9be9608",
-                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/splitExon",
+               "verb": "POST",
+               "description": "Get canned comments",
+               "methodName": "getCannedComments",
+               "jsondocId": "fd49744d-cca8-4056-8dca-f35a58a1539c",
+               "bodyobject": {
+                  "jsondocId": "e2f20dcc-1dd2-4338-ab2a-61840e850798",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getCannedComments",
+               "response": {
+                  "jsondocId": "e6db4646-eb8a-4da7-bfbd-f4af845187eb",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "splitExon"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "8daa4355-c795-4a69-bfb9-502b381cb25a",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "9eddf574-709b-4b17-8449-1cbfbcb42b30",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "5ffa58b5-ee5c-4b94-b928-608e9998dc36",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Delete feature",
                "queryparameters": [
                   {
-                     "jsondocId": "485c5a04-4614-45f1-a714-a55ce380a48a",
-                     "description": "",
+                     "jsondocId": "66f6da07-de26-4e37-bdcb-d36f0cabaf53",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "61a99b39-7b42-4099-b91a-16280e0610a2",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c27b357b-0681-48f3-b5d6-231f231cf85e",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "330c4961-8521-4532-b10b-14af6fa0a752",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "8c9f9c2e-583b-4159-b0d3-236053cc4df7",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "4625207d-2b56-4bd0-a2f6-44627d3314b8",
-                     "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
+                     "jsondocId": "bafe2278-8c30-48f4-94ff-e0909a2754a0",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/deleteFeature",
+               "verb": "POST",
+               "description": "Get gff3",
+               "methodName": "getGff3",
+               "jsondocId": "3583c54b-f395-4036-9765-4da82fb56b79",
+               "bodyobject": {
+                  "jsondocId": "64d2b0fd-f8f9-458f-915a-317258ba2c39",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getGff3",
+               "response": {
+                  "jsondocId": "d039f13d-c8e0-488e-9d5a-98cda01b234a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteFeature"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "00287053-28ef-40be-8b8d-19a16d8a2c7e",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "09af2cc3-8c35-4936-a80b-c2b3d24465da",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e0734434-32ff-4f12-bd14-9037496de8a7",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Delete exons",
                "queryparameters": [
                   {
-                     "jsondocId": "7ff90d68-f180-4b34-b25b-0e5ffe899ab3",
-                     "description": "",
+                     "jsondocId": "705602dc-be24-49c8-9c41-1bb2e7a3ec53",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "18651abf-16dd-40fc-9108-dc617a22882f",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "36811ed8-3b2d-4eef-9abd-ebd441f9d81a",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4f3ab9e1-40e4-409a-9317-b4f02c9f7cc2",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "632f77be-d155-4c35-822f-e5dcc88e5fae",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "b171c5bb-b69d-4953-8ba0-9b6d315b2d00",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aeb7e49f-0099-44a8-be89-0f2fbb8072e7",
-                     "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
-                     "name": "features",
-                     "allowedvalues": [],
+                     "jsondocId": "cfabffc5-eced-4466-8817-80fee95f3179",
+                     "name": "sequence",
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "91e89e19-4c7f-41a9-a6f4-41b3892b85d2",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "88d9267d-7170-42c1-baec-f564521ab616",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3c9b95ce-7bff-4b10-812c-9799e27dfdf4",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/deleteExon",
+               "verb": "POST",
+               "description": "Add an exon",
+               "methodName": "addExon",
+               "jsondocId": "f7d9f8fa-a5dd-4532-abbf-c859f73f5e0f",
+               "bodyobject": {
+                  "jsondocId": "fb7c9fa0-ce92-470f-bbb1-682958d9c8d5",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addExon",
+               "response": {
+                  "jsondocId": "1b808f61-2055-4f5d-bab7-1441adaa3eae",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteExon"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "120ccc71-114b-42aa-90a6-c8497d3e364a",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "d18b7b7f-5c72-4079-8771-ab963eb15ea2",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "8758de48-60cb-4d3e-94ff-2d9301f67dc2",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Make intron",
                "queryparameters": [
                   {
-                     "jsondocId": "8925f2d9-61a1-4c8e-8009-3ed8d39e5281",
-                     "description": "",
+                     "jsondocId": "d0443d73-3652-4d7f-8487-f74f8fb92431",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "147d15a9-7c5e-4c7d-a277-8763d6569e23",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "01da0ee2-80b9-46b8-b8b4-42a7797f2a7b",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a31a104e-b830-4abf-8eb8-0dbdc997366c",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "7e1cb326-a9b2-44db-afcf-5c7200e02ae1",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b7bbeba-c43a-466f-b6e2-f996ecba091b",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "4315d42d-ea83-4a0c-ad7b-8e85740be4e2",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45d38b12-7a55-4031-99a4-3749ab60b065",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
+                     "jsondocId": "9d82cb69-b265-4260-8ab0-ee27c1adda9e",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/makeIntron",
-               "produces": ["application/json"],
-               "methodName": "makeIntron"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "5c4dbfdc-809a-4d57-977e-9e16bf4c1b6c",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "2c10542a-bbd6-47a3-9923-5ff10c86a397",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "bb79f0d7-ad0c-4266-998f-208a8ee6953d",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "Split transcript",
-               "queryparameters": [
-                  {
-                     "jsondocId": "3ae90bc5-8505-4748-9c55-6ef61399deb3",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "4d718ae9-b9d0-4f45-b38d-643a1d05390f",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "af8056ab-26c3-434f-98e2-290ff0485ebc",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "916ad73d-4429-4e23-b4a5-c639aa8c626f",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "cc4ab9fa-db96-424b-8a22-3c715a7b7063",
-                     "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
+               "methodName": "splitTranscript",
+               "jsondocId": "dfb0ce3a-b863-4c02-9413-df031dcc5bcc",
+               "bodyobject": {
+                  "jsondocId": "e99b5ac2-9c5c-4356-80ae-6f6f23ff14e6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
                "path": "/annotationEditor/splitTranscript",
+               "response": {
+                  "jsondocId": "071aad84-be5f-4bc8-8d77-9a29836a11de",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "splitTranscript"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "2e7e99f6-d6ad-4e96-a15d-3bad79c530d1",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3401ded8-fe75-47ac-9064-ffb5bd4be40e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7a5c79b2-582a-4081-85d5-bfcc0cfa5137",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e28f6cc2-c6d4-41c4-b778-cbff6eb336c1",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6aa767b7-c096-4aed-9962-80f9e86b1f4a",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "83073396-5acb-4a18-a5cb-a7014657f707",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fe4e3682-7332-4fb9-a728-f7721df4c3a9",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Duplicate transcript",
+               "methodName": "duplicateTranscript",
+               "jsondocId": "b9310e92-b966-4bfc-b080-0f7c297c0e57",
                "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e77c023d-4bc8-416f-b9dd-d431f8c09beb",
+                  "jsondocId": "41908a04-b4ad-4c3a-b04f-b18d7605cc06",
                   "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
                   "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "5a21ba28-a357-4890-9ab4-16ea3a75a039",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0b0fe21e-9cba-4b7b-ad74-6686efd058f5",
-                  "mapValueObject": "",
                   "object": "annotation editor"
                },
-               "pathparameters": [],
                "apierrors": [],
+               "path": "/annotationEditor/duplicateTranscript",
+               "response": {
+                  "jsondocId": "27be38cf-90d5-44b9-8c3d-34e9dcb3387b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "ec3a6f67-b449-404f-8898-fce5f0ea2220",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bc2e0181-921e-4b71-abda-5b9ecc88177e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7d519fe9-e24a-4391-bcbe-31b37edf453c",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2384ee87-fc49-44f7-82aa-5b73279f8392",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9922cc85-d057-4fb0-b0c6-3ecc551e74bc",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Merge transcripts",
-               "queryparameters": [
-                  {
-                     "jsondocId": "b3682901-fb6e-422d-a320-1465d3e07139",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "95f95ff9-e672-4de5-9416-731ffdf4e3af",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "3e5818cb-bf8c-48b5-8e87-c5ca19b5cbba",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "37780118-a784-4a22-951d-8165722c027a",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "04206134-5540-4796-a872-0b89a7f49f55",
-                     "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
+               "methodName": "mergeTranscripts",
+               "jsondocId": "fbbdc154-5483-4f75-bd45-6f8049dcb0ea",
+               "bodyobject": {
+                  "jsondocId": "65675156-82e2-4a97-84d7-e6478777733b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
                "path": "/annotationEditor/mergeTranscripts",
+               "response": {
+                  "jsondocId": "d1db733d-71b0-41e0-a880-76f1e55a26bc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "mergeTranscripts"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "656f2681-c17a-4021-81a1-b17ed4a09c1c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2898dc72-f5f8-4d41-be93-e81fad5dcc36",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4712d8ff-a558-4fb6-8fe1-dd90bb32dcaf",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2a318cc4-bf60-4cb9-a8a9-da723bc45439",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3eb163f6-fa8c-4ba3-9615-afc5c4497a62",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5183a62f-0edb-4af9-a40d-982ad993884f",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "169168db-6811-4593-9d9d-5d05261329ab",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add non-coding genomic feature",
+               "methodName": "addFeature",
+               "jsondocId": "67f86c90-8afe-4ae9-9038-11580c0a4de2",
                "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "a7198418-dc4e-475c-889c-a590eb366391",
+                  "jsondocId": "dbebc07c-9f73-470e-a51c-178276eb3b35",
                   "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
                   "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "81a21e81-94a6-4825-85f4-2d20ed972992",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "943eb804-8d6c-46bf-81ac-49e787743b6d",
-                  "mapValueObject": "",
                   "object": "annotation editor"
                },
-               "pathparameters": [],
                "apierrors": [],
+               "path": "/annotationEditor/addFeature",
+               "response": {
+                  "jsondocId": "13817fcc-ab17-4ca7-88be-b9c1f293d0f2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e894ae43-9a26-4aa9-909e-b7df7e763b98",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f0ff666c-94e8-48c6-b3d7-8a1a5925bcd9",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3b371199-7d6c-461a-b151-1233bc1beb13",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cbbeeabe-2f4b-4e78-84e9-83419bf384e4",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2b5b634f-7f0c-4726-a492-679cb5ee9b21",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set translation start",
+               "methodName": "setTranslationStart",
+               "jsondocId": "76360508-bd82-40b7-8bf3-6393943c7f98",
+               "bodyobject": {
+                  "jsondocId": "6a912590-e645-488f-8494-eb49198e64b6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setTranslationStart",
+               "response": {
+                  "jsondocId": "a6e45f87-e8d1-451d-8cda-953b5baaa529",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e2a5240c-f0d5-42e8-a033-4c27177523ed",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "887e72bc-1931-48dc-a8ee-e2ee61e20d73",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5678e46a-cf27-468f-96c8-ea681185a84b",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b3487854-51dd-478e-bada-ff58ef686dcf",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "621c823e-efd5-4e84-b289-da1732fb7980",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set translation end",
+               "methodName": "setTranslationEnd",
+               "jsondocId": "3a94eb21-1df9-49d7-9f49-6e975196d53b",
+               "bodyobject": {
+                  "jsondocId": "ff755e1f-453c-4ba2-a429-ff36a82940dd",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setTranslationEnd",
+               "response": {
+                  "jsondocId": "a1662b29-a4b3-4405-b035-ec04c811f8f9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4149ce5a-7f7b-417f-b772-3bcd9053fe4f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "66aeb029-538a-42d0-b67e-7083952ea114",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3d3216c2-5855-4d2a-99cb-98d8557503c7",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cf8c16cf-0cec-4157-b2fb-bd9809f5a591",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c8c0b10d-510e-4440-9398-c64e9d3f0465",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete feature",
+               "methodName": "deleteFeature",
+               "jsondocId": "a60317de-6dda-437a-9dda-cbd5264da3a4",
+               "bodyobject": {
+                  "jsondocId": "204b3dd2-6585-42bb-93ef-d0e55bd5f727",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteFeature",
+               "response": {
+                  "jsondocId": "a043897d-a409-4ee3-839d-648893cd157a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7bf74c55-e270-4771-b30b-d2a34344867f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "526c8f1c-5c49-47b1-84c0-dcc438a3f8a0",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "527630c8-3831-4f32-99d3-0b09cbbb7333",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a72b44ec-ca21-43a6-9686-855745386ad6",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "35e37339-1e28-4c1c-bd84-aae92fdec695",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Flip strand",
+               "methodName": "flipStrand",
+               "jsondocId": "ae548ff3-0e51-4cb7-a6e9-e37081881360",
+               "bodyobject": {
+                  "jsondocId": "372abcd5-325e-48d0-a617-d7c8f0994cd8",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/flipStrand",
+               "response": {
+                  "jsondocId": "ec3a8c36-8ec4-4ee4-800e-f49c0f661875",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c20d0639-9987-466f-ad81-d24e07db839c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "88e3e7c4-4fb1-4c41-8185-1acd4c469f7d",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "208704e4-05bf-4dd4-92f9-97935ca8f4bc",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f7d547ae-41f7-4142-b827-bd5d126f2e5d",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "08443bf7-6470-4e22-8482-7fac8311a6d0",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Merge exons",
+               "methodName": "mergeExons",
+               "jsondocId": "9063b482-5b52-4fe4-a8b7-13913a3a0c87",
+               "bodyobject": {
+                  "jsondocId": "231197c3-c423-43aa-a024-10defaeb540a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/mergeExons",
+               "response": {
+                  "jsondocId": "87a41f7c-d826-408e-aea6-dd846fbcfb6f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [],
+               "verb": "POST",
+               "description": "Returns a translation table as JSON",
+               "methodName": "getTranslationTable",
+               "jsondocId": "676515b8-9224-43f3-bffb-7d2848914864",
+               "bodyobject": {
+                  "jsondocId": "a720f5e4-9393-4fcb-b784-82ecf12e068b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getTranslationTable",
+               "response": {
+                  "jsondocId": "cca10c1d-de2c-4e00-ad45-b163f50adea9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6c610e99-6911-4057-82a0-7d253091f1a6",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ece1c90f-a003-476f-98fa-bf71010bd671",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "acfa9eab-fc1e-44e2-bc06-a3e254a8983d",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4008ab74-6960-4947-bc1b-c866eb6a790d",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3d136a42-9256-4bc2-b5c6-1493b37f786b",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete exons",
+               "methodName": "deleteExon",
+               "jsondocId": "78be04e9-58d8-4350-884c-e1a11461e7c0",
+               "bodyobject": {
+                  "jsondocId": "08285085-2c6c-47c0-887f-0fb25fa470d1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteExon",
+               "response": {
+                  "jsondocId": "d0b88faa-9bb4-429e-a21e-abbe8a9516ab",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "9b5160aa-1a6f-4018-8351-fe72443a5fec",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2d455143-36eb-4e15-8b84-6bfa880d66ad",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6ef9521e-0d52-45e1-b734-d2959f0ade02",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e55da443-3782-4d3a-ad16-935347af4fbc",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "40413b42-f3b5-4bfc-90b4-77c85a37f7e0",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Get sequences for features",
-               "queryparameters": [
-                  {
-                     "jsondocId": "104a0526-2efd-4785-a686-5bdcb2032136",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "4a0be5d5-7407-40d9-940d-2062fa9e7b6d",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "7950f234-8353-45a4-8117-c88d123eb830",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "14b3db87-5e33-4595-b382-d0f9ca2f9f7e",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "61972ab9-5f26-4d76-9def-edf1eb100965",
-                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/getSequences",
-               "produces": ["application/json"],
-               "methodName": "getSequence"
-            },
-            {
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f94c8cac-8c18-4ebc-9c6e-54b34b93d4ca",
+               "methodName": "getSequence",
+               "jsondocId": "b65ba100-e6b8-4dd5-b16d-fbd039130d51",
+               "bodyobject": {
+                  "jsondocId": "5efd27ca-a94c-40e3-8597-4272ee656155",
                   "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
                   "object": "annotation editor"
                },
+               "apierrors": [],
+               "path": "/annotationEditor/getSequences",
+               "response": {
+                  "jsondocId": "ec9a2324-e306-45d7-9d71-e64409f737fd",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
                "headers": [],
                "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "8b41704e-bde4-45fa-bc6b-294618c5347c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8adfaa8a-97f8-473d-875f-574efd7025a1",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6e834623-c6f6-47d7-b4d6-827f9c2030f3",
+                     "name": "search",
+                     "format": "",
+                     "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
+                     "type": "JSONObject",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Search sequences",
+               "methodName": "searchSequence",
+               "jsondocId": "2a7ed7f3-3ad7-418f-880e-9f305279d493",
+               "bodyobject": {
+                  "jsondocId": "79f3d080-dc6f-4814-afd7-e319a6f29ab1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
                "apierrors": [],
-               "bodyobject": null,
-               "jsondocId": "0c5ad2ec-33f2-41c7-8349-9136d670fd32",
-               "description": "Get sequences search tools",
-               "queryparameters": [],
-               "path": "/annotationEditor/getSequenceSearchTools",
+               "path": "/annotationEditor/searchSequences",
+               "response": {
+                  "jsondocId": "b1d75633-2934-4af5-a34f-f7977688abbc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "jsondocId": "cc27b6e6-6912-4295-a53f-1b7d47719aeb",
+               "bodyobject": null,
+               "apierrors": [],
+               "path": "/annotationEditor/getSequenceSearchTools",
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [],
+               "response": {
+                  "jsondocId": "88c560fd-49c2-48a9-aea4-84bcd44a3dcc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "description": "Get sequences search tools",
                "methodName": "getSequenceSearchTools",
                "consumes": []
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "6d19e735-ac3d-4c9d-b476-1400906529e9",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "3ba0eb8d-cbfd-4838-b63f-00fdc0f30a4f",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d6bcb95d-b47e-44df-a3fc-fd9ff436a480",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get canned comments",
                "queryparameters": [
                   {
-                     "jsondocId": "988999f6-44c9-47be-a4f5-904c2c978782",
-                     "description": "",
+                     "jsondocId": "0beb1b82-f799-4d54-b67c-83b2d535480c",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "email",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9bdb7deb-0e93-4cb5-a3d5-100a61dc1db8",
-                     "description": "",
+                     "jsondocId": "6297966b-4260-4b45-a244-e8e57bd297b3",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "password"
-                  }
-               ],
-               "path": "/annotationEditor/getCannedComments",
-               "produces": ["application/json"],
-               "methodName": "getCannedComments"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "a2d80dfd-eb28-4e8c-91a7-66a1f6adab22",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "e6b61a40-8baa-49a3-9e79-d4da5e426ee5",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f848f04c-0938-4700-b669-769e94e57a5d",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Search sequences",
-               "queryparameters": [
-                  {
-                     "jsondocId": "114952b9-2db6-4884-94a4-bcd641c75b4f",
                      "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "332d65c7-3ead-4e15-b74a-f4c905f5a23a",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
+                     "jsondocId": "56727fa6-4b31-43c6-86c8-8eacf62bd14d",
+                     "name": "sequence",
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "065e5a77-aff1-4c94-92c3-8c50ce1b2815",
-                     "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
-                     "name": "search",
-                     "allowedvalues": [],
+                     "jsondocId": "58ba1a86-5d29-4897-8dab-114e84d6ef56",
+                     "name": "organism",
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "JSONObject"
-                  }
-               ],
-               "path": "/annotationEditor/searchSequences",
-               "produces": ["application/json"],
-               "methodName": "searchSequence"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f3695122-8628-4978-8c51-4251120f0e05",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "5a1a44f3-d6ce-4f80-a7c4-20ec3fae17ed",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0a4d9e4d-7c97-4116-8d20-e660aa7e6123",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get gff3",
-               "queryparameters": [
-                  {
-                     "jsondocId": "e89ccc5f-1492-4e81-a7ba-65d23a6be392",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d6818a3b-906a-49c0-9814-cab82d0cb1aa",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "feed3d8d-6be3-45fe-85cd-dabecef40a3f",
-                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
+                     "jsondocId": "ffb57e81-148c-4529-8275-f9174ee631df",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/getGff3",
+               "verb": "POST",
+               "description": "Set status of a feature",
+               "methodName": "setStatus",
+               "jsondocId": "01afe7e5-3a5d-4824-9126-25f57957f96c",
+               "bodyobject": {
+                  "jsondocId": "97cf649d-788c-467f-9d84-41caa843d8f6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setStatus",
+               "response": {
+                  "jsondocId": "837d8d3b-f517-4b00-ad3e-7d984869c8e5",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "getGff3"
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7dd9eb25-4187-4b19-978d-ad4e306ea3f4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "44c4fa31-cb23-46a3-88e3-99e9207cf8b2",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6bafcd3f-01a9-4ad0-afd8-d983a2c9c2d8",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5425c33c-ec62-4014-9e20-a931d8de52ad",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "480ccd6a-c9a1-4d60-bb23-2e475d9dcf10",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get comments",
+               "methodName": "getComments",
+               "jsondocId": "fad6817c-dc00-4c2f-8883-3009b90f31ac",
+               "bodyobject": {
+                  "jsondocId": "122a4d58-9bfe-46ab-a2ba-092b649b9ae2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getComments",
+               "response": {
+                  "jsondocId": "b077bc15-8ec7-45c1-b664-faddaec362f7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c030b77e-33c6-4655-849e-964bb70a8baf",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0056a2c8-29f4-4318-9b05-fc4af79f7bee",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "947c90dd-cba4-4db9-82c6-d9dac4cc6b67",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5438bbf5-4774-4a96-9675-b4eac838f4f8",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7c6b9f05-5ba1-443f-9d4f-e1da95824ebc",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add comments",
+               "methodName": "addComments",
+               "jsondocId": "cc7bb121-0bb0-468d-890e-a88c295f998e",
+               "bodyobject": {
+                  "jsondocId": "efac1622-d4ff-4849-8b1c-a24e338b5c7b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addComments",
+               "response": {
+                  "jsondocId": "0387464c-2e37-4ddd-8e2e-7164549061b3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c5238fe5-a998-4862-83bd-f47961b13ed8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0fd3ac13-ca0c-4a6b-acb3-d91d9ab4eb50",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2101c3c2-98e6-4d90-ab76-595a0a6db5da",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dd8d55b5-4669-4d87-a5ee-e581cc22bebc",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7febd8d1-7cde-4d71-9ca9-fd6ec7101679",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete comments",
+               "methodName": "deleteComments",
+               "jsondocId": "7f3eb9b6-5702-4ee4-98f9-46eb0c934b5f",
+               "bodyobject": {
+                  "jsondocId": "edc54441-31fe-40ce-94a5-a68002cf696e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteComments",
+               "response": {
+                  "jsondocId": "b6ff0bc3-79ef-4bd8-9686-37f12a846ae7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "81473e74-3148-44f8-b9e3-454b8a0a15af",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "31b34919-7644-4067-9c9d-9b23665db616",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ffa9b7ee-1d56-4854-b2c2-818b7204cac2",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fa396dcb-1998-44d2-8b72-09c58beed75e",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bc2fd1e8-2136-4edd-9e08-ba76e8b0f989",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update comments",
+               "methodName": "updateComments",
+               "jsondocId": "65193204-a834-40d3-8c2d-dd9ea6edd974",
+               "bodyobject": {
+                  "jsondocId": "e87a1535-14be-40b1-8e13-788954ee05fc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateComments",
+               "response": {
+                  "jsondocId": "a7e0dec0-7300-44a9-877a-d6a8eb5f358a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7f25d57b-999b-4932-82c9-37a4f9c9c29a",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dca9a809-786c-4bff-8e3a-de3b2f5802cf",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9b7da06f-5a92-4299-83e8-590dc77fe6e2",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ba1057e5-5087-4c6b-8976-85a9029161e8",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get all annotated features for a sequence",
+               "methodName": "getFeatures",
+               "jsondocId": "967db250-0b13-4652-923d-d60f8677d337",
+               "bodyobject": {
+                  "jsondocId": "8a4ebe46-6af4-4e1e-8a83-4ac44e0f05e2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getFeatures",
+               "response": {
+                  "jsondocId": "77579bd1-3cf2-4d20-ab47-6aba75c5e311",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "24805605-9d02-4a14-b2df-f4d414eb27a1",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "06fc4323-ccb5-484b-862e-27891e051aaf",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7025716f-1cf9-491c-8c5e-85344223f86d",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cd3738a0-26b4-4cd8-af1a-9f6350e9a942",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "41bda46e-553e-4159-88ba-1da739428f0a",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5dc54d78-af86-463a-afb1-13d41ae810ea",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7af738bb-2173-48e4-b8cc-a1d46ec8b31e",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add transcript",
+               "methodName": "addTranscript",
+               "jsondocId": "a98ce8a5-78f2-4437-ba42-25094d830abe",
+               "bodyobject": {
+                  "jsondocId": "44018e69-58a0-4bce-8c35-545b0c9773e2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addTranscript",
+               "response": {
+                  "jsondocId": "111e21e5-21df-4842-aa9d-463ca59b58b2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "740c646a-0087-483a-9cf4-eb7f1d08593e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "647049c4-2db6-4029-858d-4b61bfe56c59",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ec6143b8-f0c7-48ee-86ed-ddd07c570648",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b8b50a18-ab3a-4dab-ab9f-6ecacc3aee83",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2d95ebdc-437c-4133-b927-c67fff33d214",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set readthrough stop codon",
+               "methodName": "setReadthroughStopCodon",
+               "jsondocId": "e54515e8-82c1-4c03-861b-e75998ba7907",
+               "bodyobject": {
+                  "jsondocId": "d8200e56-de85-44ca-b410-06e3251f1463",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setReadthroughStopCodon",
+               "response": {
+                  "jsondocId": "4c5afae7-0706-48c2-8388-1fa6e906c5fe",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "338025fa-8771-414a-8233-517266cff259",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c90abcc1-7909-4624-9f7a-5b684fb22cf0",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cfe1a113-bca5-493b-931a-31286c67f4ba",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "528a5805-60c0-49ae-8138-de8f57782a34",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b2ee6ccc-e089-40c2-ba9a-bf6c46857320",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set longest ORF",
+               "methodName": "setLongestOrf",
+               "jsondocId": "d45f3cad-0b57-4bcd-a5d9-909f3785b271",
+               "bodyobject": {
+                  "jsondocId": "49f3e478-35a7-49d4-b8ce-1296b4167e9a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setLongestOrf",
+               "response": {
+                  "jsondocId": "4f3572f7-7c38-483e-9c37-f32db43dff04",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7204981a-6b85-4c88-8397-d8ca46fb509a",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4404a240-b383-45da-ac34-fdfc55dedd30",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f5004891-5cc9-4a8f-8ec8-2b33aa9e706d",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5ad8232e-ff81-46ab-915a-dc6e4d1725d9",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9efdc313-bf0f-4e16-91a0-78b30957b38d",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "de93163d-4c8a-4364-a739-22e8d9d5f5ae",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "072c2707-c32d-405c-9b44-c89b659d350a",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set exon feature boundaries",
+               "methodName": "setExonBoundaries",
+               "jsondocId": "88f268a6-a399-4747-a19d-824330275267",
+               "bodyobject": {
+                  "jsondocId": "5d388432-438f-48e4-b53e-f4629f8c4042",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setExonBoundaries",
+               "response": {
+                  "jsondocId": "66b4296c-e463-48c6-814a-b5a3d59df0a0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "dad0ae62-7c59-4dd3-ab73-ce3841f3978c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1360de8a-cae8-4fcc-86e2-2727b294d9a1",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "664e3546-a4e7-47e9-ab27-01395ae3fd7e",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e14042f9-8a30-4b11-b2e2-5566506e9e88",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3e33aa82-e59d-4d60-8e77-0109ec5194ae",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set boundaries of genomic feature",
+               "methodName": "setBoundaries",
+               "jsondocId": "d09144a0-0196-4060-a399-637d64957130",
+               "bodyobject": {
+                  "jsondocId": "013fab9d-28f6-4bac-8757-02b363552e81",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setBoundaries",
+               "response": {
+                  "jsondocId": "673f9211-90b4-4697-a1ac-bd3aceb5187f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "210cb334-9b83-43d2-a397-acb0ed8b3cc4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4b233720-e301-4c85-a5e8-2e0a03383528",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d76afa14-5f84-41ac-b0c9-86bfe2066429",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d34625ff-593b-4ca0-af18-af10a0af29c4",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "66942182-312a-4fa5-8255-71791c01576e",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete sequence alteration",
+               "methodName": "deleteSequenceAlteration",
+               "jsondocId": "4d869c00-aa74-4a0b-bfe4-78db579bcee9",
+               "bodyobject": {
+                  "jsondocId": "d498cb9f-8a5e-49ae-b110-87234d4471ec",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteSequenceAlteration",
+               "response": {
+                  "jsondocId": "fdcc851a-7fb7-48e3-92a2-adf5d7098016",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "254e21a8-ea1e-49e2-b2bc-47c4f53cd207",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "07ae5207-b565-478e-888a-e26e5f47aed1",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c072bf9c-2057-410b-ae16-a547b27931f9",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4d4b0835-7ead-4ac3-8f5c-72e6dce86b1b",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "981066fe-95a8-4f2c-ac97-82bb4459e605",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add sequence alteration",
+               "methodName": "addSequenceAlteration",
+               "jsondocId": "fda05842-82ba-4e32-bdac-f588238c31d4",
+               "bodyobject": {
+                  "jsondocId": "fedcb979-6a13-44cb-b254-5981eed7ebb0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addSequenceAlteration",
+               "response": {
+                  "jsondocId": "9d094546-2a5d-4da7-83a6-7d157b2ce5b0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "513f1dcd-1cab-4e94-b902-13057fb5aa10",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0a2a47e1-085f-4bae-ab7a-4a0cb3793108",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e0f8069c-5982-4a8d-976b-023f74a71f94",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "00e3e366-ad1f-4047-9933-857492f7e193",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9f6ae822-bb5f-412e-9a5f-2194bedc5d3a",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Split exons",
+               "methodName": "splitExon",
+               "jsondocId": "98e93aed-7bdd-4204-8e4c-a6edb30565a9",
+               "bodyobject": {
+                  "jsondocId": "f760ab53-2e28-4693-966d-dc1b4771c260",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/splitExon",
+               "response": {
+                  "jsondocId": "9172a61c-a841-463a-9f71-61090dec74ad",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5e3d058c-b862-41fa-99a4-22b6dad1dd9c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e3cda6cf-e6ed-4b68-80f0-49b6c15642a7",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f86fa15a-74dc-44f9-8f38-e5a1fe54bc52",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ec876415-db29-4f25-9358-34d83f1a80ed",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ad4bf7da-985b-48ac-ad67-0e3e93316640",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Make intron",
+               "methodName": "makeIntron",
+               "jsondocId": "32760480-1856-4b3a-bfc4-aa9aae8eb1ad",
+               "bodyobject": {
+                  "jsondocId": "fc6db65a-ba57-4efd-87cf-172001d7ddff",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/makeIntron",
+               "response": {
+                  "jsondocId": "1ed0c1d6-2b74-4184-a8a8-10469db812db",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "1a5046a9-f29a-475c-8cda-f0c3fae8f0d7",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5f1174e3-ded4-457d-b2b7-08f44fe51794",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "572fc769-a417-4d60-8516-d7c50038854a",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4aad307f-60e2-41f0-8a63-05b1fabb0971",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4d3e39b3-cd57-4639-94aa-b7bbf1f5f9ee",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set name of a feature",
+               "methodName": "setName",
+               "jsondocId": "114890b5-5f30-4811-8a21-4b7ee1437b55",
+               "bodyobject": {
+                  "jsondocId": "25b03de4-58ca-48d8-946d-fc4fdd404932",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setName",
+               "response": {
+                  "jsondocId": "07323518-240d-4e80-ae98-a2cebc9fea6d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
             }
          ],
-         "jsondocId": "756c979d-c75b-4711-a038-e85623a819c4",
-         "description": "Methods for running the annotation engine",
-         "name": "Annotation Services"
+         "name": "Annotation Services",
+         "description": "Methods for running the annotation engine"
       },
       {
+         "jsondocId": "7c441dd0-e31b-4b5f-86fa-dda48cdc42ea",
          "methods": [
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "5cf1d219-8f8e-4b61-826b-80edd4eaafde",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "4ff3e0bb-607b-4bb2-ac3a-0c38a109a1c8",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3a2cff60-8fb2-47a3-9143-f90fb583515f",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7d15067a-0573-48fc-ba27-70131da98bf5",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b0cb6847-75e0-46e1-b655-53d56213ff4e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3747883b-efda-4a66-921b-ef37acd7fc6f",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Create group",
-               "queryparameters": [
-                  {
-                     "jsondocId": "1f63bef5-a351-4c26-a9f4-4780d8724e24",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "16c8c920-7d40-4b92-b344-a867786b95d2",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "d4811234-9033-419b-9563-dd8974b07bee",
-                     "description": "Group name to add",
-                     "name": "name",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "createGroup",
+               "jsondocId": "87df70cc-6053-4ef1-b622-61b455fa1fa3",
+               "bodyobject": {
+                  "jsondocId": "5b482365-90ed-4e6b-87dc-5c84a1c4ae47",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
                "path": "/group/createGroup",
+               "response": {
+                  "jsondocId": "81737ca6-0184-4e5b-96a1-b6af010bcbd1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
                "produces": ["application/json"],
-               "methodName": "createGroup"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "c313e972-542e-4d35-ad59-a96dc0d66c10",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "c23a6f4e-5756-4d84-8195-7aa7af24e924",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3de9c5b9-1495-4ac5-b888-7b824726ddad",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get organism permissions for group",
                "queryparameters": [
                   {
-                     "jsondocId": "e7dfe05c-b459-4ca3-926e-b6bdbef0207f",
-                     "description": "",
+                     "jsondocId": "34b68097-60a9-4804-a074-3df938408e09",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "email",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aafa33b6-68d8-4b10-b750-00a8c6ce45c0",
-                     "description": "",
+                     "jsondocId": "66b92494-0ab3-4638-98a7-ddceaec73377",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "dea84dde-72df-4ba0-9c01-71598b855ff3",
-                     "description": "Group ID (or specify the name)",
-                     "name": "id",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "b869c54a-8dba-4a68-a04e-1a7023125766",
-                     "description": "Group name",
-                     "name": "name",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
-               "path": "/group/getOrganismPermissionsForGroup",
-               "produces": ["application/json"],
-               "methodName": "getOrganismPermissionsForGroup"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f4878ab2-25a6-4ca3-927f-a5df4eb1c4a3",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "10b27085-1ef8-40bd-8d8b-f55059ca0803",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f1eb17ae-e5aa-4359-875b-b6d7f0f7fca2",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Load all groups",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d371db74-5031-48d0-98ef-fc248e75ad5b",
                      "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e606d5c6-a8d4-40db-862b-1b034b687657",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "ae601936-7f27-4796-888e-cbe16565f565",
-                     "description": "Optional only load a specific groupId",
+                     "jsondocId": "60722889-e2b5-41be-869c-38ae65c44500",
                      "name": "groupId",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "Group ID to modify permissions for",
+                     "type": "long",
                      "required": "true",
-                     "type": "long"
-                  }
-               ],
-               "path": "/group/loadGroups",
-               "produces": ["application/json"],
-               "methodName": "loadGroups"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e3887a76-62f0-4743-9d82-b246dff6905a",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "0f378098-43b0-4a56-9de9-3a8bc328a916",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "5fa85869-2b77-4fcb-902a-d6dc7657f745",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Delete a group",
-               "queryparameters": [
-                  {
-                     "jsondocId": "6c9389b8-46cb-492d-ad31-75cbec1ce83c",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "041b7a3d-e11b-4cae-90c0-60fb47875f01",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "fec61364-463b-4423-aea1-f81e0031775e",
-                     "description": "Group ID to remove (or specify the name)",
-                     "name": "id",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "51812e8f-210b-4f90-83aa-b3d20c59c876",
-                     "description": "Group name to remove",
+                     "jsondocId": "e9f39345-deba-4c84-9c30-fd5a2bc04d4b",
                      "name": "name",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "Group name to modify permissions for",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4bb1d07f-0e4a-4e8a-961b-591c8eaa22cb",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Organism common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "251d2ae8-f957-4e82-b739-956587be4ffd",
+                     "name": "administrate",
+                     "format": "",
+                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "272ec8f3-4acb-4a20-857c-b6f86a1a6b34",
+                     "name": "write",
+                     "format": "",
+                     "description": "Indicate if user has write privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "af5188d8-fbf7-4f2d-b4c4-61d5cf6971b6",
+                     "name": "export",
+                     "format": "",
+                     "description": "Indicate if user has export privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bbcbc7ee-43a3-443d-a1a5-12ad3a8aa02f",
+                     "name": "read",
+                     "format": "",
+                     "description": "Indicate if user has read privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
                   }
                ],
-               "path": "/group/deleteGroup",
-               "produces": ["application/json"],
-               "methodName": "deleteGroup"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "79fd2b24-f242-4de3-8d6c-f88882b7489f",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "dd415bd4-5f26-4da3-a092-f6c8e275e6e5",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d08eab33-ebe4-476b-af06-2460769cd5e9",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Update group",
-               "queryparameters": [
-                  {
-                     "jsondocId": "6eaa3cc8-fdd6-49c8-b23c-4b4c382963df",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "1e1a76bb-ccb4-4865-b1dd-6d54611a4d7c",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "bc0095e6-c3f7-430c-917d-96ecad3e0d20",
-                     "description": "Group ID to update",
-                     "name": "id",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "fba52afe-45f5-4a40-9e77-2c369ab9818c",
-                     "description": "Group name to change to (the only editable optoin)",
-                     "name": "name",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
-               "path": "/group/updateGroup",
-               "produces": ["application/json"],
-               "methodName": "updateGroup"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "15b0cfba-2879-4a30-b073-09de0fd247fe",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "a4ece33c-f4e6-493c-abab-ae48864e60cc",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0b29257d-4c92-4f1b-a2b7-14ea3d711ed3",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "Update organism permission",
-               "queryparameters": [
-                  {
-                     "jsondocId": "f9328891-4701-45cc-a3ff-4e9f604d605b",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "c067993b-fe23-4c17-a93d-aa2631cae58f",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "9665f630-544b-4812-be21-4b1c08d9ca9f",
-                     "description": "Group ID to modify permissions for",
-                     "name": "groupId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "5bc71a7f-8e55-4677-beef-25279d25a27b",
-                     "description": "Group name to modify permissions for",
-                     "name": "name",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "fe1461b4-816b-4a1c-9969-ce11906eb976",
-                     "description": "Organism common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "75dc7481-c8b2-4a9f-ba7d-44a2c60efc41",
-                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
-                     "name": "administrate",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "a7a8b9e0-e28b-4294-987b-67c29c809919",
-                     "description": "Indicate if user has write privileges for the organism",
-                     "name": "write",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "ef27dffa-bdb7-4f71-a6f7-8749c568baf0",
-                     "description": "Indicate if user has export privileges for the organism",
-                     "name": "export",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "62fcde6c-088b-414a-9f93-d8d995fec132",
-                     "description": "Indicate if user has read privileges for the organism",
-                     "name": "read",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  }
-               ],
-               "path": "/group/updateOrganismPermission",
-               "produces": ["application/json"],
-               "methodName": "updateOrganismPermission"
-            },
-            {
-               "headers": [],
+               "methodName": "updateOrganismPermission",
+               "jsondocId": "e31f80e3-ead1-4dde-87e1-77aeeaf4cdb4",
                "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e2bba732-f741-44cf-a534-c6022e376bbc",
+                  "jsondocId": "4cdd4456-e243-4c70-9c90-c2efaad1acae",
                   "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
                   "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "8eb82f8a-edb5-4c9b-9004-0ef731faa9c2",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e407dd3b-b244-4858-b6e8-6c6f6738b3a5",
-                  "mapValueObject": "",
                   "object": "group"
                },
-               "pathparameters": [],
                "apierrors": [],
+               "path": "/group/updateOrganismPermission",
+               "response": {
+                  "jsondocId": "999a331a-b0fa-4629-bd14-2b015f698074",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "ee3afaeb-58e9-4be1-bfcb-70c5941418e6",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7e867e98-5f60-4941-937b-55b99cbad710",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d3c17bd6-9bde-4a1c-8774-7d519ce08e42",
+                     "name": "id",
+                     "format": "",
+                     "description": "Group ID (or specify the name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "44878288-404a-4476-943f-66446d50cff8",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for group",
+               "methodName": "getOrganismPermissionsForGroup",
+               "jsondocId": "a861dcdc-7dd2-44da-b200-36a50cfe1aee",
+               "bodyobject": {
+                  "jsondocId": "89384e81-da87-488a-b339-a0aa1e00fe00",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/getOrganismPermissionsForGroup",
+               "response": {
+                  "jsondocId": "fb061119-8d23-4adb-b02b-708b49b47c5e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "30821be1-dde2-4d76-bc1c-1a4c04732094",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2fefba03-5f72-43d4-888d-59036e382c1c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "49c38a75-0576-4776-990a-1413a19b2c55",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Optional only load a specific groupId",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Load all groups",
+               "methodName": "loadGroups",
+               "jsondocId": "8a8b2c34-bd54-4ec9-8fff-b369147da79c",
+               "bodyobject": {
+                  "jsondocId": "0309a289-5e8f-4329-b201-67d8c676d932",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/loadGroups",
+               "response": {
+                  "jsondocId": "3782c771-121b-4ce1-aa9e-88520aa8b64e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "f4e48909-23e1-452a-b404-11607cbb55f4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8add6e23-1203-4d0e-b944-50cfaca898a8",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f0d7a0de-95ec-4fc2-91bc-695bd1ea4508",
+                     "name": "id",
+                     "format": "",
+                     "description": "Group ID to remove (or specify the name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "663976f7-b46a-45dc-89e8-998b8befd973",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to remove",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete a group",
+               "methodName": "deleteGroup",
+               "jsondocId": "13c85a26-628f-45ad-ae78-186676f79f37",
+               "bodyobject": {
+                  "jsondocId": "0f2e1317-c9d4-4788-b0f0-e9a4febb500a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/deleteGroup",
+               "response": {
+                  "jsondocId": "b5e60b03-42d9-4811-a671-82a86f15574e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "ddb5c53b-6390-4bda-9f8d-8104239c6241",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3f93c4f5-58f7-457c-a6cf-4ea827cf4126",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "329f3221-a05d-434d-a887-114da70e609b",
+                     "name": "id",
+                     "format": "",
+                     "description": "Group ID to update",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a83b3d5c-894e-48f2-ae0d-5ea2963e4f8a",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to change to (the only editable optoin)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update group",
+               "methodName": "updateGroup",
+               "jsondocId": "719ba585-9a3c-4bec-9fe0-9d0ba0560845",
+               "bodyobject": {
+                  "jsondocId": "9c44fe27-23fb-4179-877f-4891b5cbf326",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/updateGroup",
+               "response": {
+                  "jsondocId": "b94b3faa-472b-4c91-a13c-66d24ad95868",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "fff3d2db-f5da-4ab0-b47b-fe779c834775",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "673bd991-48be-41c6-939c-1818e962a81d",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dcd844c2-3343-4695-a1da-f3a9c56e934c",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Group ID to alter membership of",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "70e9494c-1994-4a18-a6c5-ec87bfc5f7c2",
+                     "name": "user",
+                     "format": "",
+                     "description": "A JSON array of strings of emails of users the now belong to the group",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Update group membership",
-               "queryparameters": [
-                  {
-                     "jsondocId": "5f909207-d39f-4bf5-a205-cf3b44ffce68",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "ae7c0dd1-9a37-4229-93c8-5d02191cd2cd",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "13b98e4c-9571-46d0-b3eb-7e8ca1f393e7",
-                     "description": "Group ID to alter membership of",
-                     "name": "groupId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "0378d970-2403-4505-8310-e63776fd42bf",
-                     "description": "A JSON array of strings of emails of users the now belong to the group",
-                     "name": "user",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
+               "methodName": "updateMembership",
+               "jsondocId": "540fb3b8-4622-4ea1-94bd-fac971e80a21",
+               "bodyobject": {
+                  "jsondocId": "7f2d222e-09ff-4d44-9aa6-fb9d42c91d51",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
                "path": "/group/updateMembership",
+               "response": {
+                  "jsondocId": "eef9c2bc-9b95-46df-a502-1ad1fe1e66b1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
                "produces": ["application/json"],
-               "methodName": "updateMembership"
+               "consumes": ["application/json"]
             }
          ],
-         "jsondocId": "6bdee0db-02c8-45b3-9e42-faf4ad732a0e",
-         "description": "Methods for managing groups",
-         "name": "Group Services"
+         "name": "Group Services",
+         "description": "Methods for managing groups"
       },
       {
+         "jsondocId": "948213fd-b7da-4cd4-a2f4-aa1537c98d0b",
          "methods": [
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "757a4b12-89cf-4179-9a2c-9584442a61f1",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "i o service",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "9990e106-4989-4068-8e3f-6436242851ff",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ae4634c9-a392-4099-b930-92544b9a9dca",
-                  "mapValueObject": "",
-                  "object": "i o service"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "queryparameters": [
                   {
-                     "jsondocId": "2f2c6ff0-93b3-40ab-a7fe-61181b465044",
-                     "description": "",
+                     "jsondocId": "7871157c-8af1-4228-8d40-37446f86cf23",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "0f6e393f-8ec4-45f9-b747-a9750ba988ed",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "658d86e5-ab63-46eb-8199-8587b2173d22",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "15c45f2c-8d61-4c77-bc4d-6d659327aeba",
-                     "description": "Type of export 'FASTA','GFF3'",
-                     "name": "type",
-                     "allowedvalues": [],
+                     "jsondocId": "a3de3794-5808-4e7a-b4a4-8ee080c167d9",
+                     "name": "uuid",
                      "format": "",
+                     "description": "UUID that holds the key to the stored download.",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "295cb80f-413f-4276-9511-effe45c5fa93",
-                     "description": "Type of output sequence 'peptide','cds','cdna','genomic'",
-                     "name": "seqType",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "ee18c5e9-d44c-4982-8209-2f2dc79c68b1",
-                     "description": "'gzip' or 'text'",
+                     "jsondocId": "3564bbd3-19e7-47a8-aecc-8ce0e8c7627d",
                      "name": "format",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "'gzip' or 'text'",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "0aa00aab-207f-4c89-8321-f645d16ac4dc",
-                     "description": "Names of references sequences to add.",
-                     "name": "sequences",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "020802c4-dcec-4959-a497-fcea74bce420",
-                     "description": "Name of organism that sequences belong to.",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "04182eec-656b-4a25-9227-0972ab3f68d0",
-                     "description": "Output method 'file','text'",
-                     "name": "output",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "a9abf688-37d2-4531-ada0-805ddf453d9f",
-                     "description": "Export all sequences for an organism (over-rides 'sequences')",
-                     "name": "exportAllSequences",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "2f852237-e797-4082-a739-9bedff174ef7",
-                     "description": "Export sequences when exporting gff3",
-                     "name": "exportGff3Fasta",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/ioService/write",
-               "produces": ["application/json"],
-               "methodName": "write"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ba435102-988a-463f-9cc7-c25bed1da7e0",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "i o service",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "aa66b6bf-4097-4717-bd72-2ab866477ddd",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "cafff882-37c2-40c3-88e1-4f8d22257f17",
-                  "mapValueObject": "",
-                  "object": "i o service"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
+               "methodName": "download",
+               "jsondocId": "a2d0f350-42ca-401d-b7aa-0925a929314f",
+               "bodyobject": {
+                  "jsondocId": "4e9001ca-a3b1-47ec-81cd-dbac5314c318",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "i o service"
+               },
+               "apierrors": [],
+               "path": "/ioService/download",
+               "response": {
+                  "jsondocId": "0aa163b3-85dc-4e9b-ac63-70a75d0ef3ee",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "i o service"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "25bb776f-bcd7-4182-b790-fa968770278a",
-                     "description": "",
+                     "jsondocId": "14881869-f128-4a23-9d0a-996971cf4b07",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "398919f4-c4ee-443a-b524-547cc871b09a",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0d456d3b-b936-458c-afaa-00096c189ccf",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dd04a576-3535-45ec-a021-6af54cf07f4e",
-                     "description": "UUID that holds the key to the stored download.",
-                     "name": "uuid",
-                     "allowedvalues": [],
+                     "jsondocId": "2e3e3931-57a9-4c8f-ae00-5e0e6fdc839b",
+                     "name": "type",
                      "format": "",
+                     "description": "Type of export 'FASTA','GFF3'",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b2bd4b65-f116-4d45-8ce6-21be81e2a399",
-                     "description": "'gzip' or 'text'",
+                     "jsondocId": "14bf337c-2ba0-43ab-b4dc-3c7a5617a3da",
+                     "name": "seqType",
+                     "format": "",
+                     "description": "Type of output sequence 'peptide','cds','cdna','genomic'",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1994c0d3-cb53-4cc8-a81f-dc9a81516e98",
                      "name": "format",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "'gzip' or 'text'",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cd13622c-0f77-4f5b-a589-d5db0a93868e",
+                     "name": "sequences",
+                     "format": "",
+                     "description": "Names of references sequences to add.",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1a67350c-f5b0-498a-9cd3-e1c03009f049",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Name of organism that sequences belong to.",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4a7ead99-10bf-4eec-bc65-51177e6a9f28",
+                     "name": "output",
+                     "format": "",
+                     "description": "Output method 'file','text'",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7003bada-eea5-402d-b7c3-cc783e574a7a",
+                     "name": "exportAllSequences",
+                     "format": "",
+                     "description": "Export all sequences for an organism (over-rides 'sequences')",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a5179a7f-1dc5-413b-a2e2-520c04aadd0e",
+                     "name": "exportGff3Fasta",
+                     "format": "",
+                     "description": "Export sequences when exporting gff3",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
                   }
                ],
-               "path": "/ioService/download",
+               "verb": "POST",
+               "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
+               "methodName": "write",
+               "jsondocId": "3be6065c-0aae-42ae-aa09-bf1f88a4328f",
+               "bodyobject": {
+                  "jsondocId": "d6df77c0-076c-4c12-8285-8eb8c2e335a1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "i o service"
+               },
+               "apierrors": [],
+               "path": "/ioService/write",
+               "response": {
+                  "jsondocId": "b19402da-776c-4c9a-b04e-82d96171784a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "i o service"
+               },
                "produces": ["application/json"],
-               "methodName": "download"
+               "consumes": ["application/json"]
             }
          ],
-         "jsondocId": "32c4675f-c2c4-4983-aff1-72436c4f633a",
-         "description": "Methods for bulk importing and exporting sequence data",
-         "name": "IO Services"
+         "name": "IO Services",
+         "description": "Methods for bulk importing and exporting sequence data"
       },
       {
+         "jsondocId": "89ef57c5-ea63-42dd-ba12-4dd32e328ce9",
          "methods": [
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ff5516c4-a364-44ed-a342-f0677528cb18",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "f0da0a7e-c881-43f9-8230-cdc7a7d9e542",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "9a8503e6-e987-4689-b376-9677bd12cfaa",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c095d811-085b-491c-9b4e-58a43055580e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "21e80e06-cb83-4954-b7b7-664d7a9492d7",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fe7dc85e-f84f-4029-a828-ea157f17e5b7",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Pass an Organism JSON object with an 'id' that corresponds to the id to delete",
+                     "type": "json",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Remove an organism",
-               "queryparameters": [
-                  {
-                     "jsondocId": "b5ee7cf6-000a-459a-8376-ef39a3b7d713",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "57fb64e0-1ce2-4616-86a2-20893e2d497e",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "18dcc92c-f0f2-4b5b-a1a2-d9dd15e949cf",
-                     "description": "Pass an Organism JSON object with an 'id' that corresponds to the id to delete",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "json"
-                  }
-               ],
+               "methodName": "deleteOrganism",
+               "jsondocId": "a4cda158-bcee-4c7b-bdc8-ef9efdac4fce",
+               "bodyobject": {
+                  "jsondocId": "058869f9-01b1-4260-9b20-06d9ec249ddc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/deleteOrganism",
+               "response": {
+                  "jsondocId": "ab2098f9-05f0-4dc3-801d-b9171672bc9d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteOrganism"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "a6ab1780-d465-442d-8e36-2e85281a5eb3",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "639bfff7-4bcb-4fea-b9b1-b19e0aa6b919",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f9c88e23-ff4e-4391-83c3-43918d458831",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e6c12161-cf67-4d19-b759-7ec6a98d955f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ec504b1a-52e9-45c8-b083-2d61479f23d7",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fb2ce7cc-2388-4df8-8464-f5fbb4a9307b",
+                     "name": "organism",
+                     "format": "",
+                     "description": "An organism json object that has an 'id' or 'commonName' parameter that corresponds to an organism.",
+                     "type": "json",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Remove features from an organism",
-               "queryparameters": [
-                  {
-                     "jsondocId": "6aaf683e-f2ce-42a5-9268-9d5c275d1b56",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "1f0a63e1-7bb1-46be-b06d-d26bc1ff4d30",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "0276d877-d038-4584-b608-02f520bee8a7",
-                     "description": "An organism json object that has an 'id' or 'commonName' parameter that corresponds to an organism.",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "json"
-                  }
-               ],
+               "methodName": "deleteOrganismFeatures",
+               "jsondocId": "4548af2e-c87a-4659-8dcd-d65a70d5500f",
+               "bodyobject": {
+                  "jsondocId": "440119a1-d468-449a-a87e-da1c97945d3d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
+               "response": {
+                  "jsondocId": "ca2c071b-5a6e-4653-b379-5524c75d7f67",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteOrganismFeatures"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "8e30d9ba-db25-431c-aacd-9d14b1c099b4",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "fb2b072c-2e62-44dd-ad22-4b1bae5e8b7a",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ae3db6f2-3fed-47a8-b78b-c8b7194c66c6",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e5f12fad-f754-4c29-a7ef-114d5ac891f3",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "deb38f92-fcb3-4033-b147-99d9219266a7",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1eca5cd9-2253-47bd-867c-afdfa4103628",
+                     "name": "directory",
+                     "format": "",
+                     "description": "filesystem path for the organisms data directory (required)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d2e555d9-294e-42e5-b727-6e15ba5800bc",
+                     "name": "species",
+                     "format": "",
+                     "description": "species name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c41ff996-2ca3-4651-93a9-1f2793ba473a",
+                     "name": "genus",
+                     "format": "",
+                     "description": "species genus",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "017da2bd-34fe-43d0-8bc0-268ee61d76fe",
+                     "name": "blatdb",
+                     "format": "",
+                     "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "16290516-95fc-4005-b329-a1846eec78ab",
+                     "name": "publicMode",
+                     "format": "",
+                     "description": "a flag for whether the organism appears as in the public genomes list",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c052837f-94b2-4caf-8114-019e8007b62b",
+                     "name": "commonName",
+                     "format": "",
+                     "description": "a name used for the organism",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d04d8edf-b954-47af-821d-d15955233caa",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "6b7cc11a-a813-441d-aac2-fc4e0b328f59",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "dbfb2153-d85e-4b94-8ce7-070de61dd75b",
-                     "description": "filesystem path for the organisms data directory (required)",
-                     "name": "directory",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "471c061b-54c4-416c-8564-a8036a6daea9",
-                     "description": "species name",
-                     "name": "species",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "9cce583e-a506-402d-99df-fb67cd9e22e6",
-                     "description": "species genus",
-                     "name": "genus",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "c627b039-f7cc-4482-a904-c3741db03e33",
-                     "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
-                     "name": "blatdb",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "dc0777f8-5b3d-4b41-bcd3-761591a975be",
-                     "description": "a flag for whether the organism appears as in the public genomes list",
-                     "name": "publicMode",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "c2f52779-97ab-426c-a5d5-ddcf1eadb84f",
-                     "description": "a name used for the organism",
-                     "name": "commonName",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "addOrganism",
+               "jsondocId": "19f2dde7-92ba-4ab7-b4d3-8b8e2f706b53",
+               "bodyobject": {
+                  "jsondocId": "881746b0-0447-48a5-857a-7b99ab1b81e3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/addOrganism",
+               "response": {
+                  "jsondocId": "08f4bf6a-984f-42da-8461-9272facc4d21",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "addOrganism"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "17872466-db69-410c-8d7b-edc8817251bc",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "7120e60a-bfbc-4c13-98be-9a69530f033a",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "aa5732dc-f0fa-412c-9e31-84c601c07de4",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "20be3cea-2093-4dee-912a-d86ddf2a7689",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "871393f1-f818-4435-a879-82203e127eac",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "936f69af-d482-4e98-a727-d4ae5e66ca14",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Common name or ID for the organism",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
-               "queryparameters": [
-                  {
-                     "jsondocId": "49487b75-3ea7-45bd-8c51-026e14b355ea",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "082d179d-8b32-469b-9f22-981cb266e364",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "ab5b0327-27c6-49ee-bf86-171c3a350b9b",
-                     "description": "Common name or ID for the organism",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "getSequencesForOrganism",
+               "jsondocId": "1e2a1677-edad-405b-96f5-b06f448ae1a3",
+               "bodyobject": {
+                  "jsondocId": "6e5f5772-4a3c-44a3-bd1d-93a11da3dcd4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
+               "response": {
+                  "jsondocId": "f112bcd7-ea79-43cc-97a9-55d7c2160cfc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "getSequencesForOrganism"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3dcadb92-43a8-48e8-95f0-586b635d7cb8",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "798a28cd-4cf6-44a1-81d0-50cdc63e894d",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "44eab4c6-c4b2-4282-b16a-0de3671c256a",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "9f3f1879-d45e-48e1-a3de-0eb1b3e83d87",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7a7d0e6a-26c9-47cd-9dc0-bc654b2fa61b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "efa5ef97-466a-4588-9fa9-6558377ccb11",
+                     "name": "id",
+                     "format": "",
+                     "description": "unique id of organism to change",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e83dc3dd-2242-48d9-93af-3269c1edbd4d",
+                     "name": "directory",
+                     "format": "",
+                     "description": "filesystem path for the organisms data directory (required)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "858b7faf-02bd-4753-be53-5a5df49a95d0",
+                     "name": "species",
+                     "format": "",
+                     "description": "species name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "75183079-4aed-45ab-ab9e-b22cd9a1e6e5",
+                     "name": "genus",
+                     "format": "",
+                     "description": "species genus",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f1cc8f4a-fe75-4478-93f3-b34f87082d7d",
+                     "name": "blatdb",
+                     "format": "",
+                     "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9fb5aab1-6ba0-46bf-b294-ab2391c9912d",
+                     "name": "publicMode",
+                     "format": "",
+                     "description": "a flag for whether the organism appears as in the public genomes list",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "458ecfb6-d6c0-46d1-a0ff-f02250cb6207",
+                     "name": "name",
+                     "format": "",
+                     "description": "a common name used for the organism",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
-               "queryparameters": [
-                  {
-                     "jsondocId": "35c28f58-62fc-4467-8ef7-d7e6b7e607f4",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "35b86405-d96f-4c81-9753-4227154e9130",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "68e17b49-966e-448f-bdfe-4b255417ba43",
-                     "description": "unique id of organism to change",
-                     "name": "id",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "672183ee-265d-40f3-b65d-38d8f4d9758c",
-                     "description": "filesystem path for the organisms data directory (required)",
-                     "name": "directory",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "78b5250a-1cab-4bcb-99ee-fec771eec411",
-                     "description": "species name",
-                     "name": "species",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "bd92b746-ff4c-45ed-9d24-659820500047",
-                     "description": "species genus",
-                     "name": "genus",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "b3491c8f-358a-4329-8415-1f12308b43b4",
-                     "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
-                     "name": "blatdb",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "ff987592-86e5-4405-ae8b-7af277f2b82c",
-                     "description": "a flag for whether the organism appears as in the public genomes list",
-                     "name": "publicMode",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "b6dddf8b-2636-4dd8-8671-c59570b0dd76",
-                     "description": "a common name used for the organism",
-                     "name": "name",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "updateOrganismInfo",
+               "jsondocId": "5bc90bcc-8f73-480a-8b0e-0730aa097015",
+               "bodyobject": {
+                  "jsondocId": "8306d222-bf65-49dd-b777-8b895834ae35",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/updateOrganismInfo",
+               "response": {
+                  "jsondocId": "6e8ae37a-9af7-4834-9491-0a9736737008",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "updateOrganismInfo"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "cfa3c8c3-1365-47bc-b9e9-e484655fd04f",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "8c6dace8-7845-47e2-8faf-8d5765098da1",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "8b95d781-5b01-4d4e-b4f8-4d4fc723899f",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "queryparameters": [
                   {
-                     "jsondocId": "2e4a959e-b87f-4d0c-9050-954e7765f99b",
-                     "description": "",
+                     "jsondocId": "0ea1ad20-5737-42ab-932b-40d79ff16b9d",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "email",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3af47820-85d5-4732-8c6f-1684def486db",
-                     "description": "",
+                     "jsondocId": "3cbfdd3f-b993-46cd-bad6-b09629fa0b76",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a6069d15-0b82-430f-957d-390b36b02874",
-                     "description": "",
+                     "jsondocId": "44d9c329-5dd2-4953-920b-3f929c1f046f",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   }
                ],
+               "verb": "POST",
+               "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
+               "methodName": "findAllOrganisms",
+               "jsondocId": "b90c3ebf-baec-4242-ad6d-e2877cdfe0ad",
+               "bodyobject": {
+                  "jsondocId": "ff470acf-23f2-4ad5-87e9-2ffa5d0af06b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/findAllOrganisms",
+               "response": {
+                  "jsondocId": "43c0e9f0-1f85-4fa2-ac61-0af44d835dd9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "findAllOrganisms"
+               "consumes": ["application/json"]
             }
          ],
-         "jsondocId": "43ab2633-7006-43bd-9aca-acec8a644162",
-         "description": "Methods for managing users",
-         "name": "Organism Services"
+         "name": "Organism Services",
+         "description": "Methods for managing users"
       },
       {
+         "jsondocId": "199aab01-21bf-4bea-9192-7ff6fdac9544",
          "methods": [
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "6a5fb1fb-636d-4f40-a7be-270039a2fee6",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "c075669c-7807-4422-ab15-79b63cc769f2",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "389083d8-d106-4877-84de-49a68444f978",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get organism permissions for user, returns an array of permission objects",
                "queryparameters": [
                   {
-                     "jsondocId": "294d7191-47c9-4b5d-8d1f-efce74cc7be4",
-                     "description": "",
+                     "jsondocId": "703756fc-666e-4b3b-b22d-f5344648070b",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "1d31d56f-a4e0-43e6-ae82-50f021e8898d",
                      "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
+                     "type": "email",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "21057be5-1d2e-4346-9721-001a1ae0ce18",
-                     "description": "User ID to fetch",
-                     "name": "userId",
-                     "allowedvalues": [],
+                     "jsondocId": "2f1401f9-f266-4018-856f-2e7a532adbf4",
+                     "name": "password",
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "long"
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e0ba2315-ce7c-426c-beee-8ea9f988c222",
+                     "name": "userId",
+                     "format": "",
+                     "description": "Optionally only user a specific userId",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
                   }
                ],
-               "path": "/user/getOrganismPermissionsForUser",
-               "produces": ["application/json"],
-               "methodName": "getOrganismPermissionsForUser"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "8747ad19-b693-431b-8dee-8e1399274dbb",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "6a393b45-bc3a-4b82-80c9-2b42dffcf255",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "beeec209-ed18-41d8-bc4c-27b95ac37d0e",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Update organism permissions",
-               "queryparameters": [
-                  {
-                     "jsondocId": "2e338b7a-b79e-4c23-a2d5-9c01e3a7b812",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "9501c885-b13c-45e9-b85e-4f5eef8b57d2",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "90ce7520-679a-477d-ab5e-1a48a0292cd0",
-                     "description": "User ID to modify permissions for",
-                     "name": "userId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "71ecbd9b-18c0-4065-bff6-608a23ade701",
-                     "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
-                     "name": "user",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "bbec5a16-537a-4098-8835-742663fd4363",
-                     "description": "Name of organism to update",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "acc0c172-8eea-44ee-9345-58bea66b68fe",
-                     "description": "Permission ID to update (can get from userId/organism instead)",
-                     "name": "id",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "d596fc5d-3ae8-48a5-8650-9b81d730ec16",
-                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
-                     "name": "administrate",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "664c7d17-b76c-46af-8a33-9ab8945f04f2",
-                     "description": "Indicate if user has write privileges for the organism",
-                     "name": "write",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "d185816a-08aa-43bc-92a1-cdfd1054fe52",
-                     "description": "Indicate if user has export privileges for the organism",
-                     "name": "export",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "40c8f0d7-a1ef-4267-a8f6-75b07696d109",
-                     "description": "Indicate if user has read privileges for the organism",
-                     "name": "read",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  }
-               ],
-               "path": "/user/updateOrganismPermission",
-               "produces": ["application/json"],
-               "methodName": "updateOrganismPermission"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f75e8b9e-76a8-4f4b-bb19-2b63fb854407",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "f137587f-941c-46b5-8954-89d4d5c60708",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e51d1e82-d5cd-46d2-85df-497208ec74dd",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "Load all users",
-               "queryparameters": [
-                  {
-                     "jsondocId": "3b34131a-c75b-47ed-a6c3-77c72635eaf9",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "0d43ce6e-813e-47bc-aca3-821f93f82e0e",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "5a8aa585-d808-4a8d-9535-4c0c0547e925",
-                     "description": "Optionally only user a specific userId",
-                     "name": "userId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  }
-               ],
+               "methodName": "loadUsers",
+               "jsondocId": "d94dc1d1-3352-445e-9e4d-88654c837a84",
+               "bodyobject": {
+                  "jsondocId": "3b920df7-4a96-4f01-bb6c-acc796362de0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/loadUsers",
+               "response": {
+                  "jsondocId": "fcf8ce10-8661-435e-94d1-3c220f70e486",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "loadUsers"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "a8fb06e8-bf82-4f5e-8ee3-27110aa3b769",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "cb49c516-c86f-4711-b6a7-cd922d23fc55",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ee12e198-451f-47c3-882c-51db08c870fa",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5695a3a0-45a4-4b2f-97ca-d51299e18d5a",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2d13185e-7b4f-495c-9331-34c0f1a7cb6c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f14a0fbd-e1d4-4a25-ad3d-67be51678f0c",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "850ca007-6d34-4153-8101-7455e827eda0",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "78c25987-8b7d-4efa-b5a7-9c202121b4b6",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Add user to group",
-               "queryparameters": [
-                  {
-                     "jsondocId": "edd38d67-68e8-4fe4-bb94-cdb53e2e9749",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "57dc5f44-55b0-4a1e-be8b-47114ddfa6ef",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "230563a1-9639-441f-b565-162711b75db2",
-                     "description": "Group name",
-                     "name": "group",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "e3de2dfb-9594-43d8-b809-da6aa9dcc1cb",
-                     "description": "User id",
-                     "name": "userId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "74354a06-3d8b-46fc-bd2a-2ccb66866f32",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "name": "user",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  }
-               ],
+               "methodName": "addUserToGroup",
+               "jsondocId": "d679660e-a7f3-4714-a3a1-177e78e699e0",
+               "bodyobject": {
+                  "jsondocId": "f68073d9-cd03-440d-bbc9-144b528a0ae7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/addUserToGroup",
+               "response": {
+                  "jsondocId": "b1fa1dea-49b6-4de2-83df-959867963421",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "addUserToGroup"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "587cec01-b50b-4d79-b644-1b6f30afd8ae",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "8edef711-2c2f-4c7f-9f6f-b83d9cfc0a42",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d7dbca11-fb7f-4058-8177-31bd26201324",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "2aeea3a3-d8ac-4c4d-b5c7-351e7af68ec8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "75917c4f-bdfb-4347-ad8c-f04504de4d0d",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5815b25b-5450-480b-b1b3-9c60903371b5",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "84676c1a-5235-469c-a16e-62a6917f1710",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "29148575-da2c-4f5d-9b15-546ab84f4e02",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Remove user from group",
-               "queryparameters": [
-                  {
-                     "jsondocId": "21af3236-138c-43b7-98f9-c7c872476a69",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "0e21c5f6-2c52-4789-8d99-5a8bce74bdfa",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "baadc830-4638-4886-87e0-e84795d133b9",
-                     "description": "Group name",
-                     "name": "group",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "041a150b-40d4-4a7f-85a9-2be165f8f41c",
-                     "description": "User id",
-                     "name": "userId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "00562704-9e77-4818-bad1-ddc45603ee4c",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "name": "user",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  }
-               ],
+               "methodName": "removeUserFromGroup",
+               "jsondocId": "54fcc40e-d441-4b53-8247-a738730848d3",
+               "bodyobject": {
+                  "jsondocId": "2b1c0a7e-a96b-493a-8da4-bbac4c47bdcc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/removeUserFromGroup",
+               "response": {
+                  "jsondocId": "175b3ca8-c17d-4c06-b0fa-fe30e99c667e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "removeUserFromGroup"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "520b701a-d9d3-48e1-a322-e87e98746c1e",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "f456155f-0b72-49b7-ba76-0ecf6eff4420",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "24ece09a-c73d-4bbf-8877-a3f0e35ec723",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e91c9be6-4549-4d32-be31-2a98cb0d90cb",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ec4261a2-bb45-4d71-a098-e4b2a5dd60c7",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "372a777a-2e4e-42d0-9e30-61270d261a5c",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to add",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e597957e-9923-47b5-8b29-09be952aa7d6",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "aac9efc2-d189-45a0-a82e-f4fe8abfca84",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1e22482a-d0ef-436c-891f-67c5bca60e98",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Create user",
-               "queryparameters": [
-                  {
-                     "jsondocId": "364e9ba4-f860-49be-a6b8-10a5a0f861c3",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "f1a39dde-20fc-4724-bce9-9e12ca016208",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "03af3fe1-86bd-40ac-9928-65109e85ea7a",
-                     "description": "Email of the user to add",
-                     "name": "email",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "aad01340-ff45-404a-b42c-c62c1d05e1fc",
-                     "description": "First name of user to add",
-                     "name": "firstName",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "40ee4970-b80d-4c37-824b-8e38752efadf",
-                     "description": "Last name of user to add",
-                     "name": "lastName",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "c2ce5c0c-51ca-44b7-99bf-ef89b0bd9d24",
-                     "description": "Password of user to add",
-                     "name": "newPassword",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "createUser",
+               "jsondocId": "bc9ef75e-bfd9-49da-b6d1-2b5eaa9bf00a",
+               "bodyobject": {
+                  "jsondocId": "6429f2bd-e80a-4f82-b602-0a7182f6f05b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/createUser",
+               "response": {
+                  "jsondocId": "5b9c3bab-167f-4ba8-8a37-e1173ce66c1e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "createUser"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "6c58a8c0-98c9-4a11-a7f2-22199a3fa039",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "448a42aa-afe9-4848-93f8-3c282fbc095e",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "a1dc5f3f-58f3-4872-922d-1e0b73be628b",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "b814e9f0-d3c8-49e2-bb4a-07f3f4dc14c2",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4973a319-de82-4332-ab0d-d4a63019f8fb",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "31b62e33-b42c-45e5-aa9e-00b606456394",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "50d1f757-09b1-4a8e-b88e-ab1d86f80608",
+                     "name": "userToDelete",
+                     "format": "",
+                     "description": "Username (email) to delete",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Delete user",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d3ef9064-5829-4729-80f2-5a7ca2a2803d",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "3b530399-290b-4911-bb6f-10e1d2ee05ac",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "a8a0a5d4-02ad-415f-bd50-b8a11c647f38",
-                     "description": "User ID to delete",
-                     "name": "userId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "cf3de03a-cb74-4416-b09a-485085e3084f",
-                     "description": "Username (email) to delete",
-                     "name": "userToDelete",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  }
-               ],
+               "methodName": "deleteUser",
+               "jsondocId": "6a21c6d9-da0a-457e-b77a-ee740510017f",
+               "bodyobject": {
+                  "jsondocId": "6e0bf224-30b8-46d7-9bae-36a6d8a7971b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/deleteUser",
+               "response": {
+                  "jsondocId": "974e12c0-18f7-4806-be6f-bf1f52e899b2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteUser"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f61bd6ef-797f-4ec8-abe3-559cb771800a",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "10bbd0c7-9a5e-43f6-bd97-505f22dc051e",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "14481e76-acce-4732-929c-47b0c4d9542a",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Update user",
                "queryparameters": [
                   {
-                     "jsondocId": "e60ce9a2-a3bc-47ee-8838-5f69257a3f97",
-                     "description": "",
+                     "jsondocId": "d5676b94-b4b0-488c-b8aa-12902d0a4190",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "1b5483ad-afc9-4851-b511-2e1ffb710ad7",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "30283417-2364-4d60-a5b9-9828fdef6d67",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d54b28fc-5652-42c2-a924-80ae2c7fc705",
-                     "description": "User ID to update",
+                     "jsondocId": "3d4d16f4-c731-4401-8789-9dad69991f52",
                      "name": "userId",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "User ID to update",
+                     "type": "long",
                      "required": "true",
-                     "type": "long"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "595b33c9-5d78-43c3-8ada-ec648b434618",
-                     "description": "Email of the user to update",
+                     "jsondocId": "73d8f2ca-3491-4518-8f06-a3212af1604b",
                      "name": "email",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "Email of the user to update",
+                     "type": "email",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e1bceec5-5af4-43ae-8e3b-4d20965bb099",
-                     "description": "First name of user to update",
+                     "jsondocId": "6cbb5bf5-2c8e-48e9-bc1d-f42559ee61f9",
                      "name": "firstName",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "First name of user to update",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2830783b-2ebb-49c2-be33-9ece74d117cf",
-                     "description": "Last name of user to update",
+                     "jsondocId": "36ca9cba-c2ac-4145-af9d-8f98f57956a9",
                      "name": "lastName",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "Last name of user to update",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9dee62c-6aa4-4a0f-bfa4-a7abefbf9ac8",
-                     "description": "Password of user to update",
+                     "jsondocId": "193b8e13-a756-4337-badf-70e7ae0a3996",
                      "name": "newPassword",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "Password of user to update",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   }
                ],
+               "verb": "POST",
+               "description": "Update user",
+               "methodName": "updateUser",
+               "jsondocId": "1d43778f-ab33-4a5f-b4ff-2ab53ef3141b",
+               "bodyobject": {
+                  "jsondocId": "b2f2b24d-0c7c-4397-a278-6e40cbffe248",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/updateUser",
+               "response": {
+                  "jsondocId": "1424eabb-25a8-4301-926e-77bfa7a18a55",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "updateUser"
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "a85043d0-b7ac-46cc-94a2-7847f38342d4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d5f863de-148b-4cc3-bf96-e13b0e0e67c1",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "481cfd51-2332-4883-ad09-d831c51431be",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to modify permissions for",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8a5b5e2b-a0af-4a6c-a60b-060822f264b0",
+                     "name": "user",
+                     "format": "",
+                     "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0d09e8e9-cc6e-48b3-91fb-9582990d7966",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Name of organism to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "90302d31-44e4-4064-92b3-f21855beb77f",
+                     "name": "id",
+                     "format": "",
+                     "description": "Permission ID to update (can get from userId/organism instead)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b683455c-34f2-4108-948c-89842e9ffa30",
+                     "name": "administrate",
+                     "format": "",
+                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "88ac35c5-12a9-42eb-948e-6ac08db54527",
+                     "name": "write",
+                     "format": "",
+                     "description": "Indicate if user has write privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f01a6554-53d2-4491-86bb-8346f9b30ae0",
+                     "name": "export",
+                     "format": "",
+                     "description": "Indicate if user has export privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9bb0a052-977c-40ca-b992-2f2a6c51ec54",
+                     "name": "read",
+                     "format": "",
+                     "description": "Indicate if user has read privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update organism permissions",
+               "methodName": "updateOrganismPermission",
+               "jsondocId": "b76779f9-aaf5-463e-a660-ca6a63a9668a",
+               "bodyobject": {
+                  "jsondocId": "9399a6b8-6552-4db6-bbb5-55bf82b022d4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateOrganismPermission",
+               "response": {
+                  "jsondocId": "5b0a37b0-6a26-478b-8006-ab85b70b6448",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "3e185fa8-edf9-40a9-afb4-969e41dbed09",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a426dc5a-b54c-4163-938c-c4c669f7e56d",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4d00b18b-c14e-4a30-88e6-dcc63a5f6f34",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to fetch",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for user, returns an array of permission objects",
+               "methodName": "getOrganismPermissionsForUser",
+               "jsondocId": "965e6a95-86e3-41ed-86b6-f19447918100",
+               "bodyobject": {
+                  "jsondocId": "cf4ef688-ac65-419e-bd71-a0207634ea74",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/getOrganismPermissionsForUser",
+               "response": {
+                  "jsondocId": "266122d3-f421-4297-86cd-d95ab623ce86",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
             }
          ],
-         "jsondocId": "20abcaf9-5132-4aed-b343-38c2de1fb005",
-         "description": "Methods for managing users",
-         "name": "User Services"
+         "name": "User Services",
+         "description": "Methods for managing users"
       }
    ],
    "objects": [],

--- a/web-app/js/restapidoc/restapidoc.json
+++ b/web-app/js/restapidoc/restapidoc.json
@@ -2,14 +2,14 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
-         "jsondocId": "943812e0-1df4-4998-8a94-7a34ddefbc74",
+         "jsondocId": "152b995a-d83b-4f9e-8816-ad7a0f53fcde",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f87ca3c2-60ac-49f0-8d2e-3d61284428b1",
+                     "jsondocId": "16be2c5a-5139-49aa-bd1d-0e9e98164627",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -18,7 +18,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b56bb463-572a-4c5e-bb0b-d8aaf65b43f6",
+                     "jsondocId": "ef6390ae-ccd3-4b8c-a208-2bfe5bf83e0f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -27,7 +27,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2745554d-299e-4fea-b79a-8e8a1c7391ac",
+                     "jsondocId": "1c2a3d27-5429-4c75-9fd0-618959fc3451",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -36,7 +36,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b8373274-624c-455c-bf82-8d0ecbd912de",
+                     "jsondocId": "da6d8c58-b7c6-4e82-92bf-5a92b3460c1a",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -45,7 +45,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "43411da1-e010-44f2-89e7-ee9a76b06776",
+                     "jsondocId": "64c1206f-bda4-4899-9e83-fe25191b8b7b",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -57,9 +57,9 @@
                "verb": "POST",
                "description": "Add attribute (key,value pair) to feature",
                "methodName": "addAttribute",
-               "jsondocId": "4b7a650f-6556-4dff-858c-6dca85e6c872",
+               "jsondocId": "ebe64737-2fec-4bbc-ac9f-4ef80b4583dd",
                "bodyobject": {
-                  "jsondocId": "428ee311-1955-48cb-9585-fbb9373153de",
+                  "jsondocId": "b3069616-8a76-4960-b277-ce5d085bcf0e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -69,7 +69,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addAttribute",
                "response": {
-                  "jsondocId": "3272b695-dbc6-4d0f-8f4d-c54b8c816890",
+                  "jsondocId": "410bf0ed-4b32-45bd-9014-fb04e5cb817e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -82,7 +82,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2c4e61eb-d5a0-4138-8d8f-9bb9790d1bf0",
+                     "jsondocId": "23978c33-3d65-4601-9d53-51b043b9dbf2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -91,7 +91,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14ea9d68-517d-45fd-9d88-f1366285a791",
+                     "jsondocId": "b0410779-cbed-4ded-88a2-8bda45a553b8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -100,7 +100,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1822fa92-f998-4226-83d3-d36e30c0b8c3",
+                     "jsondocId": "3fa76d71-0b3b-49bb-85e3-24d66af44453",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -109,7 +109,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1b3527f-e69b-4ecb-8b1f-c718cc7aedc9",
+                     "jsondocId": "ac326788-a7f3-44a5-8c26-ebb6668a141e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -118,1567 +118,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f76df25d-ff12-4076-bad9-7ec501a9b2a5",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set symbol of a feature",
-               "methodName": "setSymbol",
-               "jsondocId": "98f67387-5d43-4a70-a851-1212f3084c42",
-               "bodyobject": {
-                  "jsondocId": "a5e2656d-7a47-41e0-838f-5d2f6cfeded7",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setSymbol",
-               "response": {
-                  "jsondocId": "31c4b7a5-4e35-40ca-8029-a2ff644f85af",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "d0970b25-52ed-4900-a130-0654b6a1ccb9",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a3c34869-50d2-43c5-9bee-fd359d193d62",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "82310e30-a340-44e6-8f3b-47034de5db1b",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4677f884-d8d1-42a1-bdfb-7fc2a5137c54",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7545e99e-bb59-4962-9846-df3c0d9b5feb",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set description for a feature",
-               "methodName": "setDescription",
-               "jsondocId": "f24e3124-b9b0-4f57-ab00-537de8f26176",
-               "bodyobject": {
-                  "jsondocId": "5652ac12-b054-49ec-8630-7c6d958aa8d6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setDescription",
-               "response": {
-                  "jsondocId": "1815f478-22ff-4b31-b8a6-da1d6fd0489d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "18407be7-0194-4693-9a1c-1ae8175da54c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "445b9ae0-20b1-4a48-8873-980200841dc7",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2f428058-2025-4b19-add7-5ae6bf1ce58e",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9781f64c-4a83-4fee-946b-7206f29d0575",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get sequence alterations for a given sequence",
-               "methodName": "getSequenceAlterations",
-               "jsondocId": "5bacc7bd-6873-4b8b-afe4-ee9e0189eb93",
-               "bodyobject": {
-                  "jsondocId": "125ddb6c-548d-47ea-9d5f-d95e1379e46f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getSequenceAlterations",
-               "response": {
-                  "jsondocId": "cfcbaedd-def1-4613-a967-d1fbf9821bd4",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "d20d4181-289f-4a18-8fd0-0a1c03c284fa",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "18ab4437-a8cd-4fa0-98aa-bc8fe6aa2979",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d253a13f-0753-4a3b-a321-083e9561c6ba",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bd2dbf9b-5fab-45f5-b418-2f875faaf3ae",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c55f9f56-4568-48bd-9639-82e210d445d9",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete attribute (key,value pair) for feature",
-               "methodName": "deleteAttribute",
-               "jsondocId": "d2502171-5bf3-41e3-af25-940c0a437d85",
-               "bodyobject": {
-                  "jsondocId": "4df49905-a6ae-4c9a-8937-0177a1ccc942",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/deleteAttribute",
-               "response": {
-                  "jsondocId": "69a01455-1390-41af-95d7-be62a3069af8",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "b40e0de2-7d2c-4e57-ada2-e6063569fb75",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0f2288d4-88d0-4f28-afbb-8039535d9d8e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5470609b-c318-4c32-b2fd-4e083604020b",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a5948218-6de3-4040-b578-6e78b23114c9",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c51cfa96-1a2c-47f2-82b4-2f66d95f0d0d",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update attribute (key,value pair) for feature",
-               "methodName": "updateAttribute",
-               "jsondocId": "0c707c5b-c6d4-4202-a402-5532bca29663",
-               "bodyobject": {
-                  "jsondocId": "e76a65b8-1d58-4708-bdc6-ee1e81ea73ad",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/updateAttribute",
-               "response": {
-                  "jsondocId": "55bd81c9-00cd-4310-870b-038a23b37f67",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "0ccf7126-412d-4900-a31c-8e207f19df1a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5443faec-ff86-4fdb-920d-f654119d7820",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c8327bfc-8a74-4d94-af7b-79f75a5472e9",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0f1d4343-26c8-48be-88fe-f137b7fb8fe4",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "36da50ab-f71d-4e42-939c-222594eccaf4",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add dbxref (db,id pair) to feature",
-               "methodName": "addDbxref",
-               "jsondocId": "09ccaa4a-3918-462f-ab01-ea3736241468",
-               "bodyobject": {
-                  "jsondocId": "e34d9605-81bb-49f3-8357-75abdd8245fb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addDbxref",
-               "response": {
-                  "jsondocId": "ad8a2bc3-815c-4a27-8c59-bc1a181bbb8d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "8953a556-6392-4c1c-a6c2-1b4f3d85d7c0",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "82eaed76-4852-4a9f-ab76-17f4a06d2463",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "791c896c-1a02-49eb-830b-9b10cd51bb53",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "72164104-7462-4364-a507-cba7ba4af2b5",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a339b642-1cfa-4306-850e-d1e05185c304",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update dbxrefs (db,id pairs) for a feature",
-               "methodName": "updateDbxref",
-               "jsondocId": "37fa5144-1b10-44b1-b318-eba2affc694e",
-               "bodyobject": {
-                  "jsondocId": "a46a2f8f-88a0-4442-87bf-b9c9bc9d998b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/updateDbxref",
-               "response": {
-                  "jsondocId": "bb6fc441-e846-4d7e-9fa3-063f0732b84d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "bc77b0be-8aaf-4541-bfc0-b1eb43db8128",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f3d00a7c-16f1-4361-b7c5-f2dca1cc21ce",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "09245605-bee9-4bbe-9010-6cbbcb89d17d",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a79a8fe3-ef86-4bff-8747-91c6087eebfc",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cf59ec92-7d55-481c-86d6-2a2fdab89349",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete dbxrefs (db,id pairs) for a feature",
-               "methodName": "deleteDbxref",
-               "jsondocId": "7e17ed23-4bb5-494e-bf7f-0c1f02524cab",
-               "bodyobject": {
-                  "jsondocId": "0fbfa22b-81d9-4d65-a1a9-d1e4cf6b0224",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/deleteDbxref",
-               "response": {
-                  "jsondocId": "4cf82b41-4c77-41b8-97f3-8963b21aaf24",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "501e0f27-d5d9-4bd7-a297-78bb40dcfe53",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0365026c-bf7d-4796-9f0c-a6e92def2857",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get canned comments",
-               "methodName": "getCannedComments",
-               "jsondocId": "fd49744d-cca8-4056-8dca-f35a58a1539c",
-               "bodyobject": {
-                  "jsondocId": "e2f20dcc-1dd2-4338-ab2a-61840e850798",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getCannedComments",
-               "response": {
-                  "jsondocId": "e6db4646-eb8a-4da7-bfbd-f4af845187eb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "66f6da07-de26-4e37-bdcb-d36f0cabaf53",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c27b357b-0681-48f3-b5d6-231f231cf85e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bafe2278-8c30-48f4-94ff-e0909a2754a0",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get gff3",
-               "methodName": "getGff3",
-               "jsondocId": "3583c54b-f395-4036-9765-4da82fb56b79",
-               "bodyobject": {
-                  "jsondocId": "64d2b0fd-f8f9-458f-915a-317258ba2c39",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getGff3",
-               "response": {
-                  "jsondocId": "d039f13d-c8e0-488e-9d5a-98cda01b234a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "705602dc-be24-49c8-9c41-1bb2e7a3ec53",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "36811ed8-3b2d-4eef-9abd-ebd441f9d81a",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b171c5bb-b69d-4953-8ba0-9b6d315b2d00",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cfabffc5-eced-4466-8817-80fee95f3179",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "91e89e19-4c7f-41a9-a6f4-41b3892b85d2",
-                     "name": "suppressHistory",
-                     "format": "",
-                     "description": "Suppress the history of this operation",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "88d9267d-7170-42c1-baec-f564521ab616",
-                     "name": "suppressEvents",
-                     "format": "",
-                     "description": "Suppress instant update of the user interface",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3c9b95ce-7bff-4b10-812c-9799e27dfdf4",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add an exon",
-               "methodName": "addExon",
-               "jsondocId": "f7d9f8fa-a5dd-4532-abbf-c859f73f5e0f",
-               "bodyobject": {
-                  "jsondocId": "fb7c9fa0-ce92-470f-bbb1-682958d9c8d5",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addExon",
-               "response": {
-                  "jsondocId": "1b808f61-2055-4f5d-bab7-1441adaa3eae",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "d0443d73-3652-4d7f-8487-f74f8fb92431",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "01da0ee2-80b9-46b8-b8b4-42a7797f2a7b",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7e1cb326-a9b2-44db-afcf-5c7200e02ae1",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4315d42d-ea83-4a0c-ad7b-8e85740be4e2",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9d82cb69-b265-4260-8ab0-ee27c1adda9e",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Split transcript",
-               "methodName": "splitTranscript",
-               "jsondocId": "dfb0ce3a-b863-4c02-9413-df031dcc5bcc",
-               "bodyobject": {
-                  "jsondocId": "e99b5ac2-9c5c-4356-80ae-6f6f23ff14e6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/splitTranscript",
-               "response": {
-                  "jsondocId": "071aad84-be5f-4bc8-8d77-9a29836a11de",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "2e7e99f6-d6ad-4e96-a15d-3bad79c530d1",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3401ded8-fe75-47ac-9064-ffb5bd4be40e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7a5c79b2-582a-4081-85d5-bfcc0cfa5137",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e28f6cc2-c6d4-41c4-b778-cbff6eb336c1",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6aa767b7-c096-4aed-9962-80f9e86b1f4a",
-                     "name": "suppressHistory",
-                     "format": "",
-                     "description": "Suppress the history of this operation",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "83073396-5acb-4a18-a5cb-a7014657f707",
-                     "name": "suppressEvents",
-                     "format": "",
-                     "description": "Suppress instant update of the user interface",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "fe4e3682-7332-4fb9-a728-f7721df4c3a9",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Duplicate transcript",
-               "methodName": "duplicateTranscript",
-               "jsondocId": "b9310e92-b966-4bfc-b080-0f7c297c0e57",
-               "bodyobject": {
-                  "jsondocId": "41908a04-b4ad-4c3a-b04f-b18d7605cc06",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/duplicateTranscript",
-               "response": {
-                  "jsondocId": "27be38cf-90d5-44b9-8c3d-34e9dcb3387b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "ec3a6f67-b449-404f-8898-fce5f0ea2220",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bc2e0181-921e-4b71-abda-5b9ecc88177e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7d519fe9-e24a-4391-bcbe-31b37edf453c",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2384ee87-fc49-44f7-82aa-5b73279f8392",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9922cc85-d057-4fb0-b0c6-3ecc551e74bc",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Merge transcripts",
-               "methodName": "mergeTranscripts",
-               "jsondocId": "fbbdc154-5483-4f75-bd45-6f8049dcb0ea",
-               "bodyobject": {
-                  "jsondocId": "65675156-82e2-4a97-84d7-e6478777733b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/mergeTranscripts",
-               "response": {
-                  "jsondocId": "d1db733d-71b0-41e0-a880-76f1e55a26bc",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "656f2681-c17a-4021-81a1-b17ed4a09c1c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2898dc72-f5f8-4d41-be93-e81fad5dcc36",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4712d8ff-a558-4fb6-8fe1-dd90bb32dcaf",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2a318cc4-bf60-4cb9-a8a9-da723bc45439",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3eb163f6-fa8c-4ba3-9615-afc5c4497a62",
-                     "name": "suppressHistory",
-                     "format": "",
-                     "description": "Suppress the history of this operation",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5183a62f-0edb-4af9-a40d-982ad993884f",
-                     "name": "suppressEvents",
-                     "format": "",
-                     "description": "Suppress instant update of the user interface",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "169168db-6811-4593-9d9d-5d05261329ab",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add non-coding genomic feature",
-               "methodName": "addFeature",
-               "jsondocId": "67f86c90-8afe-4ae9-9038-11580c0a4de2",
-               "bodyobject": {
-                  "jsondocId": "dbebc07c-9f73-470e-a51c-178276eb3b35",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addFeature",
-               "response": {
-                  "jsondocId": "13817fcc-ab17-4ca7-88be-b9c1f293d0f2",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "e894ae43-9a26-4aa9-909e-b7df7e763b98",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f0ff666c-94e8-48c6-b3d7-8a1a5925bcd9",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3b371199-7d6c-461a-b151-1233bc1beb13",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cbbeeabe-2f4b-4e78-84e9-83419bf384e4",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2b5b634f-7f0c-4726-a492-679cb5ee9b21",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set translation start",
-               "methodName": "setTranslationStart",
-               "jsondocId": "76360508-bd82-40b7-8bf3-6393943c7f98",
-               "bodyobject": {
-                  "jsondocId": "6a912590-e645-488f-8494-eb49198e64b6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setTranslationStart",
-               "response": {
-                  "jsondocId": "a6e45f87-e8d1-451d-8cda-953b5baaa529",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "e2a5240c-f0d5-42e8-a033-4c27177523ed",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "887e72bc-1931-48dc-a8ee-e2ee61e20d73",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5678e46a-cf27-468f-96c8-ea681185a84b",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b3487854-51dd-478e-bada-ff58ef686dcf",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "621c823e-efd5-4e84-b289-da1732fb7980",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set translation end",
-               "methodName": "setTranslationEnd",
-               "jsondocId": "3a94eb21-1df9-49d7-9f49-6e975196d53b",
-               "bodyobject": {
-                  "jsondocId": "ff755e1f-453c-4ba2-a429-ff36a82940dd",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setTranslationEnd",
-               "response": {
-                  "jsondocId": "a1662b29-a4b3-4405-b035-ec04c811f8f9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "4149ce5a-7f7b-417f-b772-3bcd9053fe4f",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "66aeb029-538a-42d0-b67e-7083952ea114",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3d3216c2-5855-4d2a-99cb-98d8557503c7",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cf8c16cf-0cec-4157-b2fb-bd9809f5a591",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c8c0b10d-510e-4440-9398-c64e9d3f0465",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete feature",
-               "methodName": "deleteFeature",
-               "jsondocId": "a60317de-6dda-437a-9dda-cbd5264da3a4",
-               "bodyobject": {
-                  "jsondocId": "204b3dd2-6585-42bb-93ef-d0e55bd5f727",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/deleteFeature",
-               "response": {
-                  "jsondocId": "a043897d-a409-4ee3-839d-648893cd157a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "7bf74c55-e270-4771-b30b-d2a34344867f",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "526c8f1c-5c49-47b1-84c0-dcc438a3f8a0",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "527630c8-3831-4f32-99d3-0b09cbbb7333",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a72b44ec-ca21-43a6-9686-855745386ad6",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "35e37339-1e28-4c1c-bd84-aae92fdec695",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Flip strand",
-               "methodName": "flipStrand",
-               "jsondocId": "ae548ff3-0e51-4cb7-a6e9-e37081881360",
-               "bodyobject": {
-                  "jsondocId": "372abcd5-325e-48d0-a617-d7c8f0994cd8",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/flipStrand",
-               "response": {
-                  "jsondocId": "ec3a8c36-8ec4-4ee4-800e-f49c0f661875",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "c20d0639-9987-466f-ad81-d24e07db839c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "88e3e7c4-4fb1-4c41-8185-1acd4c469f7d",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "208704e4-05bf-4dd4-92f9-97935ca8f4bc",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f7d547ae-41f7-4142-b827-bd5d126f2e5d",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "08443bf7-6470-4e22-8482-7fac8311a6d0",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Merge exons",
-               "methodName": "mergeExons",
-               "jsondocId": "9063b482-5b52-4fe4-a8b7-13913a3a0c87",
-               "bodyobject": {
-                  "jsondocId": "231197c3-c423-43aa-a024-10defaeb540a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/mergeExons",
-               "response": {
-                  "jsondocId": "87a41f7c-d826-408e-aea6-dd846fbcfb6f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [],
-               "verb": "POST",
-               "description": "Returns a translation table as JSON",
-               "methodName": "getTranslationTable",
-               "jsondocId": "676515b8-9224-43f3-bffb-7d2848914864",
-               "bodyobject": {
-                  "jsondocId": "a720f5e4-9393-4fcb-b784-82ecf12e068b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getTranslationTable",
-               "response": {
-                  "jsondocId": "cca10c1d-de2c-4e00-ad45-b163f50adea9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "6c610e99-6911-4057-82a0-7d253091f1a6",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ece1c90f-a003-476f-98fa-bf71010bd671",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "acfa9eab-fc1e-44e2-bc06-a3e254a8983d",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4008ab74-6960-4947-bc1b-c866eb6a790d",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3d136a42-9256-4bc2-b5c6-1493b37f786b",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete exons",
-               "methodName": "deleteExon",
-               "jsondocId": "78be04e9-58d8-4350-884c-e1a11461e7c0",
-               "bodyobject": {
-                  "jsondocId": "08285085-2c6c-47c0-887f-0fb25fa470d1",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/deleteExon",
-               "response": {
-                  "jsondocId": "d0b88faa-9bb4-429e-a21e-abbe8a9516ab",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "9b5160aa-1a6f-4018-8351-fe72443a5fec",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2d455143-36eb-4e15-8b84-6bfa880d66ad",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6ef9521e-0d52-45e1-b734-d2959f0ade02",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e55da443-3782-4d3a-ad16-935347af4fbc",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "40413b42-f3b5-4bfc-90b4-77c85a37f7e0",
+                     "jsondocId": "c916391e-81d3-4a46-9fb3-5ce3cf96a506",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -1690,9 +130,9 @@
                "verb": "POST",
                "description": "Get sequences for features",
                "methodName": "getSequence",
-               "jsondocId": "b65ba100-e6b8-4dd5-b16d-fbd039130d51",
+               "jsondocId": "44e93880-429b-4ac1-986a-ffc5031f4ae4",
                "bodyobject": {
-                  "jsondocId": "5efd27ca-a94c-40e3-8597-4272ee656155",
+                  "jsondocId": "ab62f25b-bc5f-465d-b0a2-6425d912be17",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1702,7 +142,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequences",
                "response": {
-                  "jsondocId": "ec9a2324-e306-45d7-9d71-e64409f737fd",
+                  "jsondocId": "b7afdbbc-e1c1-4d7a-a54c-bad052ffdf59",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1715,7 +155,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8b41704e-bde4-45fa-bc6b-294618c5347c",
+                     "jsondocId": "ad008b6d-c68a-4ad0-9d08-30cfcf69a884",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1724,7 +164,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8adfaa8a-97f8-473d-875f-574efd7025a1",
+                     "jsondocId": "fcc7678b-747a-41f5-aed3-c1048948086c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1733,7 +173,1065 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e834623-c6f6-47d7-b4d6-827f9c2030f3",
+                     "jsondocId": "7ba11312-36a9-46e1-b195-c61b7602cd80",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "455f643c-76c3-4c13-8ec5-5f011ba7c90d",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f1d8054e-8cea-4925-bd07-33eeea3a351c",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set symbol of a feature",
+               "methodName": "setSymbol",
+               "jsondocId": "f2600665-f1d5-403c-b169-6e663d4c8df0",
+               "bodyobject": {
+                  "jsondocId": "434d1d33-678a-4f99-8bd5-a4b96263b4c6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setSymbol",
+               "response": {
+                  "jsondocId": "d490becf-4564-4542-b70a-5491bdb2cf26",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4a87ad2d-62e6-4f5b-9fc5-08e32eee94c8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dbc5ce42-2c2f-44c7-b5d2-90295eb3b17e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5e1d71d8-09a6-43df-939b-0a93f2fce926",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "64fafefe-059a-4248-b183-5e74ef256f5a",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e2da8993-ed5b-4190-9b44-2f10949c9290",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add comments",
+               "methodName": "addComments",
+               "jsondocId": "27559249-0637-4905-8f34-9c2b7ab857c0",
+               "bodyobject": {
+                  "jsondocId": "3502c52f-ae99-4061-baba-e0936eadba6c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addComments",
+               "response": {
+                  "jsondocId": "ec08705e-6d58-46e6-8993-2b963cf68833",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "b1102ecf-c137-4fba-9eca-c6ad3ed82ad0",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6bf305c2-3420-40a7-94f3-cbb1f3f9fd32",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "332176c6-f281-46da-bdbe-efdf824ccbe3",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "67839e95-4321-4667-9c64-b3ce3ab9e6ac",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "13cc572e-62e9-4f80-9860-10918840ab75",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete comments",
+               "methodName": "deleteComments",
+               "jsondocId": "10ca80d2-c5af-49b0-bfb3-0c49944fb3ae",
+               "bodyobject": {
+                  "jsondocId": "ba3d660a-d640-4a97-ae8f-e898e4beea8b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteComments",
+               "response": {
+                  "jsondocId": "cd749147-e249-4586-8047-c055aae51611",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "d9b7be1c-124d-403a-b7ea-2de6c8bb8789",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7446843e-505c-45c1-a6e9-2659e760faf0",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d7b34971-6776-4eb6-871d-27c8726edf97",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bc4222ec-26b5-41a0-86f9-81511de7be70",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "831fca32-1b32-422b-a5e5-cbf1e9121d06",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update comments",
+               "methodName": "updateComments",
+               "jsondocId": "0c67b640-df05-488c-bd11-6bfe491c713c",
+               "bodyobject": {
+                  "jsondocId": "21eb7926-44b8-4783-a06a-96d3eace3e6c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateComments",
+               "response": {
+                  "jsondocId": "b111ef8c-235e-4c5a-b801-46eeca228c0d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "29aaf750-986b-4e47-ad4b-c520dafce7ee",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d1ed621d-80e2-438d-9aa8-be6e30795f7c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8f2cb998-d796-4c99-a859-0495c5326dfa",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "662b15b2-3d38-4021-b70f-42d82da9bf0a",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3d52044a-d837-40b8-8137-335ac5fa185d",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fd233fd2-97ea-4142-ab82-692892b4c5da",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5ed15d84-fd88-4a6f-9783-ab8202e0628c",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add transcript",
+               "methodName": "addTranscript",
+               "jsondocId": "d345097d-e629-443a-ae2c-968ed86ac434",
+               "bodyobject": {
+                  "jsondocId": "8d1672f2-2da8-458a-bcbc-9c5dcf2d1ea9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addTranscript",
+               "response": {
+                  "jsondocId": "8172eb73-3637-448c-a5cd-f56de421457c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6ff71a63-c7a1-4c86-b871-c2fd14711755",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "eee7d887-2907-439e-9ff7-41cd690e8101",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d8a7ef6d-a1cf-46da-a8be-c6fbceca0411",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "eae96bb2-849e-4cb7-b502-4cfb35ecd7eb",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "468cf2a1-120e-4cff-93e6-a724aded1aa6",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set readthrough stop codon",
+               "methodName": "setReadthroughStopCodon",
+               "jsondocId": "6a9b7dfb-e5ee-4ab7-937b-e37e073d5c0a",
+               "bodyobject": {
+                  "jsondocId": "29944b0e-5f7f-490d-ab16-2e9134dec32c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setReadthroughStopCodon",
+               "response": {
+                  "jsondocId": "f54eff1d-d0dd-4f59-8784-2f89ad743dbf",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5a38afd4-c739-4c37-b06a-f09eaef86419",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "05aabba8-efdd-47f7-ad39-7ac62acb15f4",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ef407077-747b-4c72-96ba-6dc263c830e9",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "74d189ff-9bf0-4cd6-85ac-b04f3082fddb",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "36c8a183-888a-4925-93cc-87ceef7c6417",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set longest ORF",
+               "methodName": "setLongestOrf",
+               "jsondocId": "dfc00ef5-acff-4dde-aad6-6b62b737b504",
+               "bodyobject": {
+                  "jsondocId": "d79ab383-8414-4fbd-9b27-4588adfe055c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setLongestOrf",
+               "response": {
+                  "jsondocId": "0851a86f-1bd4-4614-9b56-d648486f719d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c6d26a1b-ff83-47a3-930c-0cf412b0c80d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7b154b7f-911a-4edc-8b96-7055ae8d35f2",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e142a84a-d312-4ac2-907e-f37d9f836165",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1a374294-d6e8-4776-805b-1257ce1bcdd3",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bdec675a-9ed3-4edd-b1f0-c3b3f24abfa6",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c082c90c-7b73-474e-a5dc-c68bb33bc1e2",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0f16b3e8-19d8-4ba9-8730-df427af5c48c",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set exon feature boundaries",
+               "methodName": "setExonBoundaries",
+               "jsondocId": "4a643b60-cc0b-43c2-a922-fb7fcfb82fc0",
+               "bodyobject": {
+                  "jsondocId": "97470549-905e-4a73-b9aa-6252b0be4dd0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setExonBoundaries",
+               "response": {
+                  "jsondocId": "476e48d0-20d9-4821-8ac9-4ed508d537e0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "dd668445-4b53-4440-a8f0-4c4aebfa1b76",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0527df89-3366-470c-b995-ea560e24c7fe",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "339f3553-ca9b-4881-985c-527f7efce339",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "95989063-b639-4287-b3d8-0dc0bf52c143",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ac767af4-46d8-4833-ab17-e8cfe20de902",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set boundaries of genomic feature",
+               "methodName": "setBoundaries",
+               "jsondocId": "039917ee-421f-47e4-9aaa-ac29a3aacdf9",
+               "bodyobject": {
+                  "jsondocId": "b39031d0-c18a-47bd-a7b0-32dedc9fd787",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setBoundaries",
+               "response": {
+                  "jsondocId": "ec7f17f1-9d96-499e-8276-4a3b74fb25ca",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "22a47f09-27aa-4b87-9687-36bfb264ca34",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e668f2f2-51b2-47ec-92d1-ba1776a37691",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "352de19a-7e5b-499f-8347-098cb5a8ca50",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fb97cea5-e411-4541-aed0-62e5f0d9a999",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0287ff06-c8df-4497-b72d-38c081e15325",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete sequence alteration",
+               "methodName": "deleteSequenceAlteration",
+               "jsondocId": "90b4d514-768e-46cc-b94f-d213d1665657",
+               "bodyobject": {
+                  "jsondocId": "13cbbd2a-52e3-4831-b512-efc56b65ece1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteSequenceAlteration",
+               "response": {
+                  "jsondocId": "37257afb-ce8a-4d9e-bb41-2e3512888966",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "12ed7a38-3669-4c4f-a951-cb50a09b357f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b8a2627b-61a5-42f7-9674-9a908ca2070c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "814d2f6a-d7be-4a08-841f-551a6c590e27",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0e806c25-90db-4ca4-a0f4-e6c495e3ab5b",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "76fde1b9-cf39-4c42-bd9d-32102fc81380",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add sequence alteration",
+               "methodName": "addSequenceAlteration",
+               "jsondocId": "4a00ddf5-be35-4229-a2a4-f47f9690f4be",
+               "bodyobject": {
+                  "jsondocId": "f717ba34-2d81-43dc-a092-069e88ebefdc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addSequenceAlteration",
+               "response": {
+                  "jsondocId": "85bbbf1e-47c1-4d2b-a33e-c02a797e9e29",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "f623a49b-75a3-4367-b540-f60762707744",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8b507044-cc1d-4f79-abf0-a0c6ca2ee5cf",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4b9a86da-9fbe-4f02-b70f-ea78ca04ebc6",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "46023a1f-9d94-4a2c-a740-44375ba8bccd",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "36aa6019-ed77-4176-8e48-f9f3f0bf7214",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Split exons",
+               "methodName": "splitExon",
+               "jsondocId": "30478185-8723-4c5e-a567-0b42be8895ed",
+               "bodyobject": {
+                  "jsondocId": "c1061acc-89ec-4be7-bc53-7d468a1eac97",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/splitExon",
+               "response": {
+                  "jsondocId": "5ea712fe-1e99-4375-9c86-0459af520f16",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "bd642db9-5c68-4e6d-8a4e-5a56664b20ed",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "213dc5c2-4b30-4557-8f45-6e3d0cc59936",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "51914cbd-0463-49d1-8f66-312335a6f973",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e9b382d1-050c-4a9b-abf9-93f67050502a",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8e876756-543e-4e77-bdaa-09fb02db0703",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Merge exons",
+               "methodName": "mergeExons",
+               "jsondocId": "0f05806c-2e37-42ff-88c4-20a0b67a2b95",
+               "bodyobject": {
+                  "jsondocId": "34f47294-1846-4a19-8556-981ca33494e6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/mergeExons",
+               "response": {
+                  "jsondocId": "096e7d50-f329-4bc1-ac78-02ff6130dfd6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "66de7c4e-a0b2-4c03-b4fc-2e8efb7fbdbb",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a14c4bf8-62ee-40ce-9a35-bacbf62b8b2b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f6ab7720-227c-4ea9-a624-a8eaf9e32895",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e7e2d06b-9774-4550-bc39-49c87b423387",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "24c343a7-6845-4ad5-a1e4-7215cd24ece2",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete exons",
+               "methodName": "deleteExon",
+               "jsondocId": "6607c659-0930-4beb-956e-2e9df6c20bf8",
+               "bodyobject": {
+                  "jsondocId": "b59b6d57-3813-4543-bc9a-2dc59ff28b67",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteExon",
+               "response": {
+                  "jsondocId": "c2590fa9-a2f3-47c9-8fe1-8a22a990c793",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "40e7b2cc-b6ff-4025-9a26-189f2cf3eb5e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9e5fbf9b-49ec-47ff-8281-8157c8a1625b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "92eaaa35-d4f6-4766-848f-9771af4de27d",
                      "name": "search",
                      "format": "",
                      "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
@@ -1745,9 +1243,9 @@
                "verb": "POST",
                "description": "Search sequences",
                "methodName": "searchSequence",
-               "jsondocId": "2a7ed7f3-3ad7-418f-880e-9f305279d493",
+               "jsondocId": "25c358ce-441a-4cdc-9615-d37036b2cf47",
                "bodyobject": {
-                  "jsondocId": "79f3d080-dc6f-4814-afd7-e319a6f29ab1",
+                  "jsondocId": "ee0a5ccc-c5da-409c-a635-849db0824a37",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1757,7 +1255,7 @@
                "apierrors": [],
                "path": "/annotationEditor/searchSequences",
                "response": {
-                  "jsondocId": "b1d75633-2934-4af5-a34f-f7977688abbc",
+                  "jsondocId": "5b3d8825-f58f-4ecd-bcd4-471e15d53508",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1766,7 +1264,7 @@
                "consumes": ["application/json"]
             },
             {
-               "jsondocId": "cc27b6e6-6912-4295-a53f-1b7d47719aeb",
+               "jsondocId": "f377bae0-20c1-4eba-b744-e1e86a76d1a7",
                "bodyobject": null,
                "apierrors": [],
                "path": "/annotationEditor/getSequenceSearchTools",
@@ -1774,7 +1272,7 @@
                "pathparameters": [],
                "queryparameters": [],
                "response": {
-                  "jsondocId": "88c560fd-49c2-48a9-aea4-84bcd44a3dcc",
+                  "jsondocId": "bf2af60b-a74a-4c7a-9a13-3a14cdccb708",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1789,7 +1287,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0beb1b82-f799-4d54-b67c-83b2d535480c",
+                     "jsondocId": "4855a670-bd5b-4bb4-8d65-bab2990c1863",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1798,7 +1296,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6297966b-4260-4b45-a244-e8e57bd297b3",
+                     "jsondocId": "d2a9c278-a104-4ba2-908a-911aae0172a8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1807,7 +1305,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "56727fa6-4b31-43c6-86c8-8eacf62bd14d",
+                     "jsondocId": "91130e2a-522a-4f14-b23a-e983ffc8240d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1816,7 +1314,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "58ba1a86-5d29-4897-8dab-114e84d6ef56",
+                     "jsondocId": "af43fa66-a046-426d-b5a0-f2c0d536465b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1825,21 +1323,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ffb57e81-148c-4529-8275-f9174ee631df",
+                     "jsondocId": "e4d2ee3e-6005-4890-939a-7b59931c2d9b",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Set status of a feature",
-               "methodName": "setStatus",
-               "jsondocId": "01afe7e5-3a5d-4824-9126-25f57957f96c",
+               "description": "Set description for a feature",
+               "methodName": "setDescription",
+               "jsondocId": "94371b9a-1096-4e09-a56c-090c256ac0d6",
                "bodyobject": {
-                  "jsondocId": "97cf649d-788c-467f-9d84-41caa843d8f6",
+                  "jsondocId": "30d386a6-13a5-44c1-b619-fe6c3d02b43e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1847,9 +1345,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setStatus",
+               "path": "/annotationEditor/setDescription",
                "response": {
-                  "jsondocId": "837d8d3b-f517-4b00-ad3e-7d984869c8e5",
+                  "jsondocId": "c80701c0-c625-410c-9473-f3061d84ebbb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1862,7 +1360,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7dd9eb25-4187-4b19-978d-ad4e306ea3f4",
+                     "jsondocId": "27839a59-eb58-455e-a802-49ecaee7e28d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1871,7 +1369,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44c4fa31-cb23-46a3-88e3-99e9207cf8b2",
+                     "jsondocId": "1824bf6a-dfa7-490c-936e-b911476af035",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1880,7 +1378,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6bafcd3f-01a9-4ad0-afd8-d983a2c9c2d8",
+                     "jsondocId": "9c65e0d9-84c7-4a72-a3da-c428b3a7ae34",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1889,7 +1387,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5425c33c-ec62-4014-9e20-a931d8de52ad",
+                     "jsondocId": "ba1d6795-d966-44be-8ec6-59fb2aba5836",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1898,21 +1396,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "480ccd6a-c9a1-4d60-bb23-2e475d9dcf10",
+                     "jsondocId": "70e495cd-7b14-4d37-a4c1-68e2fba7e351",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Get comments",
-               "methodName": "getComments",
-               "jsondocId": "fad6817c-dc00-4c2f-8883-3009b90f31ac",
+               "description": "Delete feature",
+               "methodName": "deleteFeature",
+               "jsondocId": "e972acf1-ca20-443d-9b01-aedd22cadc34",
                "bodyobject": {
-                  "jsondocId": "122a4d58-9bfe-46ab-a2ba-092b649b9ae2",
+                  "jsondocId": "f80f194c-4c9a-4b02-89cc-6352736c20ab",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1920,9 +1418,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/getComments",
+               "path": "/annotationEditor/deleteFeature",
                "response": {
-                  "jsondocId": "b077bc15-8ec7-45c1-b664-faddaec362f7",
+                  "jsondocId": "0d9c29ba-1c09-4fa4-92a9-aace9068586d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1935,7 +1433,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c030b77e-33c6-4655-849e-964bb70a8baf",
+                     "jsondocId": "bbb545b1-0562-44cc-877f-538bf0f2594e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1944,7 +1442,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0056a2c8-29f4-4318-9b05-fc4af79f7bee",
+                     "jsondocId": "1d2b59c4-66f6-40ed-b9ce-469b992b6c51",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1953,7 +1451,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "947c90dd-cba4-4db9-82c6-d9dac4cc6b67",
+                     "jsondocId": "cc2456c2-d240-43db-802a-b4d19dae8b99",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1962,7 +1460,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5438bbf5-4774-4a96-9675-b4eac838f4f8",
+                     "jsondocId": "48fb0005-1019-4848-be96-6ff973fbb7dc",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1971,21 +1469,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7c6b9f05-5ba1-443f-9d4f-e1da95824ebc",
+                     "jsondocId": "98865481-60ca-4153-8396-536be1fa81df",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Add comments",
-               "methodName": "addComments",
-               "jsondocId": "cc7bb121-0bb0-468d-890e-a88c295f998e",
+               "description": "Flip strand",
+               "methodName": "flipStrand",
+               "jsondocId": "5b5a9a6e-91b6-4ec3-a8c3-427f95d08ce6",
                "bodyobject": {
-                  "jsondocId": "efac1622-d4ff-4849-8b1c-a24e338b5c7b",
+                  "jsondocId": "c8c7134c-9ad3-4d1c-9e77-cda7a14f85e6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1993,9 +1491,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/addComments",
+               "path": "/annotationEditor/flipStrand",
                "response": {
-                  "jsondocId": "0387464c-2e37-4ddd-8e2e-7164549061b3",
+                  "jsondocId": "592ddf9e-ad38-42a5-81d3-110ad7fa8d17",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2008,7 +1506,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c5238fe5-a998-4862-83bd-f47961b13ed8",
+                     "jsondocId": "8d0e5021-f4f6-4f57-bf54-44325a808015",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2017,7 +1515,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0fd3ac13-ca0c-4a6b-acb3-d91d9ab4eb50",
+                     "jsondocId": "380348af-4985-4c60-bcd3-71d6cd1c9faa",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2026,16 +1524,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2101c3c2-98e6-4d90-ab76-595a0a6db5da",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "dd8d55b5-4669-4d87-a5ee-e581cc22bebc",
+                     "jsondocId": "af1d8b9b-c70a-4c33-a5cd-b123bdc0dbfa",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2044,62 +1533,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7febd8d1-7cde-4d71-9ca9-fd6ec7101679",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete comments",
-               "methodName": "deleteComments",
-               "jsondocId": "7f3eb9b6-5702-4ee4-98f9-46eb0c934b5f",
-               "bodyobject": {
-                  "jsondocId": "edc54441-31fe-40ce-94a5-a68002cf696e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/deleteComments",
-               "response": {
-                  "jsondocId": "b6ff0bc3-79ef-4bd8-9686-37f12a846ae7",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "81473e74-3148-44f8-b9e3-454b8a0a15af",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "31b34919-7644-4067-9c9d-9b23665db616",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ffa9b7ee-1d56-4854-b2c2-818b7204cac2",
+                     "jsondocId": "659ddb4e-767e-4a8d-b639-511a0d45c906",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2108,153 +1542,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fa396dcb-1998-44d2-8b72-09c58beed75e",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bc2fd1e8-2136-4edd-9e08-ba76e8b0f989",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update comments",
-               "methodName": "updateComments",
-               "jsondocId": "65193204-a834-40d3-8c2d-dd9ea6edd974",
-               "bodyobject": {
-                  "jsondocId": "e87a1535-14be-40b1-8e13-788954ee05fc",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/updateComments",
-               "response": {
-                  "jsondocId": "a7e0dec0-7300-44a9-877a-d6a8eb5f358a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "7f25d57b-999b-4932-82c9-37a4f9c9c29a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "dca9a809-786c-4bff-8e3a-de3b2f5802cf",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9b7da06f-5a92-4299-83e8-590dc77fe6e2",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ba1057e5-5087-4c6b-8976-85a9029161e8",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get all annotated features for a sequence",
-               "methodName": "getFeatures",
-               "jsondocId": "967db250-0b13-4652-923d-d60f8677d337",
-               "bodyobject": {
-                  "jsondocId": "8a4ebe46-6af4-4e1e-8a83-4ac44e0f05e2",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getFeatures",
-               "response": {
-                  "jsondocId": "77579bd1-3cf2-4d20-ab47-6aba75c5e311",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "24805605-9d02-4a14-b2df-f4d414eb27a1",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "06fc4323-ccb5-484b-862e-27891e051aaf",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7025716f-1cf9-491c-8c5e-85344223f86d",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cd3738a0-26b4-4cd8-af1a-9f6350e9a942",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "41bda46e-553e-4159-88ba-1da739428f0a",
+                     "jsondocId": "54001dbf-e389-4dc5-a178-5cd747d7bffc",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -2263,7 +1551,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5dc54d78-af86-463a-afb1-13d41ae810ea",
+                     "jsondocId": "adefaa0b-f281-49f2-85dc-5653b7c151b3",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -2272,7 +1560,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7af738bb-2173-48e4-b8cc-a1d46ec8b31e",
+                     "jsondocId": "7cd9517c-bca1-4662-bf38-ea96cd770950",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -2282,11 +1570,11 @@
                   }
                ],
                "verb": "POST",
-               "description": "Add transcript",
-               "methodName": "addTranscript",
-               "jsondocId": "a98ce8a5-78f2-4437-ba42-25094d830abe",
+               "description": "Add an exon",
+               "methodName": "addExon",
+               "jsondocId": "f881528d-9cb9-4841-b183-87c104c064aa",
                "bodyobject": {
-                  "jsondocId": "44018e69-58a0-4bce-8c35-545b0c9773e2",
+                  "jsondocId": "c712a7fa-4cb4-4c70-8d92-1187ae409b47",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2294,9 +1582,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/addTranscript",
+               "path": "/annotationEditor/addExon",
                "response": {
-                  "jsondocId": "111e21e5-21df-4842-aa9d-463ca59b58b2",
+                  "jsondocId": "891bc3cf-d8a2-4ccb-8f64-f6ec5c15e9ae",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2309,7 +1597,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "740c646a-0087-483a-9cf4-eb7f1d08593e",
+                     "jsondocId": "0f66aa36-66c8-411a-9f6e-bbdd81b08c2f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2318,7 +1606,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "647049c4-2db6-4029-858d-4b61bfe56c59",
+                     "jsondocId": "cbdc1707-d7e5-430b-8c64-bc508d31b68d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2327,7 +1615,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ec6143b8-f0c7-48ee-86ed-ddd07c570648",
+                     "jsondocId": "004cd6ca-b776-436a-a4a2-302004c66c33",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2336,7 +1624,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b8b50a18-ab3a-4dab-ab9f-6ecacc3aee83",
+                     "jsondocId": "5964c3df-e34a-4921-a744-2d3415bd00ea",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2345,21 +1633,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2d95ebdc-437c-4133-b927-c67fff33d214",
+                     "jsondocId": "5779ae4f-c373-4173-90f8-71ea5551f10d",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
+                     "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Set readthrough stop codon",
-               "methodName": "setReadthroughStopCodon",
-               "jsondocId": "e54515e8-82c1-4c03-861b-e75998ba7907",
+               "description": "Split transcript",
+               "methodName": "splitTranscript",
+               "jsondocId": "ffa6cea1-acf3-4afe-8237-8039c87b162f",
                "bodyobject": {
-                  "jsondocId": "d8200e56-de85-44ca-b410-06e3251f1463",
+                  "jsondocId": "2af0c486-f616-4778-b299-8c98055bea32",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2367,9 +1655,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setReadthroughStopCodon",
+               "path": "/annotationEditor/splitTranscript",
                "response": {
-                  "jsondocId": "4c5afae7-0706-48c2-8388-1fa6e906c5fe",
+                  "jsondocId": "96412b91-d2c2-4ea0-8164-cc46c9a20580",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2382,7 +1670,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "338025fa-8771-414a-8233-517266cff259",
+                     "jsondocId": "bbe576ae-fef7-46e1-9139-cfed5201c468",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2391,7 +1679,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c90abcc1-7909-4624-9f7a-5b684fb22cf0",
+                     "jsondocId": "fcd0bb9d-4b94-442a-a8b0-5d0507dc7aed",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2400,7 +1688,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cfe1a113-bca5-493b-931a-31286c67f4ba",
+                     "jsondocId": "dc1cf2e1-d076-4f6d-9f8c-cefe881492bd",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2409,7 +1697,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "528a5805-60c0-49ae-8138-de8f57782a34",
+                     "jsondocId": "8ffbb050-a454-42bf-ac9c-ad17c8910900",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2418,80 +1706,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b2ee6ccc-e089-40c2-ba9a-bf6c46857320",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set longest ORF",
-               "methodName": "setLongestOrf",
-               "jsondocId": "d45f3cad-0b57-4bcd-a5d9-909f3785b271",
-               "bodyobject": {
-                  "jsondocId": "49f3e478-35a7-49d4-b8ce-1296b4167e9a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setLongestOrf",
-               "response": {
-                  "jsondocId": "4f3572f7-7c38-483e-9c37-f32db43dff04",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "7204981a-6b85-4c88-8397-d8ca46fb509a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4404a240-b383-45da-ac34-fdfc55dedd30",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f5004891-5cc9-4a8f-8ec8-2b33aa9e706d",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5ad8232e-ff81-46ab-915a-dc6e4d1725d9",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9efdc313-bf0f-4e16-91a0-78b30957b38d",
+                     "jsondocId": "3e92c0c0-ff5b-4ae7-ab5c-b093bc1b1bcc",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -2500,7 +1715,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "de93163d-4c8a-4364-a739-22e8d9d5f5ae",
+                     "jsondocId": "fc524633-2292-41ee-8f07-de9020655c36",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -2509,7 +1724,171 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "072c2707-c32d-405c-9b44-c89b659d350a",
+                     "jsondocId": "1f0a9804-9a3b-456c-b096-e763aee058bc",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Duplicate transcript",
+               "methodName": "duplicateTranscript",
+               "jsondocId": "4ebc5dd9-0270-41a6-9687-6c40c5009bca",
+               "bodyobject": {
+                  "jsondocId": "21de2d9b-760d-4c11-b959-e09e8ba0cbe9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/duplicateTranscript",
+               "response": {
+                  "jsondocId": "3bb76ad5-c5a9-45c6-9cd0-9936664be4fa",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "a84b12e2-7ba8-4de2-b48b-ec3bc3e4bd4d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6f2d2f84-923b-4e59-8cf1-1a0e6429eecd",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a3f56af1-8a49-49b1-96a0-64c4ece58b83",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a27ee2db-c9b2-4ad5-a902-f988dba1495b",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f9abf687-5666-476e-afd2-da076cb81955",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Merge transcripts",
+               "methodName": "mergeTranscripts",
+               "jsondocId": "1623590b-0321-4309-b20e-89e3715293dc",
+               "bodyobject": {
+                  "jsondocId": "4cc16dfc-cc64-4d9a-bf74-6f38f5ecb8df",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/mergeTranscripts",
+               "response": {
+                  "jsondocId": "4467035d-86bb-4bf1-93cd-eac04f0b6e0e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4da7cd05-9035-4d3b-99f2-db17757181d3",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b8472396-9f58-4b69-b741-21f67feca219",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "59e4f460-4bcd-4901-90b0-a637a1084d7b",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fdcd856d-71ff-4e58-aca5-a085093991b6",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "53d65fe3-f790-4ecf-bd37-932a92ee2c44",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7eb4cbcb-6fae-4973-b950-380ea3c0874d",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fa909ae0-0708-4441-ae8d-97cc4fe84a2a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -2519,11 +1898,11 @@
                   }
                ],
                "verb": "POST",
-               "description": "Set exon feature boundaries",
-               "methodName": "setExonBoundaries",
-               "jsondocId": "88f268a6-a399-4747-a19d-824330275267",
+               "description": "Add non-coding genomic feature",
+               "methodName": "addFeature",
+               "jsondocId": "a652d435-6cb2-4eca-acb9-5f70bdb7bb5b",
                "bodyobject": {
-                  "jsondocId": "5d388432-438f-48e4-b53e-f4629f8c4042",
+                  "jsondocId": "c18a4943-bca2-41c4-9171-12dcbc9b7a31",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2531,9 +1910,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setExonBoundaries",
+               "path": "/annotationEditor/addFeature",
                "response": {
-                  "jsondocId": "66b4296c-e463-48c6-814a-b5a3d59df0a0",
+                  "jsondocId": "c7ce9727-ebc9-4152-99a8-e3d7a752f364",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2546,7 +1925,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "dad0ae62-7c59-4dd3-ab73-ce3841f3978c",
+                     "jsondocId": "adbd9fb0-f97b-4ba9-8dcb-d18d1c57f6bd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2555,7 +1934,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1360de8a-cae8-4fcc-86e2-2727b294d9a1",
+                     "jsondocId": "71d27cd9-23bd-4e0a-acd6-9825774a07f1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2564,7 +1943,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "664e3546-a4e7-47e9-ab27-01395ae3fd7e",
+                     "jsondocId": "07a05265-43e8-4331-a2c8-8abe0ea77311",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2573,7 +1952,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e14042f9-8a30-4b11-b2e2-5566506e9e88",
+                     "jsondocId": "75eca336-0c34-4b72-877f-42fb2cd51c9d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2582,21 +1961,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3e33aa82-e59d-4d60-8e77-0109ec5194ae",
+                     "jsondocId": "c7ee4fba-081e-4d1d-8af4-7df2e47c2733",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Set boundaries of genomic feature",
-               "methodName": "setBoundaries",
-               "jsondocId": "d09144a0-0196-4060-a399-637d64957130",
+               "description": "Set translation start",
+               "methodName": "setTranslationStart",
+               "jsondocId": "975669d1-6971-4a00-8935-01f268de2ba0",
                "bodyobject": {
-                  "jsondocId": "013fab9d-28f6-4bac-8757-02b363552e81",
+                  "jsondocId": "955e9118-26b4-41fd-b2fb-95588283f30f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2604,9 +1983,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setBoundaries",
+               "path": "/annotationEditor/setTranslationStart",
                "response": {
-                  "jsondocId": "673f9211-90b4-4697-a1ac-bd3aceb5187f",
+                  "jsondocId": "f7830fb4-c973-4d92-9d2d-f294cfcced08",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2619,7 +1998,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "210cb334-9b83-43d2-a397-acb0ed8b3cc4",
+                     "jsondocId": "27e2b011-933b-446f-ad4d-7ebbf57a9308",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2628,7 +2007,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4b233720-e301-4c85-a5e8-2e0a03383528",
+                     "jsondocId": "5f81d738-0309-4605-bb6a-057867bd657d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2637,7 +2016,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d76afa14-5f84-41ac-b0c9-86bfe2066429",
+                     "jsondocId": "a3f7d0fa-c977-40ed-8710-769b336b1c5c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2646,7 +2025,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d34625ff-593b-4ca0-af18-af10a0af29c4",
+                     "jsondocId": "b4b40411-b70b-42e6-9082-61616c5a0626",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2655,21 +2034,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66942182-312a-4fa5-8255-71791c01576e",
+                     "jsondocId": "12e4badb-dede-45be-b755-4d32011c9729",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Delete sequence alteration",
-               "methodName": "deleteSequenceAlteration",
-               "jsondocId": "4d869c00-aa74-4a0b-bfe4-78db579bcee9",
+               "description": "Set translation end",
+               "methodName": "setTranslationEnd",
+               "jsondocId": "49eff872-0d5e-4e95-9942-a2619de734e9",
                "bodyobject": {
-                  "jsondocId": "d498cb9f-8a5e-49ae-b110-87234d4471ec",
+                  "jsondocId": "1aa26570-74d4-409e-b181-6c01dd06bf35",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2677,9 +2056,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/deleteSequenceAlteration",
+               "path": "/annotationEditor/setTranslationEnd",
                "response": {
-                  "jsondocId": "fdcc851a-7fb7-48e3-92a2-adf5d7098016",
+                  "jsondocId": "b069a4a0-dab8-4ba2-b14e-61fb4aee0523",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2692,7 +2071,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "254e21a8-ea1e-49e2-b2bc-47c4f53cd207",
+                     "jsondocId": "41cc8aaf-5153-40ca-ad6f-d0b53ba317a2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2701,7 +2080,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "07ae5207-b565-478e-888a-e26e5f47aed1",
+                     "jsondocId": "92c410d9-76cf-4338-b808-96ace1e4d578",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2710,7 +2089,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c072bf9c-2057-410b-ae16-a547b27931f9",
+                     "jsondocId": "67239c9d-e77b-45cc-b830-4780b6f9ebcc",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2719,7 +2098,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d4b0835-7ead-4ac3-8f5c-72e6dce86b1b",
+                     "jsondocId": "34b842bc-bd0a-4eff-bd7b-0295212ba2b9",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2728,153 +2107,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "981066fe-95a8-4f2c-ac97-82bb4459e605",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add sequence alteration",
-               "methodName": "addSequenceAlteration",
-               "jsondocId": "fda05842-82ba-4e32-bdac-f588238c31d4",
-               "bodyobject": {
-                  "jsondocId": "fedcb979-6a13-44cb-b254-5981eed7ebb0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addSequenceAlteration",
-               "response": {
-                  "jsondocId": "9d094546-2a5d-4da7-83a6-7d157b2ce5b0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "513f1dcd-1cab-4e94-b902-13057fb5aa10",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0a2a47e1-085f-4bae-ab7a-4a0cb3793108",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e0f8069c-5982-4a8d-976b-023f74a71f94",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "00e3e366-ad1f-4047-9933-857492f7e193",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9f6ae822-bb5f-412e-9a5f-2194bedc5d3a",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Split exons",
-               "methodName": "splitExon",
-               "jsondocId": "98e93aed-7bdd-4204-8e4c-a6edb30565a9",
-               "bodyobject": {
-                  "jsondocId": "f760ab53-2e28-4693-966d-dc1b4771c260",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/splitExon",
-               "response": {
-                  "jsondocId": "9172a61c-a841-463a-9f71-61090dec74ad",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "5e3d058c-b862-41fa-99a4-22b6dad1dd9c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e3cda6cf-e6ed-4b68-80f0-49b6c15642a7",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f86fa15a-74dc-44f9-8f38-e5a1fe54bc52",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ec876415-db29-4f25-9358-34d83f1a80ed",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ad4bf7da-985b-48ac-ad67-0e3e93316640",
+                     "jsondocId": "13f74896-2a63-46b9-9841-07e6691bfc48",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -2886,9 +2119,9 @@
                "verb": "POST",
                "description": "Make intron",
                "methodName": "makeIntron",
-               "jsondocId": "32760480-1856-4b3a-bfc4-aa9aae8eb1ad",
+               "jsondocId": "5098fdfe-19e7-43bc-badb-1fb71659b2b1",
                "bodyobject": {
-                  "jsondocId": "fc6db65a-ba57-4efd-87cf-172001d7ddff",
+                  "jsondocId": "21103ce5-dcbb-4416-8a69-f9c15d7d1b06",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2898,7 +2131,7 @@
                "apierrors": [],
                "path": "/annotationEditor/makeIntron",
                "response": {
-                  "jsondocId": "1ed0c1d6-2b74-4184-a8a8-10469db812db",
+                  "jsondocId": "2de2d09e-47ab-49c1-b5fe-3b72ab149497",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2911,7 +2144,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1a5046a9-f29a-475c-8cda-f0c3fae8f0d7",
+                     "jsondocId": "3a90f7ef-4100-4421-9f3e-245e7f435e07",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2920,7 +2153,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5f1174e3-ded4-457d-b2b7-08f44fe51794",
+                     "jsondocId": "e81ee5d5-2f2f-4978-a43c-0487e29c96ff",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2929,7 +2162,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "572fc769-a417-4d60-8516-d7c50038854a",
+                     "jsondocId": "65825207-28d0-4212-a825-1c9b6f2623a5",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2938,7 +2171,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4aad307f-60e2-41f0-8a63-05b1fabb0971",
+                     "jsondocId": "6234ab3f-4a2e-4c3e-b122-292be1c7c271",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2947,7 +2180,774 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d3e39b3-cd57-4639-94aa-b7bbf1f5f9ee",
+                     "jsondocId": "57d7e330-fc1e-442c-9b3f-8a0250105aa9",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add dbxref (db,id pair) to feature",
+               "methodName": "addDbxref",
+               "jsondocId": "21cb3c8b-c915-4584-bc9c-79c7abd21935",
+               "bodyobject": {
+                  "jsondocId": "95cc0cb4-e84f-4297-85a8-33f02631f575",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addDbxref",
+               "response": {
+                  "jsondocId": "a975f781-7f70-446c-a4d5-d3f357685ce4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c22e48a9-53f3-49ca-a3a1-c124f330326d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c8fc3ae1-1b49-458d-b670-e0ed99f8690e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ba8c3a0f-b4bd-4f26-b5c2-64feacdbe2cc",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "342a39b9-56e3-483b-a24f-fb4579575c59",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7b31ae15-58c0-48d6-949c-21039b4350e4",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update dbxrefs (db,id pairs) for a feature",
+               "methodName": "updateDbxref",
+               "jsondocId": "7601c37f-33b8-4a9f-a4f3-e2d7e6cf976e",
+               "bodyobject": {
+                  "jsondocId": "2aa51cf8-828e-4705-b549-137a9f760228",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateDbxref",
+               "response": {
+                  "jsondocId": "9d634114-882c-4e7a-bb3e-7cdd59c17c1f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "a12bbe91-2afb-4d3f-a5d4-b031422fca9e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0ceb80c6-8c3c-4f65-83b2-84fb39539eed",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7c51fe56-0a30-42ec-afc2-08ec05cd1a82",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "691525c4-e50b-439c-ac20-d0346861c0fd",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2443656b-7958-4f25-8b8f-80282550182f",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete dbxrefs (db,id pairs) for a feature",
+               "methodName": "deleteDbxref",
+               "jsondocId": "812c24ce-5dc4-49c7-9564-43df4c2f8f89",
+               "bodyobject": {
+                  "jsondocId": "66f16112-99ee-4a4c-ab89-5599d249c810",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteDbxref",
+               "response": {
+                  "jsondocId": "9e9edb7f-9ee4-4553-bb4b-f35414d61121",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "3de03328-facd-4e08-ac67-94e537a0a341",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f62e6017-e371-4b66-9014-7696e2af2c11",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get canned comments",
+               "methodName": "getCannedComments",
+               "jsondocId": "ed2db6fc-1a0f-4ac4-b3d6-df6b3ed7d417",
+               "bodyobject": {
+                  "jsondocId": "57f67adf-207d-45ef-b6f8-f60c39f953e2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getCannedComments",
+               "response": {
+                  "jsondocId": "7bf70f44-a3d9-49e1-9799-1d8ac462e0a1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "69f9d1ed-202b-4ffb-9d85-3b4ce7ed2595",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cb6efc04-ac2d-4c6c-bb33-003a8f9225a8",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "11a2ce14-ec71-4537-8228-32dfb23e3f2e",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get gff3",
+               "methodName": "getGff3",
+               "jsondocId": "9d1cf0bb-7a17-4a0c-bc1f-4ae70a30e4ec",
+               "bodyobject": {
+                  "jsondocId": "e83b3d30-08b0-48f6-9150-61e409f5d5cb",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getGff3",
+               "response": {
+                  "jsondocId": "5ee5d86b-919f-400b-83e6-72f7b928ecb9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "57a40421-67d9-41bb-8b70-7acf86f3c971",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5901ad27-30f7-4ec6-bc28-4e647d82c1a5",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dabe27aa-6cb2-43a1-80a0-27aa2dd77582",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "78eabb7a-801b-47ab-a459-c08cc69c4d70",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get sequence alterations for a given sequence",
+               "methodName": "getSequenceAlterations",
+               "jsondocId": "a2ef266a-fd4c-418e-b443-2ef1f9d4a821",
+               "bodyobject": {
+                  "jsondocId": "c1768212-a9ab-46cf-aee1-1ae2d3cd1c1e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getSequenceAlterations",
+               "response": {
+                  "jsondocId": "2233e0da-4ece-43f8-9d70-c64e596885b6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "9559d5b7-5c9d-4509-94be-82509f741f0d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "94d022e7-6427-4c36-a056-d23c220a054d",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b5d84e4e-50ca-42c8-b2e1-868adcc31341",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4cf79222-e764-4953-b83d-8e4bdf76285a",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "09706b6a-0a99-44d3-a560-e2a33a130556",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete attribute (key,value pair) for feature",
+               "methodName": "deleteAttribute",
+               "jsondocId": "859a3bce-375d-47ca-9042-86550d945a4d",
+               "bodyobject": {
+                  "jsondocId": "c22f77da-a108-468e-a881-8211e694fa52",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteAttribute",
+               "response": {
+                  "jsondocId": "a56b1b26-9c7b-4a9c-a722-76bc3dc10397",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "8f2ef10e-fdfc-4fdb-94d1-18f73f550a29",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "186fe2a0-e435-46e4-8a1e-2246c925cbd4",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3ca8ec68-6d96-445c-b1bb-9f337e00b8ce",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5f4317bd-29bd-4588-b976-716979afe8b4",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9fda2dcc-35c4-429f-846f-ad905110cb77",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update attribute (key,value pair) for feature",
+               "methodName": "updateAttribute",
+               "jsondocId": "bec5f181-feb7-4de7-9eb2-a26e44a258e1",
+               "bodyobject": {
+                  "jsondocId": "efd1fe67-fc2a-4431-8c85-eba806f426d8",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateAttribute",
+               "response": {
+                  "jsondocId": "2b2e046d-6109-40d8-ab72-d7db01c31eec",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6694bff2-13f1-46fe-8417-fbf673be689d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "76439c47-dd36-4e0b-8ab1-212df779138c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1829afb2-527e-43b5-a079-3fe35ea25d94",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b4552fc1-3d7e-4a57-88d0-5f143686a60e",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3b51ee06-bef1-4277-9232-ae2d3b41321d",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set status of a feature",
+               "methodName": "setStatus",
+               "jsondocId": "963fcd80-d2bc-4446-85d9-a60c0b1bbd5a",
+               "bodyobject": {
+                  "jsondocId": "689ed61c-b9cc-4af6-9d5b-4521c5be5185",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setStatus",
+               "response": {
+                  "jsondocId": "7a40d49e-6539-41a8-ab7c-68cf2c281c37",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "96f204d8-2719-461e-a426-ab94cd1d60bd",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "91616daa-9d5c-40b7-aec9-5ef6774b03cc",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e1dae084-a86e-4eb0-b263-8655a534d782",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dff84480-8db2-40b0-9448-601f2bcb55a5",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "87baff9d-5ef3-415c-955b-d81cf4e700bc",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get comments",
+               "methodName": "getComments",
+               "jsondocId": "0c6f0d9c-ac8d-450d-bfa5-e779a7b0320e",
+               "bodyobject": {
+                  "jsondocId": "a16e001e-4381-47f7-8235-e2b171173614",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getComments",
+               "response": {
+                  "jsondocId": "e9efb14f-a3d6-47fa-ac45-d8a275c94bfa",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [],
+               "verb": "POST",
+               "description": "Returns a translation table as JSON",
+               "methodName": "getTranslationTable",
+               "jsondocId": "6afb6809-01c2-4375-acfc-593eb6a5effb",
+               "bodyobject": {
+                  "jsondocId": "36f3dd41-23dd-4001-a8e6-4d990338cf93",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getTranslationTable",
+               "response": {
+                  "jsondocId": "ae343ebd-f9ee-48cf-a9ac-135033cf11b0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "08633fc4-5036-480a-b226-540a38087737",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4a1fd45c-00ba-415d-a03a-66bd8089ec29",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4a002632-9f04-4245-84f3-16ac669fbf07",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "abb7126c-1c0f-494a-9d19-5540b905fc04",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get all annotated features for a sequence",
+               "methodName": "getFeatures",
+               "jsondocId": "8c69361d-f52b-46c7-82a0-fad2a4ad50e8",
+               "bodyobject": {
+                  "jsondocId": "4a9f1d03-9326-4989-8b1d-a7c549c6b1e6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getFeatures",
+               "response": {
+                  "jsondocId": "c9ae45cc-f4c8-4b23-b30b-8aa5d2ea3ab9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "abc0e82d-1ee7-4e4d-97b5-a7cba6e158af",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "db93f056-9394-4b8b-823d-b10ddffff4e5",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "931000c2-be47-4e0b-98ff-1c14657f42ef",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dd7b3050-0378-4ce3-bd81-64ed2030d656",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "15d0685c-ec83-4111-943d-472b4465b556",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
@@ -2959,9 +2959,9 @@
                "verb": "POST",
                "description": "Set name of a feature",
                "methodName": "setName",
-               "jsondocId": "114890b5-5f30-4811-8a21-4b7ee1437b55",
+               "jsondocId": "5c48d901-06fb-4256-a806-2769f3bf863d",
                "bodyobject": {
-                  "jsondocId": "25b03de4-58ca-48d8-946d-fc4fdd404932",
+                  "jsondocId": "b9c6b40a-e4b8-452b-b2b6-9d2c020c9c10",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2971,7 +2971,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setName",
                "response": {
-                  "jsondocId": "07323518-240d-4e80-ae98-a2cebc9fea6d",
+                  "jsondocId": "75cf580b-af58-4830-a646-d6747e63c222",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2984,14 +2984,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "7c441dd0-e31b-4b5f-86fa-dda48cdc42ea",
+         "jsondocId": "5fba0155-6018-46f4-af89-3016a1d4b33d",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7d15067a-0573-48fc-ba27-70131da98bf5",
+                     "jsondocId": "a05eff40-7d59-4263-a83a-eac6c5b294c9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3000,7 +3000,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b0cb6847-75e0-46e1-b655-53d56213ff4e",
+                     "jsondocId": "18b4f703-b000-4e55-b9f2-cfaafef9ec74",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3009,7 +3009,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3747883b-efda-4a66-921b-ef37acd7fc6f",
+                     "jsondocId": "546a61ce-b629-4430-b0e9-22d4c37e6a8a",
                      "name": "name",
                      "format": "",
                      "description": "Group name to add",
@@ -3021,9 +3021,9 @@
                "verb": "POST",
                "description": "Create group",
                "methodName": "createGroup",
-               "jsondocId": "87df70cc-6053-4ef1-b622-61b455fa1fa3",
+               "jsondocId": "47beb054-a9fd-40b1-962d-69680ba7b2c9",
                "bodyobject": {
-                  "jsondocId": "5b482365-90ed-4e6b-87dc-5c84a1c4ae47",
+                  "jsondocId": "9d95cd5e-26b3-415e-aee4-adcafc34f4d0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3033,7 +3033,7 @@
                "apierrors": [],
                "path": "/group/createGroup",
                "response": {
-                  "jsondocId": "81737ca6-0184-4e5b-96a1-b6af010bcbd1",
+                  "jsondocId": "ce7ebb6b-3d7c-41ae-841c-d4b0ce299445",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3046,7 +3046,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "34b68097-60a9-4804-a074-3df938408e09",
+                     "jsondocId": "1496d539-13cb-47e8-8115-a1b026c0209a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3055,7 +3055,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66b92494-0ab3-4638-98a7-ddceaec73377",
+                     "jsondocId": "528e54ef-6776-42c9-a139-1a10fd6cc2f9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3064,116 +3064,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "60722889-e2b5-41be-869c-38ae65c44500",
-                     "name": "groupId",
-                     "format": "",
-                     "description": "Group ID to modify permissions for",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e9f39345-deba-4c84-9c30-fd5a2bc04d4b",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name to modify permissions for",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4bb1d07f-0e4a-4e8a-961b-591c8eaa22cb",
-                     "name": "organism",
-                     "format": "",
-                     "description": "Organism common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "251d2ae8-f957-4e82-b739-956587be4ffd",
-                     "name": "administrate",
-                     "format": "",
-                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "272ec8f3-4acb-4a20-857c-b6f86a1a6b34",
-                     "name": "write",
-                     "format": "",
-                     "description": "Indicate if user has write privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "af5188d8-fbf7-4f2d-b4c4-61d5cf6971b6",
-                     "name": "export",
-                     "format": "",
-                     "description": "Indicate if user has export privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bbcbc7ee-43a3-443d-a1a5-12ad3a8aa02f",
-                     "name": "read",
-                     "format": "",
-                     "description": "Indicate if user has read privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update organism permission",
-               "methodName": "updateOrganismPermission",
-               "jsondocId": "e31f80e3-ead1-4dde-87e1-77aeeaf4cdb4",
-               "bodyobject": {
-                  "jsondocId": "4cdd4456-e243-4c70-9c90-c2efaad1acae",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/updateOrganismPermission",
-               "response": {
-                  "jsondocId": "999a331a-b0fa-4629-bd14-2b015f698074",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "ee3afaeb-58e9-4be1-bfcb-70c5941418e6",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7e867e98-5f60-4941-937b-55b99cbad710",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d3c17bd6-9bde-4a1c-8774-7d519ce08e42",
+                     "jsondocId": "d474715d-cb1d-4f0d-a1f6-df7061e0674a",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -3182,7 +3073,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44878288-404a-4476-943f-66446d50cff8",
+                     "jsondocId": "fcc305e5-a0b4-4556-8d23-e6b36a92a8d7",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -3194,9 +3085,9 @@
                "verb": "POST",
                "description": "Get organism permissions for group",
                "methodName": "getOrganismPermissionsForGroup",
-               "jsondocId": "a861dcdc-7dd2-44da-b200-36a50cfe1aee",
+               "jsondocId": "08c62e5a-b971-4adc-a3cb-d763ce7a5d07",
                "bodyobject": {
-                  "jsondocId": "89384e81-da87-488a-b339-a0aa1e00fe00",
+                  "jsondocId": "1e107223-bf18-4058-816d-9611651e923f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3206,7 +3097,7 @@
                "apierrors": [],
                "path": "/group/getOrganismPermissionsForGroup",
                "response": {
-                  "jsondocId": "fb061119-8d23-4adb-b02b-708b49b47c5e",
+                  "jsondocId": "8654afba-6c5e-49b1-b4ca-b83ccac5f25b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3219,7 +3110,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "30821be1-dde2-4d76-bc1c-1a4c04732094",
+                     "jsondocId": "0c480dd4-783b-4f00-8116-6145b90da7da",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3228,7 +3119,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2fefba03-5f72-43d4-888d-59036e382c1c",
+                     "jsondocId": "da83fd9b-13ab-40a1-b600-b254e88e0383",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3237,7 +3128,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49c38a75-0576-4776-990a-1413a19b2c55",
+                     "jsondocId": "a8d05cc2-74e6-41b0-ae1c-64294cd1f112",
                      "name": "groupId",
                      "format": "",
                      "description": "Optional only load a specific groupId",
@@ -3249,9 +3140,9 @@
                "verb": "POST",
                "description": "Load all groups",
                "methodName": "loadGroups",
-               "jsondocId": "8a8b2c34-bd54-4ec9-8fff-b369147da79c",
+               "jsondocId": "cbcec83d-a721-4205-8244-c22e7d089540",
                "bodyobject": {
-                  "jsondocId": "0309a289-5e8f-4329-b201-67d8c676d932",
+                  "jsondocId": "4acf6608-6c7d-4589-8251-7f7a43edd234",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3261,7 +3152,7 @@
                "apierrors": [],
                "path": "/group/loadGroups",
                "response": {
-                  "jsondocId": "3782c771-121b-4ce1-aa9e-88520aa8b64e",
+                  "jsondocId": "2eb17b5d-2561-4ad1-b3a0-c6b0d0ae76a4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3274,7 +3165,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f4e48909-23e1-452a-b404-11607cbb55f4",
+                     "jsondocId": "b35adcbf-6405-42d0-807d-1a4c9d024f95",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3283,7 +3174,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8add6e23-1203-4d0e-b944-50cfaca898a8",
+                     "jsondocId": "6f0159e4-d957-4e7c-b618-8c3099806f57",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3292,7 +3183,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f0d7a0de-95ec-4fc2-91bc-695bd1ea4508",
+                     "jsondocId": "0dd46541-b0e7-4df1-89a3-9aa71e4f17a4",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to remove (or specify the name)",
@@ -3301,7 +3192,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "663976f7-b46a-45dc-89e8-998b8befd973",
+                     "jsondocId": "5f4c71cb-325a-4674-b0d4-53c52cc03a9c",
                      "name": "name",
                      "format": "",
                      "description": "Group name to remove",
@@ -3313,9 +3204,9 @@
                "verb": "POST",
                "description": "Delete a group",
                "methodName": "deleteGroup",
-               "jsondocId": "13c85a26-628f-45ad-ae78-186676f79f37",
+               "jsondocId": "c28a7516-3bba-4472-84e2-38d4110f64b0",
                "bodyobject": {
-                  "jsondocId": "0f2e1317-c9d4-4788-b0f0-e9a4febb500a",
+                  "jsondocId": "7dcbb6c8-2d3a-4d05-8027-67bb5aba61da",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3325,7 +3216,7 @@
                "apierrors": [],
                "path": "/group/deleteGroup",
                "response": {
-                  "jsondocId": "b5e60b03-42d9-4811-a671-82a86f15574e",
+                  "jsondocId": "e7ef9ddb-7e49-441c-a118-d3df59ba4803",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3338,7 +3229,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ddb5c53b-6390-4bda-9f8d-8104239c6241",
+                     "jsondocId": "fff40571-63f3-495f-b863-37faccbdcd25",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3347,7 +3238,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3f93c4f5-58f7-457c-a6cf-4ea827cf4126",
+                     "jsondocId": "65842105-75e3-46c7-8846-51c71fe413a6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3356,7 +3247,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "329f3221-a05d-434d-a887-114da70e609b",
+                     "jsondocId": "fe6c77e4-dd32-4052-9f03-443974bd9a92",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to update",
@@ -3365,7 +3256,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a83b3d5c-894e-48f2-ae0d-5ea2963e4f8a",
+                     "jsondocId": "21652465-9870-49c4-adec-1c454290e2e4",
                      "name": "name",
                      "format": "",
                      "description": "Group name to change to (the only editable optoin)",
@@ -3377,9 +3268,9 @@
                "verb": "POST",
                "description": "Update group",
                "methodName": "updateGroup",
-               "jsondocId": "719ba585-9a3c-4bec-9fe0-9d0ba0560845",
+               "jsondocId": "64ef7de6-f6ff-47e3-b4c9-d23423dec5cd",
                "bodyobject": {
-                  "jsondocId": "9c44fe27-23fb-4179-877f-4891b5cbf326",
+                  "jsondocId": "5d9fd750-c54c-4a89-9da4-ff2dfc625b50",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3389,7 +3280,7 @@
                "apierrors": [],
                "path": "/group/updateGroup",
                "response": {
-                  "jsondocId": "b94b3faa-472b-4c91-a13c-66d24ad95868",
+                  "jsondocId": "f16c2198-d674-4846-b7bf-b62ad27d6dae",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3402,7 +3293,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fff3d2db-f5da-4ab0-b47b-fe779c834775",
+                     "jsondocId": "72aa9420-3da6-4ef1-ac2e-cd50a7fb1e25",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3411,7 +3302,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "673bd991-48be-41c6-939c-1818e962a81d",
+                     "jsondocId": "60c7db30-20a0-47f3-85b5-cef4d4831aea",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3420,7 +3311,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dcd844c2-3343-4695-a1da-f3a9c56e934c",
+                     "jsondocId": "cdb7c96e-3851-4aec-860d-305a60e1b10c",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -3429,7 +3320,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "70e9494c-1994-4a18-a6c5-ec87bfc5f7c2",
+                     "jsondocId": "082ca98d-dd72-475b-bfa4-b7597d245f91",
                      "name": "user",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -3441,9 +3332,9 @@
                "verb": "POST",
                "description": "Update group membership",
                "methodName": "updateMembership",
-               "jsondocId": "540fb3b8-4622-4ea1-94bd-fac971e80a21",
+               "jsondocId": "7e177af1-04d6-4094-b2c8-14e8df832eb1",
                "bodyobject": {
-                  "jsondocId": "7f2d222e-09ff-4d44-9aa6-fb9d42c91d51",
+                  "jsondocId": "fbac1471-bafe-477c-81ee-a15a0c728f5c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3453,7 +3344,116 @@
                "apierrors": [],
                "path": "/group/updateMembership",
                "response": {
-                  "jsondocId": "eef9c2bc-9b95-46df-a502-1ad1fe1e66b1",
+                  "jsondocId": "317ac0d3-27e7-4690-91dc-56040f146e71",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5ac2b023-673b-479b-b71b-4566ec94b8f8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "da54d668-4661-44eb-bbf4-2da133c05be8",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6c760a5f-b5cb-4202-a85f-1f452786139e",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Group ID to modify permissions for",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b7248882-b30e-4aa2-946d-d8f9eb50c4f0",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to modify permissions for",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7bafd6ae-f730-4d4c-9a18-6cc3e683a8b8",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Organism common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "13e96d43-7f71-4e58-be74-5dc82eb9043d",
+                     "name": "administrate",
+                     "format": "",
+                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3ec90e8c-0b5b-446d-bc77-028e229a89e6",
+                     "name": "write",
+                     "format": "",
+                     "description": "Indicate if user has write privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "de8a1949-ae14-49fd-9904-89777b7354e4",
+                     "name": "export",
+                     "format": "",
+                     "description": "Indicate if user has export privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "854ae240-39d3-4fbd-a3b1-8ee85fe5d672",
+                     "name": "read",
+                     "format": "",
+                     "description": "Indicate if user has read privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update organism permission",
+               "methodName": "updateOrganismPermission",
+               "jsondocId": "44715be7-2b16-4932-98dc-432c497d6f3a",
+               "bodyobject": {
+                  "jsondocId": "3d2a3a17-2ef4-428c-863b-e9854da70277",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/updateOrganismPermission",
+               "response": {
+                  "jsondocId": "d3237b91-8e02-4ccd-91b2-2282c8dd3c62",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -3466,14 +3466,14 @@
          "description": "Methods for managing groups"
       },
       {
-         "jsondocId": "948213fd-b7da-4cd4-a2f4-aa1537c98d0b",
+         "jsondocId": "2485a575-ceb0-441d-af79-7622d52f4a43",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7871157c-8af1-4228-8d40-37446f86cf23",
+                     "jsondocId": "73601cac-65b4-41de-80f8-a90e8d0f1f4b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3482,7 +3482,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "658d86e5-ab63-46eb-8199-8587b2173d22",
+                     "jsondocId": "0bac49ab-2291-4129-bbfc-c043c1aa44e9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3491,7 +3491,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a3de3794-5808-4e7a-b4a4-8ee080c167d9",
+                     "jsondocId": "67b61d7e-022a-4267-9c0e-4e48e64358ad",
                      "name": "uuid",
                      "format": "",
                      "description": "UUID that holds the key to the stored download.",
@@ -3500,7 +3500,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3564bbd3-19e7-47a8-aecc-8ce0e8c7627d",
+                     "jsondocId": "bdbff313-4397-4077-bf04-a235e964a8cf",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -3512,9 +3512,9 @@
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
                "methodName": "download",
-               "jsondocId": "a2d0f350-42ca-401d-b7aa-0925a929314f",
+               "jsondocId": "6ba72458-1020-4ef0-bd8c-0c606a18dc9a",
                "bodyobject": {
-                  "jsondocId": "4e9001ca-a3b1-47ec-81cd-dbac5314c318",
+                  "jsondocId": "ec4718a5-a683-4dcc-b605-369b0a6314b2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3524,7 +3524,7 @@
                "apierrors": [],
                "path": "/ioService/download",
                "response": {
-                  "jsondocId": "0aa163b3-85dc-4e9b-ac63-70a75d0ef3ee",
+                  "jsondocId": "765572ea-0f0c-440a-9144-2be3e0e3ca63",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -3537,7 +3537,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "14881869-f128-4a23-9d0a-996971cf4b07",
+                     "jsondocId": "4763738c-9fca-42ac-a7e5-10887678d7e1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3546,7 +3546,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d456d3b-b936-458c-afaa-00096c189ccf",
+                     "jsondocId": "5b70fc05-237c-438b-bc57-16889ea9852b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3555,7 +3555,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2e3e3931-57a9-4c8f-ae00-5e0e6fdc839b",
+                     "jsondocId": "88c77e6e-05ea-4fb2-a509-d574dba72085",
                      "name": "type",
                      "format": "",
                      "description": "Type of export 'FASTA','GFF3'",
@@ -3564,7 +3564,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14bf337c-2ba0-43ab-b4dc-3c7a5617a3da",
+                     "jsondocId": "38b94bc0-c0cf-4573-91b3-93d9b6919a95",
                      "name": "seqType",
                      "format": "",
                      "description": "Type of output sequence 'peptide','cds','cdna','genomic'",
@@ -3573,7 +3573,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1994c0d3-cb53-4cc8-a81f-dc9a81516e98",
+                     "jsondocId": "95a3abaf-fcc5-46fc-80a3-e8e4e4b14754",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -3582,7 +3582,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cd13622c-0f77-4f5b-a589-d5db0a93868e",
+                     "jsondocId": "bd01d53c-4144-45a6-8310-7a415a33584c",
                      "name": "sequences",
                      "format": "",
                      "description": "Names of references sequences to add.",
@@ -3591,7 +3591,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1a67350c-f5b0-498a-9cd3-e1c03009f049",
+                     "jsondocId": "ba78095f-c8d2-4fd2-a717-2dff6b390a21",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism that sequences belong to.",
@@ -3600,7 +3600,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4a7ead99-10bf-4eec-bc65-51177e6a9f28",
+                     "jsondocId": "6e7c8b62-20d3-44d4-ab34-d2638f35a947",
                      "name": "output",
                      "format": "",
                      "description": "Output method 'file','text'",
@@ -3609,7 +3609,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7003bada-eea5-402d-b7c3-cc783e574a7a",
+                     "jsondocId": "5b0e21b7-d376-4da9-b3ba-efb89d42fe75",
                      "name": "exportAllSequences",
                      "format": "",
                      "description": "Export all sequences for an organism (over-rides 'sequences')",
@@ -3618,7 +3618,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a5179a7f-1dc5-413b-a2e2-520c04aadd0e",
+                     "jsondocId": "446e77d2-3766-4dea-9200-17bc41b2dbc6",
                      "name": "exportGff3Fasta",
                      "format": "",
                      "description": "Export sequences when exporting gff3",
@@ -3630,9 +3630,9 @@
                "verb": "POST",
                "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "methodName": "write",
-               "jsondocId": "3be6065c-0aae-42ae-aa09-bf1f88a4328f",
+               "jsondocId": "05962c36-3ac2-4b33-9c94-518a54b01012",
                "bodyobject": {
-                  "jsondocId": "d6df77c0-076c-4c12-8285-8eb8c2e335a1",
+                  "jsondocId": "82837b96-2c5a-48e0-a844-da922e5becdd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3642,7 +3642,7 @@
                "apierrors": [],
                "path": "/ioService/write",
                "response": {
-                  "jsondocId": "b19402da-776c-4c9a-b04e-82d96171784a",
+                  "jsondocId": "cd0ad3a3-fbb8-4625-a5de-c01a8304a29b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -3655,14 +3655,14 @@
          "description": "Methods for bulk importing and exporting sequence data"
       },
       {
-         "jsondocId": "89ef57c5-ea63-42dd-ba12-4dd32e328ce9",
+         "jsondocId": "269d81cd-df01-4a52-896d-d909f5a3a791",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c095d811-085b-491c-9b4e-58a43055580e",
+                     "jsondocId": "4cf36881-ac78-405e-819b-01746c40efef",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3671,7 +3671,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "21e80e06-cb83-4954-b7b7-664d7a9492d7",
+                     "jsondocId": "d610a160-ec85-4011-a4d4-9c5da70a3885",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3680,7 +3680,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fe7dc85e-f84f-4029-a828-ea157f17e5b7",
+                     "jsondocId": "dc3c4337-c476-492f-a6c6-c782433659e6",
                      "name": "organism",
                      "format": "",
                      "description": "Pass an Organism JSON object with an 'id' that corresponds to the id to delete",
@@ -3692,9 +3692,9 @@
                "verb": "POST",
                "description": "Remove an organism",
                "methodName": "deleteOrganism",
-               "jsondocId": "a4cda158-bcee-4c7b-bdc8-ef9efdac4fce",
+               "jsondocId": "571220fe-2dae-4592-9607-7bb8638e82ad",
                "bodyobject": {
-                  "jsondocId": "058869f9-01b1-4260-9b20-06d9ec249ddc",
+                  "jsondocId": "821496ef-e20c-4d46-bdeb-cae1de9d4c09",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3704,7 +3704,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganism",
                "response": {
-                  "jsondocId": "ab2098f9-05f0-4dc3-801d-b9171672bc9d",
+                  "jsondocId": "bdfc35f7-4c7d-463b-a9ab-f2e2b65d8020",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -3717,7 +3717,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e6c12161-cf67-4d19-b759-7ec6a98d955f",
+                     "jsondocId": "974997b1-ea44-486e-97d5-33042305e8f3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3726,7 +3726,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ec504b1a-52e9-45c8-b083-2d61479f23d7",
+                     "jsondocId": "c24f8147-e01d-4185-9685-439e524b3401",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3735,7 +3735,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fb2ce7cc-2388-4df8-8464-f5fbb4a9307b",
+                     "jsondocId": "6f531825-6488-4595-a7d7-b6a96e13d485",
                      "name": "organism",
                      "format": "",
                      "description": "An organism json object that has an 'id' or 'commonName' parameter that corresponds to an organism.",
@@ -3747,9 +3747,9 @@
                "verb": "POST",
                "description": "Remove features from an organism",
                "methodName": "deleteOrganismFeatures",
-               "jsondocId": "4548af2e-c87a-4659-8dcd-d65a70d5500f",
+               "jsondocId": "249fbbe9-9c32-462e-822d-d0d0016d5dbf",
                "bodyobject": {
-                  "jsondocId": "440119a1-d468-449a-a87e-da1c97945d3d",
+                  "jsondocId": "e7eaadca-fdf8-4329-9905-b29e73203fd0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3759,7 +3759,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
                "response": {
-                  "jsondocId": "ca2c071b-5a6e-4653-b379-5524c75d7f67",
+                  "jsondocId": "435e54c6-5deb-4100-906f-c123fd29cd5c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -3772,7 +3772,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e5f12fad-f754-4c29-a7ef-114d5ac891f3",
+                     "jsondocId": "8e2b68a2-4a8d-40db-bf73-fe17ad973ef3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3781,7 +3781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "deb38f92-fcb3-4033-b147-99d9219266a7",
+                     "jsondocId": "8ffb468f-85e7-49db-8a24-acf7e141fb36",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3790,7 +3790,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1eca5cd9-2253-47bd-867c-afdfa4103628",
+                     "jsondocId": "dcb788b9-766e-4237-bd73-f2caacd885d8",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -3799,7 +3799,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d2e555d9-294e-42e5-b727-6e15ba5800bc",
+                     "jsondocId": "21697d6f-8c78-4579-afc0-8c9e1895d610",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -3808,7 +3808,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c41ff996-2ca3-4651-93a9-1f2793ba473a",
+                     "jsondocId": "afc0fecb-0479-4323-97a5-5883cc9ed470",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -3817,7 +3817,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "017da2bd-34fe-43d0-8bc0-268ee61d76fe",
+                     "jsondocId": "058851d4-99f6-4d80-96aa-9c597cf5478f",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -3826,7 +3826,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "16290516-95fc-4005-b329-a1846eec78ab",
+                     "jsondocId": "15095eb9-2ab3-4375-8f4a-f82382c6260d",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -3835,7 +3835,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c052837f-94b2-4caf-8114-019e8007b62b",
+                     "jsondocId": "fa854cc8-7690-41ba-b270-8f895d736415",
                      "name": "commonName",
                      "format": "",
                      "description": "a name used for the organism",
@@ -3847,9 +3847,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganism",
-               "jsondocId": "19f2dde7-92ba-4ab7-b4d3-8b8e2f706b53",
+               "jsondocId": "f7f73fd2-4ffb-4854-b2cf-be7a7e23acb0",
                "bodyobject": {
-                  "jsondocId": "881746b0-0447-48a5-857a-7b99ab1b81e3",
+                  "jsondocId": "f97964bc-3522-411f-9e79-f43fd6da7a5a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3859,7 +3859,7 @@
                "apierrors": [],
                "path": "/organism/addOrganism",
                "response": {
-                  "jsondocId": "08f4bf6a-984f-42da-8461-9272facc4d21",
+                  "jsondocId": "321de043-e3f8-4c21-99cb-dc62aec620aa",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -3872,7 +3872,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "20be3cea-2093-4dee-912a-d86ddf2a7689",
+                     "jsondocId": "ea729eb6-c7b9-4121-8653-f946878f770e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3881,7 +3881,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "871393f1-f818-4435-a879-82203e127eac",
+                     "jsondocId": "3a53a8af-c097-41ab-a5b7-af0cc661f3ea",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3890,7 +3890,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "936f69af-d482-4e98-a727-d4ae5e66ca14",
+                     "jsondocId": "56914841-9a82-4804-9514-528e30b00be3",
                      "name": "organism",
                      "format": "",
                      "description": "Common name or ID for the organism",
@@ -3902,9 +3902,9 @@
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
                "methodName": "getSequencesForOrganism",
-               "jsondocId": "1e2a1677-edad-405b-96f5-b06f448ae1a3",
+               "jsondocId": "ed86ddd4-f13d-4abf-b119-99f53546d174",
                "bodyobject": {
-                  "jsondocId": "6e5f5772-4a3c-44a3-bd1d-93a11da3dcd4",
+                  "jsondocId": "0c664fc6-6b01-4a03-a14f-deeead81782e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3914,7 +3914,7 @@
                "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
                "response": {
-                  "jsondocId": "f112bcd7-ea79-43cc-97a9-55d7c2160cfc",
+                  "jsondocId": "047c12e7-a2b0-40a7-b518-3a470ece13a7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -3927,7 +3927,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9f3f1879-d45e-48e1-a3de-0eb1b3e83d87",
+                     "jsondocId": "4af5a416-1af9-489a-a78c-e45dcd4959a4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3936,7 +3936,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7a7d0e6a-26c9-47cd-9dc0-bc654b2fa61b",
+                     "jsondocId": "1762a76a-cf67-4fe2-8f06-fa2c0c91e2ca",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3945,7 +3945,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "efa5ef97-466a-4588-9fa9-6558377ccb11",
+                     "jsondocId": "5cbe69c8-a2c3-40df-94a3-eb6b895356ee",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -3954,7 +3954,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e83dc3dd-2242-48d9-93af-3269c1edbd4d",
+                     "jsondocId": "70daf934-8320-429b-9c2d-b4946003ffe7",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -3963,7 +3963,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "858b7faf-02bd-4753-be53-5a5df49a95d0",
+                     "jsondocId": "6c420b43-bb88-46c7-8a1f-0dfca09f3f63",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -3972,7 +3972,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "75183079-4aed-45ab-ab9e-b22cd9a1e6e5",
+                     "jsondocId": "988231d0-304f-4ff3-a142-7a282e90d9ea",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -3981,7 +3981,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1cc8f4a-fe75-4478-93f3-b34f87082d7d",
+                     "jsondocId": "b376c5b3-ea86-42c7-804e-4b02f5f257e6",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -3990,7 +3990,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9fb5aab1-6ba0-46bf-b294-ab2391c9912d",
+                     "jsondocId": "b4503b95-7732-4f09-b27d-ab878a566bd1",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -3999,7 +3999,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "458ecfb6-d6c0-46d1-a0ff-f02250cb6207",
+                     "jsondocId": "738ab3ba-87ae-43fd-98e3-0e934cbfa82f",
                      "name": "name",
                      "format": "",
                      "description": "a common name used for the organism",
@@ -4011,9 +4011,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "updateOrganismInfo",
-               "jsondocId": "5bc90bcc-8f73-480a-8b0e-0730aa097015",
+               "jsondocId": "13c13b6e-82b6-4218-8d53-31af9c5c33e0",
                "bodyobject": {
-                  "jsondocId": "8306d222-bf65-49dd-b777-8b895834ae35",
+                  "jsondocId": "d7d08780-8401-4841-9607-4c46e5984a5d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4023,7 +4023,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismInfo",
                "response": {
-                  "jsondocId": "6e8ae37a-9af7-4834-9491-0a9736737008",
+                  "jsondocId": "acfb4315-35d9-45de-b9be-99d071ed475e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4036,7 +4036,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0ea1ad20-5737-42ab-932b-40d79ff16b9d",
+                     "jsondocId": "afc05988-f61c-4b06-bb33-f08656e0d659",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4045,7 +4045,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3cbfdd3f-b993-46cd-bad6-b09629fa0b76",
+                     "jsondocId": "8174fabb-20e6-44f0-b553-83b24b126829",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4054,7 +4054,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44d9c329-5dd2-4953-920b-3f929c1f046f",
+                     "jsondocId": "ec096a96-9e71-48b5-85be-c545862e5d69",
                      "name": "organism",
                      "format": "",
                      "description": "",
@@ -4066,9 +4066,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "methodName": "findAllOrganisms",
-               "jsondocId": "b90c3ebf-baec-4242-ad6d-e2877cdfe0ad",
+               "jsondocId": "82c23f66-55a1-45fe-86c1-cae79d402d76",
                "bodyobject": {
-                  "jsondocId": "ff470acf-23f2-4ad5-87e9-2ffa5d0af06b",
+                  "jsondocId": "a4c90a88-d1fb-4bd6-94bd-3b885e7c1061",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4078,7 +4078,7 @@
                "apierrors": [],
                "path": "/organism/findAllOrganisms",
                "response": {
-                  "jsondocId": "43c0e9f0-1f85-4fa2-ac61-0af44d835dd9",
+                  "jsondocId": "c6b6c7d4-4d4c-4c58-9bcf-a4d22756187d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4091,14 +4091,14 @@
          "description": "Methods for managing users"
       },
       {
-         "jsondocId": "199aab01-21bf-4bea-9192-7ff6fdac9544",
+         "jsondocId": "85ad0c8a-e5ed-428b-83be-4486c1864cc2",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "703756fc-666e-4b3b-b22d-f5344648070b",
+                     "jsondocId": "ac8e5f2c-d97a-4bc5-b538-fb7fc5bab272",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4107,7 +4107,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f1401f9-f266-4018-856f-2e7a532adbf4",
+                     "jsondocId": "5daebf05-d3a2-4538-abab-80aac0c69063",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4116,563 +4116,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e0ba2315-ce7c-426c-beee-8ea9f988c222",
-                     "name": "userId",
-                     "format": "",
-                     "description": "Optionally only user a specific userId",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Load all users",
-               "methodName": "loadUsers",
-               "jsondocId": "d94dc1d1-3352-445e-9e4d-88654c837a84",
-               "bodyobject": {
-                  "jsondocId": "3b920df7-4a96-4f01-bb6c-acc796362de0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/loadUsers",
-               "response": {
-                  "jsondocId": "fcf8ce10-8661-435e-94d1-3c220f70e486",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "5695a3a0-45a4-4b2f-97ca-d51299e18d5a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2d13185e-7b4f-495c-9331-34c0f1a7cb6c",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f14a0fbd-e1d4-4a25-ad3d-67be51678f0c",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "850ca007-6d34-4153-8101-7455e827eda0",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "78c25987-8b7d-4efa-b5a7-9c202121b4b6",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add user to group",
-               "methodName": "addUserToGroup",
-               "jsondocId": "d679660e-a7f3-4714-a3a1-177e78e699e0",
-               "bodyobject": {
-                  "jsondocId": "f68073d9-cd03-440d-bbc9-144b528a0ae7",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/addUserToGroup",
-               "response": {
-                  "jsondocId": "b1fa1dea-49b6-4de2-83df-959867963421",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "2aeea3a3-d8ac-4c4d-b5c7-351e7af68ec8",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "75917c4f-bdfb-4347-ad8c-f04504de4d0d",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5815b25b-5450-480b-b1b3-9c60903371b5",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "84676c1a-5235-469c-a16e-62a6917f1710",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "29148575-da2c-4f5d-9b15-546ab84f4e02",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Remove user from group",
-               "methodName": "removeUserFromGroup",
-               "jsondocId": "54fcc40e-d441-4b53-8247-a738730848d3",
-               "bodyobject": {
-                  "jsondocId": "2b1c0a7e-a96b-493a-8da4-bbac4c47bdcc",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/removeUserFromGroup",
-               "response": {
-                  "jsondocId": "175b3ca8-c17d-4c06-b0fa-fe30e99c667e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "e91c9be6-4549-4d32-be31-2a98cb0d90cb",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ec4261a2-bb45-4d71-a098-e4b2a5dd60c7",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "372a777a-2e4e-42d0-9e30-61270d261a5c",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to add",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e597957e-9923-47b5-8b29-09be952aa7d6",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "aac9efc2-d189-45a0-a82e-f4fe8abfca84",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1e22482a-d0ef-436c-891f-67c5bca60e98",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create user",
-               "methodName": "createUser",
-               "jsondocId": "bc9ef75e-bfd9-49da-b6d1-2b5eaa9bf00a",
-               "bodyobject": {
-                  "jsondocId": "6429f2bd-e80a-4f82-b602-0a7182f6f05b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/createUser",
-               "response": {
-                  "jsondocId": "5b9c3bab-167f-4ba8-8a37-e1173ce66c1e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "b814e9f0-d3c8-49e2-bb4a-07f3f4dc14c2",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4973a319-de82-4332-ab0d-d4a63019f8fb",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "31b62e33-b42c-45e5-aa9e-00b606456394",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to delete",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "50d1f757-09b1-4a8e-b88e-ab1d86f80608",
-                     "name": "userToDelete",
-                     "format": "",
-                     "description": "Username (email) to delete",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete user",
-               "methodName": "deleteUser",
-               "jsondocId": "6a21c6d9-da0a-457e-b77a-ee740510017f",
-               "bodyobject": {
-                  "jsondocId": "6e0bf224-30b8-46d7-9bae-36a6d8a7971b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/deleteUser",
-               "response": {
-                  "jsondocId": "974e12c0-18f7-4806-be6f-bf1f52e899b2",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "d5676b94-b4b0-488c-b8aa-12902d0a4190",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "30283417-2364-4d60-a5b9-9828fdef6d67",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3d4d16f4-c731-4401-8789-9dad69991f52",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to update",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "73d8f2ca-3491-4518-8f06-a3212af1604b",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to update",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6cbb5bf5-2c8e-48e9-bc1d-f42559ee61f9",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "36ca9cba-c2ac-4145-af9d-8f98f57956a9",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "193b8e13-a756-4337-badf-70e7ae0a3996",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update user",
-               "methodName": "updateUser",
-               "jsondocId": "1d43778f-ab33-4a5f-b4ff-2ab53ef3141b",
-               "bodyobject": {
-                  "jsondocId": "b2f2b24d-0c7c-4397-a278-6e40cbffe248",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/updateUser",
-               "response": {
-                  "jsondocId": "1424eabb-25a8-4301-926e-77bfa7a18a55",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "a85043d0-b7ac-46cc-94a2-7847f38342d4",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d5f863de-148b-4cc3-bf96-e13b0e0e67c1",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "481cfd51-2332-4883-ad09-d831c51431be",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to modify permissions for",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "8a5b5e2b-a0af-4a6c-a60b-060822f264b0",
-                     "name": "user",
-                     "format": "",
-                     "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0d09e8e9-cc6e-48b3-91fb-9582990d7966",
-                     "name": "organism",
-                     "format": "",
-                     "description": "Name of organism to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "90302d31-44e4-4064-92b3-f21855beb77f",
-                     "name": "id",
-                     "format": "",
-                     "description": "Permission ID to update (can get from userId/organism instead)",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b683455c-34f2-4108-948c-89842e9ffa30",
-                     "name": "administrate",
-                     "format": "",
-                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "88ac35c5-12a9-42eb-948e-6ac08db54527",
-                     "name": "write",
-                     "format": "",
-                     "description": "Indicate if user has write privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f01a6554-53d2-4491-86bb-8346f9b30ae0",
-                     "name": "export",
-                     "format": "",
-                     "description": "Indicate if user has export privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9bb0a052-977c-40ca-b992-2f2a6c51ec54",
-                     "name": "read",
-                     "format": "",
-                     "description": "Indicate if user has read privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update organism permissions",
-               "methodName": "updateOrganismPermission",
-               "jsondocId": "b76779f9-aaf5-463e-a660-ca6a63a9668a",
-               "bodyobject": {
-                  "jsondocId": "9399a6b8-6552-4db6-bbb5-55bf82b022d4",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/updateOrganismPermission",
-               "response": {
-                  "jsondocId": "5b0a37b0-6a26-478b-8006-ab85b70b6448",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "3e185fa8-edf9-40a9-afb4-969e41dbed09",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a426dc5a-b54c-4163-938c-c4c669f7e56d",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4d00b18b-c14e-4a30-88e6-dcc63a5f6f34",
+                     "jsondocId": "e7ab3af1-138a-49f3-9d21-c327d6051aab",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to fetch",
@@ -4684,9 +4128,9 @@
                "verb": "POST",
                "description": "Get organism permissions for user, returns an array of permission objects",
                "methodName": "getOrganismPermissionsForUser",
-               "jsondocId": "965e6a95-86e3-41ed-86b6-f19447918100",
+               "jsondocId": "a4b347f9-f4e7-478b-8b2b-78aca6c2be8d",
                "bodyobject": {
-                  "jsondocId": "cf4ef688-ac65-419e-bd71-a0207634ea74",
+                  "jsondocId": "264768f2-3f26-451d-b1af-bda394e21daa",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4696,7 +4140,563 @@
                "apierrors": [],
                "path": "/user/getOrganismPermissionsForUser",
                "response": {
-                  "jsondocId": "266122d3-f421-4297-86cd-d95ab623ce86",
+                  "jsondocId": "da1c0370-021c-4bd4-b282-4b4e609df7a1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "cb887363-6fe9-4d31-89fe-5b5bf2c8c38f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "56cab4f4-fdc5-49a6-8adf-151dbfa0d421",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dc26d46d-4009-4ae6-8ed7-0c31397bc1c4",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "28132b2e-a07e-47f3-ae3e-dc9d42a72ff2",
+                     "name": "userToDelete",
+                     "format": "",
+                     "description": "Username (email) to delete",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete user",
+               "methodName": "deleteUser",
+               "jsondocId": "d77e64b2-735a-4a86-a60f-aea6c1bdf4b9",
+               "bodyobject": {
+                  "jsondocId": "6a5fbc96-8831-409b-9ca8-a09c67a30345",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/deleteUser",
+               "response": {
+                  "jsondocId": "224fc808-b009-47e3-92a8-575636811545",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c11c55f7-86b1-406b-8642-343472b5c136",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "15a87b35-1061-46ba-8714-a63c7b5fe08b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "68c7e309-b23b-4bbc-8eba-f1766194a17a",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to update",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3240268f-2697-4d3e-bd12-d2f8dab2b86b",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to update",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ccd46408-7b2b-4b8a-b074-7650fa8b38ce",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4bff59da-d29a-47d0-9747-4ad9701f2aa2",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8d0d86c9-e2b0-4096-9e2a-89519350b911",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update user",
+               "methodName": "updateUser",
+               "jsondocId": "078e9b30-8e10-4d31-bb58-e5612ed85f2f",
+               "bodyobject": {
+                  "jsondocId": "5f28c119-1f1c-4e60-9b7b-ef7ca1a1e9f2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateUser",
+               "response": {
+                  "jsondocId": "a3af3774-b56b-427b-8a19-6ac67c2c43ae",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4f6dd91f-02fb-4e57-93d4-10abce15d5bf",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5f93a542-74bc-4e2e-8ea4-e3f6ec98266b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "70829d03-2ae6-4bb9-b854-94cfe5f703b8",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to modify permissions for",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1a068683-2b07-4a7f-b6ed-2cf4f76e21c5",
+                     "name": "user",
+                     "format": "",
+                     "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "13eb755a-2b5d-48db-9898-48496207c6ef",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Name of organism to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9d8b06e7-73a6-461e-8d50-6a66666651a0",
+                     "name": "id",
+                     "format": "",
+                     "description": "Permission ID to update (can get from userId/organism instead)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0f563b84-866b-48be-8b5e-deda69b769b4",
+                     "name": "administrate",
+                     "format": "",
+                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1ca1d026-4bdd-484a-ab10-05a3b37431b2",
+                     "name": "write",
+                     "format": "",
+                     "description": "Indicate if user has write privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c9ce150e-c8c9-41ea-b368-1ef930a6dead",
+                     "name": "export",
+                     "format": "",
+                     "description": "Indicate if user has export privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "27c3af50-9e49-45a0-b0dd-9d848ddee7e7",
+                     "name": "read",
+                     "format": "",
+                     "description": "Indicate if user has read privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update organism permissions",
+               "methodName": "updateOrganismPermission",
+               "jsondocId": "fdaaaf77-6351-4887-abcb-45e720f048a8",
+               "bodyobject": {
+                  "jsondocId": "736f1be7-3dc8-4f39-be2d-4130a9024b44",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateOrganismPermission",
+               "response": {
+                  "jsondocId": "affa0433-dae3-47e9-bf82-2d70df0bff9a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "52f35d6d-a145-4b7f-b75d-a820de696307",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9f23566e-f7cd-4908-9443-9514bf4f52d5",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c29a58cb-d678-4620-bc2f-3f75d95967bd",
+                     "name": "userId",
+                     "format": "",
+                     "description": "Optionally only user a specific userId",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Load all users",
+               "methodName": "loadUsers",
+               "jsondocId": "1f1b5801-4fba-41a1-ad7d-b41eeeb7c3c3",
+               "bodyobject": {
+                  "jsondocId": "ed17d510-2eaa-47e3-81bf-df6942419d29",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/loadUsers",
+               "response": {
+                  "jsondocId": "02fedb17-6ec9-4ffd-ad52-f8eade10b41a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "57085219-540a-46ce-9a51-192e709df7ca",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dabefaf8-11a9-40fd-aec2-ff207fed7235",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9f8201c9-9b8e-416e-b6b5-f605f9e4e3c0",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3600f7f5-f7d1-42da-b6cc-0a1234b0e56e",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "91e42e5c-1895-48b7-8979-be6e854a7185",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add user to group",
+               "methodName": "addUserToGroup",
+               "jsondocId": "add2a7a5-0990-4746-9a2f-76d515f063a2",
+               "bodyobject": {
+                  "jsondocId": "afabbeca-de13-47ad-89c9-f2f986a22d00",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/addUserToGroup",
+               "response": {
+                  "jsondocId": "0994c67a-45da-4ee0-b3f6-dcd86e76b9fa",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "02e2bc40-3fd0-4723-a558-3038929d2a4d",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "81a4e7f9-6def-4447-8e57-3ddea6bb8fec",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "aa8a3f67-e1a2-48b2-85c6-24aa707cca73",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ac2d3bfd-5102-4f5c-9903-0714c2ebf6d9",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9aede555-e165-45bb-bb6f-3377c9c948ea",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Remove user from group",
+               "methodName": "removeUserFromGroup",
+               "jsondocId": "3dffcc3a-7d91-4adf-a1e1-2a7146be8f89",
+               "bodyobject": {
+                  "jsondocId": "15a05131-4376-4937-8dbd-763108660a7f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/removeUserFromGroup",
+               "response": {
+                  "jsondocId": "0fe67bb7-043d-4eb1-a04e-b6defa28c1e1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4709c032-a88b-4420-bd21-36a876418815",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c5aee476-65f0-4800-9e68-005ac323e622",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "599c767b-b67b-4b63-b635-81b1086a04c9",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to add",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3fa936b7-f57d-464c-aa39-2a935ad35c4f",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7d0e6146-5ce9-4038-9964-59dd65e38f4d",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "130120c5-b76b-4838-a312-4b66e6f44df2",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create user",
+               "methodName": "createUser",
+               "jsondocId": "6beafd9f-955b-46c5-876b-c46e66d15593",
+               "bodyobject": {
+                  "jsondocId": "03b24ebb-ff99-4025-ad44-65e71ab4734f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/createUser",
+               "response": {
+                  "jsondocId": "f8a9936e-d2cb-41ad-a3df-43d8c91fd5e0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"

--- a/web-app/js/restapidoc/restapidoc.json
+++ b/web-app/js/restapidoc/restapidoc.json
@@ -2,4346 +2,4711 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
+         "jsondocId": "943812e0-1df4-4998-8a94-7a34ddefbc74",
          "methods": [
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3ffcfc58-6a17-4c22-a289-473c4fbaf165",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "cc41df60-a79e-4087-b78b-b288a21364d5",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "129fc91d-86e1-4506-9015-26f10c446bd1",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set name of a feature",
                "queryparameters": [
                   {
-                     "jsondocId": "49fac469-c488-49f5-9141-36609bfabb09",
-                     "description": "",
+                     "jsondocId": "f87ca3c2-60ac-49f0-8d2e-3d61284428b1",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "0567cb5d-334e-48af-aa78-fe6893091308",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b56bb463-572a-4c5e-bb0b-d8aaf65b43f6",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "67190862-5051-4ab3-a80d-b0373bff7c9b",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "2745554d-299e-4fea-b79a-8e8a1c7391ac",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eeb49166-6989-4328-87dd-e26d6507e5a5",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "b8373274-624c-455c-bf82-8d0ecbd912de",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a5b3b5b6-877b-4e75-b337-f5128187f842",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
+                     "jsondocId": "43411da1-e010-44f2-89e7-ee9a76b06776",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/setName",
-               "produces": ["application/json"],
-               "methodName": "setName"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "525df69c-207a-48d2-8c2d-a0a54a1532fa",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "fd6f48df-53b7-48ad-8b67-0afe47892cfe",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e5b9f9f2-920c-4f9e-ae71-b3ea2e84c64d",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set description for a feature",
-               "queryparameters": [
-                  {
-                     "jsondocId": "cd53f728-aada-4fbe-af12-c7c8d9210d29",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "51b51c59-85ea-4d74-8b80-5ed376890422",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "9967960f-126c-4192-9387-0fdf258d6584",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "9aea06a3-2b22-4259-a7af-82d318963c7f",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "22ff9711-733c-44da-8a0b-024e1e0770ab",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setDescription",
-               "produces": ["application/json"],
-               "methodName": "setDescription"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ef8743a1-500f-4802-ae6e-117030881311",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "c2668cc2-46f1-4b45-8b03-58bc98610978",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "b72d0b51-f1b9-4c9b-968f-9c9c672a9196",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set status of a feature",
-               "queryparameters": [
-                  {
-                     "jsondocId": "1b849e4d-4eb8-4102-a8a7-f250426f5f7a",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "db432e20-c83e-448c-8f1c-d5e080d9a627",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "f592d1c6-c5a6-4d82-9b03-d5cf0cd16457",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "982da2dc-f6e6-435b-b95e-ac9565333e64",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "6f297584-f416-465c-bd6f-833dbf923020",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setStatus",
-               "produces": ["application/json"],
-               "methodName": "setStatus"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "4019684a-6d2f-452f-b858-4c682aee7143",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "b44a934c-ed44-4fb9-9f1c-6bdec007400a",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "1cd1717e-a268-46f5-ad8f-e05dfa0debb6",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get comments",
-               "queryparameters": [
-                  {
-                     "jsondocId": "5c3458bf-2470-46d7-be0d-372984c84bc2",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "a61cbe74-ddac-47b7-8fa2-dfe72f53d63d",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "cf178d4f-2a77-43e4-99ef-c70e20d41489",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "f9292b78-50f2-4256-b344-a15cc51cf4b2",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "6c106ea6-26d5-4755-814e-d70ceec9bd42",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/getComments",
-               "produces": ["application/json"],
-               "methodName": "getComments"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "23233c2d-7b0f-45de-b875-2195e54620b0",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "e93c358e-6e8a-42a9-8060-9e9aed41d1de",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "34ad49e3-5bca-4d1e-88e4-f1945c3ed174",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "Add attribute (key,value pair) to feature",
-               "queryparameters": [
-                  {
-                     "jsondocId": "1a8c978e-7056-4ac9-89c3-8178b52a7272",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "2555e280-0dd9-4667-82f6-293f28860776",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "9e6e29a5-f833-4624-aba6-0a2ac1e99811",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "e356c06d-f86b-4e7b-bf29-cb985b7a2500",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "13d19baa-a323-4e7c-bc68-42a95f3f5883",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
+               "methodName": "addAttribute",
+               "jsondocId": "4b7a650f-6556-4dff-858c-6dca85e6c872",
+               "bodyobject": {
+                  "jsondocId": "428ee311-1955-48cb-9585-fbb9373153de",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
                "path": "/annotationEditor/addAttribute",
+               "response": {
+                  "jsondocId": "3272b695-dbc6-4d0f-8f4d-c54b8c816890",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "addAttribute"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0d4aee9f-d9f2-4345-be24-4cd20ff9fc88",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "163eca75-da9c-4533-9a1f-cc26185e559d",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "60068d4a-bee3-4e48-aca4-396375e1c58e",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "2c4e61eb-d5a0-4138-8d8f-9bb9790d1bf0",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "14ea9d68-517d-45fd-9d88-f1366285a791",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1822fa92-f998-4226-83d3-d36e30c0b8c3",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d1b3527f-e69b-4ecb-8b1f-c718cc7aedc9",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f76df25d-ff12-4076-bad9-7ec501a9b2a5",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Set symbol of a feature",
-               "queryparameters": [
-                  {
-                     "jsondocId": "4b3e774a-2d7f-46cc-ab35-5ec92a8ad445",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "96d64ad1-7552-4cd4-a4ca-c337d13c1238",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "af0b7d37-1cf2-489f-89b3-f99c48b00922",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "ba790d8e-0398-4bf5-8b8a-007c07bce233",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "2fd9de8e-0ceb-44c0-9a0c-187dbfc507dc",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
+               "methodName": "setSymbol",
+               "jsondocId": "98f67387-5d43-4a70-a851-1212f3084c42",
+               "bodyobject": {
+                  "jsondocId": "a5e2656d-7a47-41e0-838f-5d2f6cfeded7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
                "path": "/annotationEditor/setSymbol",
+               "response": {
+                  "jsondocId": "31c4b7a5-4e35-40ca-8029-a2ff644f85af",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "setSymbol"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "6089370c-3c9f-4475-8fb3-bee618da02ca",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "2c793aed-65ce-4c68-9dc2-ac521bbffb44",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0a669de8-eb83-4655-ad45-5c7fa3b5abf1",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Returns a translation table as JSON",
-               "queryparameters": [],
-               "path": "/annotationEditor/getTranslationTable",
-               "produces": ["application/json"],
-               "methodName": "getTranslationTable"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e183b897-743c-49a2-8c10-ebc0b093001c",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "cea87572-9ff4-4cc6-af4c-b66678913705",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d7a50351-1a0b-44cf-87fc-941d59b7e4b4",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Add non-coding genomic feature",
                "queryparameters": [
                   {
-                     "jsondocId": "5c64d771-2c3d-4667-91d1-4f9e70441b92",
-                     "description": "",
+                     "jsondocId": "d0970b25-52ed-4900-a130-0654b6a1ccb9",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "83e800af-6861-40e0-961a-c3fa8a383e44",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a3c34869-50d2-43c5-9bee-fd359d193d62",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5f288b02-38f8-4ea0-9f76-895e73e4d70c",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "19379459-be47-4a21-9105-a9da79e81157",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "82310e30-a340-44e6-8f3b-47034de5db1b",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e878a14-100c-4905-85cd-7dd74b51f481",
-                     "description": "Suppress the history of this operation",
-                     "name": "suppressHistory",
-                     "allowedvalues": [],
+                     "jsondocId": "4677f884-d8d1-42a1-bdfb-7fc2a5137c54",
+                     "name": "organism",
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "boolean"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ab8db453-ce6d-4d70-83eb-d894b8871875",
-                     "description": "Suppress instant update of the user interface",
-                     "name": "suppressEvents",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "85f72b49-c978-4c4b-983a-79ce63b1167b",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "jsondocId": "7545e99e-bb59-4962-9846-df3c0d9b5feb",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/addFeature",
+               "verb": "POST",
+               "description": "Set description for a feature",
+               "methodName": "setDescription",
+               "jsondocId": "f24e3124-b9b0-4f57-ab00-537de8f26176",
+               "bodyobject": {
+                  "jsondocId": "5652ac12-b054-49ec-8630-7c6d958aa8d6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setDescription",
+               "response": {
+                  "jsondocId": "1815f478-22ff-4b31-b8a6-da1d6fd0489d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "addFeature"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0817316b-171c-4d0a-8a3b-b4eca7bb2a25",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "a9ddce83-f4ae-444c-828a-a76d143d62b6",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "154eb593-d731-41ac-94d6-2e888d03b005",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set exon feature boundaries",
                "queryparameters": [
                   {
-                     "jsondocId": "c5110bb8-0baf-4dfa-ae84-072a90a1db34",
-                     "description": "",
+                     "jsondocId": "18407be7-0194-4693-9a1c-1ae8175da54c",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "57bf1d78-73b5-4208-aa66-364e8866e524",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "445b9ae0-20b1-4a48-8873-980200841dc7",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ecc6fb43-b203-4ab1-a2b1-07c448f503bd",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "4564d54a-23eb-4310-a0a0-5d865a0f4722",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "2f428058-2025-4b19-add7-5ae6bf1ce58e",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3abeaf67-6228-4a09-9a7f-2a234c4cbe0d",
-                     "description": "Suppress the history of this operation",
-                     "name": "suppressHistory",
-                     "allowedvalues": [],
+                     "jsondocId": "9781f64c-4a83-4fee-946b-7206f29d0575",
+                     "name": "organism",
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "8e3a2e77-bd8f-4584-9974-760f12f7ea5f",
-                     "description": "Suppress instant update of the user interface",
-                     "name": "suppressEvents",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "c94defd7-ebdd-4f6e-8a6e-9cc71f6fa933",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/setExonBoundaries",
-               "produces": ["application/json"],
-               "methodName": "setExonBoundaries"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3319485c-b6af-4106-aab7-a8c186fc2bf0",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "797270be-7040-4433-8618-6e979827062e",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d68d3f4b-0dcc-4ae8-bd56-0eaf92ed2748",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Add an exon",
-               "queryparameters": [
-                  {
-                     "jsondocId": "609c79ef-04e6-4591-8f74-a0068532b226",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "b1877fe0-2c24-4665-b1a8-489832813898",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "30e0dc43-55e5-46ad-bd53-e6799d86c324",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "7a41ce19-d755-4800-b573-9c9af5003c6c",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "0ef6beba-028e-4696-9baf-bb7d961e1628",
-                     "description": "Suppress the history of this operation",
-                     "name": "suppressHistory",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "b9927569-9b62-4996-bb26-2fa061816100",
-                     "description": "Suppress instant update of the user interface",
-                     "name": "suppressEvents",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "804d9c91-ce57-4c74-a134-34e525851446",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/addExon",
-               "produces": ["application/json"],
-               "methodName": "addExon"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "b2e6251d-3572-4657-bf87-477db499fe15",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "dc11eb6b-45d7-45f7-83cb-7f02c1150f2d",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f01f9a1b-ea06-42eb-944d-febb4ed4e8c1",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Add comments",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d68d5f61-5898-462c-a25f-ea1580cadfd7",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "93ca1d88-4834-4fa1-8b1e-20d0c663f8f5",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "32220e64-60b8-4c72-a834-b7eebcdb9b6b",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "85cd3ef2-0f6b-43d8-9a4b-fbfe565463ed",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "42ee67ad-9064-4f21-a6f9-e5b8fff66fd6",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/addComments",
-               "produces": ["application/json"],
-               "methodName": "addComments"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "69b0d8ed-37fb-415e-9448-daa2367396f4",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "0d424e21-0a2c-4a0d-8b30-3293e2707bf0",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ef4e5435-e532-4e78-af2a-736e3398aa67",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Delete comments",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d49b548b-e2df-4e95-ad56-00548cff4d1c",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "e39db73b-5697-4b6e-913f-490d9952d758",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "be588b4c-a005-40ee-b977-e6311b456b8a",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "cfa7cb2b-85b6-4615-ac7b-92184590064f",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "dc4ce9d8-37e4-4ca4-96e7-e18669e723bc",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/deleteComments",
-               "produces": ["application/json"],
-               "methodName": "deleteComments"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "9213d2f1-c764-42df-bc0d-07c897593f83",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "423a7d33-beb2-4c7c-a111-d964e51f40c7",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "69a74123-2b4e-45f6-9d0a-d27b4ee60ffe",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Update comments",
-               "queryparameters": [
-                  {
-                     "jsondocId": "a392cac7-acdc-40ab-86af-a0f25de03b85",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "fe6fd67d-3f57-434e-838b-8977d63579f3",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "f98b04bb-10f2-47e2-affa-83caaa4f1e54",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "5a568093-c834-460f-bb3d-ed2e2708752d",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "2cc488ba-0797-499a-9487-d249c0745d32",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/updateComments",
-               "produces": ["application/json"],
-               "methodName": "updateComments"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "c8c6433c-97c4-47e9-a0d3-af79f90f859a",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "b7ba871e-62c0-4366-afe6-7ecd8c76f4a3",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "9356a390-3497-4739-9929-711f84f81b18",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Add transcript",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d14aa1fa-7cc8-438a-adac-b36b7f28906b",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "2bad314b-9c4e-4738-b569-3cbd62be2f48",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "ad203bb7-93e1-48e1-bc33-595ef637a4da",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "a7489929-487a-44e2-9243-9686039c3a26",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "ba1cb720-2db6-4763-b1ac-73d60c73be90",
-                     "description": "Suppress the history of this operation",
-                     "name": "suppressHistory",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "ed9db572-f6f1-4f74-9a86-229879f207ce",
-                     "description": "Suppress instant update of the user interface",
-                     "name": "suppressEvents",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "2685dae0-dc4e-4c04-baa6-b7d335e3892e",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/addTranscript",
-               "produces": ["application/json"],
-               "methodName": "addTranscript"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "750b4e7d-700e-4139-a779-6716c7b649ba",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "e2cb5851-5235-4fa2-b75a-8860e0857068",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "caa90556-7cd6-4bd4-9a41-0252b32d022b",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Duplicate transcript",
-               "queryparameters": [
-                  {
-                     "jsondocId": "b9f0ed80-cc44-4964-aa11-d2874465c055",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "4ece74a7-d781-497a-936a-d98393c19cbe",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "35dc39d9-3927-4f30-82a3-00f573539dcd",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "59cc367b-12d3-4e13-8c16-b431b0b308f8",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "01f4ad0c-1f09-485d-9625-a0033bf9f0c7",
-                     "description": "Suppress the history of this operation",
-                     "name": "suppressHistory",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "3ee134bd-17e5-4bae-9230-9d30a283b4e4",
-                     "description": "Suppress instant update of the user interface",
-                     "name": "suppressEvents",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "095a78b9-9087-4232-9660-1e9b45d2bd90",
-                     "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/duplicateTranscript",
-               "produces": ["application/json"],
-               "methodName": "duplicateTranscript"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "1928b906-443c-4d3a-b130-8d15cb5b7b92",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "3e9c5137-318e-4897-9310-2708e7a6756e",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "7eac8847-8204-4c97-9657-72b2a9d9cc40",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set translation start",
-               "queryparameters": [
-                  {
-                     "jsondocId": "b995cf69-a586-40bc-8fad-b49efd6c8885",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "480b0afd-a5c2-4f17-9443-1b7101b533ec",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "fcdbca81-7389-49a4-8472-883b5d50728c",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "8ea0e20a-5cde-4cb4-8113-13e2c509d6c7",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "a42950ab-c1df-484e-944c-ec89f47d0730",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setTranslationStart",
-               "produces": ["application/json"],
-               "methodName": "setTranslationStart"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "48acb6d6-1cd9-440d-b5c7-a209374729ae",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "991d10f1-5dd1-4fa0-b31d-07fcffcc18b7",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "28abd423-6fac-47f8-a29f-f8dcf19bb301",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set translation end",
-               "queryparameters": [
-                  {
-                     "jsondocId": "19982b4a-2363-4727-bb16-fda67b4be6ce",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "3362a031-15a2-4e48-963a-3b92f6531a44",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "865f97fb-b343-4813-ba63-8e761d446d36",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "f44db66b-7d58-4b88-ab59-f7675964ca25",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "a4f4480e-60c0-49a6-8da0-3d86e1fafd5f",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setTranslationEnd",
-               "produces": ["application/json"],
-               "methodName": "setTranslationEnd"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "b53f35bb-c8d9-4634-8098-34bb2fc5c4ea",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "6c85d609-ab45-4bc5-a968-b7278d6e36fd",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f257a9a9-d2fa-4166-a68a-259edc70cb51",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set longest ORF",
-               "queryparameters": [
-                  {
-                     "jsondocId": "adc697b6-1f93-4801-ae22-c8bf2adcdcc0",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "7c664ee3-368f-4596-aebd-614f33bdc7d3",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "333ddfd8-8c5e-44a0-af83-ae757203320b",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "398e81ea-4c08-41fe-b4ef-90aede701f1a",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "c7d18970-e849-480c-969d-7b9983fc6b02",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setLongestOrf",
-               "produces": ["application/json"],
-               "methodName": "setLongestOrf"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "42259241-cb42-468f-ba57-e4d5c44b3ac0",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "d8789e66-5a1b-46e3-8c9b-d6a6102dcc8d",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "db80ffa3-8de0-459c-b74e-514fed7b784b",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set boundaries of genomic feature",
-               "queryparameters": [
-                  {
-                     "jsondocId": "3e291a0b-755c-4cd2-a812-8f9f6c7b312d",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "c7195577-69c2-4a69-b284-eb6acb9d27e2",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "45b17ab0-66fd-49e2-ad24-fdb7bae40394",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "045ebb86-47e0-477d-9c8d-c049ea3650e7",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "c9dbe502-47f3-4983-aedd-6dadbd7a8842",
-                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/setBoundaries",
-               "produces": ["application/json"],
-               "methodName": "setBoundaries"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d9d4af83-c0f9-4299-8673-aa3e927a717b",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "22f7b1ac-e97f-4c10-ad4e-6acd734c4ff3",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "4d8c68e3-abe0-466a-8619-d071f531f7b7",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get all annotated features for a sequence",
-               "queryparameters": [
-                  {
-                     "jsondocId": "345ae529-7da9-4897-a305-9c2442b028f0",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "8ef755cf-4cc3-424e-b66c-9f71730f12ed",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "5ef3d65d-bb64-4b44-8f1e-1da4ed273662",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "12c0316a-243a-45b4-b449-ec4df1c6a61b",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
-               "path": "/annotationEditor/getFeatures",
-               "produces": ["application/json"],
-               "methodName": "getFeatures"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ac826575-7e00-4ef8-8a6b-4224d391dcbc",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "02dd3d8a-59d9-4f98-b0c3-bfa23aff03b5",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e274cdf4-e4c0-4869-8017-8040ed37abba",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "Get sequence alterations for a given sequence",
-               "queryparameters": [
-                  {
-                     "jsondocId": "6cfe713a-950d-4ee9-881a-aac1b83512fa",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "862e8abc-204d-4735-b56f-1e7caaf77172",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "a180cd64-d6b5-4c02-aa4f-fa00abc8f220",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "f09911cb-fef5-4162-a9ab-8bd75a0d4edc",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "getSequenceAlterations",
+               "jsondocId": "5bacc7bd-6873-4b8b-afe4-ee9e0189eb93",
+               "bodyobject": {
+                  "jsondocId": "125ddb6c-548d-47ea-9d5f-d95e1379e46f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
                "path": "/annotationEditor/getSequenceAlterations",
+               "response": {
+                  "jsondocId": "cfcbaedd-def1-4613-a967-d1fbf9821bd4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "getSequenceAlterations"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "82ed35c1-0838-44e7-8637-d3620cea239d",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "fae2d393-da0a-4151-a858-961897736277",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "26147ae2-a275-496d-b3b9-02ae86366eac",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Set readthrough stop codon",
                "queryparameters": [
                   {
-                     "jsondocId": "5568a342-5fcf-4bf8-8bb8-cf14a88054f7",
-                     "description": "",
+                     "jsondocId": "d20d4181-289f-4a18-8fd0-0a1c03c284fa",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "a3d9c6e5-4ec9-4c90-819b-fda25dbdf82b",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "18ab4437-a8cd-4fa0-98aa-bc8fe6aa2979",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e0fc7d71-b31d-4d68-b420-1f27995a0e3a",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "d253a13f-0753-4a3b-a321-083e9561c6ba",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "779fd421-388d-432c-ac14-a5e038110b09",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "bd2dbf9b-5fab-45f5-b418-2f875faaf3ae",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ea328022-16f2-43ae-88b2-a4058242f48c",
-                     "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
+                     "jsondocId": "c55f9f56-4568-48bd-9639-82e210d445d9",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/setReadthroughStopCodon",
+               "verb": "POST",
+               "description": "Delete attribute (key,value pair) for feature",
+               "methodName": "deleteAttribute",
+               "jsondocId": "d2502171-5bf3-41e3-af25-940c0a437d85",
+               "bodyobject": {
+                  "jsondocId": "4df49905-a6ae-4c9a-8937-0177a1ccc942",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteAttribute",
+               "response": {
+                  "jsondocId": "69a01455-1390-41af-95d7-be62a3069af8",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "setReadthroughStopCodon"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "7e3b23ca-9ac9-49d6-9eca-a70d241e3425",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "323ab141-a1f6-44a4-9b68-173f48cc9d4e",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "cec8a3cf-d14a-4d2f-af5c-7e443785cb8c",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Add sequence alteration",
                "queryparameters": [
                   {
-                     "jsondocId": "12c98459-4a93-4b8b-9761-61d918ee3735",
-                     "description": "",
+                     "jsondocId": "b40e0de2-7d2c-4e57-ada2-e6063569fb75",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "ee6aeccd-7947-4bbc-8321-c2bfcd0fd237",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0f2288d4-88d0-4f28-afbb-8039535d9d8e",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "067c562c-0982-4e6f-b4a0-f49a1644b843",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "5470609b-c318-4c32-b2fd-4e083604020b",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "387fb311-ef39-4350-887d-9db0f369f37b",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "a5948218-6de3-4040-b578-6e78b23114c9",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c98d259f-daa0-4206-9c75-1a0e252292e2",
-                     "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
+                     "jsondocId": "c51cfa96-1a2c-47f2-82b4-2f66d95f0d0d",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwark','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/addSequenceAlteration",
+               "verb": "POST",
+               "description": "Update attribute (key,value pair) for feature",
+               "methodName": "updateAttribute",
+               "jsondocId": "0c707c5b-c6d4-4202-a402-5532bca29663",
+               "bodyobject": {
+                  "jsondocId": "e76a65b8-1d58-4708-bdc6-ee1e81ea73ad",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateAttribute",
+               "response": {
+                  "jsondocId": "55bd81c9-00cd-4310-870b-038a23b37f67",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "addSequenceAlteration"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "99f6c7c6-d6d6-4317-ad7c-89604a0339c5",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "dfff7454-a5ed-44d3-aae6-311e2182b801",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "bee5b243-ffb1-4846-9fe5-4f7e10da4424",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Delete sequence alteration",
                "queryparameters": [
                   {
-                     "jsondocId": "82bc6104-2f99-4b32-92e3-54161b6c22f9",
-                     "description": "",
+                     "jsondocId": "0ccf7126-412d-4900-a31c-8e207f19df1a",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "484a0551-7c67-4f26-a885-5246b680398a",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5443faec-ff86-4fdb-920d-f654119d7820",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a859d332-146e-4179-b49d-7fa8d8078266",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "c8327bfc-8a74-4d94-af7b-79f75a5472e9",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "301d388c-6611-44dc-98aa-258fca4a3354",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "0f1d4343-26c8-48be-88fe-f137b7fb8fe4",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "37105ffa-9f6f-4fae-9c86-3b49d0459146",
-                     "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
+                     "jsondocId": "36da50ab-f71d-4e42-939c-222594eccaf4",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/deleteSequenceAlteration",
+               "verb": "POST",
+               "description": "Add dbxref (db,id pair) to feature",
+               "methodName": "addDbxref",
+               "jsondocId": "09ccaa4a-3918-462f-ab01-ea3736241468",
+               "bodyobject": {
+                  "jsondocId": "e34d9605-81bb-49f3-8357-75abdd8245fb",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addDbxref",
+               "response": {
+                  "jsondocId": "ad8a2bc3-815c-4a27-8c59-bc1a181bbb8d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteSequenceAlteration"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "5bd14c20-7238-471b-af0e-03a5d1faf749",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "b5318dce-92d1-4238-b07e-a164f683a537",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3df47f19-32d5-40a3-bffd-d1b8d1334da4",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Flip strand",
                "queryparameters": [
                   {
-                     "jsondocId": "503a0cf9-801a-4c88-bdaf-eb4134dcbacd",
-                     "description": "",
+                     "jsondocId": "8953a556-6392-4c1c-a6c2-1b4f3d85d7c0",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "e31e4b9a-e6a2-40e5-bab5-86ba9514e467",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "82eaed76-4852-4a9f-ab76-17f4a06d2463",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9b7ce44a-4a01-4a0c-9f33-58b5ab0eb19d",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "791c896c-1a02-49eb-830b-9b10cd51bb53",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9e75a06f-4cec-44fd-9eac-12e307b2ef37",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "72164104-7462-4364-a507-cba7ba4af2b5",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "46d517d8-0382-4147-8691-06b71454f50c",
-                     "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
+                     "jsondocId": "a339b642-1cfa-4306-850e-d1e05185c304",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/flipStrand",
+               "verb": "POST",
+               "description": "Update dbxrefs (db,id pairs) for a feature",
+               "methodName": "updateDbxref",
+               "jsondocId": "37fa5144-1b10-44b1-b318-eba2affc694e",
+               "bodyobject": {
+                  "jsondocId": "a46a2f8f-88a0-4442-87bf-b9c9bc9d998b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateDbxref",
+               "response": {
+                  "jsondocId": "bb6fc441-e846-4d7e-9fa3-063f0732b84d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "flipStrand"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "52ef834c-db90-45d8-8f55-c877a2f1a3b4",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "141f9d76-348c-4ba8-b091-688e169b8f07",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "7babf1e3-40ae-41e1-858e-ccbfd048853c",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Merge exons",
                "queryparameters": [
                   {
-                     "jsondocId": "6f3856fb-9e45-4359-ac6a-8f40d0075765",
-                     "description": "",
+                     "jsondocId": "bc77b0be-8aaf-4541-bfc0-b1eb43db8128",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "0525a073-330e-4f75-9c0b-56ec008b3176",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f3d00a7c-16f1-4361-b7c5-f2dca1cc21ce",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3bd85bba-fc5a-4940-a01e-03b9dd98f9b3",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "09245605-bee9-4bbe-9010-6cbbcb89d17d",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "22aafb90-80ed-49dc-ae38-f9969ad0de29",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "a79a8fe3-ef86-4bff-8747-91c6087eebfc",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "16727144-80b4-4dc8-b5a0-4ec11714cc88",
-                     "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
+                     "jsondocId": "cf59ec92-7d55-481c-86d6-2a2fdab89349",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/mergeExons",
+               "verb": "POST",
+               "description": "Delete dbxrefs (db,id pairs) for a feature",
+               "methodName": "deleteDbxref",
+               "jsondocId": "7e17ed23-4bb5-494e-bf7f-0c1f02524cab",
+               "bodyobject": {
+                  "jsondocId": "0fbfa22b-81d9-4d65-a1a9-d1e4cf6b0224",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteDbxref",
+               "response": {
+                  "jsondocId": "4cf82b41-4c77-41b8-97f3-8963b21aaf24",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "mergeExons"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "61513a45-61e7-4452-838d-c213c0c0f487",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "b618c86d-0a78-47f1-8c61-8feec73caa54",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "2ba591dc-df0e-457c-b02c-22c39a77ab93",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Split exons",
                "queryparameters": [
                   {
-                     "jsondocId": "56a2b09c-607c-449a-a1cf-6a914fc222b9",
-                     "description": "",
+                     "jsondocId": "501e0f27-d5d9-4bd7-a297-78bb40dcfe53",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "f024868a-5e46-4564-a277-9cd05dd5be70",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0365026c-bf7d-4796-9f0c-a6e92def2857",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "06f95054-fb31-4632-92a5-7aaea5f54c24",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "c80b57c1-eb72-4990-9284-2653cfcbd377",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "60595e68-bcfa-4199-8a41-2e9ed9be9608",
-                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/splitExon",
+               "verb": "POST",
+               "description": "Get canned comments",
+               "methodName": "getCannedComments",
+               "jsondocId": "fd49744d-cca8-4056-8dca-f35a58a1539c",
+               "bodyobject": {
+                  "jsondocId": "e2f20dcc-1dd2-4338-ab2a-61840e850798",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getCannedComments",
+               "response": {
+                  "jsondocId": "e6db4646-eb8a-4da7-bfbd-f4af845187eb",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "splitExon"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "8daa4355-c795-4a69-bfb9-502b381cb25a",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "9eddf574-709b-4b17-8449-1cbfbcb42b30",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "5ffa58b5-ee5c-4b94-b928-608e9998dc36",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Delete feature",
                "queryparameters": [
                   {
-                     "jsondocId": "485c5a04-4614-45f1-a714-a55ce380a48a",
-                     "description": "",
+                     "jsondocId": "66f6da07-de26-4e37-bdcb-d36f0cabaf53",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "61a99b39-7b42-4099-b91a-16280e0610a2",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c27b357b-0681-48f3-b5d6-231f231cf85e",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "330c4961-8521-4532-b10b-14af6fa0a752",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "8c9f9c2e-583b-4159-b0d3-236053cc4df7",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "4625207d-2b56-4bd0-a2f6-44627d3314b8",
-                     "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
+                     "jsondocId": "bafe2278-8c30-48f4-94ff-e0909a2754a0",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/deleteFeature",
+               "verb": "POST",
+               "description": "Get gff3",
+               "methodName": "getGff3",
+               "jsondocId": "3583c54b-f395-4036-9765-4da82fb56b79",
+               "bodyobject": {
+                  "jsondocId": "64d2b0fd-f8f9-458f-915a-317258ba2c39",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getGff3",
+               "response": {
+                  "jsondocId": "d039f13d-c8e0-488e-9d5a-98cda01b234a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteFeature"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "00287053-28ef-40be-8b8d-19a16d8a2c7e",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "09af2cc3-8c35-4936-a80b-c2b3d24465da",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e0734434-32ff-4f12-bd14-9037496de8a7",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Delete exons",
                "queryparameters": [
                   {
-                     "jsondocId": "7ff90d68-f180-4b34-b25b-0e5ffe899ab3",
-                     "description": "",
+                     "jsondocId": "705602dc-be24-49c8-9c41-1bb2e7a3ec53",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "18651abf-16dd-40fc-9108-dc617a22882f",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "36811ed8-3b2d-4eef-9abd-ebd441f9d81a",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4f3ab9e1-40e4-409a-9317-b4f02c9f7cc2",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "632f77be-d155-4c35-822f-e5dcc88e5fae",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "b171c5bb-b69d-4953-8ba0-9b6d315b2d00",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aeb7e49f-0099-44a8-be89-0f2fbb8072e7",
-                     "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
-                     "name": "features",
-                     "allowedvalues": [],
+                     "jsondocId": "cfabffc5-eced-4466-8817-80fee95f3179",
+                     "name": "sequence",
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "91e89e19-4c7f-41a9-a6f4-41b3892b85d2",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "88d9267d-7170-42c1-baec-f564521ab616",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3c9b95ce-7bff-4b10-812c-9799e27dfdf4",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/deleteExon",
+               "verb": "POST",
+               "description": "Add an exon",
+               "methodName": "addExon",
+               "jsondocId": "f7d9f8fa-a5dd-4532-abbf-c859f73f5e0f",
+               "bodyobject": {
+                  "jsondocId": "fb7c9fa0-ce92-470f-bbb1-682958d9c8d5",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addExon",
+               "response": {
+                  "jsondocId": "1b808f61-2055-4f5d-bab7-1441adaa3eae",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteExon"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "120ccc71-114b-42aa-90a6-c8497d3e364a",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "d18b7b7f-5c72-4079-8771-ab963eb15ea2",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "8758de48-60cb-4d3e-94ff-2d9301f67dc2",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Make intron",
                "queryparameters": [
                   {
-                     "jsondocId": "8925f2d9-61a1-4c8e-8009-3ed8d39e5281",
-                     "description": "",
+                     "jsondocId": "d0443d73-3652-4d7f-8487-f74f8fb92431",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "147d15a9-7c5e-4c7d-a277-8763d6569e23",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "01da0ee2-80b9-46b8-b8b4-42a7797f2a7b",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a31a104e-b830-4abf-8eb8-0dbdc997366c",
-                     "description": "(optional) Sequence name",
+                     "jsondocId": "7e1cb326-a9b2-44db-afcf-5c7200e02ae1",
                      "name": "sequence",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b7bbeba-c43a-466f-b6e2-f996ecba091b",
-                     "description": "(optional) Organism ID or common name",
+                     "jsondocId": "4315d42d-ea83-4a0c-ad7b-8e85740be4e2",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45d38b12-7a55-4031-99a4-3749ab60b065",
-                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
+                     "jsondocId": "9d82cb69-b265-4260-8ab0-ee27c1adda9e",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/makeIntron",
-               "produces": ["application/json"],
-               "methodName": "makeIntron"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "5c4dbfdc-809a-4d57-977e-9e16bf4c1b6c",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "2c10542a-bbd6-47a3-9923-5ff10c86a397",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "bb79f0d7-ad0c-4266-998f-208a8ee6953d",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "Split transcript",
-               "queryparameters": [
-                  {
-                     "jsondocId": "3ae90bc5-8505-4748-9c55-6ef61399deb3",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "4d718ae9-b9d0-4f45-b38d-643a1d05390f",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "af8056ab-26c3-434f-98e2-290ff0485ebc",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "916ad73d-4429-4e23-b4a5-c639aa8c626f",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "cc4ab9fa-db96-424b-8a22-3c715a7b7063",
-                     "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
+               "methodName": "splitTranscript",
+               "jsondocId": "dfb0ce3a-b863-4c02-9413-df031dcc5bcc",
+               "bodyobject": {
+                  "jsondocId": "e99b5ac2-9c5c-4356-80ae-6f6f23ff14e6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
                "path": "/annotationEditor/splitTranscript",
+               "response": {
+                  "jsondocId": "071aad84-be5f-4bc8-8d77-9a29836a11de",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "splitTranscript"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "2e7e99f6-d6ad-4e96-a15d-3bad79c530d1",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3401ded8-fe75-47ac-9064-ffb5bd4be40e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7a5c79b2-582a-4081-85d5-bfcc0cfa5137",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e28f6cc2-c6d4-41c4-b778-cbff6eb336c1",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6aa767b7-c096-4aed-9962-80f9e86b1f4a",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "83073396-5acb-4a18-a5cb-a7014657f707",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fe4e3682-7332-4fb9-a728-f7721df4c3a9",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Duplicate transcript",
+               "methodName": "duplicateTranscript",
+               "jsondocId": "b9310e92-b966-4bfc-b080-0f7c297c0e57",
                "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e77c023d-4bc8-416f-b9dd-d431f8c09beb",
+                  "jsondocId": "41908a04-b4ad-4c3a-b04f-b18d7605cc06",
                   "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
                   "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "5a21ba28-a357-4890-9ab4-16ea3a75a039",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0b0fe21e-9cba-4b7b-ad74-6686efd058f5",
-                  "mapValueObject": "",
                   "object": "annotation editor"
                },
-               "pathparameters": [],
                "apierrors": [],
+               "path": "/annotationEditor/duplicateTranscript",
+               "response": {
+                  "jsondocId": "27be38cf-90d5-44b9-8c3d-34e9dcb3387b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "ec3a6f67-b449-404f-8898-fce5f0ea2220",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bc2e0181-921e-4b71-abda-5b9ecc88177e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7d519fe9-e24a-4391-bcbe-31b37edf453c",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2384ee87-fc49-44f7-82aa-5b73279f8392",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9922cc85-d057-4fb0-b0c6-3ecc551e74bc",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Merge transcripts",
-               "queryparameters": [
-                  {
-                     "jsondocId": "b3682901-fb6e-422d-a320-1465d3e07139",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "95f95ff9-e672-4de5-9416-731ffdf4e3af",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "3e5818cb-bf8c-48b5-8e87-c5ca19b5cbba",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "37780118-a784-4a22-951d-8165722c027a",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "04206134-5540-4796-a872-0b89a7f49f55",
-                     "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
+               "methodName": "mergeTranscripts",
+               "jsondocId": "fbbdc154-5483-4f75-bd45-6f8049dcb0ea",
+               "bodyobject": {
+                  "jsondocId": "65675156-82e2-4a97-84d7-e6478777733b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
                "path": "/annotationEditor/mergeTranscripts",
+               "response": {
+                  "jsondocId": "d1db733d-71b0-41e0-a880-76f1e55a26bc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "mergeTranscripts"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "656f2681-c17a-4021-81a1-b17ed4a09c1c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2898dc72-f5f8-4d41-be93-e81fad5dcc36",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4712d8ff-a558-4fb6-8fe1-dd90bb32dcaf",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2a318cc4-bf60-4cb9-a8a9-da723bc45439",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3eb163f6-fa8c-4ba3-9615-afc5c4497a62",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5183a62f-0edb-4af9-a40d-982ad993884f",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "169168db-6811-4593-9d9d-5d05261329ab",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add non-coding genomic feature",
+               "methodName": "addFeature",
+               "jsondocId": "67f86c90-8afe-4ae9-9038-11580c0a4de2",
                "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "a7198418-dc4e-475c-889c-a590eb366391",
+                  "jsondocId": "dbebc07c-9f73-470e-a51c-178276eb3b35",
                   "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
                   "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "81a21e81-94a6-4825-85f4-2d20ed972992",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "943eb804-8d6c-46bf-81ac-49e787743b6d",
-                  "mapValueObject": "",
                   "object": "annotation editor"
                },
-               "pathparameters": [],
                "apierrors": [],
+               "path": "/annotationEditor/addFeature",
+               "response": {
+                  "jsondocId": "13817fcc-ab17-4ca7-88be-b9c1f293d0f2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e894ae43-9a26-4aa9-909e-b7df7e763b98",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f0ff666c-94e8-48c6-b3d7-8a1a5925bcd9",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3b371199-7d6c-461a-b151-1233bc1beb13",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cbbeeabe-2f4b-4e78-84e9-83419bf384e4",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2b5b634f-7f0c-4726-a492-679cb5ee9b21",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set translation start",
+               "methodName": "setTranslationStart",
+               "jsondocId": "76360508-bd82-40b7-8bf3-6393943c7f98",
+               "bodyobject": {
+                  "jsondocId": "6a912590-e645-488f-8494-eb49198e64b6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setTranslationStart",
+               "response": {
+                  "jsondocId": "a6e45f87-e8d1-451d-8cda-953b5baaa529",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e2a5240c-f0d5-42e8-a033-4c27177523ed",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "887e72bc-1931-48dc-a8ee-e2ee61e20d73",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5678e46a-cf27-468f-96c8-ea681185a84b",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b3487854-51dd-478e-bada-ff58ef686dcf",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "621c823e-efd5-4e84-b289-da1732fb7980",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set translation end",
+               "methodName": "setTranslationEnd",
+               "jsondocId": "3a94eb21-1df9-49d7-9f49-6e975196d53b",
+               "bodyobject": {
+                  "jsondocId": "ff755e1f-453c-4ba2-a429-ff36a82940dd",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setTranslationEnd",
+               "response": {
+                  "jsondocId": "a1662b29-a4b3-4405-b035-ec04c811f8f9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4149ce5a-7f7b-417f-b772-3bcd9053fe4f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "66aeb029-538a-42d0-b67e-7083952ea114",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3d3216c2-5855-4d2a-99cb-98d8557503c7",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cf8c16cf-0cec-4157-b2fb-bd9809f5a591",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c8c0b10d-510e-4440-9398-c64e9d3f0465",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete feature",
+               "methodName": "deleteFeature",
+               "jsondocId": "a60317de-6dda-437a-9dda-cbd5264da3a4",
+               "bodyobject": {
+                  "jsondocId": "204b3dd2-6585-42bb-93ef-d0e55bd5f727",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteFeature",
+               "response": {
+                  "jsondocId": "a043897d-a409-4ee3-839d-648893cd157a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7bf74c55-e270-4771-b30b-d2a34344867f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "526c8f1c-5c49-47b1-84c0-dcc438a3f8a0",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "527630c8-3831-4f32-99d3-0b09cbbb7333",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a72b44ec-ca21-43a6-9686-855745386ad6",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "35e37339-1e28-4c1c-bd84-aae92fdec695",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Flip strand",
+               "methodName": "flipStrand",
+               "jsondocId": "ae548ff3-0e51-4cb7-a6e9-e37081881360",
+               "bodyobject": {
+                  "jsondocId": "372abcd5-325e-48d0-a617-d7c8f0994cd8",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/flipStrand",
+               "response": {
+                  "jsondocId": "ec3a8c36-8ec4-4ee4-800e-f49c0f661875",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c20d0639-9987-466f-ad81-d24e07db839c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "88e3e7c4-4fb1-4c41-8185-1acd4c469f7d",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "208704e4-05bf-4dd4-92f9-97935ca8f4bc",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f7d547ae-41f7-4142-b827-bd5d126f2e5d",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "08443bf7-6470-4e22-8482-7fac8311a6d0",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Merge exons",
+               "methodName": "mergeExons",
+               "jsondocId": "9063b482-5b52-4fe4-a8b7-13913a3a0c87",
+               "bodyobject": {
+                  "jsondocId": "231197c3-c423-43aa-a024-10defaeb540a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/mergeExons",
+               "response": {
+                  "jsondocId": "87a41f7c-d826-408e-aea6-dd846fbcfb6f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [],
+               "verb": "POST",
+               "description": "Returns a translation table as JSON",
+               "methodName": "getTranslationTable",
+               "jsondocId": "676515b8-9224-43f3-bffb-7d2848914864",
+               "bodyobject": {
+                  "jsondocId": "a720f5e4-9393-4fcb-b784-82ecf12e068b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getTranslationTable",
+               "response": {
+                  "jsondocId": "cca10c1d-de2c-4e00-ad45-b163f50adea9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6c610e99-6911-4057-82a0-7d253091f1a6",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ece1c90f-a003-476f-98fa-bf71010bd671",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "acfa9eab-fc1e-44e2-bc06-a3e254a8983d",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4008ab74-6960-4947-bc1b-c866eb6a790d",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3d136a42-9256-4bc2-b5c6-1493b37f786b",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete exons",
+               "methodName": "deleteExon",
+               "jsondocId": "78be04e9-58d8-4350-884c-e1a11461e7c0",
+               "bodyobject": {
+                  "jsondocId": "08285085-2c6c-47c0-887f-0fb25fa470d1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteExon",
+               "response": {
+                  "jsondocId": "d0b88faa-9bb4-429e-a21e-abbe8a9516ab",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "9b5160aa-1a6f-4018-8351-fe72443a5fec",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2d455143-36eb-4e15-8b84-6bfa880d66ad",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6ef9521e-0d52-45e1-b734-d2959f0ade02",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e55da443-3782-4d3a-ad16-935347af4fbc",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "40413b42-f3b5-4bfc-90b4-77c85a37f7e0",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Get sequences for features",
-               "queryparameters": [
-                  {
-                     "jsondocId": "104a0526-2efd-4785-a686-5bdcb2032136",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "4a0be5d5-7407-40d9-940d-2062fa9e7b6d",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "7950f234-8353-45a4-8117-c88d123eb830",
-                     "description": "(optional) Sequence name",
-                     "name": "sequence",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "14b3db87-5e33-4595-b382-d0f9ca2f9f7e",
-                     "description": "(optional) Organism ID or common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "61972ab9-5f26-4d76-9def-edf1eb100965",
-                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
-                     "name": "features",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
-               "path": "/annotationEditor/getSequences",
-               "produces": ["application/json"],
-               "methodName": "getSequence"
-            },
-            {
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f94c8cac-8c18-4ebc-9c6e-54b34b93d4ca",
+               "methodName": "getSequence",
+               "jsondocId": "b65ba100-e6b8-4dd5-b16d-fbd039130d51",
+               "bodyobject": {
+                  "jsondocId": "5efd27ca-a94c-40e3-8597-4272ee656155",
                   "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
                   "object": "annotation editor"
                },
+               "apierrors": [],
+               "path": "/annotationEditor/getSequences",
+               "response": {
+                  "jsondocId": "ec9a2324-e306-45d7-9d71-e64409f737fd",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
                "headers": [],
                "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "8b41704e-bde4-45fa-bc6b-294618c5347c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8adfaa8a-97f8-473d-875f-574efd7025a1",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6e834623-c6f6-47d7-b4d6-827f9c2030f3",
+                     "name": "search",
+                     "format": "",
+                     "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
+                     "type": "JSONObject",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Search sequences",
+               "methodName": "searchSequence",
+               "jsondocId": "2a7ed7f3-3ad7-418f-880e-9f305279d493",
+               "bodyobject": {
+                  "jsondocId": "79f3d080-dc6f-4814-afd7-e319a6f29ab1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
                "apierrors": [],
-               "bodyobject": null,
-               "jsondocId": "0c5ad2ec-33f2-41c7-8349-9136d670fd32",
-               "description": "Get sequences search tools",
-               "queryparameters": [],
-               "path": "/annotationEditor/getSequenceSearchTools",
+               "path": "/annotationEditor/searchSequences",
+               "response": {
+                  "jsondocId": "b1d75633-2934-4af5-a34f-f7977688abbc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "jsondocId": "cc27b6e6-6912-4295-a53f-1b7d47719aeb",
+               "bodyobject": null,
+               "apierrors": [],
+               "path": "/annotationEditor/getSequenceSearchTools",
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [],
+               "response": {
+                  "jsondocId": "88c560fd-49c2-48a9-aea4-84bcd44a3dcc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "description": "Get sequences search tools",
                "methodName": "getSequenceSearchTools",
                "consumes": []
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "6d19e735-ac3d-4c9d-b476-1400906529e9",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "3ba0eb8d-cbfd-4838-b63f-00fdc0f30a4f",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d6bcb95d-b47e-44df-a3fc-fd9ff436a480",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get canned comments",
                "queryparameters": [
                   {
-                     "jsondocId": "988999f6-44c9-47be-a4f5-904c2c978782",
-                     "description": "",
+                     "jsondocId": "0beb1b82-f799-4d54-b67c-83b2d535480c",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "email",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9bdb7deb-0e93-4cb5-a3d5-100a61dc1db8",
-                     "description": "",
+                     "jsondocId": "6297966b-4260-4b45-a244-e8e57bd297b3",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "password"
-                  }
-               ],
-               "path": "/annotationEditor/getCannedComments",
-               "produces": ["application/json"],
-               "methodName": "getCannedComments"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "a2d80dfd-eb28-4e8c-91a7-66a1f6adab22",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "e6b61a40-8baa-49a3-9e79-d4da5e426ee5",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f848f04c-0938-4700-b669-769e94e57a5d",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Search sequences",
-               "queryparameters": [
-                  {
-                     "jsondocId": "114952b9-2db6-4884-94a4-bcd641c75b4f",
                      "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "332d65c7-3ead-4e15-b74a-f4c905f5a23a",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
+                     "jsondocId": "56727fa6-4b31-43c6-86c8-8eacf62bd14d",
+                     "name": "sequence",
                      "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "065e5a77-aff1-4c94-92c3-8c50ce1b2815",
-                     "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
-                     "name": "search",
-                     "allowedvalues": [],
+                     "jsondocId": "58ba1a86-5d29-4897-8dab-114e84d6ef56",
+                     "name": "organism",
                      "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
-                     "type": "JSONObject"
-                  }
-               ],
-               "path": "/annotationEditor/searchSequences",
-               "produces": ["application/json"],
-               "methodName": "searchSequence"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f3695122-8628-4978-8c51-4251120f0e05",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "annotation editor",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "5a1a44f3-d6ce-4f80-a7c4-20ec3fae17ed",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0a4d9e4d-7c97-4116-8d20-e660aa7e6123",
-                  "mapValueObject": "",
-                  "object": "annotation editor"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get gff3",
-               "queryparameters": [
-                  {
-                     "jsondocId": "e89ccc5f-1492-4e81-a7ba-65d23a6be392",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d6818a3b-906a-49c0-9814-cab82d0cb1aa",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "feed3d8d-6be3-45fe-85cd-dabecef40a3f",
-                     "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
+                     "jsondocId": "ffb57e81-148c-4529-8275-f9174ee631df",
                      "name": "features",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
                      "required": "true",
-                     "type": "JSONArray"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/annotationEditor/getGff3",
+               "verb": "POST",
+               "description": "Set status of a feature",
+               "methodName": "setStatus",
+               "jsondocId": "01afe7e5-3a5d-4824-9126-25f57957f96c",
+               "bodyobject": {
+                  "jsondocId": "97cf649d-788c-467f-9d84-41caa843d8f6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setStatus",
+               "response": {
+                  "jsondocId": "837d8d3b-f517-4b00-ad3e-7d984869c8e5",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
                "produces": ["application/json"],
-               "methodName": "getGff3"
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7dd9eb25-4187-4b19-978d-ad4e306ea3f4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "44c4fa31-cb23-46a3-88e3-99e9207cf8b2",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6bafcd3f-01a9-4ad0-afd8-d983a2c9c2d8",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5425c33c-ec62-4014-9e20-a931d8de52ad",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "480ccd6a-c9a1-4d60-bb23-2e475d9dcf10",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get comments",
+               "methodName": "getComments",
+               "jsondocId": "fad6817c-dc00-4c2f-8883-3009b90f31ac",
+               "bodyobject": {
+                  "jsondocId": "122a4d58-9bfe-46ab-a2ba-092b649b9ae2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getComments",
+               "response": {
+                  "jsondocId": "b077bc15-8ec7-45c1-b664-faddaec362f7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c030b77e-33c6-4655-849e-964bb70a8baf",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0056a2c8-29f4-4318-9b05-fc4af79f7bee",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "947c90dd-cba4-4db9-82c6-d9dac4cc6b67",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5438bbf5-4774-4a96-9675-b4eac838f4f8",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7c6b9f05-5ba1-443f-9d4f-e1da95824ebc",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add comments",
+               "methodName": "addComments",
+               "jsondocId": "cc7bb121-0bb0-468d-890e-a88c295f998e",
+               "bodyobject": {
+                  "jsondocId": "efac1622-d4ff-4849-8b1c-a24e338b5c7b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addComments",
+               "response": {
+                  "jsondocId": "0387464c-2e37-4ddd-8e2e-7164549061b3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c5238fe5-a998-4862-83bd-f47961b13ed8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0fd3ac13-ca0c-4a6b-acb3-d91d9ab4eb50",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2101c3c2-98e6-4d90-ab76-595a0a6db5da",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dd8d55b5-4669-4d87-a5ee-e581cc22bebc",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7febd8d1-7cde-4d71-9ca9-fd6ec7101679",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete comments",
+               "methodName": "deleteComments",
+               "jsondocId": "7f3eb9b6-5702-4ee4-98f9-46eb0c934b5f",
+               "bodyobject": {
+                  "jsondocId": "edc54441-31fe-40ce-94a5-a68002cf696e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteComments",
+               "response": {
+                  "jsondocId": "b6ff0bc3-79ef-4bd8-9686-37f12a846ae7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "81473e74-3148-44f8-b9e3-454b8a0a15af",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "31b34919-7644-4067-9c9d-9b23665db616",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ffa9b7ee-1d56-4854-b2c2-818b7204cac2",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fa396dcb-1998-44d2-8b72-09c58beed75e",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bc2fd1e8-2136-4edd-9e08-ba76e8b0f989",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update comments",
+               "methodName": "updateComments",
+               "jsondocId": "65193204-a834-40d3-8c2d-dd9ea6edd974",
+               "bodyobject": {
+                  "jsondocId": "e87a1535-14be-40b1-8e13-788954ee05fc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/updateComments",
+               "response": {
+                  "jsondocId": "a7e0dec0-7300-44a9-877a-d6a8eb5f358a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7f25d57b-999b-4932-82c9-37a4f9c9c29a",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dca9a809-786c-4bff-8e3a-de3b2f5802cf",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9b7da06f-5a92-4299-83e8-590dc77fe6e2",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ba1057e5-5087-4c6b-8976-85a9029161e8",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get all annotated features for a sequence",
+               "methodName": "getFeatures",
+               "jsondocId": "967db250-0b13-4652-923d-d60f8677d337",
+               "bodyobject": {
+                  "jsondocId": "8a4ebe46-6af4-4e1e-8a83-4ac44e0f05e2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getFeatures",
+               "response": {
+                  "jsondocId": "77579bd1-3cf2-4d20-ab47-6aba75c5e311",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "24805605-9d02-4a14-b2df-f4d414eb27a1",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "06fc4323-ccb5-484b-862e-27891e051aaf",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7025716f-1cf9-491c-8c5e-85344223f86d",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cd3738a0-26b4-4cd8-af1a-9f6350e9a942",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "41bda46e-553e-4159-88ba-1da739428f0a",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5dc54d78-af86-463a-afb1-13d41ae810ea",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7af738bb-2173-48e4-b8cc-a1d46ec8b31e",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add transcript",
+               "methodName": "addTranscript",
+               "jsondocId": "a98ce8a5-78f2-4437-ba42-25094d830abe",
+               "bodyobject": {
+                  "jsondocId": "44018e69-58a0-4bce-8c35-545b0c9773e2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addTranscript",
+               "response": {
+                  "jsondocId": "111e21e5-21df-4842-aa9d-463ca59b58b2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "740c646a-0087-483a-9cf4-eb7f1d08593e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "647049c4-2db6-4029-858d-4b61bfe56c59",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ec6143b8-f0c7-48ee-86ed-ddd07c570648",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b8b50a18-ab3a-4dab-ab9f-6ecacc3aee83",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2d95ebdc-437c-4133-b927-c67fff33d214",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set readthrough stop codon",
+               "methodName": "setReadthroughStopCodon",
+               "jsondocId": "e54515e8-82c1-4c03-861b-e75998ba7907",
+               "bodyobject": {
+                  "jsondocId": "d8200e56-de85-44ca-b410-06e3251f1463",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setReadthroughStopCodon",
+               "response": {
+                  "jsondocId": "4c5afae7-0706-48c2-8388-1fa6e906c5fe",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "338025fa-8771-414a-8233-517266cff259",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c90abcc1-7909-4624-9f7a-5b684fb22cf0",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cfe1a113-bca5-493b-931a-31286c67f4ba",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "528a5805-60c0-49ae-8138-de8f57782a34",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b2ee6ccc-e089-40c2-ba9a-bf6c46857320",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set longest ORF",
+               "methodName": "setLongestOrf",
+               "jsondocId": "d45f3cad-0b57-4bcd-a5d9-909f3785b271",
+               "bodyobject": {
+                  "jsondocId": "49f3e478-35a7-49d4-b8ce-1296b4167e9a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setLongestOrf",
+               "response": {
+                  "jsondocId": "4f3572f7-7c38-483e-9c37-f32db43dff04",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7204981a-6b85-4c88-8397-d8ca46fb509a",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4404a240-b383-45da-ac34-fdfc55dedd30",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f5004891-5cc9-4a8f-8ec8-2b33aa9e706d",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5ad8232e-ff81-46ab-915a-dc6e4d1725d9",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9efdc313-bf0f-4e16-91a0-78b30957b38d",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "de93163d-4c8a-4364-a739-22e8d9d5f5ae",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "072c2707-c32d-405c-9b44-c89b659d350a",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set exon feature boundaries",
+               "methodName": "setExonBoundaries",
+               "jsondocId": "88f268a6-a399-4747-a19d-824330275267",
+               "bodyobject": {
+                  "jsondocId": "5d388432-438f-48e4-b53e-f4629f8c4042",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setExonBoundaries",
+               "response": {
+                  "jsondocId": "66b4296c-e463-48c6-814a-b5a3d59df0a0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "dad0ae62-7c59-4dd3-ab73-ce3841f3978c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1360de8a-cae8-4fcc-86e2-2727b294d9a1",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "664e3546-a4e7-47e9-ab27-01395ae3fd7e",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e14042f9-8a30-4b11-b2e2-5566506e9e88",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3e33aa82-e59d-4d60-8e77-0109ec5194ae",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set boundaries of genomic feature",
+               "methodName": "setBoundaries",
+               "jsondocId": "d09144a0-0196-4060-a399-637d64957130",
+               "bodyobject": {
+                  "jsondocId": "013fab9d-28f6-4bac-8757-02b363552e81",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setBoundaries",
+               "response": {
+                  "jsondocId": "673f9211-90b4-4697-a1ac-bd3aceb5187f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "210cb334-9b83-43d2-a397-acb0ed8b3cc4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4b233720-e301-4c85-a5e8-2e0a03383528",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d76afa14-5f84-41ac-b0c9-86bfe2066429",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d34625ff-593b-4ca0-af18-af10a0af29c4",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "66942182-312a-4fa5-8255-71791c01576e",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete sequence alteration",
+               "methodName": "deleteSequenceAlteration",
+               "jsondocId": "4d869c00-aa74-4a0b-bfe4-78db579bcee9",
+               "bodyobject": {
+                  "jsondocId": "d498cb9f-8a5e-49ae-b110-87234d4471ec",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/deleteSequenceAlteration",
+               "response": {
+                  "jsondocId": "fdcc851a-7fb7-48e3-92a2-adf5d7098016",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "254e21a8-ea1e-49e2-b2bc-47c4f53cd207",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "07ae5207-b565-478e-888a-e26e5f47aed1",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c072bf9c-2057-410b-ae16-a547b27931f9",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4d4b0835-7ead-4ac3-8f5c-72e6dce86b1b",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "981066fe-95a8-4f2c-ac97-82bb4459e605",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add sequence alteration",
+               "methodName": "addSequenceAlteration",
+               "jsondocId": "fda05842-82ba-4e32-bdac-f588238c31d4",
+               "bodyobject": {
+                  "jsondocId": "fedcb979-6a13-44cb-b254-5981eed7ebb0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addSequenceAlteration",
+               "response": {
+                  "jsondocId": "9d094546-2a5d-4da7-83a6-7d157b2ce5b0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "513f1dcd-1cab-4e94-b902-13057fb5aa10",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0a2a47e1-085f-4bae-ab7a-4a0cb3793108",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e0f8069c-5982-4a8d-976b-023f74a71f94",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "00e3e366-ad1f-4047-9933-857492f7e193",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9f6ae822-bb5f-412e-9a5f-2194bedc5d3a",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Split exons",
+               "methodName": "splitExon",
+               "jsondocId": "98e93aed-7bdd-4204-8e4c-a6edb30565a9",
+               "bodyobject": {
+                  "jsondocId": "f760ab53-2e28-4693-966d-dc1b4771c260",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/splitExon",
+               "response": {
+                  "jsondocId": "9172a61c-a841-463a-9f71-61090dec74ad",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5e3d058c-b862-41fa-99a4-22b6dad1dd9c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e3cda6cf-e6ed-4b68-80f0-49b6c15642a7",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f86fa15a-74dc-44f9-8f38-e5a1fe54bc52",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ec876415-db29-4f25-9358-34d83f1a80ed",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ad4bf7da-985b-48ac-ad67-0e3e93316640",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Make intron",
+               "methodName": "makeIntron",
+               "jsondocId": "32760480-1856-4b3a-bfc4-aa9aae8eb1ad",
+               "bodyobject": {
+                  "jsondocId": "fc6db65a-ba57-4efd-87cf-172001d7ddff",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/makeIntron",
+               "response": {
+                  "jsondocId": "1ed0c1d6-2b74-4184-a8a8-10469db812db",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "1a5046a9-f29a-475c-8cda-f0c3fae8f0d7",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5f1174e3-ded4-457d-b2b7-08f44fe51794",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "572fc769-a417-4d60-8516-d7c50038854a",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4aad307f-60e2-41f0-8a63-05b1fabb0971",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4d3e39b3-cd57-4639-94aa-b7bbf1f5f9ee",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set name of a feature",
+               "methodName": "setName",
+               "jsondocId": "114890b5-5f30-4811-8a21-4b7ee1437b55",
+               "bodyobject": {
+                  "jsondocId": "25b03de4-58ca-48d8-946d-fc4fdd404932",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setName",
+               "response": {
+                  "jsondocId": "07323518-240d-4e80-ae98-a2cebc9fea6d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
             }
          ],
-         "jsondocId": "756c979d-c75b-4711-a038-e85623a819c4",
-         "description": "Methods for running the annotation engine",
-         "name": "Annotation Services"
+         "name": "Annotation Services",
+         "description": "Methods for running the annotation engine"
       },
       {
+         "jsondocId": "7c441dd0-e31b-4b5f-86fa-dda48cdc42ea",
          "methods": [
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "5cf1d219-8f8e-4b61-826b-80edd4eaafde",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "4ff3e0bb-607b-4bb2-ac3a-0c38a109a1c8",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3a2cff60-8fb2-47a3-9143-f90fb583515f",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7d15067a-0573-48fc-ba27-70131da98bf5",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b0cb6847-75e0-46e1-b655-53d56213ff4e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3747883b-efda-4a66-921b-ef37acd7fc6f",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Create group",
-               "queryparameters": [
-                  {
-                     "jsondocId": "1f63bef5-a351-4c26-a9f4-4780d8724e24",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "16c8c920-7d40-4b92-b344-a867786b95d2",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "d4811234-9033-419b-9563-dd8974b07bee",
-                     "description": "Group name to add",
-                     "name": "name",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "createGroup",
+               "jsondocId": "87df70cc-6053-4ef1-b622-61b455fa1fa3",
+               "bodyobject": {
+                  "jsondocId": "5b482365-90ed-4e6b-87dc-5c84a1c4ae47",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
                "path": "/group/createGroup",
+               "response": {
+                  "jsondocId": "81737ca6-0184-4e5b-96a1-b6af010bcbd1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
                "produces": ["application/json"],
-               "methodName": "createGroup"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "c313e972-542e-4d35-ad59-a96dc0d66c10",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "c23a6f4e-5756-4d84-8195-7aa7af24e924",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3de9c5b9-1495-4ac5-b888-7b824726ddad",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get organism permissions for group",
                "queryparameters": [
                   {
-                     "jsondocId": "e7dfe05c-b459-4ca3-926e-b6bdbef0207f",
-                     "description": "",
+                     "jsondocId": "34b68097-60a9-4804-a074-3df938408e09",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "email",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aafa33b6-68d8-4b10-b750-00a8c6ce45c0",
-                     "description": "",
+                     "jsondocId": "66b92494-0ab3-4638-98a7-ddceaec73377",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "dea84dde-72df-4ba0-9c01-71598b855ff3",
-                     "description": "Group ID (or specify the name)",
-                     "name": "id",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "b869c54a-8dba-4a68-a04e-1a7023125766",
-                     "description": "Group name",
-                     "name": "name",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
-               "path": "/group/getOrganismPermissionsForGroup",
-               "produces": ["application/json"],
-               "methodName": "getOrganismPermissionsForGroup"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f4878ab2-25a6-4ca3-927f-a5df4eb1c4a3",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "10b27085-1ef8-40bd-8d8b-f55059ca0803",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f1eb17ae-e5aa-4359-875b-b6d7f0f7fca2",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Load all groups",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d371db74-5031-48d0-98ef-fc248e75ad5b",
                      "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e606d5c6-a8d4-40db-862b-1b034b687657",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "ae601936-7f27-4796-888e-cbe16565f565",
-                     "description": "Optional only load a specific groupId",
+                     "jsondocId": "60722889-e2b5-41be-869c-38ae65c44500",
                      "name": "groupId",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "Group ID to modify permissions for",
+                     "type": "long",
                      "required": "true",
-                     "type": "long"
-                  }
-               ],
-               "path": "/group/loadGroups",
-               "produces": ["application/json"],
-               "methodName": "loadGroups"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e3887a76-62f0-4743-9d82-b246dff6905a",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "0f378098-43b0-4a56-9de9-3a8bc328a916",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "5fa85869-2b77-4fcb-902a-d6dc7657f745",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Delete a group",
-               "queryparameters": [
-                  {
-                     "jsondocId": "6c9389b8-46cb-492d-ad31-75cbec1ce83c",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "041b7a3d-e11b-4cae-90c0-60fb47875f01",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "fec61364-463b-4423-aea1-f81e0031775e",
-                     "description": "Group ID to remove (or specify the name)",
-                     "name": "id",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "51812e8f-210b-4f90-83aa-b3d20c59c876",
-                     "description": "Group name to remove",
+                     "jsondocId": "e9f39345-deba-4c84-9c30-fd5a2bc04d4b",
                      "name": "name",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "Group name to modify permissions for",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4bb1d07f-0e4a-4e8a-961b-591c8eaa22cb",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Organism common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "251d2ae8-f957-4e82-b739-956587be4ffd",
+                     "name": "administrate",
+                     "format": "",
+                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "272ec8f3-4acb-4a20-857c-b6f86a1a6b34",
+                     "name": "write",
+                     "format": "",
+                     "description": "Indicate if user has write privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "af5188d8-fbf7-4f2d-b4c4-61d5cf6971b6",
+                     "name": "export",
+                     "format": "",
+                     "description": "Indicate if user has export privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bbcbc7ee-43a3-443d-a1a5-12ad3a8aa02f",
+                     "name": "read",
+                     "format": "",
+                     "description": "Indicate if user has read privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
                   }
                ],
-               "path": "/group/deleteGroup",
-               "produces": ["application/json"],
-               "methodName": "deleteGroup"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "79fd2b24-f242-4de3-8d6c-f88882b7489f",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "dd415bd4-5f26-4da3-a092-f6c8e275e6e5",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d08eab33-ebe4-476b-af06-2460769cd5e9",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Update group",
-               "queryparameters": [
-                  {
-                     "jsondocId": "6eaa3cc8-fdd6-49c8-b23c-4b4c382963df",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "1e1a76bb-ccb4-4865-b1dd-6d54611a4d7c",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "bc0095e6-c3f7-430c-917d-96ecad3e0d20",
-                     "description": "Group ID to update",
-                     "name": "id",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "fba52afe-45f5-4a40-9e77-2c369ab9818c",
-                     "description": "Group name to change to (the only editable optoin)",
-                     "name": "name",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
-               "path": "/group/updateGroup",
-               "produces": ["application/json"],
-               "methodName": "updateGroup"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "15b0cfba-2879-4a30-b073-09de0fd247fe",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "a4ece33c-f4e6-493c-abab-ae48864e60cc",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "0b29257d-4c92-4f1b-a2b7-14ea3d711ed3",
-                  "mapValueObject": "",
-                  "object": "group"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "Update organism permission",
-               "queryparameters": [
-                  {
-                     "jsondocId": "f9328891-4701-45cc-a3ff-4e9f604d605b",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "c067993b-fe23-4c17-a93d-aa2631cae58f",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "9665f630-544b-4812-be21-4b1c08d9ca9f",
-                     "description": "Group ID to modify permissions for",
-                     "name": "groupId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "5bc71a7f-8e55-4677-beef-25279d25a27b",
-                     "description": "Group name to modify permissions for",
-                     "name": "name",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "fe1461b4-816b-4a1c-9969-ce11906eb976",
-                     "description": "Organism common name",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "75dc7481-c8b2-4a9f-ba7d-44a2c60efc41",
-                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
-                     "name": "administrate",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "a7a8b9e0-e28b-4294-987b-67c29c809919",
-                     "description": "Indicate if user has write privileges for the organism",
-                     "name": "write",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "ef27dffa-bdb7-4f71-a6f7-8749c568baf0",
-                     "description": "Indicate if user has export privileges for the organism",
-                     "name": "export",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "62fcde6c-088b-414a-9f93-d8d995fec132",
-                     "description": "Indicate if user has read privileges for the organism",
-                     "name": "read",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  }
-               ],
-               "path": "/group/updateOrganismPermission",
-               "produces": ["application/json"],
-               "methodName": "updateOrganismPermission"
-            },
-            {
-               "headers": [],
+               "methodName": "updateOrganismPermission",
+               "jsondocId": "e31f80e3-ead1-4dde-87e1-77aeeaf4cdb4",
                "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e2bba732-f741-44cf-a534-c6022e376bbc",
+                  "jsondocId": "4cdd4456-e243-4c70-9c90-c2efaad1acae",
                   "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
                   "map": "",
-                  "object": "group",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "8eb82f8a-edb5-4c9b-9004-0ef731faa9c2",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e407dd3b-b244-4858-b6e8-6c6f6738b3a5",
-                  "mapValueObject": "",
                   "object": "group"
                },
-               "pathparameters": [],
                "apierrors": [],
+               "path": "/group/updateOrganismPermission",
+               "response": {
+                  "jsondocId": "999a331a-b0fa-4629-bd14-2b015f698074",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "ee3afaeb-58e9-4be1-bfcb-70c5941418e6",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7e867e98-5f60-4941-937b-55b99cbad710",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d3c17bd6-9bde-4a1c-8774-7d519ce08e42",
+                     "name": "id",
+                     "format": "",
+                     "description": "Group ID (or specify the name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "44878288-404a-4476-943f-66446d50cff8",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for group",
+               "methodName": "getOrganismPermissionsForGroup",
+               "jsondocId": "a861dcdc-7dd2-44da-b200-36a50cfe1aee",
+               "bodyobject": {
+                  "jsondocId": "89384e81-da87-488a-b339-a0aa1e00fe00",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/getOrganismPermissionsForGroup",
+               "response": {
+                  "jsondocId": "fb061119-8d23-4adb-b02b-708b49b47c5e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "30821be1-dde2-4d76-bc1c-1a4c04732094",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2fefba03-5f72-43d4-888d-59036e382c1c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "49c38a75-0576-4776-990a-1413a19b2c55",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Optional only load a specific groupId",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Load all groups",
+               "methodName": "loadGroups",
+               "jsondocId": "8a8b2c34-bd54-4ec9-8fff-b369147da79c",
+               "bodyobject": {
+                  "jsondocId": "0309a289-5e8f-4329-b201-67d8c676d932",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/loadGroups",
+               "response": {
+                  "jsondocId": "3782c771-121b-4ce1-aa9e-88520aa8b64e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "f4e48909-23e1-452a-b404-11607cbb55f4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8add6e23-1203-4d0e-b944-50cfaca898a8",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f0d7a0de-95ec-4fc2-91bc-695bd1ea4508",
+                     "name": "id",
+                     "format": "",
+                     "description": "Group ID to remove (or specify the name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "663976f7-b46a-45dc-89e8-998b8befd973",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to remove",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete a group",
+               "methodName": "deleteGroup",
+               "jsondocId": "13c85a26-628f-45ad-ae78-186676f79f37",
+               "bodyobject": {
+                  "jsondocId": "0f2e1317-c9d4-4788-b0f0-e9a4febb500a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/deleteGroup",
+               "response": {
+                  "jsondocId": "b5e60b03-42d9-4811-a671-82a86f15574e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "ddb5c53b-6390-4bda-9f8d-8104239c6241",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3f93c4f5-58f7-457c-a6cf-4ea827cf4126",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "329f3221-a05d-434d-a887-114da70e609b",
+                     "name": "id",
+                     "format": "",
+                     "description": "Group ID to update",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a83b3d5c-894e-48f2-ae0d-5ea2963e4f8a",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to change to (the only editable optoin)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update group",
+               "methodName": "updateGroup",
+               "jsondocId": "719ba585-9a3c-4bec-9fe0-9d0ba0560845",
+               "bodyobject": {
+                  "jsondocId": "9c44fe27-23fb-4179-877f-4891b5cbf326",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/updateGroup",
+               "response": {
+                  "jsondocId": "b94b3faa-472b-4c91-a13c-66d24ad95868",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "fff3d2db-f5da-4ab0-b47b-fe779c834775",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "673bd991-48be-41c6-939c-1818e962a81d",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dcd844c2-3343-4695-a1da-f3a9c56e934c",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Group ID to alter membership of",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "70e9494c-1994-4a18-a6c5-ec87bfc5f7c2",
+                     "name": "user",
+                     "format": "",
+                     "description": "A JSON array of strings of emails of users the now belong to the group",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Update group membership",
-               "queryparameters": [
-                  {
-                     "jsondocId": "5f909207-d39f-4bf5-a205-cf3b44ffce68",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "ae7c0dd1-9a37-4229-93c8-5d02191cd2cd",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "13b98e4c-9571-46d0-b3eb-7e8ca1f393e7",
-                     "description": "Group ID to alter membership of",
-                     "name": "groupId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "0378d970-2403-4505-8310-e63776fd42bf",
-                     "description": "A JSON array of strings of emails of users the now belong to the group",
-                     "name": "user",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "JSONArray"
-                  }
-               ],
+               "methodName": "updateMembership",
+               "jsondocId": "540fb3b8-4622-4ea1-94bd-fac971e80a21",
+               "bodyobject": {
+                  "jsondocId": "7f2d222e-09ff-4d44-9aa6-fb9d42c91d51",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
                "path": "/group/updateMembership",
+               "response": {
+                  "jsondocId": "eef9c2bc-9b95-46df-a502-1ad1fe1e66b1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
                "produces": ["application/json"],
-               "methodName": "updateMembership"
+               "consumes": ["application/json"]
             }
          ],
-         "jsondocId": "6bdee0db-02c8-45b3-9e42-faf4ad732a0e",
-         "description": "Methods for managing groups",
-         "name": "Group Services"
+         "name": "Group Services",
+         "description": "Methods for managing groups"
       },
       {
+         "jsondocId": "948213fd-b7da-4cd4-a2f4-aa1537c98d0b",
          "methods": [
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "757a4b12-89cf-4179-9a2c-9584442a61f1",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "i o service",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "9990e106-4989-4068-8e3f-6436242851ff",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ae4634c9-a392-4099-b930-92544b9a9dca",
-                  "mapValueObject": "",
-                  "object": "i o service"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "queryparameters": [
                   {
-                     "jsondocId": "2f2c6ff0-93b3-40ab-a7fe-61181b465044",
-                     "description": "",
+                     "jsondocId": "7871157c-8af1-4228-8d40-37446f86cf23",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "0f6e393f-8ec4-45f9-b747-a9750ba988ed",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "658d86e5-ab63-46eb-8199-8587b2173d22",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "15c45f2c-8d61-4c77-bc4d-6d659327aeba",
-                     "description": "Type of export 'FASTA','GFF3'",
-                     "name": "type",
-                     "allowedvalues": [],
+                     "jsondocId": "a3de3794-5808-4e7a-b4a4-8ee080c167d9",
+                     "name": "uuid",
                      "format": "",
+                     "description": "UUID that holds the key to the stored download.",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "295cb80f-413f-4276-9511-effe45c5fa93",
-                     "description": "Type of output sequence 'peptide','cds','cdna','genomic'",
-                     "name": "seqType",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "ee18c5e9-d44c-4982-8209-2f2dc79c68b1",
-                     "description": "'gzip' or 'text'",
+                     "jsondocId": "3564bbd3-19e7-47a8-aecc-8ce0e8c7627d",
                      "name": "format",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "'gzip' or 'text'",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "0aa00aab-207f-4c89-8321-f645d16ac4dc",
-                     "description": "Names of references sequences to add.",
-                     "name": "sequences",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "020802c4-dcec-4959-a497-fcea74bce420",
-                     "description": "Name of organism that sequences belong to.",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "04182eec-656b-4a25-9227-0972ab3f68d0",
-                     "description": "Output method 'file','text'",
-                     "name": "output",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "a9abf688-37d2-4531-ada0-805ddf453d9f",
-                     "description": "Export all sequences for an organism (over-rides 'sequences')",
-                     "name": "exportAllSequences",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "2f852237-e797-4082-a739-9bedff174ef7",
-                     "description": "Export sequences when exporting gff3",
-                     "name": "exportGff3Fasta",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
+                     "allowedvalues": []
                   }
                ],
-               "path": "/ioService/write",
-               "produces": ["application/json"],
-               "methodName": "write"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ba435102-988a-463f-9cc7-c25bed1da7e0",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "i o service",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "aa66b6bf-4097-4717-bd72-2ab866477ddd",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "cafff882-37c2-40c3-88e1-4f8d22257f17",
-                  "mapValueObject": "",
-                  "object": "i o service"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
+               "methodName": "download",
+               "jsondocId": "a2d0f350-42ca-401d-b7aa-0925a929314f",
+               "bodyobject": {
+                  "jsondocId": "4e9001ca-a3b1-47ec-81cd-dbac5314c318",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "i o service"
+               },
+               "apierrors": [],
+               "path": "/ioService/download",
+               "response": {
+                  "jsondocId": "0aa163b3-85dc-4e9b-ac63-70a75d0ef3ee",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "i o service"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "25bb776f-bcd7-4182-b790-fa968770278a",
-                     "description": "",
+                     "jsondocId": "14881869-f128-4a23-9d0a-996971cf4b07",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "398919f4-c4ee-443a-b524-547cc871b09a",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0d456d3b-b936-458c-afaa-00096c189ccf",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dd04a576-3535-45ec-a021-6af54cf07f4e",
-                     "description": "UUID that holds the key to the stored download.",
-                     "name": "uuid",
-                     "allowedvalues": [],
+                     "jsondocId": "2e3e3931-57a9-4c8f-ae00-5e0e6fdc839b",
+                     "name": "type",
                      "format": "",
+                     "description": "Type of export 'FASTA','GFF3'",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b2bd4b65-f116-4d45-8ce6-21be81e2a399",
-                     "description": "'gzip' or 'text'",
+                     "jsondocId": "14bf337c-2ba0-43ab-b4dc-3c7a5617a3da",
+                     "name": "seqType",
+                     "format": "",
+                     "description": "Type of output sequence 'peptide','cds','cdna','genomic'",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1994c0d3-cb53-4cc8-a81f-dc9a81516e98",
                      "name": "format",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "'gzip' or 'text'",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cd13622c-0f77-4f5b-a589-d5db0a93868e",
+                     "name": "sequences",
+                     "format": "",
+                     "description": "Names of references sequences to add.",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1a67350c-f5b0-498a-9cd3-e1c03009f049",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Name of organism that sequences belong to.",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4a7ead99-10bf-4eec-bc65-51177e6a9f28",
+                     "name": "output",
+                     "format": "",
+                     "description": "Output method 'file','text'",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7003bada-eea5-402d-b7c3-cc783e574a7a",
+                     "name": "exportAllSequences",
+                     "format": "",
+                     "description": "Export all sequences for an organism (over-rides 'sequences')",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a5179a7f-1dc5-413b-a2e2-520c04aadd0e",
+                     "name": "exportGff3Fasta",
+                     "format": "",
+                     "description": "Export sequences when exporting gff3",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
                   }
                ],
-               "path": "/ioService/download",
+               "verb": "POST",
+               "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
+               "methodName": "write",
+               "jsondocId": "3be6065c-0aae-42ae-aa09-bf1f88a4328f",
+               "bodyobject": {
+                  "jsondocId": "d6df77c0-076c-4c12-8285-8eb8c2e335a1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "i o service"
+               },
+               "apierrors": [],
+               "path": "/ioService/write",
+               "response": {
+                  "jsondocId": "b19402da-776c-4c9a-b04e-82d96171784a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "i o service"
+               },
                "produces": ["application/json"],
-               "methodName": "download"
+               "consumes": ["application/json"]
             }
          ],
-         "jsondocId": "32c4675f-c2c4-4983-aff1-72436c4f633a",
-         "description": "Methods for bulk importing and exporting sequence data",
-         "name": "IO Services"
+         "name": "IO Services",
+         "description": "Methods for bulk importing and exporting sequence data"
       },
       {
+         "jsondocId": "89ef57c5-ea63-42dd-ba12-4dd32e328ce9",
          "methods": [
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ff5516c4-a364-44ed-a342-f0677528cb18",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "f0da0a7e-c881-43f9-8230-cdc7a7d9e542",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "9a8503e6-e987-4689-b376-9677bd12cfaa",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c095d811-085b-491c-9b4e-58a43055580e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "21e80e06-cb83-4954-b7b7-664d7a9492d7",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fe7dc85e-f84f-4029-a828-ea157f17e5b7",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Pass an Organism JSON object with an 'id' that corresponds to the id to delete",
+                     "type": "json",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Remove an organism",
-               "queryparameters": [
-                  {
-                     "jsondocId": "b5ee7cf6-000a-459a-8376-ef39a3b7d713",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "57fb64e0-1ce2-4616-86a2-20893e2d497e",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "18dcc92c-f0f2-4b5b-a1a2-d9dd15e949cf",
-                     "description": "Pass an Organism JSON object with an 'id' that corresponds to the id to delete",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "json"
-                  }
-               ],
+               "methodName": "deleteOrganism",
+               "jsondocId": "a4cda158-bcee-4c7b-bdc8-ef9efdac4fce",
+               "bodyobject": {
+                  "jsondocId": "058869f9-01b1-4260-9b20-06d9ec249ddc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/deleteOrganism",
+               "response": {
+                  "jsondocId": "ab2098f9-05f0-4dc3-801d-b9171672bc9d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteOrganism"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "a6ab1780-d465-442d-8e36-2e85281a5eb3",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "639bfff7-4bcb-4fea-b9b1-b19e0aa6b919",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f9c88e23-ff4e-4391-83c3-43918d458831",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e6c12161-cf67-4d19-b759-7ec6a98d955f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ec504b1a-52e9-45c8-b083-2d61479f23d7",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fb2ce7cc-2388-4df8-8464-f5fbb4a9307b",
+                     "name": "organism",
+                     "format": "",
+                     "description": "An organism json object that has an 'id' or 'commonName' parameter that corresponds to an organism.",
+                     "type": "json",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Remove features from an organism",
-               "queryparameters": [
-                  {
-                     "jsondocId": "6aaf683e-f2ce-42a5-9268-9d5c275d1b56",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "1f0a63e1-7bb1-46be-b06d-d26bc1ff4d30",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "0276d877-d038-4584-b608-02f520bee8a7",
-                     "description": "An organism json object that has an 'id' or 'commonName' parameter that corresponds to an organism.",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "json"
-                  }
-               ],
+               "methodName": "deleteOrganismFeatures",
+               "jsondocId": "4548af2e-c87a-4659-8dcd-d65a70d5500f",
+               "bodyobject": {
+                  "jsondocId": "440119a1-d468-449a-a87e-da1c97945d3d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
+               "response": {
+                  "jsondocId": "ca2c071b-5a6e-4653-b379-5524c75d7f67",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteOrganismFeatures"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "8e30d9ba-db25-431c-aacd-9d14b1c099b4",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "fb2b072c-2e62-44dd-ad22-4b1bae5e8b7a",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ae3db6f2-3fed-47a8-b78b-c8b7194c66c6",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e5f12fad-f754-4c29-a7ef-114d5ac891f3",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "deb38f92-fcb3-4033-b147-99d9219266a7",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1eca5cd9-2253-47bd-867c-afdfa4103628",
+                     "name": "directory",
+                     "format": "",
+                     "description": "filesystem path for the organisms data directory (required)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d2e555d9-294e-42e5-b727-6e15ba5800bc",
+                     "name": "species",
+                     "format": "",
+                     "description": "species name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c41ff996-2ca3-4651-93a9-1f2793ba473a",
+                     "name": "genus",
+                     "format": "",
+                     "description": "species genus",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "017da2bd-34fe-43d0-8bc0-268ee61d76fe",
+                     "name": "blatdb",
+                     "format": "",
+                     "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "16290516-95fc-4005-b329-a1846eec78ab",
+                     "name": "publicMode",
+                     "format": "",
+                     "description": "a flag for whether the organism appears as in the public genomes list",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c052837f-94b2-4caf-8114-019e8007b62b",
+                     "name": "commonName",
+                     "format": "",
+                     "description": "a name used for the organism",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d04d8edf-b954-47af-821d-d15955233caa",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "6b7cc11a-a813-441d-aac2-fc4e0b328f59",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "dbfb2153-d85e-4b94-8ce7-070de61dd75b",
-                     "description": "filesystem path for the organisms data directory (required)",
-                     "name": "directory",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "471c061b-54c4-416c-8564-a8036a6daea9",
-                     "description": "species name",
-                     "name": "species",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "9cce583e-a506-402d-99df-fb67cd9e22e6",
-                     "description": "species genus",
-                     "name": "genus",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "c627b039-f7cc-4482-a904-c3741db03e33",
-                     "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
-                     "name": "blatdb",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "dc0777f8-5b3d-4b41-bcd3-761591a975be",
-                     "description": "a flag for whether the organism appears as in the public genomes list",
-                     "name": "publicMode",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "c2f52779-97ab-426c-a5d5-ddcf1eadb84f",
-                     "description": "a name used for the organism",
-                     "name": "commonName",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "addOrganism",
+               "jsondocId": "19f2dde7-92ba-4ab7-b4d3-8b8e2f706b53",
+               "bodyobject": {
+                  "jsondocId": "881746b0-0447-48a5-857a-7b99ab1b81e3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/addOrganism",
+               "response": {
+                  "jsondocId": "08f4bf6a-984f-42da-8461-9272facc4d21",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "addOrganism"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "17872466-db69-410c-8d7b-edc8817251bc",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "7120e60a-bfbc-4c13-98be-9a69530f033a",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "aa5732dc-f0fa-412c-9e31-84c601c07de4",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "20be3cea-2093-4dee-912a-d86ddf2a7689",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "871393f1-f818-4435-a879-82203e127eac",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "936f69af-d482-4e98-a727-d4ae5e66ca14",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Common name or ID for the organism",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
-               "queryparameters": [
-                  {
-                     "jsondocId": "49487b75-3ea7-45bd-8c51-026e14b355ea",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "082d179d-8b32-469b-9f22-981cb266e364",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "ab5b0327-27c6-49ee-bf86-171c3a350b9b",
-                     "description": "Common name or ID for the organism",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "getSequencesForOrganism",
+               "jsondocId": "1e2a1677-edad-405b-96f5-b06f448ae1a3",
+               "bodyobject": {
+                  "jsondocId": "6e5f5772-4a3c-44a3-bd1d-93a11da3dcd4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
+               "response": {
+                  "jsondocId": "f112bcd7-ea79-43cc-97a9-55d7c2160cfc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "getSequencesForOrganism"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "3dcadb92-43a8-48e8-95f0-586b635d7cb8",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "798a28cd-4cf6-44a1-81d0-50cdc63e894d",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "44eab4c6-c4b2-4282-b16a-0de3671c256a",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "9f3f1879-d45e-48e1-a3de-0eb1b3e83d87",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7a7d0e6a-26c9-47cd-9dc0-bc654b2fa61b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "efa5ef97-466a-4588-9fa9-6558377ccb11",
+                     "name": "id",
+                     "format": "",
+                     "description": "unique id of organism to change",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e83dc3dd-2242-48d9-93af-3269c1edbd4d",
+                     "name": "directory",
+                     "format": "",
+                     "description": "filesystem path for the organisms data directory (required)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "858b7faf-02bd-4753-be53-5a5df49a95d0",
+                     "name": "species",
+                     "format": "",
+                     "description": "species name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "75183079-4aed-45ab-ab9e-b22cd9a1e6e5",
+                     "name": "genus",
+                     "format": "",
+                     "description": "species genus",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f1cc8f4a-fe75-4478-93f3-b34f87082d7d",
+                     "name": "blatdb",
+                     "format": "",
+                     "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9fb5aab1-6ba0-46bf-b294-ab2391c9912d",
+                     "name": "publicMode",
+                     "format": "",
+                     "description": "a flag for whether the organism appears as in the public genomes list",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "458ecfb6-d6c0-46d1-a0ff-f02250cb6207",
+                     "name": "name",
+                     "format": "",
+                     "description": "a common name used for the organism",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
-               "queryparameters": [
-                  {
-                     "jsondocId": "35c28f58-62fc-4467-8ef7-d7e6b7e607f4",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "35b86405-d96f-4c81-9753-4227154e9130",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "68e17b49-966e-448f-bdfe-4b255417ba43",
-                     "description": "unique id of organism to change",
-                     "name": "id",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "672183ee-265d-40f3-b65d-38d8f4d9758c",
-                     "description": "filesystem path for the organisms data directory (required)",
-                     "name": "directory",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "78b5250a-1cab-4bcb-99ee-fec771eec411",
-                     "description": "species name",
-                     "name": "species",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "bd92b746-ff4c-45ed-9d24-659820500047",
-                     "description": "species genus",
-                     "name": "genus",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "b3491c8f-358a-4329-8415-1f12308b43b4",
-                     "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
-                     "name": "blatdb",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "ff987592-86e5-4405-ae8b-7af277f2b82c",
-                     "description": "a flag for whether the organism appears as in the public genomes list",
-                     "name": "publicMode",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "b6dddf8b-2636-4dd8-8671-c59570b0dd76",
-                     "description": "a common name used for the organism",
-                     "name": "name",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "updateOrganismInfo",
+               "jsondocId": "5bc90bcc-8f73-480a-8b0e-0730aa097015",
+               "bodyobject": {
+                  "jsondocId": "8306d222-bf65-49dd-b777-8b895834ae35",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/updateOrganismInfo",
+               "response": {
+                  "jsondocId": "6e8ae37a-9af7-4834-9491-0a9736737008",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "updateOrganismInfo"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "cfa3c8c3-1365-47bc-b9e9-e484655fd04f",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "organism",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "8c6dace8-7845-47e2-8faf-8d5765098da1",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "8b95d781-5b01-4d4e-b4f8-4d4fc723899f",
-                  "mapValueObject": "",
-                  "object": "organism"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "queryparameters": [
                   {
-                     "jsondocId": "2e4a959e-b87f-4d0c-9050-954e7765f99b",
-                     "description": "",
+                     "jsondocId": "0ea1ad20-5737-42ab-932b-40d79ff16b9d",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "email",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3af47820-85d5-4732-8c6f-1684def486db",
-                     "description": "",
+                     "jsondocId": "3cbfdd3f-b993-46cd-bad6-b09629fa0b76",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a6069d15-0b82-430f-957d-390b36b02874",
-                     "description": "",
+                     "jsondocId": "44d9c329-5dd2-4953-920b-3f929c1f046f",
                      "name": "organism",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   }
                ],
+               "verb": "POST",
+               "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
+               "methodName": "findAllOrganisms",
+               "jsondocId": "b90c3ebf-baec-4242-ad6d-e2877cdfe0ad",
+               "bodyobject": {
+                  "jsondocId": "ff470acf-23f2-4ad5-87e9-2ffa5d0af06b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "organism"
+               },
+               "apierrors": [],
                "path": "/organism/findAllOrganisms",
+               "response": {
+                  "jsondocId": "43c0e9f0-1f85-4fa2-ac61-0af44d835dd9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "organism"
+               },
                "produces": ["application/json"],
-               "methodName": "findAllOrganisms"
+               "consumes": ["application/json"]
             }
          ],
-         "jsondocId": "43ab2633-7006-43bd-9aca-acec8a644162",
-         "description": "Methods for managing users",
-         "name": "Organism Services"
+         "name": "Organism Services",
+         "description": "Methods for managing users"
       },
       {
+         "jsondocId": "199aab01-21bf-4bea-9192-7ff6fdac9544",
          "methods": [
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "6a5fb1fb-636d-4f40-a7be-270039a2fee6",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "c075669c-7807-4422-ab15-79b63cc769f2",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "389083d8-d106-4877-84de-49a68444f978",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Get organism permissions for user, returns an array of permission objects",
                "queryparameters": [
                   {
-                     "jsondocId": "294d7191-47c9-4b5d-8d1f-efce74cc7be4",
-                     "description": "",
+                     "jsondocId": "703756fc-666e-4b3b-b22d-f5344648070b",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "1d31d56f-a4e0-43e6-ae82-50f021e8898d",
                      "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
+                     "type": "email",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "21057be5-1d2e-4346-9721-001a1ae0ce18",
-                     "description": "User ID to fetch",
-                     "name": "userId",
-                     "allowedvalues": [],
+                     "jsondocId": "2f1401f9-f266-4018-856f-2e7a532adbf4",
+                     "name": "password",
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "long"
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e0ba2315-ce7c-426c-beee-8ea9f988c222",
+                     "name": "userId",
+                     "format": "",
+                     "description": "Optionally only user a specific userId",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
                   }
                ],
-               "path": "/user/getOrganismPermissionsForUser",
-               "produces": ["application/json"],
-               "methodName": "getOrganismPermissionsForUser"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "8747ad19-b693-431b-8dee-8e1399274dbb",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "6a393b45-bc3a-4b82-80c9-2b42dffcf255",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "beeec209-ed18-41d8-bc4c-27b95ac37d0e",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
-               "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Update organism permissions",
-               "queryparameters": [
-                  {
-                     "jsondocId": "2e338b7a-b79e-4c23-a2d5-9c01e3a7b812",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "9501c885-b13c-45e9-b85e-4f5eef8b57d2",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "90ce7520-679a-477d-ab5e-1a48a0292cd0",
-                     "description": "User ID to modify permissions for",
-                     "name": "userId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "71ecbd9b-18c0-4065-bff6-608a23ade701",
-                     "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
-                     "name": "user",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "bbec5a16-537a-4098-8835-742663fd4363",
-                     "description": "Name of organism to update",
-                     "name": "organism",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "acc0c172-8eea-44ee-9345-58bea66b68fe",
-                     "description": "Permission ID to update (can get from userId/organism instead)",
-                     "name": "id",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "d596fc5d-3ae8-48a5-8650-9b81d730ec16",
-                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
-                     "name": "administrate",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "664c7d17-b76c-46af-8a33-9ab8945f04f2",
-                     "description": "Indicate if user has write privileges for the organism",
-                     "name": "write",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "d185816a-08aa-43bc-92a1-cdfd1054fe52",
-                     "description": "Indicate if user has export privileges for the organism",
-                     "name": "export",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  },
-                  {
-                     "jsondocId": "40c8f0d7-a1ef-4267-a8f6-75b07696d109",
-                     "description": "Indicate if user has read privileges for the organism",
-                     "name": "read",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "boolean"
-                  }
-               ],
-               "path": "/user/updateOrganismPermission",
-               "produces": ["application/json"],
-               "methodName": "updateOrganismPermission"
-            },
-            {
-               "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f75e8b9e-76a8-4f4b-bb19-2b63fb854407",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "f137587f-941c-46b5-8954-89d4d5c60708",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "e51d1e82-d5cd-46d2-85df-497208ec74dd",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
-               "pathparameters": [],
-               "apierrors": [],
                "verb": "POST",
                "description": "Load all users",
-               "queryparameters": [
-                  {
-                     "jsondocId": "3b34131a-c75b-47ed-a6c3-77c72635eaf9",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "0d43ce6e-813e-47bc-aca3-821f93f82e0e",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "5a8aa585-d808-4a8d-9535-4c0c0547e925",
-                     "description": "Optionally only user a specific userId",
-                     "name": "userId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  }
-               ],
+               "methodName": "loadUsers",
+               "jsondocId": "d94dc1d1-3352-445e-9e4d-88654c837a84",
+               "bodyobject": {
+                  "jsondocId": "3b920df7-4a96-4f01-bb6c-acc796362de0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/loadUsers",
+               "response": {
+                  "jsondocId": "fcf8ce10-8661-435e-94d1-3c220f70e486",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "loadUsers"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "a8fb06e8-bf82-4f5e-8ee3-27110aa3b769",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "cb49c516-c86f-4711-b6a7-cd922d23fc55",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "ee12e198-451f-47c3-882c-51db08c870fa",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5695a3a0-45a4-4b2f-97ca-d51299e18d5a",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2d13185e-7b4f-495c-9331-34c0f1a7cb6c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f14a0fbd-e1d4-4a25-ad3d-67be51678f0c",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "850ca007-6d34-4153-8101-7455e827eda0",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "78c25987-8b7d-4efa-b5a7-9c202121b4b6",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Add user to group",
-               "queryparameters": [
-                  {
-                     "jsondocId": "edd38d67-68e8-4fe4-bb94-cdb53e2e9749",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "57dc5f44-55b0-4a1e-be8b-47114ddfa6ef",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "230563a1-9639-441f-b565-162711b75db2",
-                     "description": "Group name",
-                     "name": "group",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "e3de2dfb-9594-43d8-b809-da6aa9dcc1cb",
-                     "description": "User id",
-                     "name": "userId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "74354a06-3d8b-46fc-bd2a-2ccb66866f32",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "name": "user",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  }
-               ],
+               "methodName": "addUserToGroup",
+               "jsondocId": "d679660e-a7f3-4714-a3a1-177e78e699e0",
+               "bodyobject": {
+                  "jsondocId": "f68073d9-cd03-440d-bbc9-144b528a0ae7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/addUserToGroup",
+               "response": {
+                  "jsondocId": "b1fa1dea-49b6-4de2-83df-959867963421",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "addUserToGroup"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "587cec01-b50b-4d79-b644-1b6f30afd8ae",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "8edef711-2c2f-4c7f-9f6f-b83d9cfc0a42",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "d7dbca11-fb7f-4058-8177-31bd26201324",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "2aeea3a3-d8ac-4c4d-b5c7-351e7af68ec8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "75917c4f-bdfb-4347-ad8c-f04504de4d0d",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5815b25b-5450-480b-b1b3-9c60903371b5",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "84676c1a-5235-469c-a16e-62a6917f1710",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "29148575-da2c-4f5d-9b15-546ab84f4e02",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Remove user from group",
-               "queryparameters": [
-                  {
-                     "jsondocId": "21af3236-138c-43b7-98f9-c7c872476a69",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "0e21c5f6-2c52-4789-8d99-5a8bce74bdfa",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "baadc830-4638-4886-87e0-e84795d133b9",
-                     "description": "Group name",
-                     "name": "group",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "041a150b-40d4-4a7f-85a9-2be165f8f41c",
-                     "description": "User id",
-                     "name": "userId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "00562704-9e77-4818-bad1-ddc45603ee4c",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "name": "user",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  }
-               ],
+               "methodName": "removeUserFromGroup",
+               "jsondocId": "54fcc40e-d441-4b53-8247-a738730848d3",
+               "bodyobject": {
+                  "jsondocId": "2b1c0a7e-a96b-493a-8da4-bbac4c47bdcc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/removeUserFromGroup",
+               "response": {
+                  "jsondocId": "175b3ca8-c17d-4c06-b0fa-fe30e99c667e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "removeUserFromGroup"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "520b701a-d9d3-48e1-a322-e87e98746c1e",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "f456155f-0b72-49b7-ba76-0ecf6eff4420",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "24ece09a-c73d-4bbf-8877-a3f0e35ec723",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e91c9be6-4549-4d32-be31-2a98cb0d90cb",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ec4261a2-bb45-4d71-a098-e4b2a5dd60c7",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "372a777a-2e4e-42d0-9e30-61270d261a5c",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to add",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e597957e-9923-47b5-8b29-09be952aa7d6",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "aac9efc2-d189-45a0-a82e-f4fe8abfca84",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1e22482a-d0ef-436c-891f-67c5bca60e98",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Create user",
-               "queryparameters": [
-                  {
-                     "jsondocId": "364e9ba4-f860-49be-a6b8-10a5a0f861c3",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "f1a39dde-20fc-4724-bce9-9e12ca016208",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "03af3fe1-86bd-40ac-9928-65109e85ea7a",
-                     "description": "Email of the user to add",
-                     "name": "email",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "aad01340-ff45-404a-b42c-c62c1d05e1fc",
-                     "description": "First name of user to add",
-                     "name": "firstName",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "40ee4970-b80d-4c37-824b-8e38752efadf",
-                     "description": "Last name of user to add",
-                     "name": "lastName",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  },
-                  {
-                     "jsondocId": "c2ce5c0c-51ca-44b7-99bf-ef89b0bd9d24",
-                     "description": "Password of user to add",
-                     "name": "newPassword",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "string"
-                  }
-               ],
+               "methodName": "createUser",
+               "jsondocId": "bc9ef75e-bfd9-49da-b6d1-2b5eaa9bf00a",
+               "bodyobject": {
+                  "jsondocId": "6429f2bd-e80a-4f82-b602-0a7182f6f05b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/createUser",
+               "response": {
+                  "jsondocId": "5b9c3bab-167f-4ba8-8a37-e1173ce66c1e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "createUser"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "6c58a8c0-98c9-4a11-a7f2-22199a3fa039",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "448a42aa-afe9-4848-93f8-3c282fbc095e",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "a1dc5f3f-58f3-4872-922d-1e0b73be628b",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "b814e9f0-d3c8-49e2-bb4a-07f3f4dc14c2",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4973a319-de82-4332-ab0d-d4a63019f8fb",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "31b62e33-b42c-45e5-aa9e-00b606456394",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "50d1f757-09b1-4a8e-b88e-ab1d86f80608",
+                     "name": "userToDelete",
+                     "format": "",
+                     "description": "Username (email) to delete",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
                "verb": "POST",
                "description": "Delete user",
-               "queryparameters": [
-                  {
-                     "jsondocId": "d3ef9064-5829-4729-80f2-5a7ca2a2803d",
-                     "description": "",
-                     "name": "username",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "3b530399-290b-4911-bb6f-10e1d2ee05ac",
-                     "description": "",
-                     "name": "password",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "password"
-                  },
-                  {
-                     "jsondocId": "a8a0a5d4-02ad-415f-bd50-b8a11c647f38",
-                     "description": "User ID to delete",
-                     "name": "userId",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "long"
-                  },
-                  {
-                     "jsondocId": "cf3de03a-cb74-4416-b09a-485085e3084f",
-                     "description": "Username (email) to delete",
-                     "name": "userToDelete",
-                     "allowedvalues": [],
-                     "format": "",
-                     "required": "true",
-                     "type": "email"
-                  }
-               ],
+               "methodName": "deleteUser",
+               "jsondocId": "6a21c6d9-da0a-457e-b77a-ee740510017f",
+               "bodyobject": {
+                  "jsondocId": "6e0bf224-30b8-46d7-9bae-36a6d8a7971b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/deleteUser",
+               "response": {
+                  "jsondocId": "974e12c0-18f7-4806-be6f-bf1f52e899b2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "deleteUser"
+               "consumes": ["application/json"]
             },
             {
                "headers": [],
-               "bodyobject": {
-                  "mapKeyObject": "",
-                  "jsondocId": "f61bd6ef-797f-4ec8-abe3-559cb771800a",
-                  "mapValueObject": "",
-                  "map": "",
-                  "object": "user",
-                  "multiple": "Unknow"
-               },
-               "jsondocId": "10bbd0c7-9a5e-43f6-bd97-505f22dc051e",
-               "consumes": ["application/json"],
-               "response": {
-                  "mapKeyObject": "",
-                  "jsondocId": "14481e76-acce-4732-929c-47b0c4d9542a",
-                  "mapValueObject": "",
-                  "object": "user"
-               },
                "pathparameters": [],
-               "apierrors": [],
-               "verb": "POST",
-               "description": "Update user",
                "queryparameters": [
                   {
-                     "jsondocId": "e60ce9a2-a3bc-47ee-8838-5f69257a3f97",
-                     "description": "",
+                     "jsondocId": "d5676b94-b4b0-488c-b8aa-12902d0a4190",
                      "name": "username",
-                     "allowedvalues": [],
                      "format": "",
-                     "required": "true",
-                     "type": "email"
-                  },
-                  {
-                     "jsondocId": "1b5483ad-afc9-4851-b511-2e1ffb710ad7",
                      "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "30283417-2364-4d60-a5b9-9828fdef6d67",
                      "name": "password",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "",
+                     "type": "password",
                      "required": "true",
-                     "type": "password"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d54b28fc-5652-42c2-a924-80ae2c7fc705",
-                     "description": "User ID to update",
+                     "jsondocId": "3d4d16f4-c731-4401-8789-9dad69991f52",
                      "name": "userId",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "User ID to update",
+                     "type": "long",
                      "required": "true",
-                     "type": "long"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "595b33c9-5d78-43c3-8ada-ec648b434618",
-                     "description": "Email of the user to update",
+                     "jsondocId": "73d8f2ca-3491-4518-8f06-a3212af1604b",
                      "name": "email",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "Email of the user to update",
+                     "type": "email",
                      "required": "true",
-                     "type": "email"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e1bceec5-5af4-43ae-8e3b-4d20965bb099",
-                     "description": "First name of user to update",
+                     "jsondocId": "6cbb5bf5-2c8e-48e9-bc1d-f42559ee61f9",
                      "name": "firstName",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "First name of user to update",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2830783b-2ebb-49c2-be33-9ece74d117cf",
-                     "description": "Last name of user to update",
+                     "jsondocId": "36ca9cba-c2ac-4145-af9d-8f98f57956a9",
                      "name": "lastName",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "Last name of user to update",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9dee62c-6aa4-4a0f-bfa4-a7abefbf9ac8",
-                     "description": "Password of user to update",
+                     "jsondocId": "193b8e13-a756-4337-badf-70e7ae0a3996",
                      "name": "newPassword",
-                     "allowedvalues": [],
                      "format": "",
+                     "description": "Password of user to update",
+                     "type": "string",
                      "required": "true",
-                     "type": "string"
+                     "allowedvalues": []
                   }
                ],
+               "verb": "POST",
+               "description": "Update user",
+               "methodName": "updateUser",
+               "jsondocId": "1d43778f-ab33-4a5f-b4ff-2ab53ef3141b",
+               "bodyobject": {
+                  "jsondocId": "b2f2b24d-0c7c-4397-a278-6e40cbffe248",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
                "path": "/user/updateUser",
+               "response": {
+                  "jsondocId": "1424eabb-25a8-4301-926e-77bfa7a18a55",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
                "produces": ["application/json"],
-               "methodName": "updateUser"
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "a85043d0-b7ac-46cc-94a2-7847f38342d4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d5f863de-148b-4cc3-bf96-e13b0e0e67c1",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "481cfd51-2332-4883-ad09-d831c51431be",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to modify permissions for",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8a5b5e2b-a0af-4a6c-a60b-060822f264b0",
+                     "name": "user",
+                     "format": "",
+                     "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0d09e8e9-cc6e-48b3-91fb-9582990d7966",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Name of organism to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "90302d31-44e4-4064-92b3-f21855beb77f",
+                     "name": "id",
+                     "format": "",
+                     "description": "Permission ID to update (can get from userId/organism instead)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b683455c-34f2-4108-948c-89842e9ffa30",
+                     "name": "administrate",
+                     "format": "",
+                     "description": "Indicate if user has administrative (including user/group) privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "88ac35c5-12a9-42eb-948e-6ac08db54527",
+                     "name": "write",
+                     "format": "",
+                     "description": "Indicate if user has write privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f01a6554-53d2-4491-86bb-8346f9b30ae0",
+                     "name": "export",
+                     "format": "",
+                     "description": "Indicate if user has export privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9bb0a052-977c-40ca-b992-2f2a6c51ec54",
+                     "name": "read",
+                     "format": "",
+                     "description": "Indicate if user has read privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update organism permissions",
+               "methodName": "updateOrganismPermission",
+               "jsondocId": "b76779f9-aaf5-463e-a660-ca6a63a9668a",
+               "bodyobject": {
+                  "jsondocId": "9399a6b8-6552-4db6-bbb5-55bf82b022d4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateOrganismPermission",
+               "response": {
+                  "jsondocId": "5b0a37b0-6a26-478b-8006-ab85b70b6448",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "3e185fa8-edf9-40a9-afb4-969e41dbed09",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a426dc5a-b54c-4163-938c-c4c669f7e56d",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4d00b18b-c14e-4a30-88e6-dcc63a5f6f34",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to fetch",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for user, returns an array of permission objects",
+               "methodName": "getOrganismPermissionsForUser",
+               "jsondocId": "965e6a95-86e3-41ed-86b6-f19447918100",
+               "bodyobject": {
+                  "jsondocId": "cf4ef688-ac65-419e-bd71-a0207634ea74",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/getOrganismPermissionsForUser",
+               "response": {
+                  "jsondocId": "266122d3-f421-4297-86cd-d95ab623ce86",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
             }
          ],
-         "jsondocId": "20abcaf9-5132-4aed-b343-38c2de1fb005",
-         "description": "Methods for managing users",
-         "name": "User Services"
+         "name": "User Services",
+         "description": "Methods for managing users"
       }
    ],
    "objects": [],


### PR DESCRIPTION
Fixes #829 

Adds the following API routes:

- updateAttributes
- deleteAttributes
- addDbxrefs
- updateDbxrefs
- deleteDbxrefs

Should be working fine, but I'd appreciate a sanity check on this.