### PR TITLE
Fix issue where merging fails when a transcript has a Stop Codon Read…

### DIFF
--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -2140,6 +2140,9 @@ class RequestHandlingService {
 
         JSONObject transcript2JSONObject = transcriptService.convertTranscriptsToJSON([transcript2]).getJSONObject(0)
 
+        // calculate longest ORF, to reset any changes made to the CDS, before a merge
+        featureService.setLongestORF(transcript1);
+        featureService.setLongestORF(transcript2);
         // merging transcripts
         transcriptService.mergeTranscripts(transcript1, transcript2)
         featureService.calculateCDS(transcript1)


### PR DESCRIPTION
…through; See #850 

The idea was to recalculate the longest ORF for each transcript participating in the merge (to overcome any modifications made to the CDS) and then do a merge.