### PR TITLE
Re-enable "Delete organism" button on annotator panel

### DIFF
--- a/docs/Command_line.md
+++ b/docs/Command_line.md
@@ -35,6 +35,8 @@ This command can accept an -output argument to output to file, or the stdout can
 The -username and -password can be specified via the command line (similar to `get_gff3.groovy`) or if omitted, the user
 will be prompted.
 
+The -seqtype parameter can be "cds", "cdna", or "peptide"
+
 ### add_users.groovy
 
 
@@ -80,5 +82,18 @@ docs/web_services/examples/groovy/delete_annotations_from_organism.groovy  -dest
 
 This script will delete any annotations associated with a given organism.
 
+
+
+### delete_organism.groovy
+
+Example:
+
+```
+docs/web_services/examples/groovy/delete_organism.groovy  -url http://localhost:8080/apollo\
+     -organism honeybee -username admin@webapollo.com -password admin_password
+```
+
+This script can be used to delete all organism information including the annotations from it. You can also specify the 
+-featuresOnly flag to only remove the features from the organism.
 
 

--- a/docs/Command_line.md
+++ b/docs/Command_line.md
@@ -93,7 +93,9 @@ docs/web_services/examples/groovy/delete_organism.groovy  -url http://localhost:
      -organism honeybee -username admin@webapollo.com -password admin_password
 ```
 
-This script can be used to delete all organism information including the annotations from it. You can also specify the 
--featuresOnly flag to only remove the features from the organism.
+This script can be used to delete all organism information including the annotations from it.
+
+The -username and -password refer to the admin user, and they can also be specified via stdin instead of the command
+line if they are omitted.
 
 

--- a/docs/web_services/examples/groovy/delete_organism.groovy
+++ b/docs/web_services/examples/groovy/delete_organism.groovy
@@ -9,10 +9,10 @@ import org.json.JSONObject
 
 String usageString = "delete_organism.groovy <options>\n" +
         "Example: " +
-        "./add_organism.groovy -name yeast -url http://localhost:8080/apollo/\n"+
+        "./delete_organism.groovy -name yeast -url http://localhost:8080/apollo/\n"+
         "which would prompt for user/pass\n"+
         "-or-\n"+
-        "./add_organism.groovy -name yeast -url http://localhost:8080/apollo/ -username user@site.com -password secret"
+        "./delete_organism.groovy -name yeast -url http://localhost:8080/apollo/ -username user@site.com -password secret"
 
 def cli = new CliBuilder(usage: usageString)
 cli.setStopAtNonOption(true)
@@ -21,7 +21,6 @@ cli.name('organism common name', required: true, args: 1)
 cli.username('username', required: false, args: 1)
 cli.password('password', required: false, args: 1)
 cli.ignoressl('Use this flag to ignore SSL issues', required: false)
-cli.featuresOnly('Use this flag to only delete the features', required: false)
 OptionAccessor options
 def admin_username
 def admin_password 
@@ -62,28 +61,13 @@ def argumentsArray = [
 
 def client = new RESTClient(options.url)
 if (options.ignoressl) { client.ignoreSSLIssues() }
-String fullPath = "${url.path}/organism/deleteOrganismFeatures"
 
 
-println "Deleting organism features"
+println "Deleting organism"
+String fullPath = "${url.path}/organism/deleteOrganism"
 def resp = client.post(
         contentType: 'text/javascript',
         path: fullPath,
         body: argumentsArray
 )
-
 assert resp.status == 200  // HTTP response code; 404 means not found, etc.
-println resp.getData()
-
-
-
-if(!options.featuresOnly) {
-    println "Deleting organism"
-    fullPath = "${url.path}/organism/deleteOrganism"
-    resp = client.post(
-            contentType: 'text/javascript',
-            path: fullPath,
-            body: argumentsArray
-    )
-    assert resp.status == 200  // HTTP response code; 404 means not found, etc.
-}

--- a/docs/web_services/examples/groovy/delete_organism.groovy
+++ b/docs/web_services/examples/groovy/delete_organism.groovy
@@ -17,7 +17,7 @@ String usageString = "delete_organism.groovy <options>\n" +
 def cli = new CliBuilder(usage: usageString)
 cli.setStopAtNonOption(true)
 cli.url('URL to Apollo instance', required: true, args: 1)
-cli.name('organism common name', required: true, args: 1)
+cli.organism('organism name', required: true, args: 1)
 cli.username('username', required: false, args: 1)
 cli.password('password', required: false, args: 1)
 cli.ignoressl('Use this flag to ignore SSL issues', required: false)
@@ -27,7 +27,7 @@ def admin_password
 try {
     options = cli.parse(args)
 
-    if (!(options?.url && options?.name)) {
+    if (!(options?.url && options?.organism)) {
         return
     }
 
@@ -54,7 +54,7 @@ URL url = new URL(s)
 
 
 def argumentsArray = [
-        organism: options.name,
+        organism: options.organism,
         username  : admin_username,
         password  : admin_password,
 ]

--- a/docs/web_services/examples/groovy/delete_organism.groovy
+++ b/docs/web_services/examples/groovy/delete_organism.groovy
@@ -1,0 +1,89 @@
+#!/usr/bin/env groovy
+
+@Grab(group = 'org.json', module = 'json', version = '20140107')
+@Grab(group = 'org.codehaus.groovy.modules.http-builder', module = 'http-builder', version = '0.7.2')
+
+import groovyx.net.http.RESTClient
+import org.json.JSONObject
+
+
+String usageString = "delete_organism.groovy <options>\n" +
+        "Example: " +
+        "./add_organism.groovy -name yeast -url http://localhost:8080/apollo/\n"+
+        "which would prompt for user/pass\n"+
+        "-or-\n"+
+        "./add_organism.groovy -name yeast -url http://localhost:8080/apollo/ -username user@site.com -password secret"
+
+def cli = new CliBuilder(usage: usageString)
+cli.setStopAtNonOption(true)
+cli.url('URL to Apollo instance', required: true, args: 1)
+cli.name('organism common name', required: true, args: 1)
+cli.username('username', required: false, args: 1)
+cli.password('password', required: false, args: 1)
+cli.ignoressl('Use this flag to ignore SSL issues', required: false)
+cli.featuresOnly('Use this flag to only delete the features', required: false)
+OptionAccessor options
+def admin_username
+def admin_password 
+try {
+    options = cli.parse(args)
+
+    if (!(options?.url && options?.name)) {
+        return
+    }
+
+    def cons = System.console()
+    if (!(admin_username=options?.username)) {
+        admin_username = new String(cons.readPassword('Enter admin username: ') )
+    }
+    if (!(admin_password=options?.password)) {
+        admin_password = new String(cons.readPassword('Enter admin password: ') )
+    }
+
+} catch (e) {
+    println(e)
+    return
+}
+
+
+def s=options.url
+if (s.endsWith("/")) {
+    s = s.substring(0, s.length() - 1);
+}
+
+URL url = new URL(s)
+
+
+def argumentsArray = [
+        organism: options.name,
+        username  : admin_username,
+        password  : admin_password,
+]
+
+def client = new RESTClient(options.url)
+if (options.ignoressl) { client.ignoreSSLIssues() }
+String fullPath = "${url.path}/organism/deleteOrganismFeatures"
+
+
+println "Deleting organism features"
+def resp = client.post(
+        contentType: 'text/javascript',
+        path: fullPath,
+        body: argumentsArray
+)
+
+assert resp.status == 200  // HTTP response code; 404 means not found, etc.
+println resp.getData()
+
+
+
+if(!options.featuresOnly) {
+    println "Deleting organism"
+    fullPath = "${url.path}/organism/deleteOrganism"
+    resp = client.post(
+            contentType: 'text/javascript',
+            path: fullPath,
+            body: argumentsArray
+    )
+    assert resp.status == 200  // HTTP response code; 404 means not found, etc.
+}

--- a/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
@@ -95,7 +95,7 @@ class OrganismController {
             Organism organism = Organism.findByCommonName(organismJson.organism)
 
             if (!organism) {
-                organism = Organism.findById(organismJson.organism)
+                organism = Organism.findById(organismJson.organism?:organismJson.id)
             }
 
             if (!organism) {
@@ -286,7 +286,7 @@ class OrganismController {
             if(organismJson.organism) {
                 log.debug "finding info for specific organism"
                 Organism organism=Organism.findByCommonName(organismJson.organism)
-                if(!organism) organism=Organism.findById(organismJson.organism)
+                if(!organism) organism=Organism.findById(organismJson.organism?:organismJson.id)
                 if(!organism) render ([error:"Organism not found"] as JSON)
                 List<PermissionEnum> permissionEnumList = permissionService.getOrganismPermissionsForUser(organism,permissionService.getCurrentUser(organismJson))
                 if(permissionEnumList.contains(PermissionEnum.ADMINISTRATE)){

--- a/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
@@ -52,9 +52,10 @@ class OrganismController {
                 }
                 if (organism) {
                     UserOrganismPreference.deleteAll(UserOrganismPreference.findAllByOrganism(organism))
+                    organismService.deleteAllFeatureEventsForOrganism(organism)
                     organism.delete()
+                    log.info "Success deleting organism: ${organismJson.id}"
                 }
-                log.info "Success deleting organism: ${organismJson.id}"
                 render findAllOrganisms()
             } else {
                 def error = [error: 'not authorized to delete organism']

--- a/grails-app/services/org/bbop/apollo/OrganismService.groovy
+++ b/grails-app/services/org/bbop/apollo/OrganismService.groovy
@@ -40,4 +40,28 @@ class OrganismService {
         organism.save(flush: true )
         return list.size()
     }
+    def deleteAllFeatureEventsForOrganism(Organism organism) {
+        def list=Feature.withCriteria() {
+            featureLocations {
+                sequence {
+                    eq("organism",organism)
+                }
+            }
+        }
+
+
+        def uniqueNames=list.collect {
+            it.uniqueName
+        }
+
+        def events=FeatureEvent.withCriteria() {
+            'in'("uniqueName",uniqueNames)
+        }
+
+        events.each {
+            it.delete()
+        }
+
+        return list.size()
+    }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
@@ -133,7 +133,6 @@ public class OrganismPanel extends Composite {
             }
         });
         dataGrid.addColumn(sequenceColumn, safeHtmlHeader);
-//        dataGrid.addColumn(sequenceColumn, "Ref Sequences");
         dataGrid.setEmptyTableWidget(new Label("No organisms available. Add new organisms using the form field."));
 
 
@@ -229,6 +228,19 @@ public class OrganismPanel extends Composite {
         deleteButton.setEnabled(isEditable);
     }
 
+    private class DeleteFeaturesCallback implements RequestCallback {
+
+        @Override
+        public void onResponseReceived(Request request, Response response) {
+            OrganismRestService.deleteOrganism(new UpdateInfoListCallback(), singleSelectionModel.getSelectedObject());
+        }
+
+        @Override
+        public void onError(Request request, Throwable exception) {
+            loadingDialog.hide();
+            Bootbox.alert("Error deleteing features: " + exception);
+        }
+    }
     private class UpdateInfoListCallback implements RequestCallback {
 
         @Override
@@ -333,11 +345,7 @@ public class OrganismPanel extends Composite {
     public void handleDeleteOrganism(ClickEvent clickEvent) {
         OrganismInfo organismInfo = singleSelectionModel.getSelectedObject();
         if (organismInfo == null) return;
-        if (organismInfo.getNumFeatures() > 0) {
-            new ErrorDialog("Cannot delete organism '" + organismInfo.getName() + "'", "You must first remove " + singleSelectionModel.getSelectedObject().getNumFeatures() + " annotations before deleting organism '"+organismInfo.getName()+"'.  Please see our <a href='../WebServices/'>Web Services API</a> from the 'Help' menu for more details on how to perform this operation, or use <a href='http://webapollo.readthedocs.org/en/latest/Command_line.html'>delete_organism.groovy</a> from the command line.", true, true);
-            return;
-        }
-        Bootbox.confirm("Are you sure you want to delete organism " + singleSelectionModel.getSelectedObject().getName() + "?", new ConfirmCallback() {
+        Bootbox.confirm("Are you sure you want to delete organism " + organismInfo.getName() + " with "+organismInfo.getNumFeatures() +" annotations?", new ConfirmCallback() {
             @Override
             public void callback(boolean result) {
                 if (result) {

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
@@ -228,19 +228,6 @@ public class OrganismPanel extends Composite {
         deleteButton.setEnabled(isEditable);
     }
 
-    private class DeleteFeaturesCallback implements RequestCallback {
-
-        @Override
-        public void onResponseReceived(Request request, Response response) {
-            OrganismRestService.deleteOrganism(new UpdateInfoListCallback(), singleSelectionModel.getSelectedObject());
-        }
-
-        @Override
-        public void onError(Request request, Throwable exception) {
-            loadingDialog.hide();
-            Bootbox.alert("Error deleteing features: " + exception);
-        }
-    }
     private class UpdateInfoListCallback implements RequestCallback {
 
         @Override

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
@@ -334,7 +334,7 @@ public class OrganismPanel extends Composite {
         OrganismInfo organismInfo = singleSelectionModel.getSelectedObject();
         if (organismInfo == null) return;
         if (organismInfo.getNumFeatures() > 0) {
-            new ErrorDialog("Cannot delete organism '" + organismInfo.getName() + "'", "You must first remove " + singleSelectionModel.getSelectedObject().getNumFeatures() + " annotations before deleting organism '"+organismInfo.getName()+"'.  Please see our <a href='../WebServices/'>Web Services API</a> from the 'Help' menu for more details on how to perform this operation in bulk.", true, true);
+            new ErrorDialog("Cannot delete organism '" + organismInfo.getName() + "'", "You must first remove " + singleSelectionModel.getSelectedObject().getNumFeatures() + " annotations before deleting organism '"+organismInfo.getName()+"'.  Please see our <a href='../WebServices/'>Web Services API</a> from the 'Help' menu for more details on how to perform this operation, or use <a href='http://webapollo.readthedocs.org/en/latest/Command_line.html'>delete_organism.groovy</a> from the command line.", true, true);
             return;
         }
         Bootbox.confirm("Are you sure you want to delete organism " + singleSelectionModel.getSelectedObject().getName() + "?", new ConfirmCallback() {


### PR DESCRIPTION
When the user clicks the "delete organism" button from the sidebar, they are not able to delete the organism if it has annotations, and instead get a pop-up box redirecting them to web services docs.  This seems sort of inadequate because they don't even really get a hint about why they are redirected there or what to do with it (It just says, "Please see our Web Services API from the 'Help' menu for more details on how to perform this operation in bulk.")

As it turns out, the whole process of "operation in bulk" is sort of antiquated anyways, because we don't actually have to delete all annotations before deleting the organism anyways. If you recall, we had made this whole "redirect user to web services guide" pop-up because "fetchMode: eager" was enabled on the featureLocations table, which made everything unstable, but it was reverted (ref #637). Now, you can delete the organism by itself perfectly well.

Therefore, we can re-enable the button to delete organism instead of redirecting them to the WebServices. We also add a method to delete the featureEvents associated with the organism in /organism/deleteOrganism too, since that was part of the "bulk operation"

