### PR TITLE
Fix typo

### DIFF
--- a/grails-app/services/org/bbop/apollo/NonCanonicalSplitSiteService.groovy
+++ b/grails-app/services/org/bbop/apollo/NonCanonicalSplitSiteService.groovy
@@ -275,7 +275,7 @@ class NonCanonicalSplitSiteService {
 
 
     private NonCanonicalThreePrimeSpliceSite createNonCanonicalThreePrimeSpliceSite(Transcript transcript, int position) {
-        String uniqueName = transcript.getUniqueName() + "-non_canonical_three_prive_splice_site-" + position;
+        String uniqueName = transcript.getUniqueName() + "-non_canonical_three_prime_splice_site-" + position;
         NonCanonicalThreePrimeSpliceSite spliceSite = new NonCanonicalThreePrimeSpliceSite(
                 uniqueName: uniqueName
                 ,name: uniqueName


### PR DESCRIPTION
There was a typo in the data types for non-canonical splice sites.

I don't think it would affect any past data and just look better on future data