### PR TITLE
Fix error during registering admin step

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
@@ -237,7 +237,10 @@ class AnnotatorController {
             }
             Integer index = Integer.parseInt(request)
 
-            if(!organism) render ([:] as JSON)
+            if(!organism) {
+                render ([:] as JSON)
+                return
+            }
 
             List<String> viewableTypes
 

--- a/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
@@ -237,6 +237,8 @@ class AnnotatorController {
             }
             Integer index = Integer.parseInt(request)
 
+            if(!organism) render ([:] as JSON)
+
             List<String> viewableTypes
 
             if (type) {


### PR DESCRIPTION
There are some situations where registering the admin user produces an error

![screenshot-genomes missouri edu 8080 2016-02-09 10-01-03 png resize](https://cloud.githubusercontent.com/assets/6511937/12921928/0bd96b5c-cf15-11e5-8d60-33749a4bef11.png)

This appears to happen because findAnnotationsForSequence is called even though no organisms exist

It produces the "blocking" popup box that is very annoying and prevents any further actions

Note that this does not always happen, sometimes registering admin is still allowed, but being proactive about preventing it seems necessary
