### PR TITLE
Enforce strandedness for features that don't have strand

### DIFF
--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -41,7 +41,7 @@ class FeatureService {
     public static final def singletonFeatureTypes = [RepeatRegion.alternateCvTerm, TransposableElement.alternateCvTerm]
     @Timed
     @Transactional
-    public FeatureLocation convertJSONToFeatureLocation(JSONObject jsonLocation, Sequence sequence) throws JSONException {
+    public FeatureLocation convertJSONToFeatureLocation(JSONObject jsonLocation, Sequence sequence, int defaultStrand = Strand.POSITIVE.value) throws JSONException {
         FeatureLocation gsolLocation = new FeatureLocation();
         if (jsonLocation.has(FeatureStringEnum.ID.value)) {
             gsolLocation.setId(jsonLocation.getLong(FeatureStringEnum.ID.value));
@@ -52,7 +52,7 @@ class FeatureService {
             gsolLocation.setStrand(jsonLocation.getInt(FeatureStringEnum.STRAND.value));
         }
         else {
-            gsolLocation.setStrand(Strand.POSITIVE.value);
+            gsolLocation.setStrand(defaultStrand)
         }
         gsolLocation.setSequence(sequence)
         return gsolLocation;
@@ -1102,7 +1102,13 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
 
             if (jsonFeature.has(FeatureStringEnum.LOCATION.value)) {
                 JSONObject jsonLocation = jsonFeature.getJSONObject(FeatureStringEnum.LOCATION.value);
-                FeatureLocation featureLocation = convertJSONToFeatureLocation(jsonLocation, sequence)
+                FeatureLocation featureLocation
+                if (singletonFeatureTypes.contains(type.getString(FeatureStringEnum.NAME.value))) {
+                    featureLocation = convertJSONToFeatureLocation(jsonLocation, sequence, Strand.NONE.value)
+                }
+                else {
+                    featureLocation = convertJSONToFeatureLocation(jsonLocation, sequence)
+                }
                 featureLocation.sequence = sequence
                 featureLocation.feature = gsolFeature
                 featureLocation.save()

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -52,7 +52,7 @@ class FeatureService {
             gsolLocation.setStrand(jsonLocation.getInt(FeatureStringEnum.STRAND.value));
         }
         else {
-            gsolLocation.setStrand(1);
+            gsolLocation.setStrand(Strand.POSITIVE.value);
         }
         gsolLocation.setSequence(sequence)
         return gsolLocation;

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -48,7 +48,12 @@ class FeatureService {
         }
         gsolLocation.setFmin(jsonLocation.getInt(FeatureStringEnum.FMIN.value));
         gsolLocation.setFmax(jsonLocation.getInt(FeatureStringEnum.FMAX.value));
-        gsolLocation.setStrand(jsonLocation.getInt(FeatureStringEnum.STRAND.value));
+        if (jsonLocation.getInt(FeatureStringEnum.STRAND.value) == Strand.POSITIVE.value || jsonLocation.getInt(FeatureStringEnum.STRAND.value) == Strand.NEGATIVE.value) {
+            gsolLocation.setStrand(jsonLocation.getInt(FeatureStringEnum.STRAND.value));
+        }
+        else {
+            gsolLocation.setStrand(1);
+        }
         gsolLocation.setSequence(sequence)
         return gsolLocation;
     }

--- a/src/groovy/org/bbop/apollo/sequence/Strand.groovy
+++ b/src/groovy/org/bbop/apollo/sequence/Strand.groovy
@@ -5,8 +5,9 @@ package org.bbop.apollo.sequence
  */
 enum Strand {
 
-    POSITIVE(1,"+")
-    , NEGATIVE(-1,"-")
+    POSITIVE(1,"+"),
+    NEGATIVE(-1,"-"),
+    NONE(0,".")
 
     Integer value
     String display

--- a/test/integration/org/bbop/apollo/FeatureServiceIntegrationSpec.groovy
+++ b/test/integration/org/bbop/apollo/FeatureServiceIntegrationSpec.groovy
@@ -3,12 +3,14 @@ package org.bbop.apollo
 import grails.converters.JSON
 import grails.test.spock.IntegrationSpec
 import org.bbop.apollo.gwt.shared.FeatureStringEnum
+import org.bbop.apollo.sequence.Strand
 import org.codehaus.groovy.grails.web.json.JSONArray
 import org.codehaus.groovy.grails.web.json.JSONObject
 
 class FeatureServiceIntegrationSpec extends IntegrationSpec {
 
     def featureService
+    def transcriptService
     def requestHandlingService
     def featureRelationshipService
 
@@ -188,5 +190,26 @@ class FeatureServiceIntegrationSpec extends IntegrationSpec {
         }
 
         assert expectedDbxrefForTranscript.size() == 0
+    }
+
+    void "If an annotation doesn't have strand information then it should, by default, be set to the sense strand"() {
+
+        given: "a transcript with no strand information"
+        String featureString = '{"operation":"add_feature","features":[{"location":{"fmin":761542,"strand":0,"fmax":768063},"children":[{"location":{"fmin":761542,"strand":0,"fmax":768063},"children":[{"location":{"fmin":767945,"strand":0,"fmax":768063},"type":{"name":"exon","cv":{"name":"sequence"}}},{"location":{"fmin":761542,"strand":0,"fmax":763070},"type":{"name":"exon","cv":{"name":"sequence"}}},{"location":{"fmin":761542,"strand":0,"fmax":763513},"type":{"name":"exon","cv":{"name":"sequence"}}},{"location":{"fmin":765327,"strand":0,"fmax":765472},"type":{"name":"exon","cv":{"name":"sequence"}}},{"location":{"fmin":765551,"strand":0,"fmax":766176},"type":{"name":"exon","cv":{"name":"sequence"}}},{"location":{"fmin":766255,"strand":0,"fmax":767133},"type":{"name":"exon","cv":{"name":"sequence"}}},{"location":{"fmin":767207,"strand":0,"fmax":767389},"type":{"name":"exon","cv":{"name":"sequence"}}},{"location":{"fmin":767485,"strand":0,"fmax":768063},"type":{"name":"exon","cv":{"name":"sequence"}}},{"location":{"fmin":763070,"strand":0,"fmax":767945},"type":{"name":"CDS","cv":{"name":"sequence"}}}],"type":{"name":"transcript","cv":{"name":"sequence"}}}],"type":{"name":"pseudogene","cv":{"name":"sequence"}}}],"track":"Group1.10"}'
+
+        when: "we add a feature that has its strand as 0"
+        requestHandlingService.addFeature(JSON.parse(featureString) as JSONObject)
+
+        then: "we should see the feature, and all of its sub-features, placed on the sense strand"
+        Gene gene = Gene.all.get(0)
+        Transcript transcript = transcriptService.getTranscripts(gene).iterator().next()
+        def exonList = transcriptService.getExons(transcript)
+
+        assert gene.featureLocation.strand == Strand.POSITIVE.value
+        assert transcript.featureLocation.strand == Strand.POSITIVE.value
+
+        exonList.each {
+            it.featureLocation.strand == Strand.POSITIVE.value
+        }
     }
 }


### PR DESCRIPTION
Address the issue where when a feature (that has no strand information) is added as an annotation, Apollo will default it to the sense strand.

Fixes #873.