### PR TITLE
Add style for fixing both bam reads and transcripts

### DIFF
--- a/client/apollo/css/maker_styles.css
+++ b/client/apollo/css/maker_styles.css
@@ -439,3 +439,10 @@
 .Apollo .transcript, .plus-transcript, .minus-transcript {
     background: white;
 }
+
+.Apollo .plus-feature {
+    background-color: transparent;
+}
+.Apollo .minus-feature {
+    background-color: transparent;
+}

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -98,7 +98,9 @@ return declare( [JBPlugin, HelpMixin],
         if (browser.cookie("colorCdsByFrame")=="true") {
             domClass.add(win.body(), "colorCds");
         }
-        domClass.add(win.body(), "Apollo");
+        if(!browser.config.overrideApolloStyles) {
+            domClass.add(win.body(), "Apollo");
+        }
         if (browser.config.favicon) {
             // this.setFavicon("plugins/WebApollo/img/webapollo_favicon.ico");
             this.setFavicon(browser.config.favicon);


### PR DESCRIPTION
This updates the fixes in #897 to preserve the improved styles on track features from #785

This also creates a config option called "overrideApolloStyles" which can, in the event of a "CSS emergency", disable the entire stylesheet, and go back to having the chevrons and whatnot.



Screenshot with RNA-seq BAM and features

![screenshot-localhost 8080 2016-03-01 18-17-18](https://cloud.githubusercontent.com/assets/6511937/13446630/a69ec76a-dfda-11e5-83c8-0c18817adc4d.png)
 


 