### PR TITLE
Optimize FASTA even further

### DIFF
--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -14,6 +14,7 @@ import org.codehaus.groovy.grails.web.json.JSONArray
 import org.codehaus.groovy.grails.web.json.JSONException
 import org.codehaus.groovy.grails.web.json.JSONObject
 import org.grails.plugins.metrics.groovy.Timed
+import org.hibernate.FlushMode
 
 
 @Transactional(readOnly = true)
@@ -32,6 +33,7 @@ class FeatureService {
     def sequenceService
     def permissionService
     def overlapperService
+    def sessionFactory
 
 
     @Timed
@@ -2137,7 +2139,11 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         int fmin = feature.fmin
         int fmax = feature.fmax
         Sequence sequence = feature.featureLocation.sequence
+        sessionFactory.currentSession.flushMode=FlushMode.MANUAL
+        
         List<SequenceAlteration> sequenceAlterations = SequenceAlteration.executeQuery("select distinct sa from SequenceAlteration sa join sa.featureLocations fl where fl.fmin >= :fmin and fl.fmin <= :fmax or fl.fmax >= :fmin and fl.fmax <= :fmax and fl.sequence = :seqId", [fmin: fmin, fmax: fmax, seqId: sequence])
+        sessionFactory.currentSession.flushMode=FlushMode.AUTO
+        
         return sequenceAlterations
     }
 

--- a/grails-app/services/org/bbop/apollo/SequenceService.groovy
+++ b/grails-app/services/org/bbop/apollo/SequenceService.groovy
@@ -217,27 +217,12 @@ class SequenceService {
     String loadResidueForSequence(Sequence sequence, int chunkNumber) {
         CRC32 crc = new CRC32();
         crc.update(sequence.name.getBytes());
-        String hex = String.format("%08x", crc.getValue());
-        String []dirs = splitStringByNumberOfCharacters(hex, 3);
+        String hex = String.format("%08x", crc.getValue())
+        String []dirs = hex.toList().collate( 3 )*.join()
         String seqDir = String.format("%s/seq/%s/%s/%s", sequence.organism.directory, dirs[0], dirs[1], dirs[2]);
         String filePath = seqDir+ "/"+ sequence.name + "-" + chunkNumber + ".txt"
 
         return new File(filePath).getText().toUpperCase()
-    }
-
-    private String[] splitStringByNumberOfCharacters(String str, int numOfChars) {
-        int numTokens = str.length() / numOfChars;
-        if (str.length() % numOfChars != 0) {
-            ++numTokens;
-        }
-        String []tokens = new String[numTokens];
-        int idx = 0;
-        for (int i = 0; i < numTokens; ) {
-            tokens[i] = str.substring(idx, idx + numOfChars < str.length() ? idx + numOfChars : str.length());
-            ++i
-            idx += numOfChars
-        }
-        return tokens;
     }
 
 

--- a/grails-app/services/org/bbop/apollo/SequenceService.groovy
+++ b/grails-app/services/org/bbop/apollo/SequenceService.groovy
@@ -218,11 +218,15 @@ class SequenceService {
         CRC32 crc = new CRC32();
         crc.update(sequence.name.getBytes());
         String hex = String.format("%08x", crc.getValue())
-        String []dirs = hex.toList().collate( 3 )*.join()
+        String []dirs = splitStringByNumberOfCharacters(hex, 3)
         String seqDir = String.format("%s/seq/%s/%s/%s", sequence.organism.directory, dirs[0], dirs[1], dirs[2]);
         String filePath = seqDir+ "/"+ sequence.name + "-" + chunkNumber + ".txt"
 
         return new File(filePath).getText().toUpperCase()
+    }
+
+    String[] splitStringByNumberOfCharacters(String label, int size) {
+        return label.toList().collate(size)*.join()
     }
 
 

--- a/test/integration/org/bbop/apollo/SequenceServiceIntegrationSpec.groovy
+++ b/test/integration/org/bbop/apollo/SequenceServiceIntegrationSpec.groovy
@@ -5,6 +5,8 @@ import grails.test.spock.IntegrationSpec
 import org.bbop.apollo.gwt.shared.FeatureStringEnum
 import org.codehaus.groovy.grails.web.json.JSONObject
 import spock.lang.Ignore
+import java.util.zip.CRC32
+
 
 class SequenceServiceIntegrationSpec extends IntegrationSpec {
     
@@ -47,7 +49,6 @@ class SequenceServiceIntegrationSpec extends IntegrationSpec {
         assert MRNA.count == 1
         assert Exon.count == 1
         assert CDS.count == 1
-//        assert FeatureLocation.count == 4 + FlankingRegion.count
         assert FeatureRelationship.count == 3
 
         String getSequenceString = "{\"operation\":\"get_sequence\",\"features\":[{\"uniquename\":\"@UNIQUENAME@\"}],\"track\":\"Group1.10\",\"type\":\"@SEQUENCE_TYPE@\"}"
@@ -344,7 +345,17 @@ class SequenceServiceIntegrationSpec extends IntegrationSpec {
         assert Gene.count == 1
         assert MRNA.count == 1
         assert Exon.count == 6
-        
+   
+        when: "we getSequences"
+        CRC32 crc = new CRC32();
+        crc.update("Group1.1".getBytes());
+        String hex = String.format("%08x", crc.getValue())
+
+        then: "it is split appropriately"
+        String []dirs = sequenceService.splitStringByNumberOfCharacters(hex, 3)
+        assert dirs == ['e15','221','82']
+
+
         when: "we call getResiduesForFeature"
         String geneSequence = sequenceService.getResiduesFromFeature(Gene.findByName("GB40744-RA"))
         


### PR DESCRIPTION
Currently the FASTA export still seems to have bottlenecks, and I was seeing it take a very long time on the honeybee datasets with only modest amounts of genes (with 172 genes, it took over 14 minutes and sometimes never finished).

I looked at the flamegraph and found that the main time that was being taken up was during getSequenceAlterationsForFeature



![screenshot- domain date time](https://cloud.githubusercontent.com/assets/6511937/12924077/ff40b7de-cf1d-11e5-8c59-70c729144d56.png)



Specifically, there is a step where hibernate appears to want to flush some data before calling the HQL. As a workaround, simply disabling this "flush" step saves a lot of time during exports.


Before this fix, as reported in #858, time for exporting FASTA on 341 pythium genes took ~24 seconds, now it takes about ~5 seconds (see graph below)

![out](https://cloud.githubusercontent.com/assets/6511937/12925732/5a7ab03a-cf25-11e5-9f9d-a480414f6a6a.png)


This seems modest, but for honeybee, the gains are more dramatic, over 14x faster, and sometimes, when trying to export before this fix was applied, it would literally just never finish after running for hours.


![out2](https://cloud.githubusercontent.com/assets/6511937/12925734/5df2ffba-cf25-11e5-849c-ec6c558eaf20.png)



