### PR TITLE
modify GFF3 export to (a) comport with GVF4.x conventions and (b) be VCF-ready

### DIFF
--- a/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
+++ b/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
@@ -391,20 +391,22 @@ public class Gff3HandlerService {
                 calendar.setTime(feature.lastUpdated);
                 attributes.put(FeatureStringEnum.DATE_LAST_MODIFIED.value, encodeString(formatDate(calendar.time)));
             }
+	    FeatureLocation f1loc = feature.getFeatureLocations().iterator().next();
             if(feature.class.name in [Insertion.class.name]) {
 	      attributes.put(FeatureStringEnum.VARIANT_SEQ.value, feature.alterationResidue);
 	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, '-');
-	      attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(featureLocation.sequence,featureLocation.fmin-1,featureLocation.fmin));
+	      attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(f1loc.sequence,f1loc.fmin-1,f1loc.fmin));
             }
             if(feature.class.name in [Substitution.class.name]) {
 	      // NB: 
 	      attributes.put(FeatureStringEnum.VARIANT_SEQ.value, feature.alterationResidue);
-	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()));
+	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(f1loc));
             }
             if(feature.class.name in [Deletion.class.name]) {
 	      attributes.put(FeatureStringEnum.VARIANT_SEQ.value, '-');
-	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()));
-	      attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(featureLocation.sequence,featureLocation.fmin-1,featureLocation.fmin));
+	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(f1loc));
+	      // attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(featureLocation.sequence,featureLocation.fmin-1,featureLocation.fmin));
+	      attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getResidueFromFeatureLocation(f1loc.sequence,f1loc.fmin-1,f1loc.fmin));
             }
         }
         return attributes;

--- a/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
+++ b/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
@@ -391,10 +391,17 @@ public class Gff3HandlerService {
                 calendar.setTime(feature.lastUpdated);
                 attributes.put(FeatureStringEnum.DATE_LAST_MODIFIED.value, encodeString(formatDate(calendar.time)));
             }
-
-
-            if(feature.class.name in [Insertion.class.name,Substitution.class.name]) {
+            if(feature.class.name in [Insertion.class.name]) {
                 attributes.put(FeatureStringEnum.RESIDUES.value, feature.alterationResidue)
+                attributes.put(FeatureStringEnum.REFERENCE.value, ".")
+            }
+            if(feature.class.name in [Substitution.class.name]) {
+                attributes.put(FeatureStringEnum.RESIDUES.value, feature.alterationResidue)
+                attributes.put(FeatureStringEnum.REFERENCE.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()))
+            }
+            if(feature.class.name in [Deletion.class.name]) {
+                attributes.put(FeatureStringEnum.RESIDUES.value, '.')
+                attributes.put(FeatureStringEnum.REFERENCE.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()))
             }
         }
         return attributes;

--- a/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
+++ b/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
@@ -392,19 +392,19 @@ public class Gff3HandlerService {
                 attributes.put(FeatureStringEnum.DATE_LAST_MODIFIED.value, encodeString(formatDate(calendar.time)));
             }
             if(feature.class.name in [Insertion.class.name]) {
-                attributes.put(FeatureStringEnum.VARIANT_SEQ.value, feature.alterationResidue)
-                attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, '-')
-                attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(featureLocation.sequence,featureLocation.fmin-1,featureLocation.fmin))
+	      attributes.put(FeatureStringEnum.VARIANT_SEQ.value, feature.alterationResidue);
+	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, '-');
+	      attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(featureLocation.sequence,featureLocation.fmin-1,featureLocation.fmin));
             }
             if(feature.class.name in [Substitution.class.name]) {
 	      // NB: 
-	      attributes.put(FeatureStringEnum.VARIANT_SEQ.value, feature.alterationResidue)
-	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()))
+	      attributes.put(FeatureStringEnum.VARIANT_SEQ.value, feature.alterationResidue);
+	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()));
             }
             if(feature.class.name in [Deletion.class.name]) {
-                attributes.put(FeatureStringEnum.VARIANT_SEQ.value, '-')
-                attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()))
-                attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(featureLocation.sequence,featureLocation.fmin-1,featureLocation.fmin))
+	      attributes.put(FeatureStringEnum.VARIANT_SEQ.value, '-');
+	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()));
+	      attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(featureLocation.sequence,featureLocation.fmin-1,featureLocation.fmin));
             }
         }
         return attributes;

