### PR TITLE
Fix session logout code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Chat at Gitter](https://badges.gitter.im/GMOD/Apollo.svg)](https://gitter.im/GMOD/Apollo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 
-## Apollo 2.0.4 is now released. [Download the latest release](https://github.com/GMOD/Apollo/releases/tag/2.0.4).
+## Apollo 2.0.4 is now released. [Download the latest release](https://github.com/GMOD/Apollo/releases/latest).
 
 An instantaneous, collaborative, genome annotation editor.  The stack is a Java web application / database backend and a
 Javascript client that runs in a web browser as a JBrowse plugin.  

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -428,17 +428,17 @@ define([
 
                     if (changeData.operation == "logout" && changeData.username == track.username) {
                         if(track.getClientToken()!=changeData.clientToken){
-                            alert('attempting to logout');
                             track.logout();
                         }
-                        alert("You have been logged out or your session has expired");
-                        if (window.parent) {
-                            parent.location.reload();
+                        else{
+                            alert("You have been logged out or your session has expired");
+                            if (window.parent) {
+                                parent.location.reload();
+                            }
+                            else {
+                                location.reload();
+                            }
                         }
-                        else {
-                            location.reload();
-                        }
-
                         return;
                     }
 

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -427,11 +427,11 @@ define([
                     }
 
                     if (changeData.operation == "logout" && changeData.username == track.username) {
+                        alert("You have been logged out or your session has expired");
                         if(track.getClientToken()!=changeData.clientToken){
                             track.logout();
                         }
                         else{
-                            alert("You have been logged out or your session has expired");
                             if (window.parent) {
                                 parent.location.reload();
                             }

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -427,6 +427,10 @@ define([
                     }
 
                     if (changeData.operation == "logout" && changeData.username == track.username) {
+                        if(track.getClientToken()!=changeData.clientToken){
+                            alert('attempting to logout');
+                            track.logout();
+                        }
                         alert("You have been logged out or your session has expired");
                         if (window.parent) {
                             parent.location.reload();

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -427,11 +427,11 @@ define([
                     }
 
                     if (changeData.operation == "logout" && changeData.username == track.username) {
-                        alert("You have been logged out or your session has expired");
                         if(track.getClientToken()!=changeData.clientToken){
                             track.logout();
                         }
                         else{
+                            alert("You have been logged out or your session has expired");
                             if (window.parent) {
                                 parent.location.reload();
                             }
@@ -4297,7 +4297,7 @@ define([
                         else window.location.reload();
                     },
                     error: function (response, ioArgs) { //
-                        alert('Failed to log out cleanly.  Please refresh your browser.');
+                        console.log('Failed to log out cleanly.  May already be logged out.');
                     }
                 });
             },

--- a/grails-app/controllers/org/bbop/apollo/LoginController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/LoginController.groovy
@@ -198,9 +198,11 @@ class LoginController extends AbstractApolloController {
 
     def logout(){
         log.debug "LOGOUT SESSION ${SecurityUtils?.subject?.getSession(false)?.id}"
-        SecurityUtils.subject.logout()
         println "logging out with params: ${params}"
-        sendLogout(SecurityUtils.subject.principal,params.get(FeatureStringEnum.CLIENT_TOKEN.value).toString())
+        // have to retrive the username first
+        String username = SecurityUtils.subject.principal
+        SecurityUtils.subject.logout()
+        sendLogout(username,params.get(FeatureStringEnum.CLIENT_TOKEN.value).toString())
         if(params.targetUri){
             redirect(uri:"/auth/login?targetUri=${params.targetUri}")
         }
@@ -211,7 +213,7 @@ class LoginController extends AbstractApolloController {
 
     def sendLogout(String username,String clientToken) {
         User user = User.findByUsername(username)
-        log.debug "sending logout for ${user} via ${username}"
+        log.debug "sending logout for ${user} via ${username} with ${clientToken}"
         JSONObject jsonObject = new JSONObject()
         if(!user){
             log.error("Already logged out or user not found: ${username}")

--- a/grails-app/controllers/org/bbop/apollo/LoginController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/LoginController.groovy
@@ -201,8 +201,8 @@ class LoginController extends AbstractApolloController {
         println "logging out with params: ${params}"
         // have to retrive the username first
         String username = SecurityUtils.subject.principal
-        SecurityUtils.subject.logout()
         sendLogout(username,params.get(FeatureStringEnum.CLIENT_TOKEN.value).toString())
+        SecurityUtils.subject.logout()
         if(params.targetUri){
             redirect(uri:"/auth/login?targetUri=${params.targetUri}")
         }

--- a/grails-app/controllers/org/bbop/apollo/LoginController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/LoginController.groovy
@@ -198,8 +198,9 @@ class LoginController extends AbstractApolloController {
 
     def logout(){
         log.debug "LOGOUT SESSION ${SecurityUtils?.subject?.getSession(false)?.id}"
-        sendLogout(SecurityUtils.subject.principal)
         SecurityUtils.subject.logout()
+        println "logging out with params: ${params}"
+        sendLogout(SecurityUtils.subject.principal,params.get(FeatureStringEnum.CLIENT_TOKEN.value).toString())
         if(params.targetUri){
             redirect(uri:"/auth/login?targetUri=${params.targetUri}")
         }
@@ -208,7 +209,7 @@ class LoginController extends AbstractApolloController {
         }
     }
 
-    def sendLogout(String username ) {
+    def sendLogout(String username,String clientToken) {
         User user = User.findByUsername(username)
         log.debug "sending logout for ${user} via ${username}"
         JSONObject jsonObject = new JSONObject()
@@ -217,6 +218,7 @@ class LoginController extends AbstractApolloController {
             return jsonObject.toString()
         }
         jsonObject.put(FeatureStringEnum.USERNAME.value,username)
+        jsonObject.put(FeatureStringEnum.CLIENT_TOKEN.value,clientToken)
         jsonObject.put(REST_OPERATION,"logout")
         log.debug "sending to: '/topic/AnnotationNotification/user/' + ${user.username}"
         try {

--- a/grails-app/controllers/org/bbop/apollo/LoginController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/LoginController.groovy
@@ -201,8 +201,14 @@ class LoginController extends AbstractApolloController {
         println "logging out with params: ${params}"
         // have to retrive the username first
         String username = SecurityUtils.subject.principal
+        println "sending logout"
         sendLogout(username,params.get(FeatureStringEnum.CLIENT_TOKEN.value).toString())
+        println "sent logout"
+        sleep(1000)
+        println "doing local logout"
         SecurityUtils.subject.logout()
+        sleep(1000)
+        println "logged out"
         if(params.targetUri){
             redirect(uri:"/auth/login?targetUri=${params.targetUri}")
         }

--- a/grails-app/services/org/bbop/apollo/PermissionService.groovy
+++ b/grails-app/services/org/bbop/apollo/PermissionService.groovy
@@ -436,6 +436,10 @@ class PermissionService {
      * @return
      */
     Boolean hasGlobalPermissions(JSONObject jsonObject, PermissionEnum permissionEnum) {
+        if(!jsonObject.username){
+            log.debug "Username not supplied so can not authenticate."
+            return false
+        }
         jsonObject = validateSessionForJsonObject(jsonObject)
         User user = User.findByUsername(jsonObject.username)
         if (!user) {


### PR DESCRIPTION
This handles the error @monicacecilia  found in #493 and also handles loadGroups and loadUsers without a username (like when logged out) with a 401 instead of a 500.  

@deepakunni3  Can you look at this when you have some time.   You should confirm that when you log out of one screen, that it logs out of ALL of them.