### PR TITLE
added feature deletion history for #1257 - do not merge

### DIFF
--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -1805,6 +1805,9 @@ class RequestHandlingService {
                             )
 
                             fireAnnotationEvent(annotationEvent)
+                            if (!suppressHistory) {
+                                featureEventService.addNewFeatureEvent(FeatureOperation.DELETE_TRANSCRIPT, feature.name, feature.uniqueName, inputObject, new JSONObject().put(FeatureStringEnum.FEATURES.value, oldJsonObjectsArray), new JSONObject(), permissionService.getCurrentUser(inputObject))
+                            }
                         }
                     } else {
                         featureRelationshipService.removeFeatureRelationship(gene, transcript)
@@ -1849,6 +1852,9 @@ class RequestHandlingService {
                         )
 
                         fireAnnotationEvent(annotationEvent)
+                        if (!suppressHistory) {
+                            featureEventService.addNewFeatureEvent(FeatureOperation.DELETE_FEATURE, feature.name, feature.uniqueName, inputObject, new JSONObject().put(FeatureStringEnum.FEATURES.value, oldJsonObjectsArray), new JSONObject(), permissionService.getCurrentUser(inputObject))
+                        }
                     }
                 }
             } else {
@@ -1889,7 +1895,7 @@ class RequestHandlingService {
                 featureContainer.getJSONArray(FeatureStringEnum.FEATURES.value).put(newJsonObject);
 
 
-                if (!suppressEvents) {
+                if (!suppressEvents && !suppressHistory) {
                     featureEventService.addNewFeatureEvent(featureOperation, featureName, feature.uniqueName, inputObject, new JSONObject().put(FeatureStringEnum.FEATURES.value, oldJsonObjectsArray), newJsonObject, permissionService.getCurrentUser(inputObject))
                 }
             }

--- a/test/integration/org/bbop/apollo/RequestHandlingServiceIntegrationSpec.groovy
+++ b/test/integration/org/bbop/apollo/RequestHandlingServiceIntegrationSpec.groovy
@@ -5,6 +5,7 @@ import org.bbop.apollo.gwt.shared.FeatureStringEnum
 import org.bbop.apollo.sequence.Strand
 import org.codehaus.groovy.grails.web.json.JSONArray
 import org.codehaus.groovy.grails.web.json.JSONObject
+import sun.org.mozilla.javascript.internal.Context
 
 class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec{
 
@@ -430,9 +431,10 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec{
         commandString = commandString.replaceAll("@TRANSCRIPT_NAME@", transcriptUniqueName)
         JSONObject commandObject = JSON.parse(commandString) as JSONObject
         JSONObject returnedAfterExonObject = requestHandlingService.deleteFeature(commandObject)
+        List<FeatureEvent> featureEventList = FeatureEvent.findAllByOperation(org.bbop.apollo.history.FeatureOperation.DELETE_TRANSCRIPT)
 
         then: "we should see that it is removed"
-        def allFeatures = Feature.all
+        assert featureEventList.size()==1
         assert returnedAfterExonObject != null
         assert Feature.count == 0
         JSONArray returnFeaturesArray = returnedAfterExonObject.getJSONArray(FeatureStringEnum.FEATURES.value)


### PR DESCRIPTION

There is some trickiness with deletion and adding feature history properly.  We need to suppress feature history when undoing.  

FeatureEventServiceIntegrationSpec
Package: org.bbop.apollo
Tests with failure and errors
Package summary
Show all tests
FeatureEventServiceIntegrationSpec
Executed 9 tests with 5 errors and 3 failures .
we can undo and redo a transcript split
Executed in 0.512 seconds.
JSONObject["sequence"] not found.
org.codehaus.groovy.grails.web.json.JSONException: JSONObject["sequence"] not found.
	at org.bbop.apollo.FeatureEventService._tt__setHistoryState_closure34(FeatureEventService.groovy:519)
	at org.bbop.apollo.FeatureEventService.$tt__setHistoryState(FeatureEventService.groovy:505)
	at org.bbop.apollo.FeatureEventService.$tt__redo(FeatureEventService.groovy:639)
	at org.bbop.apollo.RequestHandlingService.$tt__redo(RequestHandlingService.groovy:2218)
	at org.bbop.apollo.FeatureEventServiceIntegrationSpec.we can undo and redo a transcript split(FeatureEventServiceIntegrationSpec.groovy:85)
we can undo a split twice
Executed in 0.31 seconds.
we can undo and redo a split
Executed in 0.38 seconds.
Feature event list is the wrong size 0
org.bbop.apollo.AnnotationException: Feature event list is the wrong size 0
	at org.bbop.apollo.FeatureEventService.$tt__getCurrentFeatureEventIndex(FeatureEventService.groovy:660)
	at org.bbop.apollo.FeatureEventService.$tt__setTransactionForFeature(FeatureEventService.groovy:418)
	at org.bbop.apollo.FeatureEventService.$tt__setHistoryState(FeatureEventService.groovy:502)
	at org.bbop.apollo.FeatureEventService.$tt__redo(FeatureEventService.groovy:639)
	at org.bbop.apollo.RequestHandlingService.$tt__redo(RequestHandlingService.groovy:2218)
	at org.bbop.apollo.FeatureEventServiceIntegrationSpec.we can undo and redo a split(FeatureEventServiceIntegrationSpec.groovy:219)
we can undo and redo and redo other side
Executed in 0.351 seconds.
Feature event list is the wrong size 0
org.bbop.apollo.AnnotationException: Feature event list is the wrong size 0
	at org.bbop.apollo.FeatureEventService.$tt__getCurrentFeatureEventIndex(FeatureEventService.groovy:660)
	at org.bbop.apollo.FeatureEventService.$tt__setTransactionForFeature(FeatureEventService.groovy:418)
	at org.bbop.apollo.FeatureEventService.$tt__setHistoryState(FeatureEventService.groovy:502)
	at org.bbop.apollo.FeatureEventService.$tt__redo(FeatureEventService.groovy:639)
	at org.bbop.apollo.RequestHandlingService.$tt__redo(RequestHandlingService.groovy:2218)
	at org.bbop.apollo.FeatureEventServiceIntegrationSpec.we can undo and redo and redo other side(FeatureEventServiceIntegrationSpec.groovy:279)
we can undo and redo a merge transcript
Executed in 0.392 seconds.
Condition not satisfied: FeatureEvent.count == 3 | | 4 false
junit.framework.AssertionFailedError: Condition not satisfied:

FeatureEvent.count == 3
             |     |
             4     false

	at org.bbop.apollo.FeatureEventServiceIntegrationSpec.we can undo and redo a merge transcript(FeatureEventServiceIntegrationSpec.groovy:365)
should handle merge, change on upstream / RHS gene, undo, redo
Executed in 0.637 seconds.
Index: 0, Size: 0
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:635)
	at java.util.ArrayList.get(ArrayList.java:411)
	at org.bbop.apollo.FeatureEventService.$tt__setTransactionForFeature(FeatureEventService.groovy:433)
	at org.bbop.apollo.FeatureEventService.$tt__setHistoryState(FeatureEventService.groovy:502)
	at org.bbop.apollo.FeatureEventService.$tt__redo(FeatureEventService.groovy:639)
	at org.bbop.apollo.RequestHandlingService.$tt__redo(RequestHandlingService.groovy:2218)
	at org.bbop.apollo.FeatureEventServiceIntegrationSpec.should handle merge, change on upstream / RHS gene, undo, redo(FeatureEventServiceIntegrationSpec.groovy:538)
should handle merge, change on downstream / LHS , undo, redo
Executed in 0.482 seconds.
Condition not satisfied: history.size()==3 | | | | 4 false [[org.bbop.apollo.FeatureEvent : 983], [org.bbop.apollo.FeatureEvent : 1001, org.bbop.apollo.FeatureEvent : 1002], [org.bbop.apollo.FeatureEvent : 1012], [org.bbop.apollo.FeatureEvent : 1013]]
junit.framework.AssertionFailedError: Condition not satisfied:

history.size()==3
|       |     |
|       4     false
[[org.bbop.apollo.FeatureEvent : 983], [org.bbop.apollo.FeatureEvent : 1001, org.bbop.apollo.FeatureEvent : 1002], [org.bbop.apollo.FeatureEvent : 1012], [org.bbop.apollo.FeatureEvent : 1013]]

	at org.bbop.apollo.FeatureEventServiceIntegrationSpec.should handle merge, change on downstream / LHS , undo, redo(FeatureEventServiceIntegrationSpec.groovy:673)
should handle merge, change on downstream / LHS , undo, undo
Executed in 0.509 seconds.
Condition not satisfied: history.size()==3 | | | | 4 false [[org.bbop.apollo.FeatureEvent : 1063], [org.bbop.apollo.FeatureEvent : 1082, org.bbop.apollo.FeatureEvent : 1081], [org.bbop.apollo.FeatureEvent : 1092], [org.bbop.apollo.FeatureEvent : 1093]]
junit.framework.AssertionFailedError: Condition not satisfied:

history.size()==3
|       |     |
|       4     false
[[org.bbop.apollo.FeatureEvent : 1063], [org.bbop.apollo.FeatureEvent : 1082, org.bbop.apollo.FeatureEvent : 1081], [org.bbop.apollo.FeatureEvent : 1092], [org.bbop.apollo.FeatureEvent : 1093]]

	at org.bbop.apollo.FeatureEventServiceIntegrationSpec.should handle merge, change on downstream / LHS , undo, undo(FeatureEventServiceIntegrationSpec.groovy:837)
we should be able to create a uniform tree merge and undo it
Executed in 0.637 seconds.
Cannot get property 'featureLocation' on null object
java.lang.NullPointerException: Cannot get property 'featureLocation' on null object
	at org.bbop.apollo.FeatureEventServiceIntegrationSpec.we should be able to create a uniform tree merge and undo it(FeatureEventServiceIntegrationSpec.groovy:1011)


and RHS::

when we change an annotation type from one form to another, we should see the proper changes and be able to go back in history
Executed in 0.435 seconds.
JSONObject["sequence"] not found.
org.codehaus.groovy.grails.web.json.JSONException: JSONObject["sequence"] not found.
	at org.bbop.apollo.FeatureEventService._tt__setHistoryState_closure34(FeatureEventService.groovy:519)
	at org.bbop.apollo.FeatureEventService.$tt__setHistoryState(FeatureEventService.groovy:505)
	at org.bbop.apollo.FeatureEventService.$tt__redo(FeatureEventService.groovy:639)
	at org.bbop.apollo.RequestHandlingService.$tt__redo(RequestHandlingService.groovy:2218)
	at org.bbop.apollo.RequestHandlingServiceIntegrationSpec.when we change an annotation type from one form to another, we should see the proper changes and be able to go back in history(RequestHandlingServiceIntegrationSpec.groovy:2813)
