### PR TITLE
Fix draggable alignments style

### DIFF
--- a/client/apollo/css/maker_styles.css
+++ b/client/apollo/css/maker_styles.css
@@ -429,17 +429,12 @@
 
 
 .Apollo .feature {
-    height: 16px;
-    background-color: transparent;
     background-image: none;
 }
  
 .Apollo .generic_parent {
-    height: 16px;
-    background-color: transparent;
     background-image: none;
 }
-
 
 .Apollo .transcript, .plus-transcript, .minus-transcript {
     background: white;


### PR DESCRIPTION
The current draggable alignments style was modified when we made the maker2jbrowse patch. I'm reverting some of that change, which reduces the prettyness of maker2jbrowse style a bit, but that can be addressed later most likely.

Ref #785




