### PR TITLE
Speedup fasta export

### DIFF
--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -8,7 +8,6 @@ import org.bbop.apollo.filter.Cds3Filter
 import org.bbop.apollo.filter.StopCodonFilter
 import org.bbop.apollo.sequence.SequenceTranslationHandler
 import org.bbop.apollo.sequence.Strand
-import org.bbop.apollo.sequence.Strand
 import org.bbop.apollo.alteration.SequenceAlterationInContext
 import org.bbop.apollo.sequence.TranslationTable
 import org.codehaus.groovy.grails.web.json.JSONArray
@@ -17,12 +16,7 @@ import org.codehaus.groovy.grails.web.json.JSONObject
 import org.grails.plugins.metrics.groovy.Timed
 
 
-/**
- * taken from AbstractBioFeature
- */
-//@GrailsCompileStatic
 @Transactional(readOnly = true)
-//@CompileStatic
 class FeatureService {
 
 
@@ -1335,8 +1329,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
      * @return Local coordinate, -1 if source coordinate is <= fmin or >= fmax
      */
     public int convertSourceCoordinateToLocalCoordinate(Feature feature, int sourceCoordinate) {
-        FeatureLocation featureLocation = FeatureLocation.findByFeature(feature)
-        return convertSourceCoordinateToLocalCoordinate(featureLocation.fmin,featureLocation.fmax,Strand.getStrandForValue(featureLocation.strand),sourceCoordinate)
+        return convertSourceCoordinateToLocalCoordinate(feature.featureLocation.fmin,feature.featureLocation.fmax,Strand.getStrandForValue(feature.featureLocation.strand),sourceCoordinate)
     }
 
     public int convertSourceCoordinateToLocalCoordinate(int fmin, int fmax, Strand strand, int sourceCoordinate) {
@@ -2142,11 +2135,13 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
     }
 
     List<SequenceAlteration> getSequenceAlterationsForFeature(Feature feature) {
-        int fmin = feature.fmin
-        int fmax = feature.fmax
-        Sequence sequence = feature.featureLocation.sequence
-        List<SequenceAlteration> sequenceAlterations = SequenceAlteration.executeQuery("select distinct sa from SequenceAlteration sa join sa.featureLocations fl where fl.fmin >= :fmin and fl.fmin <= :fmax or fl.fmax >= :fmin and fl.fmax <= :fmax and fl.sequence = :seqId", [fmin: fmin, fmax: fmax, seqId: sequence])
-        return sequenceAlterations
+        return SequenceAlteration.createCriteria().list {
+            featureLocations {
+                eq('sequence', feature.featureLocation.sequence)
+                le('fmax',feature.featureLocation.fmax)
+                ge('fmin',feature.featureLocation.fmin)
+            }
+        }
     }
 
 

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -2133,16 +2133,14 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
 
         return residues.toString();
     }
-
     List<SequenceAlteration> getSequenceAlterationsForFeature(Feature feature) {
-        return SequenceAlteration.createCriteria().list {
-            featureLocations {
-                eq('sequence', feature.featureLocation.sequence)
-                le('fmax',feature.featureLocation.fmax)
-                ge('fmin',feature.featureLocation.fmin)
-            }
-        }
+        int fmin = feature.fmin
+        int fmax = feature.fmax
+        Sequence sequence = feature.featureLocation.sequence
+        List<SequenceAlteration> sequenceAlterations = SequenceAlteration.executeQuery("select distinct sa from SequenceAlteration sa join sa.featureLocations fl where fl.fmin >= :fmin and fl.fmin <= :fmax or fl.fmax >= :fmin and fl.fmax <= :fmax and fl.sequence = :seqId", [fmin: fmin, fmax: fmax, seqId: sequence])
+        return sequenceAlterations
     }
+
 
 
 

