### PR TITLE
Add full feature list to WebApolloCanvasFeatures. See #868

### DIFF
--- a/client/apollo/js/View/Track/WebApolloCanvasFeatures.js
+++ b/client/apollo/js/View/Track/WebApolloCanvasFeatures.js
@@ -8,8 +8,8 @@ define( [
             'dijit/MenuSeparator',
             'dijit/PopupMenuItem',
             'dijit/Dialog',
-            'JBrowse/Util', 
-            'JBrowse/Model/SimpleFeature', 
+            'JBrowse/Util',
+            'JBrowse/Model/SimpleFeature',
             'WebApollo/SequenceOntologyUtils'
         ],
         function( declare,
@@ -17,12 +17,12 @@ define( [
             CanvasFeaturesTrack,
             FeatureSelectionManager,
             dijitMenu,
-            dijitMenuItem, 
+            dijitMenuItem,
             dijitCheckedMenuItem,
             dijitMenuSeparator,
             dijitPopupMenuItem,
             dijitDialog,
-            Util, 
+            Util,
             SimpleFeature,
             SeqOnto )
 {
@@ -62,35 +62,42 @@ return declare( CanvasFeaturesTrack,
                      var atrack=thisB.webapollo.getAnnotTrack();
                      atrack.createGenericAnnotations([this.feature], "repeat_region", null, "gene");
                    }
-                },               
+                },
                 {
                   "label" : "transposable element",
                   "action" : function() {
                      var atrack=thisB.webapollo.getAnnotTrack();
                      atrack.createGenericAnnotations([this.feature], "transposable_element", null, "gene");
                    }
-                },               
+                },
+                {
+                  "label" : "tRNA",
+                  "action" : function() {
+                     var atrack=thisB.webapollo.getAnnotTrack();
+                     atrack.createGenericAnnotations([this.feature], "tRNA", null, "gene");
+                   }
+                },
                 {
                   "label" : "snRNA",
                   "action" : function() {
                      var atrack=thisB.webapollo.getAnnotTrack();
                      atrack.createGenericAnnotations([this.feature], "snRNA", null, "gene");
                    }
-                },               
+                },
                 {
                   "label" : "miRNA",
                   "action" : function() {
                      var atrack=thisB.webapollo.getAnnotTrack();
                      atrack.createGenericAnnotations([this.feature], "miRNA", null, "gene");
                    }
-                },               
+                },
                 {
                   "label" : "rRNA",
                   "action" : function() {
                      var atrack=thisB.webapollo.getAnnotTrack();
                      atrack.createGenericAnnotations([this.feature], "rRNA", null, "gene");
                    }
-                },               
+                },
                 {
                   "label" : "snoRNA",
                   "action" : function() {
@@ -103,7 +110,7 @@ return declare( CanvasFeaturesTrack,
         );
         return config;
     }
-                    
+
 
 });
 

--- a/client/apollo/js/View/Track/WebApolloCanvasFeatures.js
+++ b/client/apollo/js/View/Track/WebApolloCanvasFeatures.js
@@ -57,20 +57,6 @@ return declare( CanvasFeaturesTrack,
                   }
                 },
                 {
-                  "label" : "repeat_region",
-                  "action" : function() {
-                     var atrack=thisB.webapollo.getAnnotTrack();
-                     atrack.createGenericAnnotations([this.feature], "repeat_region", null, "gene");
-                   }
-                },
-                {
-                  "label" : "transposable element",
-                  "action" : function() {
-                     var atrack=thisB.webapollo.getAnnotTrack();
-                     atrack.createGenericAnnotations([this.feature], "transposable_element", null, "gene");
-                   }
-                },
-                {
                   "label" : "tRNA",
                   "action" : function() {
                      var atrack=thisB.webapollo.getAnnotTrack();
@@ -85,10 +71,17 @@ return declare( CanvasFeaturesTrack,
                    }
                 },
                 {
-                  "label" : "miRNA",
+                  "label" : "snoRNA",
                   "action" : function() {
                      var atrack=thisB.webapollo.getAnnotTrack();
-                     atrack.createGenericAnnotations([this.feature], "miRNA", null, "gene");
+                     atrack.createGenericAnnotations([this.feature], "snoRNA", null, "gene");
+                   }
+                },
+                {
+                  "label" : "ncRNA",
+                  "action" : function() {
+                     var atrack=thisB.webapollo.getAnnotTrack();
+                     atrack.createGenericAnnotations([this.feature], "ncRNA", null, "gene");
                    }
                 },
                 {
@@ -99,10 +92,24 @@ return declare( CanvasFeaturesTrack,
                    }
                 },
                 {
-                  "label" : "snoRNA",
+                  "label" : "miRNA",
                   "action" : function() {
                      var atrack=thisB.webapollo.getAnnotTrack();
-                     atrack.createGenericAnnotations([this.feature], "snoRNA", null, "gene");
+                     atrack.createGenericAnnotations([this.feature], "miRNA", null, "gene");
+                   }
+                },
+                {
+                  "label" : "repeat_region",
+                  "action" : function() {
+                     var atrack=thisB.webapollo.getAnnotTrack();
+                     atrack.createGenericAnnotations([this.feature], "repeat_region", null, "gene");
+                   }
+                },
+                {
+                  "label" : "transposable element",
+                  "action" : function() {
+                     var atrack=thisB.webapollo.getAnnotTrack();
+                     atrack.createGenericAnnotations([this.feature], "transposable_element", null, "gene");
                    }
                 }
               ]


### PR DESCRIPTION
The tRNA option was missing from the canvas features as reported in #868. ncRNA was missing too, so that is added back as well. The order matches the order on the DraggableHTMLFeatures.

![screenshot-localhost 8080 2016-02-15 13-15-20 1 png resize](https://cloud.githubusercontent.com/assets/6511937/13058095/539014c0-d3e6-11e5-832d-bba74180baed.png)


