### PR TITLE
allowing for older version of plugins

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -372,7 +372,13 @@ class JbrowseController {
                 jsonObject.plugins = new JSONArray()
             } else {
                 for (int i = 0; i < jsonObject.plugins.size(); i++) {
-                    pluginKeys.add(jsonObject.plugins[i].name)
+                    if(jsonObject.plugins[i] instanceof JSONObject){
+                        pluginKeys.add(jsonObject.plugins[i].name)
+                    }
+                    else
+                    if(jsonObject.plugins[i] instanceof String){
+                        pluginKeys.add(jsonObject.plugins[i])
+                    }
                 }
             }
             // add core plugin: https://github.com/GMOD/jbrowse/blob/master/src/JBrowse/Browser.js#L244


### PR DESCRIPTION
Fixes #1187 . 

@deepakunni3  Can you check this when you have a chance.  

In the jbrowse sample_data directory plugins are of the form:

```
 "plugins" : [
      "NeatHTMLFeatures",
      "NeatCanvasFeatures",
      "HideTrackLabels"
   ]
```

though we explicitly support this format:

```
    "plugins" : [
      {
         "location" : "./plugins/WebApollo",
         "name" : "WebApollo"
      }
   ],
```

This PR should allow supporting both. 