--- a/grails-app/services/org/bbop/apollo/SequenceService.groovy
+++ b/grails-app/services/org/bbop/apollo/SequenceService.groovy
@@ -207,44 +207,14 @@ class SequenceService {
         int startChunkNumber = fmin / sequence.seqChunkSize;
         int endChunkNumber = (fmax - 1 ) / sequence.seqChunkSize;
 
-        def c=SequenceChunk.createCriteria()
-        def chunks=c.list() {
-            eq('sequence',sequence)
-            'in'('chunkNumber',startChunkNumber..endChunkNumber)
-            order("chunkNumber", "asc")
+        
+        for(int i = startChunkNumber ; i<= endChunkNumber ; i++){
+            sequenceString.append(loadResidueForSequence(sequence,i))
         }
-        log.debug("${chunks.size()} ${endChunkNumber-startChunkNumber+1}")
-        if(chunks.size()==endChunkNumber-startChunkNumber+1) {
-            chunks.each {
-                sequenceString.append(it.residue)
-            }
-        }
-        else {
-            for(int i = startChunkNumber ; i<= endChunkNumber ; i++){
-                SequenceChunk sequenceChunk = getSequenceChunkForChunk(sequence,i)
-                sequenceString.append(sequenceChunk.residue)
-            }
-        }
-
 
         int startPosition = fmin - (startChunkNumber * sequence.seqChunkSize);
 
         return sequenceString.substring(startPosition,startPosition + (fmax-fmin))
-    }
-
-    SequenceChunk getSequenceChunkForChunk(Sequence sequence, int i) {
-        SequenceChunk sequenceChunk = SequenceChunk.findBySequenceAndChunkNumber(sequence,i)
-        if(!sequenceChunk){
-            String residue = loadResidueForSequence(sequence,i)
-            log.debug "RESIDUE load: ${residue?.size()}"
-            sequenceChunk = new SequenceChunk(
-                    sequence: sequence
-                    ,chunkNumber: i
-                    ,residue: residue
-            ).save(flush:true)
-        }
-        log.debug "RESIDUE loaded from DB: ${sequenceChunk.residue?.size()}"
-        return sequenceChunk
     }
 
     private static String generatorSampleDNA(int size){

--- a/grails-app/services/org/bbop/apollo/SequenceService.groovy
+++ b/grails-app/services/org/bbop/apollo/SequenceService.groovy
@@ -40,13 +40,18 @@ class SequenceService {
      * @return
      */
     String getResiduesFromFeature(Feature feature) {
-        String returnResidue = getResidueFromFeatureLocation(feature.featureLocation)
-        
-        if(feature.featureLocation.strand==Strand.NEGATIVE.value){
-            returnResidue = SequenceTranslationHandler.reverseComplementSequence(returnResidue)
+        String returnResidues = ""
+        def orderedFeatureLocations = feature.featureLocations.sort { it.fmin }
+        for(FeatureLocation featureLocation in orderedFeatureLocations) {
+            String residues = getResidueFromFeatureLocation(featureLocation)
+            if(featureLocation.strand == Strand.NEGATIVE.value) {
+                returnResidues += SequenceTranslationHandler.reverseComplementSequence(residues)
+            }
+            else returnResidues += residues
         }
 
-        return returnResidue
+
+        return returnResidues
     }
 
     String getResidueFromFeatureLocation(FeatureLocation featureLocation) {

--- a/grails-app/services/org/bbop/apollo/SequenceService.groovy
+++ b/grails-app/services/org/bbop/apollo/SequenceService.groovy
@@ -39,18 +39,10 @@ class SequenceService {
      * @param feature
      * @return
      */
-    String getResiduesFromFeature(Feature feature ) {
-        List<FeatureLocation> featureLocationList = FeatureLocation.createCriteria().list {
-            eq("feature",feature)
-            order("fmin","asc")
-        }
-        String returnResidue = ""
-
-        for(FeatureLocation featureLocation in featureLocationList){
-            returnResidue += getResidueFromFeatureLocation(featureLocation)
-        }
+    String getResiduesFromFeature(Feature feature) {
+        String returnResidue = getResidueFromFeatureLocation(feature.featureLocation)
         
-        if(featureLocationList.first().strand==Strand.NEGATIVE.value){
+        if(feature.featureLocation.strand==Strand.NEGATIVE.value){
             returnResidue = SequenceTranslationHandler.reverseComplementSequence(returnResidue)
         }
 


### PR DESCRIPTION
I found several places for optimizing FASTA exports with regards to #854. With the pythium data (340 genes), the time taken is now down to about 25s with this PR (repeated runs 28s,23.7s,22.7s)


Therefore, this new method is about ~16x faster

Some notes

1) This stops using SequenceChunks table. SequenceChunks does not really do anything for us compared with just reading the sequence from file. As a comparison, if I add back SequenceChunks, then the times are ~5x longer than without it (takes 1m59s,1m52s). Still better than 6min30s for export, but again, we don't really need to query database for those chunks.

2)  The getResiduesFromFeature had support for multiple feature locations, but it did something weird where if one of the feature locations was on the negative strand, then all of the residues are flipped. That assumption seemed unnecessary, so I just made it check strand for each chunk. Multiple feature locations are currently unused in our codebase, but in any case, having this model is probably more correct

The new FASTA outputs are bit-identical to 2.0.1 according to file hashes too




