### PR TITLE
BLAT search results shows incorrect start and end of the search results

### DIFF
--- a/client/apollo/js/SequenceSearch.js
+++ b/client/apollo/js/SequenceSearch.js
@@ -183,8 +183,8 @@ searchSequence: function(trackName, refSeqName, starts) {
                         var refSeqEnd = starts[subject.feature.uniquename] || 0;
                         subject.location.fmin += refSeqStart;
                         subject.location.fmax += refSeqStart;
-                        var subjectStart = subject.location.fmin + 1;
-                        var subjectEnd = subject.location.fmax + 1;
+                        var subjectStart = subject.location.fmin;
+                        var subjectEnd = subject.location.fmax;
                         if (subject.location.strand == -1) {
                             var tmp = subjectStart;
                             subjectStart = subjectEnd;


### PR DESCRIPTION
When we query the genome with BLAT, the result shown in the table displays the hit-start and hit-end incorrectly. Specifically, its always off by 1.

When BLAT is used for search, and if the output requested from BLAT is a tab-delimited format then the coordinates reported by BLAT will always be 1-based. This is the case for the configurations used in Apollo.

This PR aims to fix this tiny issue.