### PR TITLE
Use more readable colors for canvasfeatures dark theme

### DIFF
--- a/client/apollo/js/View/Track/WebApolloCanvasFeatures.js
+++ b/client/apollo/js/View/Track/WebApolloCanvasFeatures.js
@@ -15,7 +15,6 @@ define( [
         function( declare,
             array,
             CanvasFeaturesTrack,
-            FeatureSelectionManager,
             dijitMenu,
             dijitMenuItem,
             dijitCheckedMenuItem,
@@ -36,8 +35,17 @@ return declare( CanvasFeaturesTrack,
         }));
     },
     _defaultConfig: function() {
-        console.log("WA config");
-        var config= this.inherited(arguments);
+        console.log("WA config",document.body);
+        var config = Util.deepUpdate(dojo.clone(this.inherited(arguments)),
+            {
+                style: {
+                    textColor: function() { return dojo.hasClass(document.body,'Dark') ?'white': 'black'; },
+                    text2Color: function() { return dojo.hasClass(document.body,'Dark')? 'white': 'black'; },
+                    text2Color: function() { return dojo.hasClass(document.body,'Dark') ?'white' :'black'; },
+                    connectorColor: function() { return dojo.hasClass(document.body,'Dark')? 'lightgrey': 'black'; },
+                    color: function() { return dojo.hasClass(document.body,'Dark')? 'orange': 'goldenrod'; }
+                }
+            });
         var thisB=this;
         config.menuTemplate.push(            {
               "label" : "Create new annotation",

--- a/client/apollo/js/View/Track/WebApolloCanvasFeatures.js
+++ b/client/apollo/js/View/Track/WebApolloCanvasFeatures.js
@@ -40,8 +40,7 @@ return declare( CanvasFeaturesTrack,
             {
                 style: {
                     textColor: function() { return dojo.hasClass(document.body,'Dark') ?'white': 'black'; },
-                    text2Color: function() { return dojo.hasClass(document.body,'Dark')? 'white': 'black'; },
-                    text2Color: function() { return dojo.hasClass(document.body,'Dark') ?'white' :'black'; },
+                    text2Color: function() { return dojo.hasClass(document.body,'Dark')? 'LightSteelBlue': 'blue'; },
                     connectorColor: function() { return dojo.hasClass(document.body,'Dark')? 'lightgrey': 'black'; },
                     color: function() { return dojo.hasClass(document.body,'Dark')? 'orange': 'goldenrod'; }
                 }


### PR DESCRIPTION
Checks for the dark theme and creates special styles on CanvasFeatures tracks

Note that it uses this "Util.deepUpdate" which is a nice way where the user can override the config in their trackList.json, but we supply the default value in _defaultConfig


