### PR TITLE
Fix white background on select box. See #870

### DIFF
--- a/src/gwt/org/bbop/apollo/gwt/client/MainPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/MainPanel.ui.xml
@@ -52,7 +52,7 @@
             margin-left: 5px;
             margin-right: 5px;
             display: inline-table;
-            background-color: gray;
+            background-color: gray !important;
             color: white;
             font-size: smaller;
             height: 25px;
@@ -89,7 +89,6 @@
                         <gwt:ListBox ui:field="organismListBox" styleName="{style.dropdown-display}"/>
                         <gwt:SuggestBox ui:field="sequenceSuggestBox" stylePrimaryName="{style.lookup-display}"/>
                         <b:Panel styleName="pull-right">
-                            <!--<gwt:HTML ui:field="userName" styleName="{style.username}"/>-->
                             <b:Button ui:field="userName" icon="USER"/>
                             <b:Button ui:field="logoutButton" styleName="{style.logout-button}" icon="SIGN_OUT" title="Logout"/>
                         </b:Panel>

--- a/src/gwt/org/bbop/apollo/gwt/client/MainPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/MainPanel.ui.xml
@@ -37,22 +37,28 @@
             font-size: smaller;
         }
 
+        .dropdown-display:focus {
+            background-color: gray;
+        }
         .dropdown-display {
             margin-left: 5px;
             margin-right: 5px;
             display: inline-table;
-            background: gray !important;
+            background: gray;
             color: white;
             font-size: smaller;
             height: 25px;
             width: 100px;
         }
 
+        .lookup-display:focus {
+            background-color: gray;
+        }
         .lookup-display {
             margin-left: 5px;
             margin-right: 5px;
             display: inline-table;
-            background-color: gray !important;
+            background-color: gray;
             color: white;
             font-size: smaller;
             height: 25px;

--- a/src/gwt/org/bbop/apollo/gwt/client/MainPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/MainPanel.ui.xml
@@ -41,7 +41,7 @@
             margin-left: 5px;
             margin-right: 5px;
             display: inline-table;
-            background-color: gray;
+            background: gray !important;
             color: white;
             font-size: smaller;
             height: 25px;


### PR DESCRIPTION
I found that the OS added a default background-color: white when the select box was selected, and since text color was white, it created the effect seen in #870 

This PR just adds the background-color: gray when element is focused

