### PR TITLE
Fix REMORE_USER authentication with galaxy (#1423)

### DIFF
--- a/grails-app/services/org/bbop/apollo/authenticator/RemoteUserAuthenticatorService.groovy
+++ b/grails-app/services/org/bbop/apollo/authenticator/RemoteUserAuthenticatorService.groovy
@@ -33,7 +33,7 @@ class RemoteUserAuthenticatorService implements AuthenticatorService {
 //            } else {
 //            remoteUser = request.getHeader(FeatureStringEnum.REMOTE_USER.value)
 //            }
-            
+
             remoteUser = request.getHeader(FeatureStringEnum.REMOTE_USER.value)
             log.warn "Remote user found [${remoteUser}]"
             if (!remoteUser) {
@@ -95,6 +95,6 @@ class RemoteUserAuthenticatorService implements AuthenticatorService {
     //    @Override
     def authenticate(UsernamePasswordToken authToken, HttpServletRequest request) {
         // token is ignored
-        return authToken(request)
+        return authenticate(request)
     }
 }


### PR DESCRIPTION
A small patch that fixes the problem described in #1423 (probably just a typo?)