### PR TITLE
Add .Dark styling for NeatHTMLFeatures

### DIFF
--- a/client/apollo/css/maker_darkbackground.css
+++ b/client/apollo/css/maker_darkbackground.css
@@ -340,4 +340,13 @@
     border-right: solid red 3px;
 }
 
+/* NeatHTMLFeatures styles */
+
+.Dark div.neat-UTR {
+    background-color: #DDD;
+}
+.Dark polyline.neat-intron {
+    stroke: lightgrey;
+}
+
 /* end of MAKER styles */


### PR DESCRIPTION
Address #1437 - UTR colors and Intron colors for .Dark theme.

Requires JBrowse commit: https://github.com/GMOD/jbrowse/commit/29795a1bbb8da4706eba2b0f73724ac1b3e1e4e6