### PR TITLE
Avoid creating requests to web services when user is not logged in

### DIFF
--- a/src/gwt/org/bbop/apollo/gwt/client/AnnotatorPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/AnnotatorPanel.java
@@ -106,8 +106,6 @@ public class AnnotatorPanel extends Composite {
     private MultiWordSuggestOracle sequenceOracle = new ReferenceSequenceOracle();
 
     private static AsyncDataProvider<AnnotationInfo> dataProvider;
-    //    private static List<AnnotationInfo> annotationInfoList = new ArrayList<>();
-    //    private static List<AnnotationInfo> filteredAnnotationList = dataProvider.getList();
     private final Set<String> showingTranscripts = new HashSet<String>();
 
     public AnnotatorPanel() {
@@ -217,8 +215,10 @@ public class AnnotatorPanel extends Composite {
                     }
                 };
                 try {
-                    builder.setCallback(requestCallback);
-                    builder.send();
+                    if(MainPanel.getInstance().getCurrentUser()!=null) {
+                        builder.setCallback(requestCallback);
+                        builder.send();
+                    }
                 } catch (RequestException e) {
                     // Couldn't connect to server
                     Bootbox.alert(e.getMessage());
@@ -343,7 +343,9 @@ public class AnnotatorPanel extends Composite {
                 Bootbox.alert("Error retrieving users: " + exception.fillInStackTrace());
             }
         };
-        UserRestService.loadUsers(requestCallback);
+        if(MainPanel.getInstance().getCurrentUser()!=null) {
+            UserRestService.loadUsers(requestCallback);
+        }
     }
 
     private void initializeTypes() {

--- a/src/gwt/org/bbop/apollo/gwt/client/GroupPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GroupPanel.java
@@ -177,9 +177,10 @@ public class GroupPanel extends Composite {
             }
         });
 
-        GroupRestService.loadGroups(groupInfoList);
-
-        UserRestService.loadUsers(allUsersList);
+        if(MainPanel.getInstance().getCurrentUser()!=null) {
+            GroupRestService.loadGroups(groupInfoList);
+            UserRestService.loadUsers(allUsersList);
+        }
     }
 
     @UiHandler("updateUsers")
@@ -379,7 +380,9 @@ public class GroupPanel extends Composite {
     }
 
     public void reload() {
-        GroupRestService.loadGroups(groupInfoList);
+        if(MainPanel.getInstance().getCurrentUser()!= null) {
+            GroupRestService.loadGroups(groupInfoList);
+        }
 //        dataGrid.redraw();
     }
 

--- a/src/gwt/org/bbop/apollo/gwt/client/UserPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/UserPanel.java
@@ -628,7 +628,9 @@ public class UserPanel extends Composite {
     }
 
     public void reload() {
-        UserRestService.loadUsers(userInfoList);
+        if(MainPanel.getInstance().getCurrentUser()!=null) {
+            UserRestService.loadUsers(userInfoList);
+        }
         dataGrid.redraw();
     }
 


### PR DESCRIPTION
Currently when you visit an Apollo instance, several requests for web services are launched when the user is not logged in which creates errors in the javascript console and in the catalina logs

Javascript console
```
XMLHttpRequest.java:305POST http://localhost:8080/apollo/user/loadUsers/ 401 (Unauthorized)
JSONParser.java:200Uncaught java.lang.IllegalArgumentException: empty argument
XMLHttpRequest.java:305POST http://localhost:8080/apollo/user/loadUsers/ 500 (Internal Server Error)
XMLHttpRequest.java:305POST http://localhost:8080/apollo/group/loadGroups/ 500 (Internal Server Error)
```


Server logs
```
2016-02-19 16:30:19,273 [http-bio-8080-exec-9] WARN  apollo.AnnotatorController  - Permission exception: User has no access to an organism and/or is not admin
| Error 2016-02-19 16:17:46,992 [http-bio-8080-exec-12] ERROR apollo.UserController  - {error=User does not have permission for any organisms.}
| Error 2016-02-19 16:17:46,992 [http-bio-8080-exec-1] ERROR apollo.GroupController  - {error=User does not have permission for any organisms.}
```

I think it is preferable to just not create those warnings/errors so we can just avoid launching those web service requests