### PR TITLE
Fixes bower installation and check for NPM, add JVM version 

### DIFF
--- a/apollo
+++ b/apollo
@@ -57,14 +57,15 @@ function check_node(){
             alias node="nodejs"
         fi
     fi
+    npm_executable=$(which npm)
 }
 
 function check_bower(){
     bower_executable=$(which bower)
     if ! [ -x "$bower_executable" ] ; then
-        $node_executable install -g bower
+        $npm_executable install -g bower
         if ! [ -x "$bower_executable" ] ; then
-            echo "You must install 'Bower' to do a release of Apollo."
+            echo "You must install 'Bower' to do a release of Apollo.  sudo ${npm_executable} install -g bower"
             exit 1 ;
         fi
     fi
@@ -116,6 +117,7 @@ function check_configs(){
     fi
 
     check_node
+    check_bower
 }
 
 function copy_configs(){

--- a/docs/Apollo2Build.md
+++ b/docs/Apollo2Build.md
@@ -12,9 +12,13 @@ This guide will cover the "development mode" scenario which should be easy to st
 
 You have to install Java and the Java Development Kit (JDK) 7 or higher to run Apollo.  Both the Oracle and OpenJDK versions have been tested.
 
-### Node.js / NPM
+### Node.js / NPM / Bower
 
 You will need to [install node.js](https://nodejs.org/en/download/), which includes NPM (the node package manager) to build Apollo.
+
+Once node.js / npm is installed, install bower using (you may need sudo):
+
+    npm install -g bower 
 
 ### Grails / Groovy / Gradle  (optional)
 

--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -445,6 +445,10 @@ class JbrowseController {
     def passthrough() {
         String dataFileName = params.prefix + "/" + params.path
         String fileName = FilenameUtils.getName(params.path)
+        // have to prefix with a "/"
+        if(!dataFileName.startsWith("/")){
+            dataFileName = "/" + dataFileName
+        }
         File file = new File(servletContext.getRealPath(dataFileName))
 
         if (!file.exists()) {


### PR DESCRIPTION
On some older java versions an NPE getServletPath fails.  This fixes that. 