### PR TITLE
Add instructions to download the specific version

### DIFF
--- a/docs/Apollo2Build.md
+++ b/docs/Apollo2Build.md
@@ -29,12 +29,10 @@ It is not required but you can also install the groovy command line
 To setup Apollo, you can download the code from github:
 
 - git clone https://github.com/GMOD/Apollo.git Apollo
+- git checkout 2.0.2
 - cd Apollo
 
-Alternatively, download a .tar.gz file or .zip file from the releases page:
-[https://github.com/GMOD/Apollo/releases](https://github.com/GMOD/Apollo/releases).
-
-There won't be any difference in the workflow either way that you choose to get the code.
+Alternatively, download a .tar.gz file or .zip file source package of the latest release [https://github.com/GMOD/Apollo/releases/tag/2.0.2](version 2.0.2).
 
 
 ### Verify install requirements


### PR DESCRIPTION
This PR adds instructions for users to download a specific version of Apollo during the Quick-start guide.

This change is made with the intention to get users to use stable releases instead of master branch, which although sometimes helpful (they catch bugs....) it is not nice to test our master branch on our newest users

I had thought it might be nice to automatically populate this version information from a config but instead this info would have to be manually updated when new versions are released.