### PR TITLE
Chado export ui tweak

### DIFF
--- a/grails-app/services/org/bbop/apollo/ChadoHandlerService.groovy
+++ b/grails-app/services/org/bbop/apollo/ChadoHandlerService.groovy
@@ -543,8 +543,8 @@ class ChadoHandlerService {
         org.gmod.chado.Feature srcFeature
         long startTime = System.currentTimeMillis()
         def sequenceFeatureResult = org.gmod.chado.Feature.executeQuery(
-                "SELECT DISTINCT sf FROM org.gmod.chado.Feature sf WHERE sf.name = :querySequenceName AND sf.organism.genus = :queryGenus and sf.organism.species = :querySpecies",
-                [querySequenceName: sequence.name, queryGenus: organism.genus, querySpecies: organism.species])
+                "SELECT DISTINCT sf FROM org.gmod.chado.Feature sf WHERE sf.name = :querySequenceName AND sf.organism.genus = :queryGenus AND sf.organism.species = :querySpecies AND sf.type.name = :querySequenceType",
+                [querySequenceName: sequence.name, queryGenus: organism.genus, querySpecies: organism.species, querySequenceType: "chromosome"])
         long endTime = System.currentTimeMillis()
         log.debug "Time taken for querying for sequence ${sequence.name} of organism ${organism.genus} ${organism.species}: ${endTime - startTime} ms"
 