--- a/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
+++ b/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
@@ -392,16 +392,19 @@ public class Gff3HandlerService {
                 attributes.put(FeatureStringEnum.DATE_LAST_MODIFIED.value, encodeString(formatDate(calendar.time)));
             }
             if(feature.class.name in [Insertion.class.name]) {
-                attributes.put(FeatureStringEnum.RESIDUES.value, feature.alterationResidue)
-                attributes.put(FeatureStringEnum.REFERENCE.value, ".")
+                attributes.put(FeatureStringEnum.VARIANT_SEQ.value, feature.alterationResidue)
+                attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, '-')
+                attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(featureLocation.sequence,featureLocation.fmin-1,featureLocation.fmin))
             }
             if(feature.class.name in [Substitution.class.name]) {
-                attributes.put(FeatureStringEnum.RESIDUES.value, feature.alterationResidue)
-                attributes.put(FeatureStringEnum.REFERENCE.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()))
+	      // NB: 
+	      attributes.put(FeatureStringEnum.VARIANT_SEQ.value, feature.alterationResidue)
+	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()))
             }
             if(feature.class.name in [Deletion.class.name]) {
-                attributes.put(FeatureStringEnum.RESIDUES.value, '.')
-                attributes.put(FeatureStringEnum.REFERENCE.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()))
+                attributes.put(FeatureStringEnum.VARIANT_SEQ.value, '-')
+                attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(feature.getFeatureLocations().iterator().next()))
+                attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(featureLocation.sequence,featureLocation.fmin-1,featureLocation.fmin))
             }
         }
         return attributes;

--- a/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
+++ b/grails-app/services/org/bbop/apollo/Gff3HandlerService.groovy
@@ -406,7 +406,7 @@ public class Gff3HandlerService {
 	      attributes.put(FeatureStringEnum.VARIANT_SEQ.value, '-');
 	      attributes.put(FeatureStringEnum.REFERENCE_SEQ.value, sequenceService.getResidueFromFeatureLocation(f1loc));
 	      // attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(featureLocation.sequence,featureLocation.fmin-1,featureLocation.fmin));
-	      attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getResidueFromFeatureLocation(f1loc.sequence,f1loc.fmin-1,f1loc.fmin));
+	      attributes.put(FeatureStringEnum.VCF_ANCHOR_SEQ.value, sequenceService.getRawResiduesFromSequence(f1loc.sequence,f1loc.fmin-1,f1loc.fmin));
             }
         }
         return attributes;

--- a/src/gwt/org/bbop/apollo/gwt/shared/FeatureStringEnum.java
+++ b/src/gwt/org/bbop/apollo/gwt/shared/FeatureStringEnum.java
@@ -131,7 +131,8 @@ public enum FeatureStringEnum {
         HISTORY,
         DOCK_OPEN("dockOpen"),
         DOCK_WIDTH("dockWidth"),
-        USE_CDS
+        USE_CDS,
+	REFERENCE
         ;
 
 

--- a/src/gwt/org/bbop/apollo/gwt/shared/FeatureStringEnum.java
+++ b/src/gwt/org/bbop/apollo/gwt/shared/FeatureStringEnum.java
@@ -132,7 +132,9 @@ public enum FeatureStringEnum {
         DOCK_OPEN("dockOpen"),
         DOCK_WIDTH("dockWidth"),
         USE_CDS,
-	REFERENCE
+	REFERENCE_SEQ("Reference_seq"),
+	VARIANT_SEQ("Variant_seq"),
+	VCF_ANCHOR_SEQ("VCF_anchor_seq")
         ;
 
 


### PR DESCRIPTION
GFF column 9 attribute change
 + "residues" changed to "Variant_seq"
 + new attribute, "Reference_seq"
 + new non-standard attribute, "VCF_anchor_seq" being the single reference residue upstream (to the left) of the variant position.

The presence of VCF_anchor_seq allows for conversion to VCF4.x format w/o needing to appeal to the reference sequence, such as can be done with (new) Perl script vcfFromApolloGff3 (forthcoming - need to know where/how/whether to submit this to Apollo project), which in turn can be used with vcf-consensus (part of VCFtools) to produce updated reference sequence edited so as to reflect the variations.