### PR TITLE
allowing REMOTE_USER to be sent if it exists fixed #1487

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
@@ -140,7 +140,8 @@ class AnnotatorController {
         log.debug "loading the index"
         String uuid = UUID.randomUUID().toString()
         String clientToken = params.containsKey(FeatureStringEnum.CLIENT_TOKEN.value) ? params.get(FeatureStringEnum.CLIENT_TOKEN.value) : null
-        [userKey: uuid, clientToken: clientToken]
+        String remoteUser = request.getHeader(FeatureStringEnum.REMOTE_USER.value)
+        [userKey: uuid, clientToken: clientToken,remoteUser:remoteUser]
     }
 
 

--- a/grails-app/views/annotator/index.gsp
+++ b/grails-app/views/annotator/index.gsp
@@ -21,6 +21,7 @@
             showFrame: '${params.showFrame  && params.showFrame == 'true' ? 'true' : 'false' }'
             ,userId: '${userKey}'
             ,clientToken:'${clientToken}'
+            ,REMOTE_USER:'${remoteUser}'
 //            ,top: "10"
 //            ,topUnit: "PCT" // PX, EM, PC, PT, IN, CM
 //            ,height: "80"

--- a/src/gwt/org/bbop/apollo/gwt/client/MainPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/MainPanel.java
@@ -543,6 +543,10 @@ public class MainPanel extends Composite {
     }
 
     public static void updateGenomicViewer(boolean forceReload) {
+        if(currentSequence==null) {
+            GWT.log("Current sequence not set");
+        }
+
         if (currentStartBp != null && currentEndBp != null) {
             updateGenomicViewerForLocation(currentSequence.getName(), currentStartBp, currentEndBp, forceReload);
         } else {

--- a/src/gwt/org/bbop/apollo/gwt/client/rest/RestService.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/rest/RestService.java
@@ -1,10 +1,8 @@
 package org.bbop.apollo.gwt.client.rest;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.*;
 import com.google.gwt.i18n.client.Dictionary;
 import com.google.gwt.json.client.JSONObject;
-import com.google.gwt.user.client.Window;
 import org.bbop.apollo.gwt.client.Annotator;
 import org.bbop.apollo.gwt.shared.FeatureStringEnum;
 import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
@@ -40,6 +38,10 @@ public class RestService {
             builder.setRequestData(data);
         }
         builder.setHeader("Content-type", "application/x-www-form-urlencoded");
+        String remoteUserString = Dictionary.getDictionary("Options").get(FeatureStringEnum.REMOTE_USER.getValue());
+        if(remoteUserString!=null && remoteUserString.trim().length()>0){
+            builder.setHeader(FeatureStringEnum.REMOTE_USER.getValue(), remoteUserString);
+        }
         try {
             if(requestCallback!=null){
                 builder.setCallback(requestCallback);


### PR DESCRIPTION
@abretaud  This is a nice starting place for #1487.  I'm not sure if it fixes it, but ideally it should do a pass-through.  Please test, though and let me know if it works.   

The ping.json just checks to make sure the client still has read-access so the user doesn't die on the backend.

I'm not sure if this solution will be a security loophole or not.   Let me know.    Maybe worth another think if this isn't dire.

Maybe @erasche  has a thought on this as well?
