### PR TITLE
Add watchman configuration

### DIFF
--- a/apollo
+++ b/apollo
@@ -66,12 +66,16 @@ function check_configs_for_release(){
     check_perldependencies
 }
 
+
 function check_configs(){
 
     grails_executable=$(which grails)
     gradle_executable=$(which gradle)
     git_executable=$(which git)
-
+    watchman_executable=$(which watchman)
+    if ! [ -x "$watchman_executable" ] ; then
+        echo "Watchman not found. Install watchman to automatically update the client side plugins for apollo development modes"
+    fi
     if ! [ -x "$grails_executable" ] ; then
 	   if [ -f 'grailsw' ]; then 
 		   echo "Grails not found using grailsw";
@@ -103,7 +107,8 @@ if [[ $1 == "devmode" ]];then
     # should call the copy target first
     check_configs
     $gradle_executable devmode &
-    $grails_executable -reloading run-app  
+    $grails_executable -reloading run-app
+    if [ -x "$watchman_executable" ]; then $watchman_executable -- trigger $(PWD) jsfilescopy 'client/apollo/**/*.js' -- scripts/copy_client.sh; fi;
 elif [[ $1 == "run-local" ]];then
     # should call the copy target first
     check_configs
@@ -112,6 +117,7 @@ elif [[ $1 == "run-local" ]];then
     else
         $gradle_executable handleJBrowse copy-resources gwtc && $grails_executable run-app
     fi
+    if [ -x "$watchman_executable" ]; then $watchman_executable -- trigger $(PWD) jsfilescopy 'client/apollo/**/*.js' -- scripts/copy_client.sh; fi;
 elif [[ $1 == "debug" ]];then
     # TODO: feel like there is a better way to do this
     OLD_MAVEN_OPTS=$MAVEN_OPTS
@@ -121,6 +127,7 @@ elif [[ $1 == "debug" ]];then
     $grails_executable -reloading debug
     export MAVEN_OPTS=$OLD_MAVEN_OPTS
     unset OLD_MAVEN_OPTS
+    if [ -x "$watchman_executable" ]; then $watchman_executable -- trigger $(PWD) jsfilescopy 'client/apollo/**/*.js' -- scripts/copy_client.sh; fi;
 elif [[ $1 == "test" ]];then
     # should call the copy target first
     check_configs


### PR DESCRIPTION
This sets up a "watchman" when using standard apollo development commands.

The watchman software checks for filesystem changes and in this case runs script/copy_client.sh


This helps client side plugin development by not having to manually copy over files