### PR TITLE
Fix error when getSequences is called during login

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
@@ -170,6 +170,8 @@ class SequenceController {
     def getSequences(String name, Integer start, Integer length, String sort, Boolean asc, Integer minFeatureLength, Integer maxFeatureLength) {
         try {
             Organism organism = preferenceService.getCurrentOrganismForCurrentUser()
+
+            if(!organism) return ([] as JSON)
             def sequences = Sequence.createCriteria().list() {
                 if(name) {
                     ilike('name', '%'+name+'%')
@@ -179,6 +181,9 @@ class SequenceController {
                 lt('length',maxFeatureLength ?: Integer.MAX_VALUE)
                 if(sort=="length") {
                     order('length',asc?"asc":"desc")
+                }
+                if(sort=="name") {
+                    order('name', asc?"asc":"desc")
                 }
             }
             def sequenceCounts = Feature.executeQuery("select fl.sequence.name, count(fl.sequence.id) from Feature f join f.featureLocations fl where fl.sequence.organism = :organism and fl.sequence.length < :maxFeatureLength and fl.sequence.length > :minFeatureLength and f.class in :viewableAnnotationList group by fl.sequence.name", [minFeatureLength: minFeatureLength ?: 0, maxFeatureLength: maxFeatureLength ?: Integer.MAX_VALUE, viewableAnnotationList: requestHandlingService.viewableAnnotationList, organism: organism])

--- a/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
@@ -171,7 +171,10 @@ class SequenceController {
         try {
             Organism organism = preferenceService.getCurrentOrganismForCurrentUser()
 
-            if(!organism) return ([] as JSON)
+            if(!organism) {
+                render ([] as JSON)
+                return
+            }
             def sequences = Sequence.createCriteria().list() {
                 if(name) {
                     ilike('name', '%'+name+'%')


### PR DESCRIPTION
This is a bug that is similar to #862, because every time the login screen is presented, the GWT calls getSequences anyways, which fails with this error


```
2016-02-09 09:56:05,269 [http-nio-8080-exec-24] ERROR errors.GrailsExceptionResolver  - IllegalArgumentException occurred when processing request: [POST] /Apollo202mod/sequence
/getSequences/
Named parameter [organism] value may not be null. Stacktrace follows:
java.lang.IllegalArgumentException: Named parameter [organism] value may not be null
    at org.bbop.apollo.SequenceController.$tt__getSequences(SequenceController.groovy:187)
    at grails.plugin.cache.web.filter.PageFragmentCachingFilter.doFilter(PageFragmentCachingFilter.java:198)
    at grails.plugin.cache.web.filter.AbstractFilter.doFilter(AbstractFilter.java:63)
    at org.apache.shiro.web.servlet.AbstractShiroFilter.executeChain(AbstractShiroFilter.java:449)
    at org.apache.shiro.web.servlet.AbstractShiroFilter$1.call(AbstractShiroFilter.java:365)
    at org.apache.shiro.subject.support.SubjectCallable.doCall(SubjectCallable.java:90)
    at org.apache.shiro.subject.support.SubjectCallable.call(SubjectCallable.java:83)
```

 
Therefore, we can return blank results in this case to avoid an error on the server side. This error does not affect any usability, but is good to avoid fatal errors overwhelming logfiles

Also note, the name sort on the sequence names was missing so I added that here too