### PR TITLE
#844 was adding a json object as a database table

### DIFF
--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -1177,7 +1177,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
                             newDB,
                             dbxref.getString(FeatureStringEnum.ACCESSION.value)
                     ).save()
-                    gsolFeature.addToFeatureDBXrefs(dbxref)
+                    gsolFeature.addToFeatureDBXrefs(newDBXref)
                     gsolFeature.save()
                 }
             }


### PR DESCRIPTION
@cmdcolin   Can you take a quick look at this to confirm?   

I tested it via an export of a fully annotated export of a gff3 (including GFF3).  Fixing this allowed the export.

Thanks. 