### PR TITLE
Remove Chado data source configuration for H2 and MySQL

### DIFF
--- a/sample-h2-apollo-config.groovy
+++ b/sample-h2-apollo-config.groovy
@@ -21,19 +21,11 @@ environments {
             dbCreate = "update" // one of 'create', 'create-drop', 'update', 'validate', ''
             url = "jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
         }
-        dataSource_chado {
-            dbCreate = "update" // one of 'create', 'create-drop', 'update', 'validate', ''
-            url = "jdbc:h2:mem:devChadoDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
-        }
     }
     test {
         dataSource {
             dbCreate = "create-drop" // one of 'create', 'create-drop', 'update', 'validate', ''
             url = "jdbc:h2:mem:testDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
-        }
-        dataSource_chado {
-            dbCreate = "create-drop" // one of 'create', 'create-drop', 'update', 'validate', ''
-            url = "jdbc:h2:mem:testChadoDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
         }
     }
 
@@ -64,33 +56,6 @@ environments {
                testOnReturn = false
                jdbcInterceptors = "ConnectionState"
                defaultTransactionIsolation = java.sql.Connection.TRANSACTION_READ_COMMITTED
-            }
-        }
-        dataSource_chado {
-            dbCreate = "update"
-            //NOTE: production mode uses file instead of mem database
-            //Please speicify the appropriate absolute file path of your h2 database.
-            //url = "jdbc:h2:/opt/apollo/h2/prodDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
-            url = "jdbc:h2:/tmp/prodChadoDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
-            properties {
-                // See http://grails.org/doc/latest/guide/conf.html#dataSource for documentation
-                jmxEnabled = true
-                initialSize = 5
-                maxActive = 50
-                minIdle = 5
-                maxIdle = 25
-                maxWait = 10000
-                maxAge = 10 * 60000
-                timeBetweenEvictionRunsMillis = 5000
-                minEvictableIdleTimeMillis = 60000
-                validationQuery = "SELECT 1"
-                validationQueryTimeout = 3
-                validationInterval = 15000
-                testOnBorrow = true
-                testWhileIdle = true
-                testOnReturn = false
-                jdbcInterceptors = "ConnectionState"
-                defaultTransactionIsolation = java.sql.Connection.TRANSACTION_READ_COMMITTED
             }
         }
     }

--- a/sample-mysql-apollo-config.groovy
+++ b/sample-mysql-apollo-config.groovy
@@ -17,14 +17,6 @@ environments {
             dialect = org.hibernate.dialect.MySQL5InnoDBDialect
             url = "jdbc:mysql://localhost/apollo"
         }
-        dataSource_chado{
-            dbCreate = "update" // one of 'create', 'create-drop', 'update', 'validate', ''
-            username = "<CHANGEME>"
-            password = "<CHANGEME>"
-            driverClassName = "com.mysql.jdbc.Driver"
-            dialect = org.hibernate.dialect.MySQL5InnoDBDialect
-            url = "jdbc:mysql://localhost/apollo-chado"
-        }
     }
     test {
         dataSource{
@@ -35,14 +27,6 @@ environments {
             dialect = org.hibernate.dialect.MySQL5InnoDBDialect
             url = "jdbc:mysql://localhost/apollo-test"
         }
-        dataSource_chado{
-            dbCreate = "create-drop" // one of 'create', 'create-drop', 'update', 'validate', ''
-            username = "<CHANGEME>"
-            password = "<CHANGEME>"
-            driverClassName = "com.mysql.jdbc.Driver"
-            dialect = org.hibernate.dialect.MySQL5InnoDBDialect
-            url = "jdbc:mysql://localhost/apollo-test-chado"
-        }
     }
     production {
         dataSource{
@@ -52,34 +36,6 @@ environments {
             driverClassName = "com.mysql.jdbc.Driver"
             dialect = org.hibernate.dialect.MySQL5InnoDBDialect
             url = "jdbc:mysql://localhost/apollo-production"
-            properties {
-                // See http://grails.org/doc/latest/guide/conf.html#dataSource for documentation
-                jmxEnabled = true
-                initialSize = 5
-                maxActive = 50
-                minIdle = 5
-                maxIdle = 25
-                maxWait = 10000
-                maxAge = 10 * 60000
-                timeBetweenEvictionRunsMillis = 5000
-                minEvictableIdleTimeMillis = 60000
-                validationQuery = "SELECT 1"
-                validationQueryTimeout = 3
-                validationInterval = 15000
-                testOnBorrow = true
-                testWhileIdle = true
-                testOnReturn = false
-                jdbcInterceptors = "ConnectionState"
-                defaultTransactionIsolation = java.sql.Connection.TRANSACTION_READ_COMMITTED
-            }
-        }
-        dataSource_chado{
-            dbCreate = "update" // one of 'create', 'create-drop', 'update', 'validate', ''
-            username = "<CHANGEME>"
-            password = "<CHANGEME>"
-            driverClassName = "com.mysql.jdbc.Driver"
-            dialect = org.hibernate.dialect.MySQL5InnoDBDialect
-            url = "jdbc:mysql://localhost/apollo-production-chado"
             properties {
                 // See http://grails.org/doc/latest/guide/conf.html#dataSource for documentation
                 jmxEnabled = true


### PR DESCRIPTION
Currently at master branch, the sample config files for H2 and MySQL has configuration lines for a Chado data source. This PR removes these configurations since Chado will not be compatible with H2 and MySQL.