### PR TITLE
Make Apollo work with 'bare' features without subfeatures

### DIFF
--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -970,7 +970,6 @@ define([
                     var singleParent = keys.length == 1;
                     var featureToAdd;
                     if (singleParent) {
-
                         featureToAdd = JSONUtils.makeSimpleFeature(parentFeatures[keys[0]]);
                     }
                     else {
@@ -999,8 +998,12 @@ define([
                         }
                         featureToAdd.get("subfeatures").push(dragfeat);
                     });
-                    featureToAdd.set("start", fmin);
-                    featureToAdd.set("end", fmax);
+                    if(!subfeatures.length) {
+                        featureToAdd = new SimpleFeature({data: {strand: strand, start: featureToAdd.get('start'), end: featureToAdd.get('end'), subfeatures: [featureToAdd]}});
+                    }
+
+                    if(fmin) featureToAdd.set("start", fmin);
+                    if(fmax) featureToAdd.set("end", fmax);
                     var afeat = JSONUtils.createApolloFeature(featureToAdd, "mRNA", true);
                     featuresToAdd.push(afeat);
 


### PR DESCRIPTION
In the SPARQL thread, we had examples of a SPARQL query that created features without subfeatures, which was something Apollo rejected.

Reasons it rejected it

- it would assign fmin and fmax to undefined
- it would not initialize a needed subfeature used for calculating the ORFs

This fixes fmin/fmax and initializes a subfeature to allow the bare features to be annotated

Ref #827

Note this scenario is basically the same as the CDS with no parent on the volvox sample browser http://jbrowse.org/code/JBrowse-1.11.6/?data=sample_data%2Fjson%2Fvolvox&loc=ctgA%3A2376..24986&tracks=DNA%2Cvolvox_vcf_test%2CCDS&highlight=


