### PR TITLE
better blast configuration instruction

### DIFF
--- a/docs/Configure.md
+++ b/docs/Configure.md
@@ -210,7 +210,8 @@ View your instances page for more details. For example
 Apollo can be configured to work with various sequence search tools. UCSC's BLAT tool is configured by default and you
 can customize it as follows by making modifications in the ```apollo-config.groovy``` file.  Here we replace blat with blast 
 (there is an existing wrapper for Blast).  The database for each file will be passed in via params (globally) or using the 
-```Blat database``` field in the organism tab:
+```Blat database``` field in the organism tab.  For blast the database will be the root name of the blast database files 
+without the suffix.
 
 ``` 
 apollo{

--- a/docs/Configure.md
+++ b/docs/Configure.md
@@ -208,29 +208,33 @@ View your instances page for more details. For example
 ### Search tools
 
 Apollo can be configured to work with various sequence search tools. UCSC's BLAT tool is configured by default and you
-can customize it as follows:
+can customize it as follows by making modifications in the ```apollo-config.groovy``` file.  Here we replace blat with blast 
+(there is an existing wrapper for Blast).  The database for each file will be passed in via params (globally) or using the 
+```Blat database``` field in the organism tab:
 
 ``` 
-sequence_search_tools = [
-  blat_nuc: [
-    search_exe: "/usr/local/bin/blat",
-    search_class: "org.bbop.apollo.sequence.search.blat.BlatCommandLineNucleotideToNucleotide",
-    name: "Blat nucleotide",
-    params: ""
-  ],
-  blat_prot: [
-    search_exe: "/usr/local/bin/blat",
-    search_class: "org.bbop.apollo.sequence.search.blat.BlatCommandLineProteinToNucleotide",
-    name: "Blat protein",
-    params: "",
-    tmp_dir: "/opt/apollo/tmp" //optional, uses system tmp dir by default
-  ]
-  your_custom_search_tool: [
-    search_exe: "/usr/local/customtool",
-    search_class: "org.your.custom.Class",
-    name: "Custom search"
-  ]
-]
+apollo{
+	sequence_search_tools {
+        blat_nuc {
+            search_exe = "/usr/local/bin/blastn"
+            search_class = "org.bbop.apollo.sequence.search.blast.BlastCommandLine"
+            name = "Blast nucleotide"
+            params = ""
+        }
+        blat_prot {
+            search_exe = "/usr/local/bin/tblastn"
+            search_class = "org.bbop.apollo.sequence.search.blast.BlastCommandLine"
+            name = "Blast protein to translated nucleotide"
+            params = ""
+            //tmp_dir: "/opt/apollo/tmp" optional param
+        }
+        your_custom_search_tool {
+          search_exe = "/usr/local/customtool"
+          search_class = "org.your.custom.Class"
+          name: "Custom search"
+        }
+    }
+}
 
 ```
 

--- a/src/groovy/org/bbop/apollo/sequence/search/blast/BlastCommandLine.java
+++ b/src/groovy/org/bbop/apollo/sequence/search/blast/BlastCommandLine.java
@@ -75,7 +75,8 @@ public class BlastCommandLine extends SequenceSearchTool {
             throws IOException, AlignmentParsingException, InterruptedException {
         PrintWriter log = new PrintWriter(new BufferedWriter(new FileWriter(dir + "/search.log")));
         String queryArg = createQueryFasta(dir, query);
-        String databaseArg = database + (databaseId != null ? ":" + databaseId : "");
+//        String databaseArg = database + (databaseId != null ? ":" + databaseId : "");
+        String databaseArg = database ;
         String outputArg = dir.getAbsolutePath() + "/results.tab";
         List<String> commands = new ArrayList<String>();
         commands.add(blastBin);
@@ -111,8 +112,10 @@ public class BlastCommandLine extends SequenceSearchTool {
     }
     private void runCommand(List<String> commands, PrintWriter log) throws IOException, InterruptedException {
         log.println("Command:");
+        System.out.println("ASDFASDFASDFASDFASDFASDFADSF");
         for (String arg : commands) {
             log.print(arg + " ");
+            System.out.print(arg + " ");
         }
         ProcessBuilder pb = new ProcessBuilder(commands);
         Process p = pb.start();

--- a/src/groovy/org/bbop/apollo/sequence/search/blast/BlastCommandLine.java
+++ b/src/groovy/org/bbop/apollo/sequence/search/blast/BlastCommandLine.java
@@ -112,10 +112,8 @@ public class BlastCommandLine extends SequenceSearchTool {
     }
     private void runCommand(List<String> commands, PrintWriter log) throws IOException, InterruptedException {
         log.println("Command:");
-        System.out.println("ASDFASDFASDFASDFASDFASDFADSF");
         for (String arg : commands) {
             log.print(arg + " ");
-            System.out.print(arg + " ");
         }
         ProcessBuilder pb = new ProcessBuilder(commands);
         Process p = pb.start();

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.ui.xml
@@ -82,7 +82,7 @@
                         <b:Row styleName="{style.row}">
                             <b:Column size="XS_12" styleName="{style.widgetPanel}">
                                 <b:InputGroup>
-                                    <b:InputGroupAddon>Blat database</b:InputGroupAddon>
+                                    <b:InputGroupAddon>Search database</b:InputGroupAddon>
                                     <b:TextBox autoComplete="false" ui:field="blatdb" enabled="false"/>
                                 </b:InputGroup>
                             </b:Column>


### PR DESCRIPTION
I updated the configuration to better show what the file would look like.

@deepakunni3  I don't think that blastn uses a databaseId argument.  blat uses it to specify the chromosome, but I don't think that the same is true for blast.  The result was that if you had the "search all genomes" box checked it would work, but otherwise would fail (for blast, works fine for blat).

@monicacecilia  You should be able to pass these instructions along. 
