### PR TITLE
Add jshint checker for client side plugin

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,29 @@
+{
+    "asi": true,      //allow missing semicolon
+    "-W041": false,
+    "-W009": false,
+    "-W010": false,
+    "-W018":false,    //incorrect use of !
+    "-W032":false,    //unnecessary semicolon allowed
+    "expr": true,     // allow returning assignment expressions
+    "boss": true,     // allow if statement assignment expressions
+    "browser": true,
+    "dojo": true,
+    "evil": true,     // allow eval
+    "laxbreak": true,
+    "laxcomma": true,
+    "loopfunc": true,
+    "funcscope": true,
+    "maxlen": 10000,
+    "indent": 4,
+    "shadow": true,
+    "maxerr": 250,
+    "sub": true,
+    "predef": [ "require", "define", "SockJS", "Stomp", "bbop", "amigo" ],
+    "maxcomplexity": 40,
+    "indent": 2,
+    "undef": true,
+    "trailing": true,
+    "devel": true
+}
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
 services:
 - postgresql
 - mysql
+before_install:
+- npm install -g jshint
 before_script:
 - if [ ${DB} == "mysql" ]; then cp config/mysql.travis apollo-config.groovy; mysql -e 'create database apollo'; fi;
 - if [ ${DB} == "postgres" ]; then cp config/postgres.travis apollo-config.groovy; psql -c 'create database apollo;' -U postgres; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ cache:
 script:
     - ./gradlew copy-resources gwtc && ./grailsw refresh-dependencies --stacktrace && ./grailsw test-app --stacktrace
     - node web-app/jbrowse/src/dojo/dojo.js load=build --require "web-app/jbrowse/src/JBrowse/init.js" --profile "web-app/jbrowse/plugins/WebApollo/js/WebApollo"
+    - jshint client/apollo/js

