### PR TITLE
Modified apollo config

### DIFF
--- a/sample-h2-apollo-config.groovy
+++ b/sample-h2-apollo-config.groovy
@@ -26,7 +26,7 @@ environments {
         dataSource {
             dbCreate = "update"
             //NOTE: production mode uses file instead of mem database
-            //Please speicify the appropriate absolute file path of your h2 database.
+            //Please specify the appropriate file path, otherwise /tmp/prodDb will be used.
             //url = "jdbc:h2:/opt/apollo/h2/prodDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
             url = "jdbc:h2:/tmp/prodDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
             properties {

--- a/sample-h2-apollo-config.groovy
+++ b/sample-h2-apollo-config.groovy
@@ -9,6 +9,14 @@ dataSource {
 // environment specific settings
 environments {
     development {
+        // sample config to turn on debug logging in development e.g. for apollo run-local
+        log4j.main = {
+            debug "grails.app"
+        }
+        // sample config to edit apollo specific configs in development mode
+        apollo {
+            gff3.source = "testing"
+        }
         dataSource {
             dbCreate = "update" // one of 'create', 'create-drop', 'update', 'validate', ''
             url = "jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"

--- a/sample-mysql-apollo-config.groovy
+++ b/sample-mysql-apollo-config.groovy
@@ -1,6 +1,14 @@
 
 environments {
     development {
+        // sample config to turn on debug logging in development e.g. for apollo run-local
+        log4j.main = {
+            debug "grails.app"
+        }
+        // sample config to edit apollo specific configs in development mode
+        apollo {
+            gff3.source = "testing"
+        }
         dataSource{
             dbCreate = "update" // one of 'create', 'create-drop', 'update', 'validate', ''
             username = "<CHANGEME>"

--- a/sample-postgres-apollo-config.groovy
+++ b/sample-postgres-apollo-config.groovy
@@ -1,5 +1,13 @@
 environments {
     development {
+        // sample config to turn on debug logging in development e.g. for apollo run-local
+        log4j.main = {
+            debug "grails.app"
+        }
+        // sample config to edit apollo specific configs in development mode
+        apollo {
+            gff3.source = "testing"
+        }
         dataSource.dbCreate = "update" // one of 'create', 'create-drop', 'update', 'validate', ''
         dataSource.username = "<CHANGEME>"
         dataSource.password = "<CHANGEME>"
@@ -12,7 +20,6 @@ environments {
         dataSource.username = "<CHANGEME>"
         dataSource.password = "<CHANGEME>"
         dataSource.driverClassName = "org.postgresql.Driver"
-//        dataSource.dialect = org.hibernate.dialect.PostgresPlusDialect
         dataSource.dialect = "org.bbop.apollo.ImprovedPostgresDialect"
         dataSource.url = "jdbc:postgresql://localhost/apollo-test"
     }


### PR DESCRIPTION
I thought it would be good to have an example of modifying the configurations directly in apollo-config.groovy rather than having to modify grails-app/conf/Config.groovy.

This PR therefore adds two example customizations (1) adding debug logging for the development environment as an example of customizing the logging (2) adding an apollo.gff3.source parameter as an example of customizing the main apollo config

