### PR TITLE
Fix error with annotator panel on IE11

### DIFF
--- a/src/gwt/org/bbop/apollo/gwt/client/MainPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/MainPanel.ui.xml
@@ -13,7 +13,7 @@
         }
 
         .details-button {
-            display: inline-table;
+            display: inline;
             cursor: pointer;
         }
 
@@ -33,14 +33,14 @@
         }
 
         .username {
-            display: inline-table;
+            display: inline;
             font-size: smaller;
         }
 
         .dropdown-display {
             margin-left: 5px;
             margin-right: 5px;
-            display: inline-table;
+            display: inline;
             background-color: gray;
             color: white;
             font-size: smaller;
@@ -51,7 +51,7 @@
         .lookup-display {
             margin-left: 5px;
             margin-right: 5px;
-            display: inline-table;
+            display: inline;
             background-color: gray;
             color: white;
             font-size: smaller;


### PR DESCRIPTION
I was testing #872 on a bunch of different platforms and found that the top of the annotator panel did not show up in IE11 on Win7

![virtualbox_ie11 - win7_12_02_2016_13_26_43](https://cloud.githubusercontent.com/assets/6511937/13019493/6dc25b44-d195-11e5-82d4-2bda4cd835c3.png)


This issue with the annotator panel and IE11 also seemed to affect WA2.0.1.

The reason for the bug is that the form elements were being rendered in weird places off the screen entirely.

I made a fix for this that that changes "display: inline-table" to just use "display:inline", so now it appears fixed. 

![virtualbox_ie11 - win7_12_02_2016_14_36_30](https://cloud.githubusercontent.com/assets/6511937/13019597/066276fe-d196-11e5-8ad8-a829e0f75e9c.png)


