### PR TITLE
Refactor updateFeatureLocation method in AnnotatorController to better handle updates to exon boundaries when a request is sent from GWT-land

### DIFF
--- a/src/gwt/org/bbop/apollo/gwt/client/ExonDetailPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/ExonDetailPanel.java
@@ -30,6 +30,7 @@ import org.bbop.apollo.gwt.client.event.AnnotationInfoChangeEvent;
 import org.bbop.apollo.gwt.client.resources.TableResources;
 import org.bbop.apollo.gwt.client.rest.AnnotationRestService;
 import org.bbop.apollo.gwt.client.rest.RestService;
+import org.bbop.apollo.gwt.shared.FeatureStringEnum;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Container;
 import org.gwtbootstrap3.client.ui.TextBox;
@@ -230,6 +231,14 @@ public class ExonDetailPanel extends Composite {
             negativeStrandValue.setType(ButtonType.PRIMARY);
         }
 
+        String type = this.internalAnnotationInfo.getType();
+        if (type.equals("exon")) {
+            enableFields(true);
+        }
+        else {
+            enableFields(false);
+        }
+
         SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
         for (String note : annotationInfo.getNoteList()) {
             safeHtmlBuilder.appendHtmlConstant("<div class='label label-warning'>" + note + "</div>");
@@ -255,7 +264,7 @@ public class ExonDetailPanel extends Composite {
     }
 
     private boolean isEditableType(String type) {
-        return type.equals("CDS") || type.equals("exon");
+        return type.equals("exon");
     }
 
     private void updateFeatureLocation(final AnnotationInfo originalInfo) {
@@ -282,7 +291,7 @@ public class ExonDetailPanel extends Composite {
                 enableFields(true);
             }
         };
-        RestService.sendRequest(requestCallback, "annotator/updateFeatureLocation/", AnnotationRestService.convertAnnotationInfoToJSONObject(this.internalAnnotationInfo));
+        RestService.sendRequest(requestCallback, "annotator/setExonBoundaries/", AnnotationRestService.convertAnnotationInfoToJSONObject(this.internalAnnotationInfo));
     }
 
     private int getDisplayMin(int min) {
@@ -363,9 +372,7 @@ public class ExonDetailPanel extends Composite {
         if (!(this.inputFmin < this.internalAnnotationInfo.getMax()) || !(this.inputFmax > this.internalAnnotationInfo.getMin())) {
             return false;
         }
-        if (!verifyBoundaries()) {
-            return false;
-        }
+
         return true;
     }
 
@@ -400,14 +407,5 @@ public class ExonDetailPanel extends Composite {
 
     private void getAnnotationInfoWithTopLevelFeature(AnnotationInfo annotationInfo) {
         this.annotationInfoWithTopLevelFeature = annotationInfo;
-    }
-
-    private boolean verifyBoundaries() {
-        if (this.inputFmin >= annotationInfoWithTopLevelFeature.getMin() && this.inputFmax <= annotationInfoWithTopLevelFeature.getMax()) {
-            return true;
-        } else {
-            Bootbox.alert("Cannot extend beyond the boundaries of the mRNA");
-            return false;
-        }
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/rest/AnnotationRestService.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/rest/AnnotationRestService.java
@@ -15,6 +15,7 @@ public class AnnotationRestService {
 
        jsonObject.put("name",new JSONString(annotationInfo.getName()));
        jsonObject.put("uniquename",new JSONString(annotationInfo.getUniqueName()));
+       jsonObject.put("track", new JSONString(annotationInfo.getSequence()));
        jsonObject.put("symbol",annotationInfo.getSymbol()!=null ? new JSONString(annotationInfo.getSymbol()):new JSONString(""));
        jsonObject.put("description",annotationInfo.getDescription()!=null ? new JSONString(annotationInfo.getDescription()):new JSONString(""));
        jsonObject.put("type",new JSONString(annotationInfo.getType()));


### PR DESCRIPTION
Fixes #1428 

To test:

Create the following types of annotations:
* gene
* pseudogene
* tRNA
* rRNA
* snRNA
* snoRNA
* ncRNA
* rRNA
* miRNA
* repeat_region
* transposable_element


From the Exon Detail Panel,
1. Modifying the boundaries of exons (and only exons) should properly be reflected in the rendering of the annotation. This is applicable for gene, pseudogene and all *RNA features.
2. Make sure that you cannot modify CDS boundaries from the Exon Detail Panel.
3. Make sure that Exon Detail Panel doesn't show up for repeat_region and transposable_element.