### PR TITLE
Add new 'default_group' param for remote_user auth

### DIFF
--- a/grails-app/services/org/bbop/apollo/PermissionService.groovy
+++ b/grails-app/services/org/bbop/apollo/PermissionService.groovy
@@ -528,6 +528,9 @@ class PermissionService {
                 def authenticationService
                 if("remoteUserAuthenticatorService" == auth.className ){
                     authenticationService = remoteUserAuthenticatorService
+                    if (auth.params.containsKey("default_group")) {
+                        authenticationService.setDefaultGroup(auth.params.get("default_group"))
+                    }
                 }
                 else
                 if("usernamePasswordAuthenticatorService" == auth.className ){

--- a/grails-app/services/org/bbop/apollo/authenticator/RemoteUserAuthenticatorService.groovy
+++ b/grails-app/services/org/bbop/apollo/authenticator/RemoteUserAuthenticatorService.groovy
@@ -65,17 +65,11 @@ class RemoteUserAuthenticatorService implements AuthenticatorService {
                 user.addToRoles(role)
                 role.addToUsers(user)
 
-                if (this.default_group != null) {
+                if (this.default_group) {
                     log.debug "adding user to default group: ${this.default_group}"
                     UserGroup userGroup = UserGroup.findByName(this.default_group)
 
-                    if (userGroup == null) {
-                        userGroup = new UserGroup(
-                                name: this.default_group
-                        ).save(flush: true)
-
-                        log.info "Created new default group ${this.default_group}"
-                    }
+                    userGroup = userGroup ?: new UserGroup(name: this.default_group).save(flush: true)
 
                     user.addToUserGroups(userGroup)
                 }


### PR DESCRIPTION
Hi,
As discussed in https://github.com/galaxy-genome-annotation/dockerized-gmod-deployment/issues/6, a patch to add a new param for RemoteUserAuthenticatorService to allow adding automatically new users to a group.
I don't know if it's the best way to implement it, but it works :)
Anthony