### PR TITLE
Canned key attributes

### DIFF
--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -2297,6 +2297,8 @@ define([
                 var pubmedIdDb = "PMID";
                 var goIdDb = "GO";
                 var cannedComments;
+                var cannedKeys;
+                var cannedValues;
 
                 var timeout = 100;
 
@@ -2590,6 +2592,8 @@ define([
 
                 var initAttributes = function (feature, config) {
                     if (config.hasAttributes) {
+                        cannedKeys = feature.canned_keys;
+                        cannedValues = feature.canned_values;
                         var oldTag;
                         var oldValue;
                         var attributes = new dojoItemFileWriteStore({
@@ -2607,6 +2611,8 @@ define([
                                     name: 'Tag',
                                     field: 'tag',
                                     width: '40%',
+                                    type: dojox.grid.cells.ComboBox,
+                                    options: cannedKeys,
                                     formatter: function (tag) {
                                         if (!tag) {
                                             return "Enter new tag";
@@ -2619,6 +2625,8 @@ define([
                                     name: 'Value',
                                     field: 'value',
                                     width: '60%',
+                                    type: dojox.grid.cells.ComboBox,
+                                    options: cannedValues,
                                     formatter: function (value) {
                                         if (!value) {
                                             return "Enter new value";
@@ -3016,7 +3024,7 @@ define([
                 function updateTimeLastUpdated() {
                     var date = new Date();
                     dateLastModifiedField.set("value", FormatUtils.formatDate(date.getTime()));
-                };
+                }
 
                 var updateName = function (name) {
                     name = escapeString(name);

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -316,6 +316,8 @@ apollo {
     // customize admin tab on annotator panel with these links
     administrativePanel = [
             ['label': "Canned Comments", 'link': "/cannedComment/"]
+            ,['label': "Canned Key", 'link': "/cannedKey/"]
+            ,['label': "Canned Values", 'link': "/cannedValue/"]
             ,['label': "Feature Types", 'link': "/featureType/"]
             ,['label': "Statuses", 'link': "/availableStatus/"]
             ,['label': "Proxies", 'link': "/proxy/"]

--- a/grails-app/conf/org/bbop/apollo/SecurityFilters.groovy
+++ b/grails-app/conf/org/bbop/apollo/SecurityFilters.groovy
@@ -25,6 +25,9 @@ class SecurityFilters {
             before = {
                 if (controllerName == "organism"
                         || controllerName == "home"
+                        || controllerName == "cannedKey"
+                        || controllerName == "cannedValue"
+                        || controllerName == "cannedComment"
                         || actionName == "report"
                         || actionName == "loadLink"
                 ) {

--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -1029,7 +1029,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
                 if (featureTypeList) {
                     cannedKeyStrings.addAll(CannedKey.executeQuery("select cc from CannedKey cc join cc.featureTypes ft where ft in (:featureTypeList)", [featureTypeList: featureTypeList]).label)
                 }
-                cannedKeyStrings.addAll(CannedKey.executeQuery("select cc from CannedComment cc where cc.featureTypes is empty").label)
+                cannedKeyStrings.addAll(CannedKey.executeQuery("select cc from CannedKey cc where cc.featureTypes is empty").label)
                 if (cannedKeyStrings != null) {
                     for (String comment : cannedKeyStrings) {
                         cannedKeys.put(comment);
@@ -1041,9 +1041,9 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
                 JSONArray cannedValues = new JSONArray();
                 newFeature.put(FeatureStringEnum.CANNED_VALUES.value, cannedValues);
                 if (featureTypeList) {
-                    cannedValueStrings.addAll(CannedKey.executeQuery("select cc from CannedKey cc join cc.featureTypes ft where ft in (:featureTypeList)", [featureTypeList: featureTypeList]).label)
+                    cannedValueStrings.addAll(CannedValue.executeQuery("select cc from CannedValue cc join cc.featureTypes ft where ft in (:featureTypeList)", [featureTypeList: featureTypeList]).label)
                 }
-                cannedValueStrings.addAll(CannedKey.executeQuery("select cc from CannedComment cc where cc.featureTypes is empty").label)
+                cannedValueStrings.addAll(CannedValue.executeQuery("select cc from CannedValue cc where cc.featureTypes is empty").label)
                 if (cannedValueStrings != null) {
                     for (String comment : cannedValueStrings) {
                         cannedValues.put(comment);

--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -1019,6 +1019,37 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
                     jsonProperty.put(FeatureStringEnum.VALUE.value, property.getValue());
                     properties.put(jsonProperty);
                 }
+
+                List<FeatureType> featureTypeList = FeatureType.findAllByOntologyId(feature.ontologyId)
+
+
+                List<String> cannedKeyStrings = new ArrayList<>()
+                JSONArray cannedKeys = new JSONArray();
+                newFeature.put(FeatureStringEnum.CANNED_KEYS.value, cannedKeys);
+                if (featureTypeList) {
+                    cannedKeyStrings.addAll(CannedKey.executeQuery("select cc from CannedKey cc join cc.featureTypes ft where ft in (:featureTypeList)", [featureTypeList: featureTypeList]).label)
+                }
+                cannedKeyStrings.addAll(CannedKey.executeQuery("select cc from CannedComment cc where cc.featureTypes is empty").label)
+                if (cannedKeyStrings != null) {
+                    for (String comment : cannedKeyStrings) {
+                        cannedKeys.put(comment);
+                    }
+                }
+
+                // handle canned Values
+                List<String> cannedValueStrings = new ArrayList<>()
+                JSONArray cannedValues = new JSONArray();
+                newFeature.put(FeatureStringEnum.CANNED_VALUES.value, cannedValues);
+                if (featureTypeList) {
+                    cannedValueStrings.addAll(CannedKey.executeQuery("select cc from CannedKey cc join cc.featureTypes ft where ft in (:featureTypeList)", [featureTypeList: featureTypeList]).label)
+                }
+                cannedValueStrings.addAll(CannedKey.executeQuery("select cc from CannedComment cc where cc.featureTypes is empty").label)
+                if (cannedValueStrings != null) {
+                    for (String comment : cannedValueStrings) {
+                        cannedValues.put(comment);
+                    }
+                }
+
             }
             if (configWrapperService.hasDbxrefs() || configWrapperService.hasPubmedIds() || configWrapperService.hasGoIds()) {
                 JSONArray dbxrefs = new JSONArray();
@@ -1052,6 +1083,9 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
                     }
                 }
             }
+
+
+
             returnObject.getJSONArray(FeatureStringEnum.FEATURES.value).put(newFeature);
         }
 

--- a/grails-app/controllers/org/bbop/apollo/CannedKeyController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/CannedKeyController.groovy
@@ -29,6 +29,9 @@ class CannedKeyController {
     }
 
     def create() {
+        CannedKey cannedKey = new CannedKey(params)
+        println "validated ${cannedKey.validate()} and errors: ${cannedKey.errors}"
+
         respond new CannedKey(params)
     }
 
@@ -40,6 +43,7 @@ class CannedKeyController {
         }
 
         if (cannedKeyInstance.hasErrors()) {
+            println "has errors: ${cannedKeyInstance.errors}"
             respond cannedKeyInstance.errors, view:'create'
             return
         }

--- a/grails-app/controllers/org/bbop/apollo/CannedKeyController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/CannedKeyController.groovy
@@ -1,0 +1,113 @@
+package org.bbop.apollo
+
+
+
+import static org.springframework.http.HttpStatus.*
+import grails.transaction.Transactional
+
+@Transactional(readOnly = true)
+class CannedKeyController {
+
+    static allowedMethods = [save: "POST", update: "PUT", delete: "DELETE"]
+
+    def permissionService
+
+    def beforeInterceptor = {
+        if(!permissionService.isAdmin()){
+            forward action: "notAuthorized" ,controller: "annotator"
+            return
+        }
+    }
+
+    def index(Integer max) {
+        params.max = Math.min(max ?: 10, 100)
+        respond CannedKey.list(params), model:[cannedKeyInstanceCount: CannedKey.count()]
+    }
+
+    def show(CannedKey cannedKeyInstance) {
+        respond cannedKeyInstance
+    }
+
+    def create() {
+        respond new CannedKey(params)
+    }
+
+    @Transactional
+    def save(CannedKey cannedKeyInstance) {
+        if (cannedKeyInstance == null) {
+            notFound()
+            return
+        }
+
+        if (cannedKeyInstance.hasErrors()) {
+            respond cannedKeyInstance.errors, view:'create'
+            return
+        }
+
+        cannedKeyInstance.save flush:true
+
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.created.message', args: [message(code: 'cannedKey.label', default: 'CannedKey'), cannedKeyInstance.id])
+                redirect cannedKeyInstance
+            }
+            '*' { respond cannedKeyInstance, [status: CREATED] }
+        }
+    }
+
+    def edit(CannedKey cannedKeyInstance) {
+        respond cannedKeyInstance
+    }
+
+    @Transactional
+    def update(CannedKey cannedKeyInstance) {
+        if (cannedKeyInstance == null) {
+            notFound()
+            return
+        }
+
+        if (cannedKeyInstance.hasErrors()) {
+            respond cannedKeyInstance.errors, view:'edit'
+            return
+        }
+
+        cannedKeyInstance.save flush:true
+
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.updated.message', args: [message(code: 'CannedKey.label', default: 'CannedKey'), cannedKeyInstance.id])
+                redirect cannedKeyInstance
+            }
+            '*'{ respond cannedKeyInstance, [status: OK] }
+        }
+    }
+
+    @Transactional
+    def delete(CannedKey cannedKeyInstance) {
+
+        if (cannedKeyInstance == null) {
+            notFound()
+            return
+        }
+
+        cannedKeyInstance.delete flush:true
+
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.deleted.message', args: [message(code: 'CannedKey.label', default: 'CannedKey'), cannedKeyInstance.id])
+                redirect action:"index", method:"GET"
+            }
+            '*'{ render status: NO_CONTENT }
+        }
+    }
+
+    protected void notFound() {
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.not.found.message', args: [message(code: 'cannedKey.label', default: 'CannedKey'), params.id])
+                redirect action: "index", method: "GET"
+            }
+            '*'{ render status: NOT_FOUND }
+        }
+    }
+}

--- a/grails-app/controllers/org/bbop/apollo/CannedValueController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/CannedValueController.groovy
@@ -1,0 +1,113 @@
+package org.bbop.apollo
+
+
+
+import static org.springframework.http.HttpStatus.*
+import grails.transaction.Transactional
+
+@Transactional(readOnly = true)
+class CannedValueController {
+
+    static allowedMethods = [save: "POST", update: "PUT", delete: "DELETE"]
+
+    def permissionService
+
+    def beforeInterceptor = {
+        if(!permissionService.isAdmin()){
+            forward action: "notAuthorized" ,controller: "annotator"
+            return
+        }
+    }
+
+    def index(Integer max) {
+        params.max = Math.min(max ?: 10, 100)
+        respond CannedValue.list(params), model:[cannedValueInstanceCount: CannedValue.count()]
+    }
+
+    def show(CannedValue cannedValueInstance) {
+        respond cannedValueInstance
+    }
+
+    def create() {
+        respond new CannedValue(params)
+    }
+
+    @Transactional
+    def save(CannedValue cannedValueInstance) {
+        if (cannedValueInstance == null) {
+            notFound()
+            return
+        }
+
+        if (cannedValueInstance.hasErrors()) {
+            respond cannedValueInstance.errors, view:'create'
+            return
+        }
+
+        cannedValueInstance.save flush:true
+
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.created.message', args: [message(code: 'cannedValue.label', default: 'CannedValue'), cannedValueInstance.id])
+                redirect cannedValueInstance
+            }
+            '*' { respond cannedValueInstance, [status: CREATED] }
+        }
+    }
+
+    def edit(CannedValue cannedValueInstance) {
+        respond cannedValueInstance
+    }
+
+    @Transactional
+    def update(CannedValue cannedValueInstance) {
+        if (cannedValueInstance == null) {
+            notFound()
+            return
+        }
+
+        if (cannedValueInstance.hasErrors()) {
+            respond cannedValueInstance.errors, view:'edit'
+            return
+        }
+
+        cannedValueInstance.save flush:true
+
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.updated.message', args: [message(code: 'CannedValue.label', default: 'CannedValue'), cannedValueInstance.id])
+                redirect cannedValueInstance
+            }
+            '*'{ respond cannedValueInstance, [status: OK] }
+        }
+    }
+
+    @Transactional
+    def delete(CannedValue cannedValueInstance) {
+
+        if (cannedValueInstance == null) {
+            notFound()
+            return
+        }
+
+        cannedValueInstance.delete flush:true
+
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.deleted.message', args: [message(code: 'CannedValue.label', default: 'CannedValue'), cannedValueInstance.id])
+                redirect action:"index", method:"GET"
+            }
+            '*'{ render status: NO_CONTENT }
+        }
+    }
+
+    protected void notFound() {
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.not.found.message', args: [message(code: 'cannedValue.label', default: 'CannedValue'), params.id])
+                redirect action: "index", method: "GET"
+            }
+            '*'{ render status: NOT_FOUND }
+        }
+    }
+}

--- a/grails-app/domain/org/bbop/apollo/CannedKey.groovy
+++ b/grails-app/domain/org/bbop/apollo/CannedKey.groovy
@@ -11,7 +11,6 @@ class CannedKey {
     String metadata
 
     static hasMany = [
-            featureTypes: FeatureType
-            ,values: CannedValue
+        featureTypes: FeatureType
     ]
 }

--- a/grails-app/domain/org/bbop/apollo/CannedKey.groovy
+++ b/grails-app/domain/org/bbop/apollo/CannedKey.groovy
@@ -1,0 +1,17 @@
+package org.bbop.apollo
+
+class CannedKey {
+
+    static constraints = {
+        label nullable: false
+        metadata nullable: true
+    }
+
+    String label
+    String metadata
+
+    static hasMany = [
+            featureTypes: FeatureType
+            ,values: CannedValue
+    ]
+}

--- a/grails-app/domain/org/bbop/apollo/CannedValue.groovy
+++ b/grails-app/domain/org/bbop/apollo/CannedValue.groovy
@@ -1,0 +1,20 @@
+package org.bbop.apollo
+
+class CannedValue {
+
+    static constraints = {
+        label nullable: false
+        metadata nullable: true
+    }
+
+    String label
+    String metadata
+
+    static belongsTo = [
+       CannedKey
+    ]
+
+    static hasMany = [
+        featureTypes: FeatureType
+    ]
+}

--- a/grails-app/domain/org/bbop/apollo/CannedValue.groovy
+++ b/grails-app/domain/org/bbop/apollo/CannedValue.groovy
@@ -10,10 +10,6 @@ class CannedValue {
     String label
     String metadata
 
-    static belongsTo = [
-       CannedKey
-    ]
-
     static hasMany = [
         featureTypes: FeatureType
     ]

--- a/grails-app/views/cannedKey/_form.gsp
+++ b/grails-app/views/cannedKey/_form.gsp
@@ -30,13 +30,13 @@
 
 </div>
 
-<div class="fieldcontain ${hasErrors(bean: cannedKeyInstance, field: 'values', 'error')} ">
-    <label for="values">
-        <g:message code="cannedKey.values.label" default="Values"/>
+%{--<div class="fieldcontain ${hasErrors(bean: cannedKeyInstance, field: 'values', 'error')} ">--}%
+    %{--<label for="values">--}%
+        %{--<g:message code="cannedKey.values.label" default="Values"/>--}%
 
-    </label>
-    <g:select name="values" from="${org.bbop.apollo.CannedValue.list()}" multiple="multiple" optionKey="id" size="5" optionValue="label"
-              value="${cannedKeyInstance?.values*.id}" class="many-to-many"/>
+    %{--</label>--}%
+    %{--<g:select name="values" from="${org.bbop.apollo.CannedValue.list()}" multiple="multiple" optionKey="id" size="5" optionValue="label"--}%
+              %{--value="${cannedKeyInstance?.values*.id}" class="many-to-many"/>--}%
 
-</div>
+%{--</div>--}%
 

--- a/grails-app/views/cannedKey/_form.gsp
+++ b/grails-app/views/cannedKey/_form.gsp
@@ -1,0 +1,42 @@
+<%@ page import="org.bbop.apollo.CannedKey" %>
+
+
+
+<div class="fieldcontain ${hasErrors(bean: cannedKeyInstance, field: 'label', 'error')} required">
+    <label for="label">
+        <g:message code="cannedKey.label.label" default="Label"/>
+        <span class="required-indicator">*</span>
+    </label>
+    <g:textField name="label" required="" value="${cannedKeyInstance?.label}"/>
+
+</div>
+
+<div class="fieldcontain ${hasErrors(bean: cannedKeyInstance, field: 'metadata', 'error')} ">
+    <label for="metadata">
+        <g:message code="cannedKey.metadata.label" default="Metadata"/>
+
+    </label>
+    <g:textField name="metadata" value="${cannedKeyInstance?.metadata}"/>
+
+</div>
+
+<div class="fieldcontain ${hasErrors(bean: cannedKeyInstance, field: 'featureTypes', 'error')} ">
+    <label for="featureTypes">
+        <g:message code="cannedKey.featureTypes.label" default="Feature Types"/>
+
+    </label>
+    <g:select name="featureTypes" from="${org.bbop.apollo.FeatureType.list()}" multiple="multiple" optionKey="id"
+              size="10" value="${cannedKeyInstance?.featureTypes*.id}" class="many-to-many" optionValue="display"/>
+
+</div>
+
+<div class="fieldcontain ${hasErrors(bean: cannedKeyInstance, field: 'values', 'error')} ">
+    <label for="values">
+        <g:message code="cannedKey.values.label" default="Values"/>
+
+    </label>
+    <g:select name="values" from="${org.bbop.apollo.CannedValue.list()}" multiple="multiple" optionKey="id" size="5" optionValue="label"
+              value="${cannedKeyInstance?.values*.id}" class="many-to-many"/>
+
+</div>
+

--- a/grails-app/views/cannedKey/create.gsp
+++ b/grails-app/views/cannedKey/create.gsp
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="layout" content="main">
+		<g:set var="entityName" value="${message(code: 'cannedKey.label', default: 'CannedKey')}" />
+		<title><g:message code="default.create.label" args="[entityName]" /></title>
+	</head>
+	<body>
+		<a href="#create-cannedKey" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+		<div class="nav" role="navigation">
+			<ul>
+				<li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+				<li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]" /></g:link></li>
+			</ul>
+		</div>
+		<div id="create-cannedKey" class="content scaffold-create" role="main">
+			<h1><g:message code="default.create.label" args="[entityName]" /></h1>
+			<g:if test="${flash.message}">
+			<div class="message" role="status">${flash.message}</div>
+			</g:if>
+			<g:hasErrors bean="${cannedKeyInstance}">
+			<ul class="errors" role="alert">
+				<g:eachError bean="${cannedKeyInstance}" var="error">
+				<li <g:if test="${error in org.springframework.validation.FieldError}">data-field-id="${error.field}"</g:if>><g:message error="${error}"/></li>
+				</g:eachError>
+			</ul>
+			</g:hasErrors>
+			<g:form url="[resource:cannedKeyInstance, action:'save']" >
+				<fieldset class="form">
+					<g:render template="form"/>
+				</fieldset>
+				<fieldset class="buttons">
+					<g:submitButton name="create" class="save" value="${message(code: 'default.button.create.label', default: 'Create')}" />
+				</fieldset>
+			</g:form>
+		</div>
+	</body>
+</html>

--- a/grails-app/views/cannedKey/edit.gsp
+++ b/grails-app/views/cannedKey/edit.gsp
@@ -1,0 +1,41 @@
+<%@ page import="org.bbop.apollo.CannedKey" %>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="layout" content="main">
+		<g:set var="entityName" value="${message(code: 'cannedKey.label', default: 'CannedKey')}" />
+		<title><g:message code="default.edit.label" args="[entityName]" /></title>
+	</head>
+	<body>
+		<a href="#edit-cannedKey" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+		<div class="nav" role="navigation">
+			<ul>
+				<li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+				<li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]" /></g:link></li>
+				<li><g:link class="create" action="create"><g:message code="default.new.label" args="[entityName]" /></g:link></li>
+			</ul>
+		</div>
+		<div id="edit-cannedKey" class="content scaffold-edit" role="main">
+			<h1><g:message code="default.edit.label" args="[entityName]" /></h1>
+			<g:if test="${flash.message}">
+			<div class="message" role="status">${flash.message}</div>
+			</g:if>
+			<g:hasErrors bean="${cannedKeyInstance}">
+			<ul class="errors" role="alert">
+				<g:eachError bean="${cannedKeyInstance}" var="error">
+				<li <g:if test="${error in org.springframework.validation.FieldError}">data-field-id="${error.field}"</g:if>><g:message error="${error}"/></li>
+				</g:eachError>
+			</ul>
+			</g:hasErrors>
+			<g:form url="[resource:cannedKeyInstance, action:'update']" method="PUT" >
+				<g:hiddenField name="version" value="${cannedKeyInstance?.version}" />
+				<fieldset class="form">
+					<g:render template="form"/>
+				</fieldset>
+				<fieldset class="buttons">
+					<g:actionSubmit class="save" action="update" value="${message(code: 'default.button.update.label', default: 'Update')}" />
+				</fieldset>
+			</g:form>
+		</div>
+	</body>
+</html>

--- a/grails-app/views/cannedKey/index.gsp
+++ b/grails-app/views/cannedKey/index.gsp
@@ -1,0 +1,50 @@
+
+<%@ page import="org.bbop.apollo.CannedKey" %>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="layout" content="main">
+		<g:set var="entityName" value="${message(code: 'cannedKey.label', default: 'CannedKey')}" />
+		<title><g:message code="default.list.label" args="[entityName]" /></title>
+	</head>
+	<body>
+		<a href="#list-cannedKey" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+		<div class="nav" role="navigation">
+			<ul>
+				<li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+				<li><g:link class="create" action="create"><g:message code="default.new.label" args="[entityName]" /></g:link></li>
+			</ul>
+		</div>
+		<div id="list-cannedKey" class="content scaffold-list" role="main">
+			<h1><g:message code="default.list.label" args="[entityName]" /></h1>
+			<g:if test="${flash.message}">
+				<div class="message" role="status">${flash.message}</div>
+			</g:if>
+			<table>
+			<thead>
+					<tr>
+					
+						<g:sortableColumn property="label" title="${message(code: 'cannedKey.label.label', default: 'Label')}" />
+					
+						<g:sortableColumn property="metadata" title="${message(code: 'cannedKey.metadata.label', default: 'Metadata')}" />
+					
+					</tr>
+				</thead>
+				<tbody>
+				<g:each in="${cannedKeyInstanceList}" status="i" var="cannedKeyInstance">
+					<tr class="${(i % 2) == 0 ? 'even' : 'odd'}">
+					
+						<td><g:link action="show" id="${cannedKeyInstance.id}">${fieldValue(bean: cannedKeyInstance, field: "label")}</g:link></td>
+					
+						<td>${fieldValue(bean: cannedKeyInstance, field: "metadata")}</td>
+					
+					</tr>
+				</g:each>
+				</tbody>
+			</table>
+			<div class="pagination">
+				<g:paginate total="${cannedKeyInstanceCount ?: 0}" />
+			</div>
+		</div>
+	</body>
+</html>

--- a/grails-app/views/cannedKey/show.gsp
+++ b/grails-app/views/cannedKey/show.gsp
@@ -57,7 +57,7 @@
 					<span id="values-label" class="property-label"><g:message code="cannedKey.values.label" default="Values" /></span>
 					
 						<g:each in="${cannedKeyInstance.values}" var="v">
-						<span class="property-value" aria-labelledby="values-label"><g:link controller="cannedValue" action="show" id="${v.id}">${v?.encodeAsHTML()}</g:link></span>
+						<span class="property-value" aria-labelledby="values-label"><g:link controller="cannedValue" action="show" id="${v.id}">${v?.label}</g:link></span>
 						</g:each>
 					
 				</li>

--- a/grails-app/views/cannedKey/show.gsp
+++ b/grails-app/views/cannedKey/show.gsp
@@ -1,0 +1,75 @@
+
+<%@ page import="org.bbop.apollo.CannedKey" %>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="layout" content="main">
+		<g:set var="entityName" value="${message(code: 'cannedKey.label', default: 'CannedKey')}" />
+		<title><g:message code="default.show.label" args="[entityName]" /></title>
+	</head>
+	<body>
+		<a href="#show-cannedKey" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+		<div class="nav" role="navigation">
+			<ul>
+				<li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+				<li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]" /></g:link></li>
+				<li><g:link class="create" action="create"><g:message code="default.new.label" args="[entityName]" /></g:link></li>
+			</ul>
+		</div>
+		<div id="show-cannedKey" class="content scaffold-show" role="main">
+			<h1><g:message code="default.show.label" args="[entityName]" /></h1>
+			<g:if test="${flash.message}">
+			<div class="message" role="status">${flash.message}</div>
+			</g:if>
+			<ol class="property-list cannedKey">
+			
+				<g:if test="${cannedKeyInstance?.label}">
+				<li class="fieldcontain">
+					<span id="label-label" class="property-label"><g:message code="cannedKey.label.label" default="Label" /></span>
+					
+						<span class="property-value" aria-labelledby="label-label"><g:fieldValue bean="${cannedKeyInstance}" field="label"/></span>
+					
+				</li>
+				</g:if>
+			
+				<g:if test="${cannedKeyInstance?.metadata}">
+				<li class="fieldcontain">
+					<span id="metadata-label" class="property-label"><g:message code="cannedKey.metadata.label" default="Metadata" /></span>
+					
+						<span class="property-value" aria-labelledby="metadata-label"><g:fieldValue bean="${cannedKeyInstance}" field="metadata"/></span>
+					
+				</li>
+				</g:if>
+			
+				<g:if test="${cannedKeyInstance?.featureTypes}">
+				<li class="fieldcontain">
+					<span id="featureTypes-label" class="property-label"><g:message code="cannedKey.featureTypes.label" default="Feature Types" /></span>
+					
+						<g:each in="${cannedKeyInstance.featureTypes}" var="f">
+						<span class="property-value" aria-labelledby="featureTypes-label"><g:link controller="featureType" action="show" id="${f.id}">${f?.display}</g:link></span>
+						</g:each>
+					
+				</li>
+				</g:if>
+			
+				%{--<g:if test="${cannedKeyInstance?.values}">--}%
+				<li class="fieldcontain">
+					<span id="values-label" class="property-label"><g:message code="cannedKey.values.label" default="Values" /></span>
+					
+						<g:each in="${cannedKeyInstance.values}" var="v">
+						<span class="property-value" aria-labelledby="values-label"><g:link controller="cannedValue" action="show" id="${v.id}">${v?.encodeAsHTML()}</g:link></span>
+						</g:each>
+					
+				</li>
+				%{--</g:if>--}%
+			
+			</ol>
+			<g:form url="[resource:cannedKeyInstance, action:'delete']" method="DELETE">
+				<fieldset class="buttons">
+					<g:link class="edit" action="edit" resource="${cannedKeyInstance}"><g:message code="default.button.edit.label" default="Edit" /></g:link>
+					<g:actionSubmit class="delete" action="delete" value="${message(code: 'default.button.delete.label', default: 'Delete')}" onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');" />
+				</fieldset>
+			</g:form>
+		</div>
+	</body>
+</html>

--- a/grails-app/views/cannedKey/show.gsp
+++ b/grails-app/views/cannedKey/show.gsp
@@ -53,14 +53,14 @@
 				</g:if>
 			
 				%{--<g:if test="${cannedKeyInstance?.values}">--}%
-				<li class="fieldcontain">
-					<span id="values-label" class="property-label"><g:message code="cannedKey.values.label" default="Values" /></span>
-					
-						<g:each in="${cannedKeyInstance.values}" var="v">
-						<span class="property-value" aria-labelledby="values-label"><g:link controller="cannedValue" action="show" id="${v.id}">${v?.label}</g:link></span>
-						</g:each>
-					
-				</li>
+				%{--<li class="fieldcontain">--}%
+					%{--<span id="values-label" class="property-label"><g:message code="cannedKey.values.label" default="Values" /></span>--}%
+					%{----}%
+						%{--<g:each in="${cannedKeyInstance.values}" var="v">--}%
+						%{--<span class="property-value" aria-labelledby="values-label"><g:link controller="cannedValue" action="show" id="${v.id}">${v?.label}</g:link></span>--}%
+						%{--</g:each>--}%
+					%{----}%
+				%{--</li>--}%
 				%{--</g:if>--}%
 			
 			</ol>

--- a/grails-app/views/cannedValue/_form.gsp
+++ b/grails-app/views/cannedValue/_form.gsp
@@ -1,0 +1,31 @@
+<%@ page import="org.bbop.apollo.CannedValue" %>
+
+
+
+<div class="fieldcontain ${hasErrors(bean: cannedValueInstance, field: 'label', 'error')} required">
+	<label for="label">
+		<g:message code="cannedValue.label.label" default="Label" />
+		<span class="required-indicator">*</span>
+	</label>
+	<g:textField name="label" required="" value="${cannedValueInstance?.label}"/>
+
+</div>
+
+<div class="fieldcontain ${hasErrors(bean: cannedValueInstance, field: 'metadata', 'error')} ">
+	<label for="metadata">
+		<g:message code="cannedValue.metadata.label" default="Metadata" />
+		
+	</label>
+	<g:textField name="metadata" value="${cannedValueInstance?.metadata}"/>
+
+</div>
+
+<div class="fieldcontain ${hasErrors(bean: cannedValueInstance, field: 'featureTypes', 'error')} ">
+	<label for="featureTypes">
+		<g:message code="cannedValue.featureTypes.label" default="Feature Types" />
+		
+	</label>
+	<g:select name="featureTypes" from="${org.bbop.apollo.FeatureType.list()}" multiple="multiple" optionKey="id" size="10" value="${cannedValueInstance?.featureTypes*.id}" class="many-to-many" optionValue="display"/>
+
+</div>
+

--- a/grails-app/views/cannedValue/create.gsp
+++ b/grails-app/views/cannedValue/create.gsp
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="layout" content="main">
+		<g:set var="entityName" value="${message(code: 'cannedValue.label', default: 'CannedValue')}" />
+		<title><g:message code="default.create.label" args="[entityName]" /></title>
+	</head>
+	<body>
+		<a href="#create-cannedValue" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+		<div class="nav" role="navigation">
+			<ul>
+				<li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+				<li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]" /></g:link></li>
+			</ul>
+		</div>
+		<div id="create-cannedValue" class="content scaffold-create" role="main">
+			<h1><g:message code="default.create.label" args="[entityName]" /></h1>
+			<g:if test="${flash.message}">
+			<div class="message" role="status">${flash.message}</div>
+			</g:if>
+			<g:hasErrors bean="${cannedValueInstance}">
+			<ul class="errors" role="alert">
+				<g:eachError bean="${cannedValueInstance}" var="error">
+				<li <g:if test="${error in org.springframework.validation.FieldError}">data-field-id="${error.field}"</g:if>><g:message error="${error}"/></li>
+				</g:eachError>
+			</ul>
+			</g:hasErrors>
+			<g:form url="[resource:cannedValueInstance, action:'save']" >
+				<fieldset class="form">
+					<g:render template="form"/>
+				</fieldset>
+				<fieldset class="buttons">
+					<g:submitButton name="create" class="save" value="${message(code: 'default.button.create.label', default: 'Create')}" />
+				</fieldset>
+			</g:form>
+		</div>
+	</body>
+</html>

--- a/grails-app/views/cannedValue/edit.gsp
+++ b/grails-app/views/cannedValue/edit.gsp
@@ -1,0 +1,41 @@
+<%@ page import="org.bbop.apollo.CannedValue" %>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="layout" content="main">
+		<g:set var="entityName" value="${message(code: 'cannedValue.label', default: 'CannedValue')}" />
+		<title><g:message code="default.edit.label" args="[entityName]" /></title>
+	</head>
+	<body>
+		<a href="#edit-cannedValue" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+		<div class="nav" role="navigation">
+			<ul>
+				<li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+				<li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]" /></g:link></li>
+				<li><g:link class="create" action="create"><g:message code="default.new.label" args="[entityName]" /></g:link></li>
+			</ul>
+		</div>
+		<div id="edit-cannedValue" class="content scaffold-edit" role="main">
+			<h1><g:message code="default.edit.label" args="[entityName]" /></h1>
+			<g:if test="${flash.message}">
+			<div class="message" role="status">${flash.message}</div>
+			</g:if>
+			<g:hasErrors bean="${cannedValueInstance}">
+			<ul class="errors" role="alert">
+				<g:eachError bean="${cannedValueInstance}" var="error">
+				<li <g:if test="${error in org.springframework.validation.FieldError}">data-field-id="${error.field}"</g:if>><g:message error="${error}"/></li>
+				</g:eachError>
+			</ul>
+			</g:hasErrors>
+			<g:form url="[resource:cannedValueInstance, action:'update']" method="PUT" >
+				<g:hiddenField name="version" value="${cannedValueInstance?.version}" />
+				<fieldset class="form">
+					<g:render template="form"/>
+				</fieldset>
+				<fieldset class="buttons">
+					<g:actionSubmit class="save" action="update" value="${message(code: 'default.button.update.label', default: 'Update')}" />
+				</fieldset>
+			</g:form>
+		</div>
+	</body>
+</html>

--- a/grails-app/views/cannedValue/index.gsp
+++ b/grails-app/views/cannedValue/index.gsp
@@ -1,0 +1,50 @@
+
+<%@ page import="org.bbop.apollo.CannedValue" %>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="layout" content="main">
+		<g:set var="entityName" value="${message(code: 'cannedValue.label', default: 'CannedValue')}" />
+		<title><g:message code="default.list.label" args="[entityName]" /></title>
+	</head>
+	<body>
+		<a href="#list-cannedValue" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+		<div class="nav" role="navigation">
+			<ul>
+				<li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+				<li><g:link class="create" action="create"><g:message code="default.new.label" args="[entityName]" /></g:link></li>
+			</ul>
+		</div>
+		<div id="list-cannedValue" class="content scaffold-list" role="main">
+			<h1><g:message code="default.list.label" args="[entityName]" /></h1>
+			<g:if test="${flash.message}">
+				<div class="message" role="status">${flash.message}</div>
+			</g:if>
+			<table>
+			<thead>
+					<tr>
+					
+						<g:sortableColumn property="label" title="${message(code: 'cannedValue.label.label', default: 'Label')}" />
+					
+						<g:sortableColumn property="metadata" title="${message(code: 'cannedValue.metadata.label', default: 'Metadata')}" />
+					
+					</tr>
+				</thead>
+				<tbody>
+				<g:each in="${cannedValueInstanceList}" status="i" var="cannedValueInstance">
+					<tr class="${(i % 2) == 0 ? 'even' : 'odd'}">
+					
+						<td><g:link action="show" id="${cannedValueInstance.id}">${fieldValue(bean: cannedValueInstance, field: "label")}</g:link></td>
+					
+						<td>${fieldValue(bean: cannedValueInstance, field: "metadata")}</td>
+					
+					</tr>
+				</g:each>
+				</tbody>
+			</table>
+			<div class="pagination">
+				<g:paginate total="${cannedValueInstanceCount ?: 0}" />
+			</div>
+		</div>
+	</body>
+</html>

--- a/grails-app/views/cannedValue/show.gsp
+++ b/grails-app/views/cannedValue/show.gsp
@@ -1,0 +1,78 @@
+<%@ page import="org.bbop.apollo.CannedValue" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="layout" content="main">
+    <g:set var="entityName" value="${message(code: 'cannedValue.label', default: 'CannedValue')}"/>
+    <title><g:message code="default.show.label" args="[entityName]"/></title>
+</head>
+
+<body>
+<a href="#show-cannedValue" class="skip" tabindex="-1"><g:message code="default.link.skip.label"
+                                                                  default="Skip to content&hellip;"/></a>
+
+<div class="nav" role="navigation">
+    <ul>
+        <li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+        <li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]"/></g:link></li>
+        <li><g:link class="create" action="create"><g:message code="default.new.label"
+                                                              args="[entityName]"/></g:link></li>
+    </ul>
+</div>
+
+<div id="show-cannedValue" class="content scaffold-show" role="main">
+    <h1><g:message code="default.show.label" args="[entityName]"/></h1>
+    <g:if test="${flash.message}">
+        <div class="message" role="status">${flash.message}</div>
+    </g:if>
+    <ol class="property-list cannedValue">
+
+        <g:if test="${cannedValueInstance?.label}">
+            <li class="fieldcontain">
+                <span id="label-label" class="property-label"><g:message code="cannedValue.label.label"
+                                                                         default="Label"/></span>
+
+                <span class="property-value" aria-labelledby="label-label"><g:fieldValue bean="${cannedValueInstance}"
+                                                                                         field="label"/></span>
+
+            </li>
+        </g:if>
+
+        <g:if test="${cannedValueInstance?.metadata}">
+            <li class="fieldcontain">
+                <span id="metadata-label" class="property-label"><g:message code="cannedValue.metadata.label"
+                                                                            default="Metadata"/></span>
+
+                <span class="property-value" aria-labelledby="metadata-label"><g:fieldValue
+                        bean="${cannedValueInstance}" field="metadata"/></span>
+
+            </li>
+        </g:if>
+
+        <g:if test="${cannedValueInstance?.featureTypes}">
+            <li class="fieldcontain">
+                <span id="featureTypes-label" class="property-label"><g:message code="cannedValue.featureTypes.label"
+                                                                                default="Feature Types"/></span>
+
+                <g:each in="${cannedValueInstance.featureTypes}" var="f">
+                    <span class="property-value" aria-labelledby="featureTypes-label"><g:link controller="featureType"
+                                                                                              action="show"
+                                                                                              id="${f.id}">${f?.name}</g:link></span>
+                </g:each>
+
+            </li>
+        </g:if>
+
+    </ol>
+    <g:form url="[resource: cannedValueInstance, action: 'delete']" method="DELETE">
+        <fieldset class="buttons">
+            <g:link class="edit" action="edit" resource="${cannedValueInstance}"><g:message
+                    code="default.button.edit.label" default="Edit"/></g:link>
+            <g:actionSubmit class="delete" action="delete"
+                            value="${message(code: 'default.button.delete.label', default: 'Delete')}"
+                            onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');"/>
+        </fieldset>
+    </g:form>
+</div>
+</body>
+</html>

--- a/src/gwt/org/bbop/apollo/gwt/shared/FeatureStringEnum.java
+++ b/src/gwt/org/bbop/apollo/gwt/shared/FeatureStringEnum.java
@@ -42,6 +42,8 @@ public enum FeatureStringEnum {
         TAG_VALUE_DELIMITER("="),
         COMMENTS,
         CANNED_COMMENTS,
+        CANNED_KEYS,
+        CANNED_VALUES,
         STATUS,
         NOTES,
         TAG,

--- a/test/unit/org/bbop/apollo/CannedKeyControllerSpec.groovy
+++ b/test/unit/org/bbop/apollo/CannedKeyControllerSpec.groovy
@@ -1,0 +1,152 @@
+package org.bbop.apollo
+
+
+
+import grails.test.mixin.*
+import spock.lang.*
+
+@TestFor(CannedKeyController)
+@Mock([CannedKey,CannedValue,FeatureType])
+class CannedKeyControllerSpec extends Specification {
+
+    def populateValidParams(params) {
+        assert params != null
+        // TODO: Populate valid properties like...
+        params["label"] = 'someValidName'
+    }
+
+    void "Test the index action returns the correct model"() {
+
+        when:"The index action is executed"
+            controller.index()
+
+        then:"The model is correct"
+            !model.cannedKeyInstanceList
+            model.cannedKeyInstanceCount == 0
+    }
+
+    void "Test the create action returns the correct model"() {
+        when:"The create action is executed"
+            controller.create()
+
+        then:"The model is correctly created"
+            model.cannedKeyInstance!= null
+    }
+
+    void "Test the save action correctly persists an instance"() {
+
+        when:"The save action is executed with an invalid instance"
+            request.contentType = FORM_CONTENT_TYPE
+            request.method = 'POST'
+            def cannedKey = new CannedKey()
+            cannedKey.validate()
+            controller.save(cannedKey)
+
+        then:"The create view is rendered again with the correct model"
+            model.cannedKeyInstance!= null
+            view == 'create'
+
+        when:"The save action is executed with a valid instance"
+            response.reset()
+            populateValidParams(params)
+            cannedKey = new CannedKey(params)
+
+            controller.save(cannedKey)
+
+        then:"A redirect is issued to the show action"
+            response.redirectedUrl == '/cannedKey/show/1'
+            controller.flash.message != null
+            CannedKey.count() == 1
+    }
+
+    void "Test that the show action returns the correct model"() {
+        when:"The show action is executed with a null domain"
+            controller.show(null)
+
+        then:"A 404 error is returned"
+            response.status == 404
+
+        when:"A domain instance is passed to the show action"
+            populateValidParams(params)
+            def cannedKey = new CannedKey(params)
+            controller.show(cannedKey)
+
+        then:"A model is populated containing the domain instance"
+            model.cannedKeyInstance == cannedKey
+    }
+
+    void "Test that the edit action returns the correct model"() {
+        when:"The edit action is executed with a null domain"
+            controller.edit(null)
+
+        then:"A 404 error is returned"
+            response.status == 404
+
+        when:"A domain instance is passed to the edit action"
+            populateValidParams(params)
+            def cannedKey = new CannedKey(params)
+            controller.edit(cannedKey)
+
+        then:"A model is populated containing the domain instance"
+            model.cannedKeyInstance == cannedKey
+    }
+
+    void "Test the update action performs an update on a valid domain instance"() {
+        when:"Update is called for a domain instance that doesn't exist"
+            request.contentType = FORM_CONTENT_TYPE
+            request.method = 'PUT'
+            controller.update(null)
+
+        then:"A 404 error is returned"
+            response.redirectedUrl == '/cannedKey/index'
+            flash.message != null
+
+
+        when:"An invalid domain instance is passed to the update action"
+            response.reset()
+            def cannedKey = new CannedKey()
+            cannedKey.validate()
+            controller.update(cannedKey)
+
+        then:"The edit view is rendered again with the invalid instance"
+            view == 'edit'
+            model.cannedKeyInstance == cannedKey
+
+        when:"A valid domain instance is passed to the update action"
+            response.reset()
+            populateValidParams(params)
+            cannedKey = new CannedKey(params).save(flush: true)
+            controller.update(cannedKey)
+
+        then:"A redirect is issues to the show action"
+            response.redirectedUrl == "/cannedKey/show/$cannedKey.id"
+            flash.message != null
+    }
+
+    void "Test that the delete action deletes an instance if it exists"() {
+        when:"The delete action is called for a null instance"
+            request.contentType = FORM_CONTENT_TYPE
+            request.method = 'DELETE'
+            controller.delete(null)
+
+        then:"A 404 is returned"
+            response.redirectedUrl == '/cannedKey/index'
+            flash.message != null
+
+        when:"A domain instance is created"
+            response.reset()
+            populateValidParams(params)
+            def cannedKey = new CannedKey(params).save(flush: true)
+
+        then:"It exists"
+            CannedKey.count() == 1
+
+        when:"The domain instance is passed to the delete action"
+            controller.delete(cannedKey)
+
+        then:"The instance is deleted"
+            CannedKey.count() == 0
+            response.redirectedUrl == '/cannedKey/index'
+            flash.message != null
+    }
+}

--- a/test/unit/org/bbop/apollo/CannedKeyControllerSpec.groovy
+++ b/test/unit/org/bbop/apollo/CannedKeyControllerSpec.groovy
@@ -6,7 +6,7 @@ import grails.test.mixin.*
 import spock.lang.*
 
 @TestFor(CannedKeyController)
-@Mock([CannedKey,CannedValue,FeatureType])
+@Mock(CannedKey)
 class CannedKeyControllerSpec extends Specification {
 
     def populateValidParams(params) {

--- a/test/unit/org/bbop/apollo/CannedValueControllerSpec.groovy
+++ b/test/unit/org/bbop/apollo/CannedValueControllerSpec.groovy
@@ -12,7 +12,7 @@ class CannedValueControllerSpec extends Specification {
     def populateValidParams(params) {
         assert params != null
         // TODO: Populate valid properties like...
-        params["value"] = 'someValidName'
+        params["label"] = 'someValidName'
     }
 
     void "Test the index action returns the correct model"() {

--- a/test/unit/org/bbop/apollo/CannedValueControllerSpec.groovy
+++ b/test/unit/org/bbop/apollo/CannedValueControllerSpec.groovy
@@ -1,0 +1,152 @@
+package org.bbop.apollo
+
+
+
+import grails.test.mixin.*
+import spock.lang.*
+
+@TestFor(CannedValueController)
+@Mock(CannedValue)
+class CannedValueControllerSpec extends Specification {
+
+    def populateValidParams(params) {
+        assert params != null
+        // TODO: Populate valid properties like...
+        params["value"] = 'someValidName'
+    }
+
+    void "Test the index action returns the correct model"() {
+
+        when:"The index action is executed"
+            controller.index()
+
+        then:"The model is correct"
+            !model.cannedValueInstanceList
+            model.cannedValueInstanceCount == 0
+    }
+
+    void "Test the create action returns the correct model"() {
+        when:"The create action is executed"
+            controller.create()
+
+        then:"The model is correctly created"
+            model.cannedValueInstance!= null
+    }
+
+    void "Test the save action correctly persists an instance"() {
+
+        when:"The save action is executed with an invalid instance"
+            request.contentType = FORM_CONTENT_TYPE
+            request.method = 'POST'
+            def cannedValue = new CannedValue()
+            cannedValue.validate()
+            controller.save(cannedValue)
+
+        then:"The create view is rendered again with the correct model"
+            model.cannedValueInstance!= null
+            view == 'create'
+
+        when:"The save action is executed with a valid instance"
+            response.reset()
+            populateValidParams(params)
+            cannedValue = new CannedValue(params)
+
+            controller.save(cannedValue)
+
+        then:"A redirect is issued to the show action"
+            response.redirectedUrl == '/cannedValue/show/1'
+            controller.flash.message != null
+            CannedValue.count() == 1
+    }
+
+    void "Test that the show action returns the correct model"() {
+        when:"The show action is executed with a null domain"
+            controller.show(null)
+
+        then:"A 404 error is returned"
+            response.status == 404
+
+        when:"A domain instance is passed to the show action"
+            populateValidParams(params)
+            def cannedValue = new CannedValue(params)
+            controller.show(cannedValue)
+
+        then:"A model is populated containing the domain instance"
+            model.cannedValueInstance == cannedValue
+    }
+
+    void "Test that the edit action returns the correct model"() {
+        when:"The edit action is executed with a null domain"
+            controller.edit(null)
+
+        then:"A 404 error is returned"
+            response.status == 404
+
+        when:"A domain instance is passed to the edit action"
+            populateValidParams(params)
+            def cannedValue = new CannedValue(params)
+            controller.edit(cannedValue)
+
+        then:"A model is populated containing the domain instance"
+            model.cannedValueInstance == cannedValue
+    }
+
+    void "Test the update action performs an update on a valid domain instance"() {
+        when:"Update is called for a domain instance that doesn't exist"
+            request.contentType = FORM_CONTENT_TYPE
+            request.method = 'PUT'
+            controller.update(null)
+
+        then:"A 404 error is returned"
+            response.redirectedUrl == '/cannedValue/index'
+            flash.message != null
+
+
+        when:"An invalid domain instance is passed to the update action"
+            response.reset()
+            def cannedValue = new CannedValue()
+            cannedValue.validate()
+            controller.update(cannedValue)
+
+        then:"The edit view is rendered again with the invalid instance"
+            view == 'edit'
+            model.cannedValueInstance == cannedValue
+
+        when:"A valid domain instance is passed to the update action"
+            response.reset()
+            populateValidParams(params)
+            cannedValue = new CannedValue(params).save(flush: true)
+            controller.update(cannedValue)
+
+        then:"A redirect is issues to the show action"
+            response.redirectedUrl == "/cannedValue/show/$cannedValue.id"
+            flash.message != null
+    }
+
+    void "Test that the delete action deletes an instance if it exists"() {
+        when:"The delete action is called for a null instance"
+            request.contentType = FORM_CONTENT_TYPE
+            request.method = 'DELETE'
+            controller.delete(null)
+
+        then:"A 404 is returned"
+            response.redirectedUrl == '/cannedValue/index'
+            flash.message != null
+
+        when:"A domain instance is created"
+            response.reset()
+            populateValidParams(params)
+            def cannedValue = new CannedValue(params).save(flush: true)
+
+        then:"It exists"
+            CannedValue.count() == 1
+
+        when:"The domain instance is passed to the delete action"
+            controller.delete(cannedValue)
+
+        then:"The instance is deleted"
+            CannedValue.count() == 0
+            response.redirectedUrl == '/cannedValue/index'
+            flash.message != null
+    }
+}


### PR DESCRIPTION
Initial foray into #86.   This is pretty basic, but we can get fancier later.  

FYI @childers , @mpoelchau, @monicacecilia 

We have canned keys and canned values.   They are related.  

They are filtered by type.  Having a key with related types is "difficult", though possible.  Let's see where this gets us.  

You use the admin interface to edit the Canned Keys and Canned Values, similar to the Canned Comments. 

<img width="750" alt="screen shot 2016-06-24 at 9 06 44 pm" src="https://cloud.githubusercontent.com/assets/751274/16353855/1268d1dc-3a50-11e6-9cc0-dd055a83ed37.png">
<img width="732" alt="screen shot 2016-06-24 at 9 08 14 pm" src="https://cloud.githubusercontent.com/assets/751274/16353856/126e1c00-3a50-11e6-98ed-f6892be5ffaf.png">

<img width="615" alt="screen shot 2016-06-24 at 9 11 03 pm" src="https://cloud.githubusercontent.com/assets/751274/16353865/5a0b6568-3a50-11e6-9d2e-cbf1a2010a35.png">
<img width="589" alt="screen shot 2016-06-24 at 9 11 40 pm" src="https://cloud.githubusercontent.com/assets/751274/16353866/5a10614e-3a50-11e6-8ae1-6f6544880f60.png">
<img width="998" alt="screen shot 2016-06-24 at 9 11 45 pm" src="https://cloud.githubusercontent.com/assets/751274/16353867/5a2080ba-3a50-11e6-9f61-07cf114aac39.png">
