### PR TITLE
2.0.2 new changelog

### DIFF
--- a/grails-app/migrations/changelog-2.0.2.groovy
+++ b/grails-app/migrations/changelog-2.0.2.groovy
@@ -1,0 +1,7 @@
+databaseChangeLog = {
+	changeSet(author: "cmdcolin (generated)", id: "1454711582784-1") {
+        createIndex( indexName: "feature_event_s123", tableName: "feature_event", unique: "true" ) {
+            column( name: "unique_name" )
+        }
+    }
+}

--- a/grails-app/migrations/changelog-2.0.2.groovy
+++ b/grails-app/migrations/changelog-2.0.2.groovy
@@ -1,6 +1,6 @@
 databaseChangeLog = {
 	changeSet(author: "cmdcolin (generated)", id: "1454711582784-1") {
-        createIndex( indexName: "feature_event_s123", tableName: "feature_event", unique: "true" ) {
+        createIndex( indexName: "feature_event_s123", tableName: "feature_event", unique: "false" ) {
             column( name: "unique_name" )
         }
     }

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -1,5 +1,4 @@
 databaseChangeLog = {
     include file: "changelog-2.0.1.groovy"
-
-	include file: 'changelog-2.0.2.groovy'
+    include file: 'changelog-2.0.2.groovy'
 }

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -1,3 +1,5 @@
 databaseChangeLog = {
     include file: "changelog-2.0.1.groovy"
+
+	include file: 'changelog-2.0.2.groovy'
 }


### PR DESCRIPTION
This adds a stripped down groovy changelog-2.0.2.groovy and addresses #848

One important thing to note is that the createIndex command here requires "unique":false, because I tried it with true and then found some errors. I imagine it's because the history contains multiple entires for each feature's uniqueName


Some of the basic testing cases mentioned in #848 may need to be addressed but I figured I would get this code out there.