--- a/client/apollo/js/EUtils.js
+++ b/client/apollo/js/EUtils.js
@@ -10,6 +10,7 @@ function EUtils(contextPath, errorHandler) {
 
 EUtils.prototype.validateId = function(db, id) {
 	var valid;
+    var thisB = this;
 	dojo.xhrGet( {
 		url: this.url + "&operation=search&db=" + db + "&id=" + id,
 		handleAs: "json",
@@ -19,7 +20,7 @@ EUtils.prototype.validateId = function(db, id) {
 			valid = !response.eSearchResult.ErrorList;
 		}, 
 		error: function(response, ioArgs) {
-			errorHandler(response);
+			thisB.errorHandler(response);
 		}
 	});
 	return valid;
@@ -27,6 +28,7 @@ EUtils.prototype.validateId = function(db, id) {
 
 EUtils.prototype.fetch = function(db, id) {
 	var record;
+    var thisB = this;
 	dojo.xhrGet( {
 		url: this.url + "&operation=fetch&db=" + db + "&id=" + id,
 		handleAs: "json",
@@ -36,7 +38,7 @@ EUtils.prototype.fetch = function(db, id) {
 			record = response.PubmedArticleSet.PubmedArticle ? response : null;
 		}, 
 		error: function(response, ioArgs) {
-			errorHandler(response);
+			thisB.errorHandler(response);
 		}
 	});
 	return record;

--- a/client/apollo/js/EUtils.js
+++ b/client/apollo/js/EUtils.js
@@ -4,50 +4,50 @@ define( [
 function( declare ) {
 
 function EUtils(contextPath, errorHandler) {
-	this.url = contextPath + "/ProxyService?proxy=eutils";
-	this.errorHandler = errorHandler;
+    this.url = contextPath + "/ProxyService?proxy=eutils";
+    this.errorHandler = errorHandler;
 };
 
 EUtils.prototype.validateId = function(db, id) {
-	var valid;
+    var valid;
     var thisB = this;
-	dojo.xhrGet( {
-		url: this.url + "&operation=search&db=" + db + "&id=" + id,
-		handleAs: "json",
-		timeout: 5000 * 1000, // Time in milliseconds
-		sync: true,
-		load: function(response, ioArgs) {
-			valid = !response.eSearchResult.ErrorList;
-		}, 
-		error: function(response, ioArgs) {
-			thisB.errorHandler(response);
-		}
-	});
-	return valid;
+    dojo.xhrGet( {
+        url: this.url + "&operation=search&db=" + db + "&id=" + id,
+        handleAs: "json",
+        timeout: 5000 * 1000, // Time in milliseconds
+        sync: true,
+        load: function(response, ioArgs) {
+            valid = !response.eSearchResult.ErrorList;
+        }, 
+        error: function(response, ioArgs) {
+            thisB.errorHandler(response);
+        }
+    });
+    return valid;
 };
 
 EUtils.prototype.fetch = function(db, id) {
-	var record;
+    var record;
     var thisB = this;
-	dojo.xhrGet( {
-		url: this.url + "&operation=fetch&db=" + db + "&id=" + id,
-		handleAs: "json",
-		timeout: 5000 * 1000, // Time in milliseconds
-		sync: true,
-		load: function(response, ioArgs) {
-			record = response.PubmedArticleSet.PubmedArticle ? response : null;
-		}, 
-		error: function(response, ioArgs) {
-			thisB.errorHandler(response);
-		}
-	});
-	return record;
+    dojo.xhrGet( {
+        url: this.url + "&operation=fetch&db=" + db + "&id=" + id,
+        handleAs: "json",
+        timeout: 5000 * 1000, // Time in milliseconds
+        sync: true,
+        load: function(response, ioArgs) {
+            record = response.PubmedArticleSet.PubmedArticle ? response : null;
+        }, 
+        error: function(response, ioArgs) {
+            thisB.errorHandler(response);
+        }
+    });
+    return record;
 };
 
 return EUtils;
 
 });
-	
+    
 /*
 define( [
             'dojo/_base/declare',
@@ -61,21 +61,21 @@ function EUtils() {
 };
 
 EUtils.validateId = function(db, id, success, error) {
-	dojoScript.get({
-		url: "http://jsonproxy.appspot.com/proxy",
-		callbackParamName: "callback",
-		content: {
-			url: eutilsUrl + "?db=" + db + "&term=" + id + "[uid]",
-		},
-		load: function(response) {
-			response.eSearchResult.ErrorList ? error("Invalid " + db + " ID: " + id) : success();
-		}
-	});
+    dojoScript.get({
+        url: "http://jsonproxy.appspot.com/proxy",
+        callbackParamName: "callback",
+        content: {
+            url: eutilsUrl + "?db=" + db + "&term=" + id + "[uid]",
+        },
+        load: function(response) {
+            response.eSearchResult.ErrorList ? error("Invalid " + db + " ID: " + id) : success();
+        }
+    });
 
 };
 
 return EUtils;
-	
+    
 });
 
 */

--- a/client/apollo/js/FormatUtils.js
+++ b/client/apollo/js/FormatUtils.js
@@ -8,7 +8,7 @@ function() {
         var year = date.getFullYear();
         var month = date.getMonth() + 1;
         var day = ("" + date.getDate()).length == 1 ? "0" + date.getDate() : date.getDate();
-        if (new String(month).length == 1) {
+        if (String(month).length == 1) {
             month = "0" + month;
         }
         return year + "-" + month + "-" + day;

--- a/client/apollo/js/SequenceSearch.js
+++ b/client/apollo/js/SequenceSearch.js
@@ -103,7 +103,7 @@ searchSequence: function(trackName, refSeqName, starts) {
                     return;
                 }
                 ok = true;
-                for(key in response.sequence_search_tools) {
+                for(var key in response.sequence_search_tools) {
                     if (response.sequence_search_tools.hasOwnProperty(key)) {
                         dojo.create("option", { innerHTML: response.sequence_search_tools[key].name, id: key }, sequenceToolsSelect);
                     }

--- a/client/apollo/js/Store/SeqFeature/ScratchPad.js
+++ b/client/apollo/js/Store/SeqFeature/ScratchPad.js
@@ -3,57 +3,35 @@ define( ['dojo/_base/declare',
         ],
         function( declare, SeqFeatureStore ) {
 
-// return declare( "testScratchPadClass", SeqFeatureStore,
 return declare( SeqFeatureStore,
 {
     constructor: function( args ) {
         this.refSeq = args.refSeq;
         this.features = {};
-	this.sorted_feats = [];
+        this.sorted_feats = [];
         this._calculateStats();
     },
 
     insert: function( feature ) {
         this.features[ feature.id() ] = feature;
-//	this._sort();
         this._calculateStats();
     },
 
     replace: function( feature ) {
-	this.features[ feature.id() ] = feature;
-//	this._sort();
+        this.features[ feature.id() ] = feature;
         this._calculateStats();
     }, 
 
-/*    _sort: function()  {
-	sorted_feats.sort(function(a, b) {
-	    var astart = a.get('start');
-	    var bstart = b.get('start');
-            if (astart != bstart)  {
-		return astart - bstart;
-	    }
-            else {
-		return b.get('end') - a.get('end');
-	    }
-	} );
-    }, 
-*/
-
-/*
-    delete: function( feature ) {
-	this.deleteFeatureById[ feature.id() ];
-    },
-*/
 
     deleteFeatureById: function( id ) {
-	delete  this.features[ id ];
+        delete  this.features[ id ];
         this._calculateStats();
     },
     
 
     /* if feature with given id is present in store, return it.  Otherwise return null */
     getFeatureById: function( id )  {
-	return this.features[ id ];
+        return this.features[ id ];
     },
 
     _calculateStats: function() {

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -2028,8 +2028,8 @@ define([
                     innerHTML: "Delete",
                     'class': "annotation_info_editor_button"
                 }, dbxrefButtons);
-		var dbxrefss="Use this field if this model has Cross-references in other databases (e.g. the GenBank Accession number of a cDNA from this gene from the same species). Do NOT use this field to list IDs of models from other species that you used as annotation evidence.";
-		new Tooltip({
+        var dbxrefss="Use this field if this model has Cross-references in other databases (e.g. the GenBank Accession number of a cDNA from this gene from the same species). Do NOT use this field to list IDs of models from other species that you used as annotation evidence.";
+        new Tooltip({
                         connectId: dbxrefsDiv,
                         label: dbxrefss,
                         position: ["above"],
@@ -2075,8 +2075,8 @@ define([
                     innerHTML: "Delete",
                     'class': "annotation_info_editor_button"
                 }, pubmedIdButtons);
-		var pubmedss="Use this field if this model has been mentioned in a publication. Do NOT use this field to list publications on models from other species that you used as annotation evidence.";
-		new Tooltip({
+        var pubmedss="Use this field if this model has been mentioned in a publication. Do NOT use this field to list publications on models from other species that you used as annotation evidence.";
+        new Tooltip({
                         connectId: pubmedIdsDiv,
                         label: dbxrefss,
                         position: ["above"],
@@ -2244,7 +2244,7 @@ define([
                             initPubmedIds(feature, config);
                             initGoIds(feature, config);
                             initComments(feature, config);
-			    
+                
                         }
                     });
                 };

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -2028,13 +2028,13 @@ define([
                     innerHTML: "Delete",
                     'class': "annotation_info_editor_button"
                 }, dbxrefButtons);
-        var dbxrefss="Use this field if this model has Cross-references in other databases (e.g. the GenBank Accession number of a cDNA from this gene from the same species). Do NOT use this field to list IDs of models from other species that you used as annotation evidence.";
-        new Tooltip({
-                        connectId: dbxrefsDiv,
-                        label: dbxrefss,
-                        position: ["above"],
-                        showDelay: 600
-                    });
+                var dbxrefss="Use this field if this model has Cross-references in other databases (e.g. the GenBank Accession number of a cDNA from this gene from the same species). Do NOT use this field to list IDs of models from other species that you used as annotation evidence.";
+                new Tooltip({
+                    connectId: dbxrefsDiv,
+                    label: dbxrefss,
+                    position: ["above"],
+                    showDelay: 600
+                });
 
                 var attributesDiv = dojo.create("div", {'class': "annotation_info_editor_section"}, content);
                 var attributesLabel = dojo.create("div", {
@@ -2075,13 +2075,13 @@ define([
                     innerHTML: "Delete",
                     'class': "annotation_info_editor_button"
                 }, pubmedIdButtons);
-        var pubmedss="Use this field if this model has been mentioned in a publication. Do NOT use this field to list publications on models from other species that you used as annotation evidence.";
-        new Tooltip({
-                        connectId: pubmedIdsDiv,
-                        label: dbxrefss,
-                        position: ["above"],
-                        showDelay: 600
-                    });
+                var pubmedss="Use this field if this model has been mentioned in a publication. Do NOT use this field to list publications on models from other species that you used as annotation evidence.";
+                new Tooltip({
+                    connectId: pubmedIdsDiv,
+                    label: dbxrefss,
+                    position: ["above"],
+                    showDelay: 600
+                });
                 var goIdsDiv = dojo.create("div", {'class': "annotation_info_editor_section"}, content);
                 var goIdsLabel = dojo.create("div", {
                     'class': "annotation_info_editor_section_header",

--- a/client/apollo/js/View/Track/AnnotTrackSocket.js
+++ b/client/apollo/js/View/Track/AnnotTrackSocket.js
@@ -3,246 +3,246 @@ define( [
             'dojo/request/xhr',
             'dojox/socket'
 ], 
-	function( declare, xhr, Socket ) {
+    function( declare, xhr, Socket ) {
 
-	var maxTries = 5;
-	
-	var AnnotTrackSocket = declare ( null, {
-	
-		constructor: function(contextPath, track) {
-			this.contextPath = contextPath;
-			this.track = track;
-			this.tryNum = 0;
-			this.socketSupport = this.hasWebSocketSupport();
-			this.open();
-		},
-	
-		open: function() {
-			if (this.socketSupport) {
-				this._initWebSocket();
-			}
-			else {
-				this._initLongPoll();
-			}
-		},
-	
-		close: function() {
-			if (this.socketSupport) {
-				if (this.socket) {
-					this.socket.close();
-				}
-			}
-			else {
-				if (this.socket && !this.socket.isResolved() ) {
-					this.socket.cancel();
-				}
-			}
-		},
-	
-		send: function(updateData, loadCallback) {
-			var track = this.track;
-			var socket = this;
-		    if (!this.socket) {
-		    	this.track.handleError({responseText: '{ "error": "Server connection error - try reloading the page" }'});
-		    	return;
-		    }
-		    if (this.socketSupport) {
-		    	this.socket.send(updateData);
-		    }
-		    else {
+    var maxTries = 5;
+    
+    var AnnotTrackSocket = declare ( null, {
+    
+        constructor: function(contextPath, track) {
+            this.contextPath = contextPath;
+            this.track = track;
+            this.tryNum = 0;
+            this.socketSupport = this.hasWebSocketSupport();
+            this.open();
+        },
+    
+        open: function() {
+            if (this.socketSupport) {
+                this._initWebSocket();
+            }
+            else {
+                this._initLongPoll();
+            }
+        },
+    
+        close: function() {
+            if (this.socketSupport) {
+                if (this.socket) {
+                    this.socket.close();
+                }
+            }
+            else {
+                if (this.socket && !this.socket.isResolved() ) {
+                    this.socket.cancel();
+                }
+            }
+        },
+    
+        send: function(updateData, loadCallback) {
+            var track = this.track;
+            var socket = this;
+            if (!this.socket) {
+                this.track.handleError({responseText: '{ "error": "Server connection error - try reloading the page" }'});
+                return;
+            }
+            if (this.socketSupport) {
+                this.socket.send(updateData);
+            }
+            else {
                 alert('Web sockets are not support by this browser');
-		        //if (!this.socket || this.socket.isResolved() ) {
-		        //	track.handleError({responseText: '{ "error": "Server connection error - try reloading the page" }'});
-		        //	return;
-		        //}
-		        //xhr(socket.contextPath + "/AnnotationEditorService", {
-		        //	method: "post",
-		        //	data: updateData,
-		        //	handleAs: "json"
-		        //}).then(function(response) {
-		        //	if (loadCallback) {
-		        //		loadCallback(response);
-		        //	}
-		        //	if (response && response.alert) {
-		        //		alert(response.alert);
-		        //	}
-		        //}, function(response) {
-		        //	track.handleError(response);
-		        //});
-		
-		    }
-		},
-	
-		hasWebSocketSupport: function() {
-		    return "WebSocket" in window || "MozWebSocket" in window;
-		},
-	
-		_initWebSocket: function() {
-			var track = this.track;
-		    //this.socket = new Socket(this.contextPath + "/AnnotationEditor/" + track.getUniqueTrackName());
+                //if (!this.socket || this.socket.isResolved() ) {
+                //  track.handleError({responseText: '{ "error": "Server connection error - try reloading the page" }'});
+                //  return;
+                //}
+                //xhr(socket.contextPath + "/AnnotationEditorService", {
+                //  method: "post",
+                //  data: updateData,
+                //  handleAs: "json"
+                //}).then(function(response) {
+                //  if (loadCallback) {
+                //      loadCallback(response);
+                //  }
+                //  if (response && response.alert) {
+                //      alert(response.alert);
+                //  }
+                //}, function(response) {
+                //  track.handleError(response);
+                //});
+        
+            }
+        },
+    
+        hasWebSocketSupport: function() {
+            return "WebSocket" in window || "MozWebSocket" in window;
+        },
+    
+        _initWebSocket: function() {
+            var track = this.track;
+            //this.socket = new Socket(this.contextPath + "/AnnotationEditor/" + track.getUniqueTrackName());
             this.socket = new Socket(this.contextPath + "/AnnotationNotification/incoming");
-		    var socket = this;
-		    this.socket.on("message", function(event) {
-		    	socket.tryNum = 0;
-		    	var response = JSON.parse(event.data);
-		        if (response.confirm) {
-		            if (track.handleConfirm(response.confirm)) {
-		            	var json = { track : response.track, features: response.features, operation: response.operation, confirm: true };
-		            	var postData = JSON.stringify(json);
-		            	track.executeUpdateOperation(postData);
-		            }
-		        }
-		        else if (response.error) {
-		        	track.handleError({ response: { data: response } });
-		        }
-		        else {
-		        	socket._handleUpdate(response);
-		        }
-		    });
-		
-		    this.socket.on("close", function(event) {
-		    	switch (event.code) {
-		    	case 1000:
-		        	var reason = event.reason;
-		        	if (reason == "Logged out") {
-		    			track.hide();
-		    			track.changed();
-		    			track.handleError({responseText: '{ "error": "Logged out" }'});
-		    			window.location.reload();
-		        	}
-		        	break;
-		    	case 1001:
-					track.handleError({responseText: '{ "error": "Server connection error" }'});
-					window.location.reload();
-					break;
-				default:
-		    		if (socket.tryNum < maxTries) {
-		    			window.setTimeout(function() {
-		    				socket.tryNum++;
-		    				socket._initWebSocket();
-		    			}, socket.tryNum * 500);
-		    		}
-		    		else {
-		    			track.handleError({responseText: '{ "error": "Server connection error" }'});
-		    			window.location.reload();
-		    		}
-					break;
-		    	}
-		    });
-		    
-		},
-	
-		_initLongPoll: function() {
-			var track = this.track;
-			var socket = this;
-		    this.socket = xhr( socket.contextPath + "/AnnotationChangeNotificationService", {
-		    	query: { track: track.getUniqueTrackName() },
-		        handleAs: "json",
-		        preventCache: true, 
-		        timeout: 5 * 60 * 1000
-		    }).then(function(response) {
-		    	if (response != null) {
-		    		socket._handleUpdate(response);
-		    	}
-		    	socket.tryNum = 0;
-	    		socket._initLongPoll();
-		    }, function(response, ioArgs) {
-		    	// client cancel
-		    	if (response.dojoType == "cancel") {
-		    		return;
-		    	}
-		    	// client timeout
-		    	if (response.dojoType == "timeout") {
-		    		socket._initLongPoll();
-		    		return;
-		    	}
-		    	if (response.response.status == 0) {
-		    		if (socket.tryNum < maxTries) {
-		    			window.setTimeout(function() {
-		    				socket.tryNum++;
-		    				socket._initLongPoll();
-		    			}, socket.tryNum * 500);
-		    			return;
-		    		}
-		    		else {
-		    			track.handleError({responseText: '{ "error": "Server connection error" }'});
-		    			window.location.reload();
-		    			return;
-		    		}
-		    	}
-		    	// bad gateway
-		    	if (response.response.status == 502) {
-		    		socket._initLongPoll();
-		    		return;
-		    	}
-		    	// server killed
-		    	if (response.response.status == 503) {
-		    		track.handleError({responseText: '{ "error": "Server connection error" }'});
-		    		window.location.reload();
-		    		return;
-		    	}
-		    	// server timeout
-		    	else if (response.response.status == 504){
-		    		socket._initLongPoll();
-		    		return;
-		    	}
-		    	// forbidden
-		    	else if (response.response.status == 403) {
-		    		track.hide();
-		    		track.changed();
-		    		track.handleError({responseText: '{ "error": "Logged out" }'});
-		    		window.location.reload();
-		    		return;
-		    	}
-		    	// actual error
-		    	if (response.responseText) {
-		    		track.handleError(response);
-		    		track.comet_working = false;
-		    		console.error("HTTP status code: ", response.response.status); //
-		    		return response;
-		    	}
-		    	// everything else
-		    	else {
-		    		track.handleError({responseText: '{ "error": "Server connection error" }'});
-		    		return;
-		    	}
-		    });
-		
-		},
-	
-		_handleUpdate: function(response) {
-			var track = this.track;
-			for (var i in response) {
-				var changeData = response[i];
-				if (changeData.operation == "ADD") {
-					if (changeData.sequenceAlterationEvent) {
-						track.getSequenceTrack().annotationsAddedNotification(changeData.features);
-					}
-					else {
-						track.annotationsAddedNotification(changeData.features);
-					}
-				}
-				else if (changeData.operation == "DELETE") {
-					if (changeData.sequenceAlterationEvent) {
-						track.getSequenceTrack().annotationsDeletedNotification(changeData.features);
-					}
-					else {
-						track.annotationsDeletedNotification(changeData.features);
-					}
-				}
-				else if (changeData.operation == "UPDATE") {
-					if (changeData.sequenceAlterationEvent) {
-						track.getSequenceTrack().annotationsUpdatedNotification(changeData.features);
-					}
-					else {
-						track.annotationsUpdatedNotification(changeData.features);
-					}
-				}
-			}
-			track.changed();
-		}
-	});
+            var socket = this;
+            this.socket.on("message", function(event) {
+                socket.tryNum = 0;
+                var response = JSON.parse(event.data);
+                if (response.confirm) {
+                    if (track.handleConfirm(response.confirm)) {
+                        var json = { track : response.track, features: response.features, operation: response.operation, confirm: true };
+                        var postData = JSON.stringify(json);
+                        track.executeUpdateOperation(postData);
+                    }
+                }
+                else if (response.error) {
+                    track.handleError({ response: { data: response } });
+                }
+                else {
+                    socket._handleUpdate(response);
+                }
+            });
+        
+            this.socket.on("close", function(event) {
+                switch (event.code) {
+                case 1000:
+                    var reason = event.reason;
+                    if (reason == "Logged out") {
+                        track.hide();
+                        track.changed();
+                        track.handleError({responseText: '{ "error": "Logged out" }'});
+                        window.location.reload();
+                    }
+                    break;
+                case 1001:
+                    track.handleError({responseText: '{ "error": "Server connection error" }'});
+                    window.location.reload();
+                    break;
+                default:
+                    if (socket.tryNum < maxTries) {
+                        window.setTimeout(function() {
+                            socket.tryNum++;
+                            socket._initWebSocket();
+                        }, socket.tryNum * 500);
+                    }
+                    else {
+                        track.handleError({responseText: '{ "error": "Server connection error" }'});
+                        window.location.reload();
+                    }
+                    break;
+                }
+            });
+            
+        },
+    
+        _initLongPoll: function() {
+            var track = this.track;
+            var socket = this;
+            this.socket = xhr( socket.contextPath + "/AnnotationChangeNotificationService", {
+                query: { track: track.getUniqueTrackName() },
+                handleAs: "json",
+                preventCache: true, 
+                timeout: 5 * 60 * 1000
+            }).then(function(response) {
+                if (response != null) {
+                    socket._handleUpdate(response);
+                }
+                socket.tryNum = 0;
+                socket._initLongPoll();
+            }, function(response, ioArgs) {
+                // client cancel
+                if (response.dojoType == "cancel") {
+                    return;
+                }
+                // client timeout
+                if (response.dojoType == "timeout") {
+                    socket._initLongPoll();
+                    return;
+                }
+                if (response.response.status == 0) {
+                    if (socket.tryNum < maxTries) {
+                        window.setTimeout(function() {
+                            socket.tryNum++;
+                            socket._initLongPoll();
+                        }, socket.tryNum * 500);
+                        return;
+                    }
+                    else {
+                        track.handleError({responseText: '{ "error": "Server connection error" }'});
+                        window.location.reload();
+                        return;
+                    }
+                }
+                // bad gateway
+                if (response.response.status == 502) {
+                    socket._initLongPoll();
+                    return;
+                }
+                // server killed
+                if (response.response.status == 503) {
+                    track.handleError({responseText: '{ "error": "Server connection error" }'});
+                    window.location.reload();
+                    return;
+                }
+                // server timeout
+                else if (response.response.status == 504){
+                    socket._initLongPoll();
+                    return;
+                }
+                // forbidden
+                else if (response.response.status == 403) {
+                    track.hide();
+                    track.changed();
+                    track.handleError({responseText: '{ "error": "Logged out" }'});
+                    window.location.reload();
+                    return;
+                }
+                // actual error
+                if (response.responseText) {
+                    track.handleError(response);
+                    track.comet_working = false;
+                    console.error("HTTP status code: ", response.response.status); //
+                    return response;
+                }
+                // everything else
+                else {
+                    track.handleError({responseText: '{ "error": "Server connection error" }'});
+                    return;
+                }
+            });
+        
+        },
+    
+        _handleUpdate: function(response) {
+            var track = this.track;
+            for (var i in response) {
+                var changeData = response[i];
+                if (changeData.operation == "ADD") {
+                    if (changeData.sequenceAlterationEvent) {
+                        track.getSequenceTrack().annotationsAddedNotification(changeData.features);
+                    }
+                    else {
+                        track.annotationsAddedNotification(changeData.features);
+                    }
+                }
+                else if (changeData.operation == "DELETE") {
+                    if (changeData.sequenceAlterationEvent) {
+                        track.getSequenceTrack().annotationsDeletedNotification(changeData.features);
+                    }
+                    else {
+                        track.annotationsDeletedNotification(changeData.features);
+                    }
+                }
+                else if (changeData.operation == "UPDATE") {
+                    if (changeData.sequenceAlterationEvent) {
+                        track.getSequenceTrack().annotationsUpdatedNotification(changeData.features);
+                    }
+                    else {
+                        track.annotationsUpdatedNotification(changeData.features);
+                    }
+                }
+            }
+            track.changed();
+        }
+    });
 
-	return AnnotTrackSocket;
+    return AnnotTrackSocket;
 } );
 

--- a/client/apollo/js/View/Track/DraggableHTMLFeatures.js
+++ b/client/apollo/js/View/Track/DraggableHTMLFeatures.js
@@ -1103,28 +1103,6 @@ var draggableTrack = declare( HTMLFeatureTrack,
         }
     },
 
-    /**
-     *  get the GenomeView's sequence track -- maybe move this to GenomeView?
-     *  WebApollo assumes there is only one SequenceTrack
-     *     if there are multiple SequenceTracks, getSequenceTrack returns first one found
-     *         iterating through tracks list
-     */
-    getSequenceTrack: function()  {
-        if( this.seqTrack )  {
-             return this.seqTrack;
-        }
-        else  {
-            var tracks = this.gview.tracks;
-            for (var i = 0; i < tracks.length; i++)  {
-                if (tracks[i] instanceof SequenceTrack)  {
-                    this.seqTrack = tracks[i];
-                    tracks[i].setAnnotTrack(this);
-                    break;
-                }
-            }
-            return this.seqTrack;
-        }
-    }, 
 
 
 /*

--- a/client/apollo/js/View/Track/DraggableResultFeatures.js
+++ b/client/apollo/js/View/Track/DraggableResultFeatures.js
@@ -1,8 +1,9 @@
 define( [
          'dojo/_base/declare',
-         'WebApollo/View/Track/DraggableHTMLFeatures'
+         'WebApollo/View/Track/DraggableHTMLFeatures',
+         'WebApollo/JSONUtils'
          ],
-         function( declare, DraggableFeatureTrack) {
+         function( declare, DraggableFeatureTrack, JSONUtils ) {
 
 var DraggableResultFeatures = declare( DraggableFeatureTrack, {   
     constructor: function(args)  {  },

--- a/client/apollo/js/View/Track/SequenceTrack.js
+++ b/client/apollo/js/View/Track/SequenceTrack.js
@@ -6,7 +6,8 @@ define( [
     'WebApollo/View/Track/DraggableHTMLFeatures',
     'WebApollo/JSONUtils',
     'WebApollo/Permission',
-    'dojox/widget/Standby'
+    'dojox/widget/Standby',
+    'jquery/jquery'
      ],
 function( declare,
     xhr,
@@ -15,7 +16,8 @@ function( declare,
     DraggableFeatureTrack,
     JSONUtils,
     Permission,
-    Standby
+    Standby,
+    $
 ) {
 
 var SequenceTrack = declare( "SequenceTrack", DraggableFeatureTrack,

--- a/client/apollo/js/View/Track/SequenceTrack.js
+++ b/client/apollo/js/View/Track/SequenceTrack.js
@@ -1034,10 +1034,6 @@ var SequenceTrack = declare( "SequenceTrack", DraggableFeatureTrack,
                 alert("Input cannot be empty for " + type);
                 ok = false;
             }
-        if (commentFieldValue.length == 0) {
-                alert("Input cannot be empty for " + type);
-                ok = false;
-            }
             if (ok) {
                 var input = inputField.value.toUpperCase();
                 if (type == "deletion") {

--- a/client/apollo/js/View/Track/SequenceTrack.js
+++ b/client/apollo/js/View/Track/SequenceTrack.js
@@ -1034,7 +1034,7 @@ var SequenceTrack = declare( "SequenceTrack", DraggableFeatureTrack,
                 alert("Input cannot be empty for " + type);
                 ok = false;
             }
-	    if (commentFieldValue.length == 0) {
+        if (commentFieldValue.length == 0) {
                 alert("Input cannot be empty for " + type);
                 ok = false;
             }

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -38,6 +38,7 @@ define([
            'JBrowse/View/FileDialog/TrackList/GFF3Driver',
            'JBrowse/CodonTable',
            'dojo/io-query',
+           'jquery/jquery',
            'lazyload/lazyload'
        ],
     function( declare,
@@ -68,6 +69,7 @@ define([
             GFF3Driver,
             CodonTable,
             ioQuery,
+            $,
             LazyLoad ) {
 
 return declare( [JBPlugin, HelpMixin],
@@ -105,7 +107,7 @@ return declare( [JBPlugin, HelpMixin],
             // this.setFavicon("plugins/WebApollo/img/webapollo_favicon.ico");
             this.setFavicon(browser.config.favicon);
         }
-        queryParams=ioQuery.queryToObject( window.location.search.slice(1) );
+        var queryParams = ioQuery.queryToObject( window.location.search.slice(1) );
 
         if(queryParams.organism) {
             this.organism=queryParams.organism;
@@ -422,7 +424,7 @@ return declare( [JBPlugin, HelpMixin],
         }
 
         if (typeof window.parent.getEmbeddedVersion == 'undefined') {
-            annotatorButton = new dijitButton(
+            var annotatorButton = new dijitButton(
                 {
                     innerHTML: "Annotator View",
                     onClick: function () {


### PR DESCRIPTION
Adding a basic syntax checker to the javascript can help catch syntax errors. In fact, running it over the current codebase caught a number of minor issues. None were critical. The rules for jshint are not super strict, and basically match those on GMOD/jbrowse.


Also retabbed several files (standardize on spaces, not tabs)

