### PR TITLE
Cleanup AnnotTrack.js

### DIFF
--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -5683,7 +5683,7 @@ define([
                 }
 
                 console.log('connected and sending notifications');
-                this.client.send("/app/AnnotationNotification", {}, JSON.stringify(postData));
+                this.client.send("/app/AnnotationNotification", {}, JSON.stringify(JSON.stringify(postData)));
                 console.log('sent notification message');
             },
 

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -1448,7 +1448,7 @@ define([
                 }
                 if (this.verbose_delete) {
                     console.log("annotations to delete:");
-                    console.log(features);
+                    console.log(postData.features);
                 }
                 track.executeUpdateOperation(postData);
             },
@@ -1570,7 +1570,7 @@ define([
                             {
                                 uniquename: leftAnnot.id(),
                                 location: {
-                                    fmax: coodinate,
+                                    fmax: coordinate,
                                     fmin: (coordinate + 1)
                                 }
                             }
@@ -1743,7 +1743,7 @@ define([
                         var trackdiv = track.div;
                         var trackName = track.getUniqueTrackName();
 
-                        postData.features.push({ uniquename: uniquename })
+                        postData.features.push({ uniquename: uniqueName })
                     }
                 }
                 track.executeUpdateOperation(postData);

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -870,7 +870,7 @@ define([
                     var source_track = subfeat.track;
                     if (subfeat.get('type') != "wholeCDS") {
                         var jsonFeature = JSONUtils.createApolloFeature(subfeats[i], "exon");
-                        postData[features].push(jsonFeature);
+                        postData.features.push(jsonFeature);
                     }
                 }
                 // var parent = JSONUtils.createApolloFeature(annot, target_track.fields,


### PR DESCRIPTION
While fixing #1009 I saw lots of JSON string building which could be avoided entirely (i.e. hopefully decrease potential errors by letting the browser's JS parser catch any issues with your `postData` object rather than watching them fail on the server side when improper json is sent)

- all string building replaced with JS objects
- for WS requests, all `stringify`ing done at the very end, in `executeUpdateOperation`