### PR TITLE
Account for pre-existing stop_codon_read_through when recalculating longest ORF after adding/deleting sequence alterations

### DIFF
--- a/grails-app/services/org/bbop/apollo/CdsService.groovy
+++ b/grails-app/services/org/bbop/apollo/CdsService.groovy
@@ -80,6 +80,7 @@ class CdsService {
     def deleteStopCodonReadThrough(CDS cds, StopCodonReadThrough stopCodonReadThrough) {
         featureRelationshipService.deleteChildrenForTypes(cds, StopCodonReadThrough.ontologyId)
         featureRelationshipService.deleteParentForTypes(stopCodonReadThrough, Transcript.ontologyId)
+        stopCodonReadThrough.delete()
     }
 
     def deleteStopCodonReadThrough(CDS cds) {
@@ -134,7 +135,11 @@ class CdsService {
         cds.save(flush: true,failOnError: true)
 
     }
-    
+
+    def hasStopCodonReadThrough(CDS cds) {
+        return getStopCodonReadThrough(cds).size() != 0
+    }
+
     def getResiduesFromCDS(CDS cds) {
         // New implementation that infers CDS based on overlapping exons
         Transcript transcript = transcriptService.getTranscript(cds)

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -526,7 +526,8 @@ class FeatureService {
     @Transactional
     def calculateCDS(Transcript transcript) {
         // NOTE: isPseudogene call seemed redundant with isProtenCoding
-        calculateCDS(transcript, false)
+        CDS cds = transcriptService.getCDS(transcript)
+        calculateCDS(transcript, cdsService.hasStopCodonReadThrough(cds))
 //        if (transcriptService.isProteinCoding(transcript) && (transcriptService.getGene(transcript) == null)) {
 ////            calculateCDS(editor, transcript, transcript.getCDS() != null ? transcript.getCDS().getStopCodonReadThrough() != null : false);
 ////            calculateCDS(transcript, transcript.getCDS() != null ? transcript.getCDS().getStopCodonReadThrough() != null : false);

--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -1192,7 +1192,8 @@ class RequestHandlingService {
             for (Feature feature : featureService.getOverlappingFeatures(sequenceAlterationFeatureLocation, false)) {
                 if (feature instanceof Gene) {
                     for (Transcript transcript : transcriptService.getTranscripts((Gene) feature)) {
-                        featureService.setLongestORF(transcript)
+                        CDS cds = transcriptService.getCDS(transcript)
+                        featureService.setLongestORF(transcript, cdsService.hasStopCodonReadThrough(cds))
                         nonCanonicalSplitSiteService.findNonCanonicalAcceptorDonorSpliceSites(transcript)
                         updateFeatureContainer.getJSONArray(FeatureStringEnum.FEATURES.value).put(featureService.convertFeatureToJSON(transcript, true));
                     }
@@ -1274,7 +1275,8 @@ class RequestHandlingService {
             for (Feature feature : featureService.getOverlappingFeatures(sequenceAlteration.getFeatureLocation(), false)) {
                 if (feature instanceof Gene) {
                     for (Transcript transcript : transcriptService.getTranscripts((Gene) feature)) {
-                        featureService.setLongestORF(transcript)
+                        CDS cds = transcriptService.getCDS(transcript)
+                        featureService.setLongestORF(transcript, cdsService.hasStopCodonReadThrough(cds))
                         nonCanonicalSplitSiteService.findNonCanonicalAcceptorDonorSpliceSites(transcript)
                         updateFeatureContainer.getJSONArray(FeatureStringEnum.FEATURES.value).put(featureService.convertFeatureToJSON(transcript, false));
                     }


### PR DESCRIPTION
Fixes #1527 

@nathandunn Ready for test and review.