### PR TITLE
fixed problem when issuing a redirect

### DIFF
--- a/grails-app/conf/org/bbop/apollo/SecurityFilters.groovy
+++ b/grails-app/conf/org/bbop/apollo/SecurityFilters.groovy
@@ -39,7 +39,9 @@ class SecurityFilters {
                             if (req.username && req.password) {
                                 def authToken = new UsernamePasswordToken(req.username, req.password)
                                 subject.login(authToken)
-                                redirect(uri: params.targetUri)
+                                if(params.targetUri){
+                                    redirect(uri: params.targetUri)
+                                }
                                 return true
                             } else {
                                 log.warn "username/password not submitted"


### PR DESCRIPTION
Fixed problem that the system was trying to issue a redirect when no redirect was requested (i.e., no params.targetUri was specified).  This was messing up some web services.  