### PR TITLE
user list should be unique, empty permissions will be deleted, non-or…

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/UserController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/UserController.groovy
@@ -34,7 +34,7 @@ class UserController {
             JSONObject dataObject = (request.JSON ?: (JSON.parse(params.data ?: "{}"))) as JSONObject
             permissionService.handleToken(params,dataObject)
             JSONArray returnArray = new JSONArray()
-            if (!permissionService.hasPermissions(dataObject, PermissionEnum.ADMINISTRATE)) {
+            if (!permissionService.hasGlobalPermissions(dataObject, PermissionEnum.ADMINISTRATE)) {
                 render status: HttpStatus.UNAUTHORIZED
                 return
             }
@@ -52,9 +52,6 @@ class UserController {
                 userOrganismPermissionListTemp.add(userOrganismPermission)
                 userOrganismPermissionMap.put(userOrganismPermission.user.username, userOrganismPermissionListTemp)
             }
-            for (v in userOrganismPermissionMap) {
-                log.debug "${v.key} ${v.value}"
-            }
 
             def c = User.createCriteria()
             def users = c.list() {
@@ -64,6 +61,8 @@ class UserController {
                 if (dataObject.userId && dataObject.userId in String) {
                     eq('username', dataObject.userId)
                 }
+            }.unique{ a, b ->
+                a.id <=> b.id
             }
             users.each {
                 def userObject = new JSONObject()
@@ -208,7 +207,7 @@ class UserController {
     @Transactional
     def addUserToGroup() {
         JSONObject dataObject = permissionService.handleInput(request, params)
-        if (!permissionService.hasPermissions(dataObject, PermissionEnum.ADMINISTRATE)) {
+        if (!permissionService.hasGlobalPermissions(dataObject, PermissionEnum.ADMINISTRATE)) {
             render status: HttpStatus.UNAUTHORIZED
             return
         }
@@ -232,7 +231,7 @@ class UserController {
     @Transactional
     def removeUserFromGroup() {
         JSONObject dataObject = permissionService.handleInput(request, params)
-        if (!permissionService.hasPermissions(dataObject, PermissionEnum.ADMINISTRATE)) {
+        if (!permissionService.hasGlobalPermissions(dataObject, PermissionEnum.ADMINISTRATE)) {
             render status: HttpStatus.UNAUTHORIZED
             return
         }
@@ -312,7 +311,7 @@ class UserController {
         try {
             log.info "Removing user"
             JSONObject dataObject = permissionService.handleInput(request, params)
-            if (!permissionService.hasPermissions(dataObject, PermissionEnum.ADMINISTRATE)) {
+            if (!permissionService.hasGlobalPermissions(dataObject, PermissionEnum.ADMINISTRATE)) {
                 render status: HttpStatus.UNAUTHORIZED
                 return
             }
@@ -440,7 +439,6 @@ class UserController {
         }
         UserOrganismPermission userOrganismPermission = UserOrganismPermission.findById(dataObject.id)
 
-
         User user = dataObject.userId ? User.findById(dataObject.userId) : User.findByUsername(dataObject.user)
 
         Organism organism = Organism.findByCommonName(dataObject.organism)
@@ -460,7 +458,6 @@ class UserController {
         }
 
 
-
         JSONArray permissionsArray = new JSONArray()
         if (dataObject.getBoolean(PermissionEnum.ADMINISTRATE.name())) {
             permissionsArray.add(PermissionEnum.ADMINISTRATE.name())
@@ -475,13 +472,18 @@ class UserController {
             permissionsArray.add(PermissionEnum.READ.name())
         }
 
+        if(permissionsArray.size()==0){
+            userOrganismPermission.delete(flush: true)
+            render userOrganismPermission as JSON
+            return
+        }
 
         userOrganismPermission.permissions = permissionsArray.toString()
         userOrganismPermission.save(flush: true)
-
         log.info "Updated organism permissions for user ${user.username} and organism ${organism.commonName} and permissions ${permissionsArray.toString()}"
-
         render userOrganismPermission as JSON
+
+
     }
 
 }

--- a/grails-app/services/org/bbop/apollo/PermissionService.groovy
+++ b/grails-app/services/org/bbop/apollo/PermissionService.groovy
@@ -406,10 +406,9 @@ class PermissionService {
         return highestValue
     }
 
-    Boolean hasPermissions(JSONObject jsonObject, PermissionEnum permissionEnum) {
+    Boolean hasGlobalPermissions(JSONObject jsonObject,PermissionEnum permissionEnum){
         // not sure if permissions with translate through or not
         Session session = SecurityUtils.subject.getSession(false)
-        String clientToken = jsonObject.getString(FeatureStringEnum.CLIENT_TOKEN.value)
         if (!session) {
             // login with jsonObject tokens
             log.debug "creating session with found json object ${jsonObject.username}, ${jsonObject.password as String}"
@@ -434,6 +433,13 @@ class PermissionService {
             jsonObject.username = session.getAttribute(FeatureStringEnum.USERNAME.value)
         }
 
+    }
+
+    Boolean hasPermissions(JSONObject jsonObject, PermissionEnum permissionEnum) {
+        if(!hasGlobalPermissions(jsonObject,permissionEnum)){
+            log.info("User for ${jsonObject} lacks permissions ${permissionEnum.display}" )
+        }
+        String clientToken = jsonObject.getString(FeatureStringEnum.CLIENT_TOKEN.value)
 
         Organism organism = getCurrentOrganismPreference(clientToken)?.organism
         log.debug "passing in an organism ${jsonObject.organism}"

--- a/grails-app/services/org/bbop/apollo/PermissionService.groovy
+++ b/grails-app/services/org/bbop/apollo/PermissionService.groovy
@@ -438,6 +438,7 @@ class PermissionService {
     Boolean hasPermissions(JSONObject jsonObject, PermissionEnum permissionEnum) {
         if(!hasGlobalPermissions(jsonObject,permissionEnum)){
             log.info("User for ${jsonObject} lacks permissions ${permissionEnum.display}" )
+            return false
         }
         String clientToken = jsonObject.getString(FeatureStringEnum.CLIENT_TOKEN.value)
 


### PR DESCRIPTION
This should fix #1067 and the remnants of #1061 . . . 

Not sure if it passes the integration test, though due to issues with Chado. 

Getting a weird error locally, though:

```
| Running 13 integration tests... 2 of 13
ERROR:  permission denied for relation cvterm
STATEMENT:  select count(*) as y0_ from cvterm this_
| Error 2016-05-26 13:48:22,955 [main] ERROR spi.SqlExceptionHelper  - ERROR: permission denied for relation cvterm
| Failure:  test CHADO export for standard annotations(org.bbop.apollo.ChadoHandlerServiceIntegrationSpec)
|  org.springframework.jdbc.BadSqlGrammarException: Hibernate operation: could not extract ResultSet; bad SQL grammar [n/a]; nested exception is org.postgresql.util.PSQLException: ERROR: permission denied for relation cvterm
	at org.grails.datastore.gorm.GormStaticApi.getCount(GormStaticApi.groovy:385)
	at org.bbop.apollo.ChadoHandlerService.$tt__checkForOntologies(ChadoHandlerService.groovy:1443)
	at org.bbop.apollo.ChadoHandlerService.$tt__writeFeatures(ChadoHandlerService.groovy:54)
	at org.bbop.apollo.ChadoHandlerServiceIntegrationSpec.test CHADO export for standard annotations(ChadoHandlerServiceIntegrationSpec.groovy:112)
Caused by: org.postgresql.util.PSQLException: ERROR: permission denied for relation cvterm
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2161)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1890)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:255)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:559)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:417)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.executeQuery(AbstractJdbc2Statement.java:302)
	... 4 more
| Running 13 integration tests... 3 of 13
ERROR:  permission denied for relation cvterm
STATEMENT:  select count(*) as y0_ from cvterm this_
| Error 2016-05-26 13:48:23,488 [main] ERROR spi.SqlExceptionHelper  - ERROR: permission denied for relation cvterm
| Failure:  test CHADO export for annotations with additional information(org.bbop.apollo.ChadoHandlerServiceIntegrationSpec)
|  org.springframework.jdbc.BadSqlGrammarException: Hibernate operation: could not extract ResultSet; bad SQL grammar [n/a]; nested exception is org.postgresql.util.PSQLException: ERROR: permission denied for relation cvterm
	at org.grails.datastore.gorm.GormStaticApi.getCount(GormStaticApi.groovy:385)
	at org.bbop.apollo.ChadoHandlerService.$tt__checkForOntologies(ChadoHandlerService.groovy:1443)
	at org.bbop.apollo.ChadoHandlerService.$tt__writeFeatures(ChadoHandlerService.groovy:54)
	at org.bbop.apollo.ChadoHandlerServiceIntegrationSpec.test CHADO export for annotations with additional information(ChadoHandlerServiceIntegrationSpec.groovy:233)
Caused by: org.postgresql.util.PSQLException: ERROR: permission denied for relation cvterm
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2161)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1890)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:255)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:559)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:417)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.executeQuery(AbstractJdbc2Statement.java:302)
	... 4 more
| Running 13 integration tests... 4 of 13
ERROR:  permission denied for relation cvterm
STATEMENT:  select count(*) as y0_ from cvterm this_
| Error 2016-05-26 13:48:24,210 [main] ERROR spi.SqlExceptionHelper  - ERROR: permission denied for relation cvterm
| Failure:  test CHADO export and re-export(org.bbop.apollo.ChadoHandlerServiceIntegrationSpec)
|  org.springframework.jdbc.BadSqlGrammarException: Hibernate operation: could not extract ResultSet; bad SQL grammar [n/a]; nested exception is org.postgresql.util.PSQLException: ERROR: permission denied for relation cvterm
	at org.grails.datastore.gorm.GormStaticApi.getCount(GormStaticApi.groovy:385)
	at org.bbop.apollo.ChadoHandlerService.$tt__checkForOntologies(ChadoHandlerService.groovy:1443)
	at org.bbop.apollo.ChadoHandlerService.$tt__writeFeatures(ChadoHandlerService.groovy:54)
	at org.bbop.apollo.ChadoHandlerServiceIntegrationSpec.test CHADO export and re-export(ChadoHandlerServiceIntegrationSpec.groovy:337)
Caused by: org.postgresql.util.PSQLException: ERROR: permission denied for relation cvterm
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2161)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1890)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:255)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:559)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:417)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.executeQuery(AbstractJdbc2Statement.java:302)
	... 4 more
| Running 13 integration tests... 8 of 13
2016-05-26 13:48:25,446 [main] WARN  apollo.FeatureEventService  - Can not undo any further
| Running 13 integration tests... 20 of 20
2016-05-26 13:48:31,273 [main] WARN  apollo.FeatureService  - No proper type for the CV is set {"cv":{"name":"feature_property"}}
2016-05-26 13:48:31,275 [main] WARN  apollo.FeatureService  - No proper type for the CV is set {"cv":{"name":"feature_property"}}
2016-05-26 13:48:31,276 [main] WARN  apollo.FeatureService  - No proper type for the CV is set {"cv":{"name":"feature_property"}}
2016-05-26 13:48:31,277 [main] WARN  apollo.FeatureService  - No proper type for the CV is set {"cv
```