### PR TITLE
added a less jarring way to navigate between sequences and locations

### DIFF
--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -319,6 +319,12 @@ define([
                     }));
 
 
+                    var navigateToLocation = function (urlObject) {
+                        browser.callLocation(urlObject.url);
+                    };
+
+                    window.parent.registerFunction("navigateToLocation",navigateToLocation);
+
                     var sendTracks = function (trackList, visibleTrackNames, showLabels) {
                         var filteredTrackList = [];
                         for (var trackConfigIndex in trackList) {

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -320,7 +320,13 @@ define([
 
 
                     var navigateToLocation = function (urlObject) {
-                        browser.callLocation(urlObject.url);
+                        if(urlObject.exact){
+                            browser.callLocation(urlObject.url);
+                        }
+                        else{
+                            var location = Util.parseLocString( urlObject.url);
+                            browser.showRegion(location);
+                        }
                     };
 
                     window.parent.registerFunction("navigateToLocation",navigateToLocation);

--- a/src/gwt/org/bbop/apollo/gwt/client/Annotator.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/Annotator.java
@@ -2,7 +2,9 @@ package org.bbop.apollo.gwt.client;
 
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.event.shared.SimpleEventBus;
@@ -165,10 +167,4 @@ public class Annotator implements EntryPoint {
 
     }
 
-    private native void getInnerDiv()/*-{
-        var iframe = $doc.getElementById("genomeViewer");
-        var innerDoc = iframe.contentDocument ; // .contentWindow.document
-        // this is the JBrowse div
-        var genomeBrowser = innerDoc.getElementById("GenomeBrowser");
-    }-*/;
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/AnnotatorPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/AnnotatorPanel.java
@@ -648,7 +648,7 @@ public class AnnotatorPanel extends Composite {
         Integer min = selectedAnnotationInfo.getMin() - 50;
         Integer max = selectedAnnotationInfo.getMax() + 50;
         min = min < 0 ? 0 : min;
-        MainPanel.updateGenomicViewerForLocation(selectedAnnotationInfo.getSequence(), min, max, false);
+        MainPanel.updateGenomicViewerForLocation(selectedAnnotationInfo.getSequence(), min, max, false,false);
     }
 
 
@@ -686,7 +686,7 @@ public class AnnotatorPanel extends Composite {
         Integer min = selectedAnnotationInfo.getMin() - 50;
         Integer max = selectedAnnotationInfo.getMax() + 50;
         min = min < 0 ? 0 : min;
-        MainPanel.updateGenomicViewerForLocation(selectedAnnotationInfo.getSequence(), min, max, false);
+        MainPanel.updateGenomicViewerForLocation(selectedAnnotationInfo.getSequence(), min, max, false,false);
     }
 
     // also used by javascript function
@@ -703,7 +703,7 @@ public class AnnotatorPanel extends Composite {
         Integer min = selectedAnnotationInfo.getMin() - 50;
         Integer max = selectedAnnotationInfo.getMax() + 50;
         min = min < 0 ? 0 : min;
-        MainPanel.updateGenomicViewerForLocation(selectedAnnotationInfo.getSequence(), min, max, false);
+        MainPanel.updateGenomicViewerForLocation(selectedAnnotationInfo.getSequence(), min, max, false,false);
     }
 
     public static native void exportStaticMethod(AnnotatorPanel annotatorPanel) /*-{

--- a/src/gwt/org/bbop/apollo/gwt/client/MainPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/MainPanel.java
@@ -301,7 +301,6 @@ public class MainPanel extends Composite {
                 Annotator.eventBus.fireEvent(new OrganismChangeEvent(OrganismChangeEvent.Action.LOADED_ORGANISMS, currentSequence.getName(),currentOrganism.getName()));
 
                 if (updateViewer) {
-//                    updateGenomicViewer();
                     updateGenomicViewerForLocation(currentSequence.getName(),currentStartBp,currentEndBp,true,false);
                 }
                 if (blocking) {
@@ -315,7 +314,7 @@ public class MainPanel extends Composite {
                 if (blocking) {
                     loadingDialog.hide();
                 }
-                Bootbox.alert("failed to set JBrowse sequence: " + exception);
+                Bootbox.alert("Failed to sequence: " + exception);
             }
         };
 
@@ -535,11 +534,6 @@ public class MainPanel extends Composite {
         $wnd.history.pushState(newUrl, "", newUrl);
     }-*/;
 
-    public static void navigateToUrl(String url){
-//        if(browserObject!=null){
-//            browserObject.
-//        }
-    }
 
     public static native Element getInnerDiv()/*-{
         var iframe = $doc.getElementById("genomeViewer");
@@ -1091,4 +1085,18 @@ public class MainPanel extends Composite {
     public static SequencePanel getSequencePanel() {
         return sequencePanel;
     }
+
+    public static SequenceInfo getCurrentSequence() {
+        return currentSequence;
+    }
+
+    SequenceInfo setCurrentSequenceAndEnds(SequenceInfo newSequence) {
+        currentSequence = newSequence;
+        currentStartBp = currentSequence.getStartBp()!=null ? currentSequence.getStartBp() : 0 ;
+        currentEndBp = currentSequence.getEndBp()!=null ? currentSequence.getEndBp() : currentSequence.getLength() ;
+        currentSequence.setStartBp(currentStartBp);
+        currentSequence.setEndBp(currentEndBp);
+        return currentSequence;
+    }
+
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/SequencePanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/SequencePanel.java
@@ -44,6 +44,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static org.bbop.apollo.gwt.client.MainPanel.sequenceSuggestBox;
+
 /**
  * Created by ndunn on 12/17/14.
  */
@@ -213,9 +215,12 @@ public class SequencePanel extends Composite {
                     RequestCallback requestCallback = new RequestCallback() {
                         @Override
                         public void onResponseReceived(Request request, Response response) {
-                            if (sequenceInfo != null) {
-                                OrganismRestService.switchSequenceById(sequenceInfo.getId().toString());
-                            }
+                            JSONObject sequenceInfoJson = JSONParser.parseStrict(response.getText()).isObject();
+                            MainPanel mainPanel = MainPanel.getInstance();
+                            SequenceInfo currentSequence = mainPanel.setCurrentSequenceAndEnds(SequenceInfoConverter.convertFromJson(sequenceInfoJson));
+                            mainPanel.sequenceSuggestBox.setText(currentSequence.getName());
+                            Annotator.eventBus.fireEvent(new OrganismChangeEvent(OrganismChangeEvent.Action.LOADED_ORGANISMS, currentSequence.getName(),mainPanel.getCurrentOrganism().getName()));
+                            MainPanel.updateGenomicViewerForLocation(currentSequence.getName(),currentSequence.getStartBp(),currentSequence.getEndBp(),true,false);
                         }
 
                         @Override
@@ -244,9 +249,6 @@ public class SequencePanel extends Composite {
                         }
                     });
                 }
-//                else {
-//                    GWT.log("Unable to handle organism action " + organismChangeEvent.getAction());
-//                }
             }
         });
 

--- a/src/gwt/org/bbop/apollo/gwt/client/TrackPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/TrackPanel.java
@@ -15,7 +15,6 @@ import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent;
 import com.google.gwt.user.cellview.client.DataGrid;
 import com.google.gwt.user.cellview.client.TextColumn;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwt.view.client.SelectionChangeEvent;
@@ -35,8 +34,6 @@ import org.gwtbootstrap3.extras.toggleswitch.client.ui.ToggleSwitch;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ArrayList;
-
-import static org.bbop.apollo.gwt.client.MainPanel.frame;
 
 
 /**
@@ -377,7 +374,7 @@ public class TrackPanel extends Composite {
                     new ErrorDialog("Error Updating User",o.get(FeatureStringEnum.ERROR.getValue()).isString().stringValue(),true,true);
                 }
 
-                MainPanel.updateGenomicViewer(true);
+                MainPanel.updateGenomicViewer(true,true);
             }
 
             @Override


### PR DESCRIPTION
@deepakunni3   Can you take a look at this when you have a chance. 

Basically, this uses the API directly to handle navigation in cases where you don't change organisms (e.g., navigating to a location or a sequence).     The exception is that when double-clicking the sequence panel, it handles it as an organism change.  