### PR TITLE
Update release build rules to fix #941

### DIFF
--- a/apollo
+++ b/apollo
@@ -101,13 +101,13 @@ function check_configs(){
         fi
     fi
     if ! [ -x "$gradle_executable" ] ; then
-	   if [ -f 'gradlew' ]; then
-		   echo "Gradle not found using gradlew";
-		   gradle_executable="./gradlew"
-	   else
-		   echo "You must install 'gradle' to install Apollo."
-		   exit 1 ;
-		fi
+       if [ -f 'gradlew' ]; then
+           echo "Gradle not found using gradlew";
+           gradle_executable="./gradlew"
+       else
+           echo "You must install 'gradle' to install Apollo."
+           exit 1 ;
+        fi
     fi
     if ! [ -x "$git_executable" ] ; then
        echo "You must install 'git' to install Apollo."
@@ -124,13 +124,11 @@ function copy_configs(){
 
 
 if [[ $1 == "devmode" ]];then
-    # should call the copy target first
     check_configs
     $gradle_executable devmode &
     $grails_executable -reloading run-app
     if [ -x "$watchman_executable" ]; then $watchman_executable -- trigger $(PWD) jsfilescopy 'client/apollo/**/*.js' -- scripts/copy_client.sh; fi;
 elif [[ $1 == "run-local" ]];then
-    # should call the copy target first
     check_configs
     if [[ $# == 2 ]]; then
         $gradle_executable handleJBrowse copy-resources gwtc && $grails_executable -Dserver.port=$2 run-app
@@ -139,7 +137,6 @@ elif [[ $1 == "run-local" ]];then
     fi
     if [ -x "$watchman_executable" ]; then $watchman_executable -- trigger $(PWD) jsfilescopy 'client/apollo/**/*.js' -- scripts/copy_client.sh; fi;
 elif [[ $1 == "run-app" ]];then
-    # should call the copy target first
     check_configs
     if [[ $# == 2 ]]; then
         $gradle_executable handleJBrowse copy-resources && $grails_executable -Dserver.port=$2 run-app
@@ -159,44 +156,31 @@ elif [[ $1 == "debug" ]];then
     unset OLD_MAVEN_OPTS
     if [ -x "$watchman_executable" ]; then $watchman_executable -- trigger $(PWD) jsfilescopy 'client/apollo/**/*.js' -- scripts/copy_client.sh; fi;
 elif [[ $1 == "test" ]];then
-    # should call the copy target first
     check_configs
     copy_configs
     $grails_executable test-app
 elif [[ $1 == "test-unit" ]];then
-    # should call the copy target first
     check_configs
     copy_configs
     $grails_executable test-app :unit
-#    mvn test
 elif [[ $1 == "deploy" ]];then
-    # should call the copy target first
     check_configs
-    # this makes it globally available
     copy_configs
-    #grails deploy
     $gradle_executable handleJBrowse copy-resources gwtc &&  $grails_executable war
     deploy_message
 elif [[ $1 == "release" ]];then
-    # should call the copy target first
     check_configs
     check_configs_for_release
     copy_configs
-#   $gradle_executable clean-all handleJBrowseRelease gwtc && $grails_executable war
-#    $gradle_executable clean-all handleJBrowse release gwtc && $grails_executable war
-    $gradle_executable clean-all release gwtc && $grails_executable war  # this is the original call
+    $gradle_executable clean-all handleJBrowse release gwtc && $grails_executable war
     deploy_message
 elif [[ $1 == "compile" ]];then
-    # should call the copy target first
     check_configs
     $gradle_executable handleJBrowse gwtc && $grails_executable compile
 elif [[ $1 == "create-rest-doc" ]];then
     check_configs
-    # should call the copy target first
-	# need to copy it 
     $grails_executable compile && $grails_executable rest-api-doc && cp restapidoc.json web-app/js/restapidoc/
 elif [[ $1 == "clean-all" ]];then
-    # should call the copy target first
     check_configs
     rm -rf bin
     rm -rf jbrowse-download
@@ -204,14 +188,11 @@ elif [[ $1 == "clean-all" ]];then
     rm -rf src/main/webapp/jbrowse
     rm -f *.zip
     $gradle_executable clean-all
-    $grails_executable clean 
+    $grails_executable clean
 elif [[ $1 == "clean" ]];then
-    # should call the copy target first
     check_configs
-    $gradle_executable clean &&  $grails_executable clean
+    $gradle_executable clean-ant &&  $grails_executable clean
 elif [[ $1 == "jbrowse" ]];then
-    # used to update / force jbrowse?
-    # should call the copy target first
     check_configs
     $gradle_executable handleJbrowse
 else

--- a/build.xml
+++ b/build.xml
@@ -69,7 +69,7 @@
 
     <target name="build" depends="gwtc" description="Build this project"/>
 
-    <target name="clean" depends="clean-grails,clean-grailsw" description="Cleans this project using grails">
+    <target name="clean-ant" depends="clean-grails,clean-grailsw" description="Cleans this project using grails">
     </target>
 
     <property name="grails-clean" value="false"/>
@@ -91,10 +91,9 @@
         </exec>
     </target>
 
-    <target name="clean-all" depends="clean" description="Cleans this project">
+    <target name="clean-all" depends="clean-ant" description="Cleans this project">
         <delete dir="web-app/WEB-INF/deploy" failonerror="false"/>
         <delete dir="web-app/annotator" failonerror="false"/>
-        <!--<delete dir="target/classes/gwt" failonerror="false"/>-->
         <delete dir="target" failonerror="false"/>
     </target>
 
@@ -143,7 +142,7 @@
     </target>
 
     <target name="release" description=""
-            depends="clean,cloneJBrowse,copy.apollo.plugin.jbrowse,build.jbrowse,install.jbrowse.perl">
+            depends="clean-ant,cloneJBrowse,copy.apollo.plugin.jbrowse,build.jbrowse,install.jbrowse.perl">
         <copy file="${jbrowse.download.directory}/JBrowse-${jbrowse.version}.zip" todir="${basedir}"/>
         <exec executable="unzip" failifexecutionfails="false" errorproperty="">
             <arg value="JBrowse-${jbrowse.version}.zip"/>
@@ -160,7 +159,7 @@
     </target>
 
     <target name="debug" description=""
-            depends="clean,cloneJBrowse,copy.apollo.plugin.jbrowse,build.jbrowse">
+            depends="clean-ant,cloneJBrowse,copy.apollo.plugin.jbrowse,build.jbrowse">
         <copy file="${jbrowse.download.directory}/JBrowse-${jbrowse.version}-dev.zip" todir="${basedir}"/>
         <exec executable="unzip" failifexecutionfails="false" errorproperty="">
             <arg value="JBrowse-${jbrowse.version}-dev.zip"/>

--- a/build.xml
+++ b/build.xml
@@ -126,7 +126,7 @@
     <target name="build.jbrowse" description="Build JBrowse using the build/Makefile">
         <exec executable="sh" failifexecutionfails="false">
             <arg value="-c"/>
-            <arg line="'ulimit -n 1000; cd ${jbrowse.download.directory} &amp;&amp; make -f build/Makefile release-notest'"/>
+            <arg line="'ulimit -n 1000; cd ${jbrowse.download.directory} &amp;&amp; make -f build/Makefile RELEASE_VERSION=dev release-notest'"/>
         </exec>
     </target>
 

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -1,5 +1,5 @@
 databaseChangeLog = {
     include file: 'changelog-2_0_1.groovy'
     include file: 'changelog-2_0_2.groovy'
-	include file: 'changelog-2_0_3.groovy'
+    include file: 'changelog-2_0_3.groovy'
 }


### PR DESCRIPTION
#941 discusses a scenario where builds were breaking during release mode, which includes jbrowse build (which we had targetted using "dev" versions of the build artifacts, but those were renamed, breaking the build. this just retains the naming).

