### PR TITLE
Fix error when adding or updating multiple feature properties at once

### DIFF
--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -1317,7 +1317,7 @@ class RequestHandlingService {
             Feature feature = Feature.findByUniqueName(jsonFeature.getString(FeatureStringEnum.UNIQUENAME.value))
             JSONArray properties = jsonFeature.getJSONArray(FeatureStringEnum.NON_RESERVED_PROPERTIES.value);
             for (int j = 0; j < properties.length(); ++j) {
-                JSONObject property = properties.getJSONObject(i);
+                JSONObject property = properties.getJSONObject(j);
 
                 String tag = property.getString(FeatureStringEnum.TAG.value)
                 String value = property.getString(FeatureStringEnum.VALUE.value)
@@ -1388,8 +1388,8 @@ class RequestHandlingService {
             JSONArray oldProperties = jsonFeature.getJSONArray(FeatureStringEnum.OLD_NON_RESERVED_PROPERTIES.value);
             JSONArray newProperties = jsonFeature.getJSONArray(FeatureStringEnum.NEW_NON_RESERVED_PROPERTIES.value);
             for (int j = 0; j < oldProperties.length(); ++j) {
-                JSONObject oldProperty = oldProperties.getJSONObject(i);
-                JSONObject newProperty = newProperties.getJSONObject(i);
+                JSONObject oldProperty = oldProperties.getJSONObject(j);
+                JSONObject newProperty = newProperties.getJSONObject(j);
                 String oldTag = oldProperty.getString(FeatureStringEnum.TAG.value)
                 String oldValue = oldProperty.getString(FeatureStringEnum.VALUE.value)
                 String newTag = newProperty.getString(FeatureStringEnum.TAG.value)


### PR DESCRIPTION
There is a bug when updating or adding multiple feature properties at once where it would use the wrong loop counter.