@@ -1172,9 +1172,11 @@ class ChadoHandlerService {
      * @return
      */
     def createChadoFeatureForSequences(Organism organism, Collection<Sequence> sequences, boolean storeSequence = false) {
+        org.gmod.chado.Feature chadoFeature
         sequences.each { sequence ->
-            createChadoFeatureForSequence(organism, sequence, storeSequence)
+            chadoFeature = createChadoFeatureForSequence(organism, sequence, storeSequence)
         }
+        chadoFeature.save(flush: true)
     }
 
     /**
@@ -1211,7 +1213,7 @@ class ChadoHandlerService {
             chadoFeature.md5checksum = generateMD5checksum(residues)
         }
 
-        chadoFeature.save(flush: true)
+        chadoFeature.save()
         exportStatisticsMap['sequence_feature_count'] += 1
         endTime = System.currentTimeMillis()
         log.debug "Time taken to create Chado Feature for sequence ${sequence.name}: ${endTime - startTime} ms"
@@ -1221,8 +1223,8 @@ class ChadoHandlerService {
     def getChadoFeatureForSequence(Organism organism, org.bbop.apollo.Sequence sequence) {
         org.gmod.chado.Feature chadoFeature
         def sequenceResults = org.gmod.chado.Feature.executeQuery(
-                "SELECT DISTINCT s FROM org.gmod.chado.Feature s WHERE s.name = :querySequenceName AND s.organism.genus = :queryGenus AND s.organism.species = :querySpecies",
-                [querySequenceName: sequence.name, queryGenus: organism.genus, querySpecies: organism.species])
+                "SELECT DISTINCT s FROM org.gmod.chado.Feature s WHERE s.name = :querySequenceName AND s.organism.genus = :queryGenus AND s.organism.species = :querySpecies AND s.type.name = :querySequenceType",
+                [querySequenceName: sequence.name, queryGenus: organism.genus, querySpecies: organism.species, querySequenceType: "chromosome"])
         if (sequenceResults.size() == 0) {
             chadoFeature = null
         }

--- a/src/gwt/org/bbop/apollo/gwt/client/ExportPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/ExportPanel.java
@@ -32,7 +32,7 @@ public class ExportPanel extends Modal {
     private List<SequenceInfo> sequenceList;
     private Boolean exportAll = false;
     private OrganismInfo currentOrganismInfo;
-
+    private Boolean exportAllSequencesToChado = false;
     HTML sequenceInfoLabel = new HTML();
     HTML typeLabel = new HTML();
     HTML sequenceTypeLabel = new HTML();
@@ -44,8 +44,8 @@ public class ExportPanel extends Modal {
     RadioButton cdnaRadioButton = new RadioButton("cDNA", "cDNA", true);
     RadioButton cdsRadioButton = new RadioButton("CDS", "CDS", true);
     RadioButton peptideRadioButton = new RadioButton("Peptide", "Peptide", true);
-    RadioButton chadoCleanButton = new RadioButton("Chado", "Verify export to Chado database", true);
-    //RadioButton chadoExistingButton = new RadioButton("Chado", "Chado (update)", true);
+    RadioButton chadoExportButton1 = new RadioButton("chadoExportOption1", "Export all sequences (that have annotations) to Chado", true);
+    RadioButton chadoExportButton2 = new RadioButton("chadoExportOption2", "Export all sequences to Chado", true);
 
     ModalBody modalBody = new ModalBody();
     ModalHeader modalHeader = new ModalHeader();
@@ -82,8 +82,8 @@ public class ExportPanel extends Modal {
         }
         else
         if (type.equals(FeatureStringEnum.TYPE_CHADO.getValue())) {
-            buttonGroup.add(chadoCleanButton);
-            //buttonGroup.add(chadoExistingButton);
+            buttonGroup.add(chadoExportButton1);
+            buttonGroup.add(chadoExportButton2);
         }
         modalBody.add(buttonGroup);
 
@@ -138,8 +138,21 @@ public class ExportPanel extends Modal {
         gff3WithFastaButton.addClickHandler(exportClickHandler);
         gff3Button.addClickHandler(exportClickHandler);
 
-        chadoCleanButton.addClickHandler(exportClickHandler);
-        //chadoExistingButton.addClickHandler(exportClickHandler);
+        chadoExportButton1.addClickHandler(new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent clickEvent) {
+                setExportAllSequencesToChado(false);
+                exportButton.setEnabled(true);
+            }
+        });
+
+        chadoExportButton2.addClickHandler(new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent clickEvent) {
+                setExportAllSequencesToChado(true);
+                exportButton.setEnabled(true);
+            }
+        });
     }
 
 
@@ -172,8 +185,8 @@ public class ExportPanel extends Modal {
     }
 
     public void showExportStatus(String exportStatus) {
-        //this.chadoExistingButton.setVisible(false);
-        this.chadoCleanButton.setVisible(false);
+        this.chadoExportButton1.setVisible(false);
+        this.chadoExportButton2.setVisible(false);
         this.exportButton.setVisible(false);
         this.closeButton.setText("OK");
         this.closeButton.setWidth("45px");
@@ -226,13 +239,13 @@ public class ExportPanel extends Modal {
             return FeatureStringEnum.TYPE_PEPTIDE.getValue();
         }
         else
-        if(chadoCleanButton.isActive()){
+        if(chadoExportButton1.isActive()){
             return FeatureStringEnum.TYPE_CHADO.getValue();
         }
-//        else
-//        if (chadoExistingButton.isActive()) {
-//            return  FeatureStringEnum.TYPE_CHADO.getValue();
-//        }
+        else
+        if(chadoExportButton2.isActive()) {
+            return FeatureStringEnum.TYPE_CHADO.getValue();
+        }
         // this is the default . . . may handle to GFF3 with FASTA
         else{
             return FeatureStringEnum.TYPE_GENOMIC.getValue();
@@ -242,12 +255,12 @@ public class ExportPanel extends Modal {
     public String getChadoExportType() {
         String exportType = null;
         if (type.equals(FeatureStringEnum.TYPE_CHADO.getValue())) {
-            if (chadoCleanButton.isActive()) {
+            if (chadoExportButton1.isActive()) {
                 exportType = FeatureStringEnum.EXPORT_CHADO_CLEAN.getValue();
             }
-//            else if (chadoExistingButton.isActive()) {
-//                exportType = FeatureStringEnum.EXPORT_CHADO_UPDATE.getValue();
-//            }
+            else if (chadoExportButton2.isActive()) {
+                exportType = FeatureStringEnum.EXPORT_CHADO_UPDATE.getValue();
+            }
         }
         return exportType;
     }
@@ -273,5 +286,13 @@ public class ExportPanel extends Modal {
 
     public List<SequenceInfo> getSequenceList() {
         return sequenceList;
+    }
+
+    public Boolean getExportAllSequencesToChado() {
+        return this.exportAllSequencesToChado;
+    }
+
+    public void setExportAllSequencesToChado(Boolean value) {
+        this.exportAllSequencesToChado = value;
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/rest/SequenceRestService.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/rest/SequenceRestService.java
@@ -8,7 +8,6 @@ import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONParser;
 import com.google.gwt.json.client.JSONString;
-import com.google.gwt.user.client.Window;
 import org.bbop.apollo.gwt.client.Annotator;
 import org.bbop.apollo.gwt.client.ExportPanel;
 import org.bbop.apollo.gwt.client.SequencePanel;
@@ -33,6 +32,7 @@ public class SequenceRestService {
         jsonObject.put("exportAllSequences", new JSONString(exportPanel.getExportAll().toString()));
 
         if (type.equals(FeatureStringEnum.TYPE_CHADO.getValue())) {
+            jsonObject.put("exportAllSequences", new JSONString(exportPanel.getExportAllSequencesToChado().toString()));
             jsonObject.put("chadoExportType", new JSONString(exportPanel.getChadoExportType()));
             jsonObject.put("seqType", new JSONString(""));
             jsonObject.put("exportGff3Fasta", new JSONString(""));


### PR DESCRIPTION
This PR adds the functionality to provide user with the option to limit their Chado export to only those sequences that have annotations, to Chado.

This PR also improves the speed of export when exporting all sequences for an organism.