### PR TITLE
Add REST API for availableStatus and canned comments/keys/values

### DIFF
--- a/grails-app/conf/org/bbop/apollo/SecurityFilters.groovy
+++ b/grails-app/conf/org/bbop/apollo/SecurityFilters.groovy
@@ -30,6 +30,7 @@ class SecurityFilters {
                         || controllerName == "cannedKey"
                         || controllerName == "cannedValue"
                         || controllerName == "cannedComment"
+                        || controllerName == "availableStatus"
                         || controllerName == "proxy"
                         || controllerName == "featureType"
                         || actionName == "report"

--- a/grails-app/controllers/org/bbop/apollo/AvailableStatusController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AvailableStatusController.groovy
@@ -260,10 +260,7 @@ class AvailableStatusController {
             }
 
             if (statusJson.id || statusJson.name) {
-                AvailableStatus status = AvailableStatus.findById(statusJson.id)
-                if (!status) {
-                    status = AvailableStatus.findByValue(statusJson.name)
-                }
+                AvailableStatus status = AvailableStatus.findById(statusJson.id) ?: AvailableStatus.findByValue(statusJson.name)
 
                 if (!status) {
                     JSONObject jsonObject = new JSONObject()

--- a/grails-app/controllers/org/bbop/apollo/AvailableStatusController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AvailableStatusController.groovy
@@ -1,23 +1,25 @@
 package org.bbop.apollo
 
 
-
+import grails.converters.JSON
 import static org.springframework.http.HttpStatus.*
 import grails.transaction.Transactional
+import org.bbop.apollo.gwt.shared.PermissionEnum
+import org.codehaus.groovy.grails.web.json.JSONObject
+import org.restapidoc.annotation.RestApi
+import org.restapidoc.annotation.RestApiMethod
+import org.restapidoc.annotation.RestApiParam
+import org.restapidoc.annotation.RestApiParams
+import org.restapidoc.pojo.RestApiParamType
+import org.restapidoc.pojo.RestApiVerb
 
+@RestApi(name = "Available Status Services", description = "Methods for managing available statuses")
 @Transactional(readOnly = true)
 class AvailableStatusController {
 
     static allowedMethods = [save: "POST", update: "PUT", delete: "DELETE"]
 
     def permissionService
-
-    def beforeInterceptor = {
-        if(!permissionService.isAdmin()){
-            forward action: "notAuthorized" ,controller: "annotator"
-            return
-        }
-    }
 
     def index(Integer max) {
         params.max = Math.min(max ?: 10, 100)
@@ -110,4 +112,177 @@ class AvailableStatusController {
             '*'{ render status: NOT_FOUND }
         }
     }
+
+    @RestApiMethod(description = "Create status", path = "/availableStatus/createStatus", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "name", type = "string", paramType = RestApiParamType.QUERY, description = "Status name to add")
+    ]
+    )
+    @Transactional
+    def createStatus() {
+        JSONObject statusJson = permissionService.handleInput(request, params)
+        try {
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(statusJson))) {
+                if (statusJson.get("name") == "") {
+                    throw new Exception('empty fields detected')
+                }
+
+                log.debug "Adding ${statusJson.name}"
+                AvailableStatus status = new AvailableStatus(
+                        label: statusJson.name
+                ).save(flush: true)
+
+                render status as JSON
+            } else {
+                def error = [error: 'not authorized to add AvailableStatus']
+                render error as JSON
+                log.error(error.error)
+            }
+        } catch (e) {
+            def error = [error: 'problem saving AvailableStatus: ' + e]
+            render error as JSON
+            e.printStackTrace()
+            log.error(error.error)
+        }
+    }
+
+    @RestApiMethod(description = "Update status", path = "/availableStatus/updateStatus", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Status ID to update (or specify the old_name)")
+            , @RestApiParam(name = "old_name", type = "string", paramType = RestApiParamType.QUERY, description = "Status name to update")
+            , @RestApiParam(name = "new_name", type = "string", paramType = RestApiParamType.QUERY, description = "Status name to change to (the only editable option)")
+    ]
+    )
+    @Transactional
+    def updateStatus() {
+        try {
+            JSONObject statusJson = permissionService.handleInput(request, params)
+            log.debug "Updating status ${statusJson}"
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(statusJson))) {
+
+                log.debug "status ID: ${statusJson.id}"
+                AvailableStatus status = AvailableStatus.findById(statusJson.id)
+                if (!status) {
+                    status = AvailableStatus.findByLabel(statusJson.old_name)
+                }
+
+                if (!status) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to update the status")
+                    render jsonObject as JSON
+                    return
+                }
+
+                status.label = statusJson.new_name
+                status.save(flush: true)
+
+                log.info "Success updating status: ${status.id}"
+                render new JSONObject() as JSON
+            } else {
+                def error = [error: 'not authorized to delete status']
+                log.error(error.error)
+                render error as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem deleting status: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Remove a status", path = "/availableStatus/deleteStatus", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Status ID to remove (or specify the name)")
+            , @RestApiParam(name = "name", type = "string", paramType = RestApiParamType.QUERY, description = "Status name to delete")
+    ])
+    @Transactional
+    def deleteStatus() {
+        try {
+            JSONObject statusJson = permissionService.handleInput(request, params)
+            log.debug "Deleting status ${statusJson}"
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(statusJson))) {
+
+                AvailableStatus status = AvailableStatus.findById(statusJson.id)
+                if (!status) {
+                    status = AvailableStatus.findByLabel(statusJson.name)
+                }
+
+                if (!status) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the status")
+                    render jsonObject as JSON
+                    return
+                }
+
+                status.delete()
+
+                log.info "Success deleting status: ${statusJson}"
+                render new JSONObject() as JSON
+            } else {
+                def error = [error: 'not authorized to delete status']
+                log.error(error.error)
+                render error as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem deleting status: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Returns a JSON array of all statuses, or optionally, gets information about a specific status", path = "/availableStatus/showStatus", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Status ID to show (or specify a name)")
+            , @RestApiParam(name = "name", type = "string", paramType = RestApiParamType.QUERY, description = "Status name to show")
+    ])
+    @Transactional
+    def showStatus() {
+        try {
+            JSONObject statusJson = permissionService.handleInput(request, params)
+            log.debug "Showing status ${statusJson}"
+            if (!permissionService.hasGlobalPermissions(statusJson, PermissionEnum.ADMINISTRATE)) {
+                render status: UNAUTHORIZED
+                return
+            }
+
+            if (statusJson.id || statusJson.name) {
+                AvailableStatus status = AvailableStatus.findById(statusJson.id)
+                if (!status) {
+                    status = AvailableStatus.findByLabel(statusJson.name)
+                }
+
+                if (!status) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the status")
+                    render jsonObject as JSON
+                    return
+                }
+
+                log.info "Success showing status: ${statusJson}"
+                render status as JSON
+            }
+            else {
+                statuses = AvailableStatus.all
+
+                log.info "Success showing all statuses"
+                render statuses as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem showing statuses: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
 }

--- a/grails-app/controllers/org/bbop/apollo/CannedCommentController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/CannedCommentController.groovy
@@ -1,10 +1,19 @@
 package org.bbop.apollo
 
 
-
+import grails.converters.JSON
 import static org.springframework.http.HttpStatus.*
 import grails.transaction.Transactional
+import org.bbop.apollo.gwt.shared.PermissionEnum
+import org.codehaus.groovy.grails.web.json.JSONObject
+import org.restapidoc.annotation.RestApi
+import org.restapidoc.annotation.RestApiMethod
+import org.restapidoc.annotation.RestApiParam
+import org.restapidoc.annotation.RestApiParams
+import org.restapidoc.pojo.RestApiParamType
+import org.restapidoc.pojo.RestApiVerb
 
+@RestApi(name = "Canned Comments Services", description = "Methods for managing canned comments")
 @Transactional(readOnly = true)
 class CannedCommentController {
 
@@ -108,6 +117,184 @@ class CannedCommentController {
                 redirect action: "index", method: "GET"
             }
             '*'{ render status: NOT_FOUND }
+        }
+    }
+
+    @RestApiMethod(description = "Create canned comment", path = "/cannedComment/createComment", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "comment", type = "string", paramType = RestApiParamType.QUERY, description = "Canned comment to add")
+            , @RestApiParam(name = "metadata", type = "string", paramType = RestApiParamType.QUERY, description = "Optional additional information")
+    ]
+    )
+    @Transactional
+    def createComment() {
+        JSONObject commentJson = permissionService.handleInput(request, params)
+        try {
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(commentJson))) {
+                if (!commentJson.comment) {
+                    throw new Exception('empty fields detected')
+                }
+
+                if (!commentJson.metadata) {
+                    commentJson.metadata = ""
+                }
+
+                log.debug "Adding canned comment ${commentJson.comment}"
+                CannedComment comment = new CannedComment(
+                        comment: commentJson.comment,
+                        metadata: commentJson.metadata
+                ).save(flush: true)
+
+                render comment as JSON
+            } else {
+                def error = [error: 'not authorized to add CannedComment']
+                render error as JSON
+                log.error(error.error)
+            }
+        } catch (e) {
+            def error = [error: 'problem saving CannedComment: ' + e]
+            render error as JSON
+            e.printStackTrace()
+            log.error(error.error)
+        }
+    }
+
+    @RestApiMethod(description = "Update canned comment", path = "/cannedComment/updateComment", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Canned comment ID to update (or specify the old_comment)")
+            , @RestApiParam(name = "old_comment", type = "string", paramType = RestApiParamType.QUERY, description = "Canned comment to update")
+            , @RestApiParam(name = "new_comment", type = "string", paramType = RestApiParamType.QUERY, description = "Canned comment to change to (the only editable option)")
+            , @RestApiParam(name = "metadata", type = "string", paramType = RestApiParamType.QUERY, description = "Optional additional information")
+    ]
+    )
+    @Transactional
+    def updateComment() {
+        try {
+            JSONObject commentJson = permissionService.handleInput(request, params)
+            log.debug "Updating canned comment ${commentJson}"
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(commentJson))) {
+
+                log.debug "Canned comment ID: ${commentJson.id}"
+                CannedComment comment = CannedComment.findById(commentJson.id) ?: CannedComment.findByComment(commentJson.old_comment)
+
+                if (!comment) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to update the canned comment")
+                    render jsonObject as JSON
+                    return
+                }
+
+                comment.comment = commentJson.new_comment
+
+                if (commentJson.metadata) {
+                    comment.metadata = commentJson.metadata
+                }
+
+                comment.save(flush: true)
+
+                log.info "Success updating canned comment: ${comment.id}"
+                render new JSONObject() as JSON
+            } else {
+                def error = [error: 'not authorized to edit canned comment']
+                log.error(error.error)
+                render error as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem editing canned comment: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Remove a canned comment", path = "/cannedComment/deleteComment", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Canned comment ID to remove (or specify the name)")
+            , @RestApiParam(name = "comment", type = "string", paramType = RestApiParamType.QUERY, description = "Canned comment to delete")
+    ])
+    @Transactional
+    def deleteComment() {
+        try {
+            JSONObject commentJson = permissionService.handleInput(request, params)
+            log.debug "Deleting canned comment ${commentJson}"
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(commentJson))) {
+
+                CannedComment comment = CannedComment.findById(commentJson.id) ?: CannedComment.findByComment(commentJson.comment)
+
+                if (!comment) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the canned comment")
+                    render jsonObject as JSON
+                    return
+                }
+
+                comment.delete()
+
+                log.info "Success deleting canned comment: ${commentJson}"
+                render new JSONObject() as JSON
+            } else {
+                def error = [error: 'not authorized to delete canned comment']
+                log.error(error.error)
+                render error as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem deleting canned comment: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Returns a JSON array of all canned comments, or optionally, gets information about a specific canned comment", path = "/cannedComment/showComment", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Comment ID to show (or specify a comment)")
+            , @RestApiParam(name = "comment", type = "string", paramType = RestApiParamType.QUERY, description = "Comment to show")
+    ])
+    @Transactional
+    def showComment() {
+        try {
+            JSONObject commentJson = permissionService.handleInput(request, params)
+            log.debug "Showing canned comment ${commentJson}"
+            if (!permissionService.hasGlobalPermissions(commentJson, PermissionEnum.ADMINISTRATE)) {
+                render status: UNAUTHORIZED
+                return
+            }
+
+            if (commentJson.id || commentJson.comment) {
+                CannedComment comment = CannedComment.findById(commentJson.id)
+                if (!comment) {
+                    comment = CannedComment.findByComment(commentJson.comment)
+                }
+
+                if (!comment) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the canned comments")
+                    render jsonObject as JSON
+                    return
+                }
+
+                log.info "Success showing comment: ${commentJson}"
+                render comment as JSON
+            }
+            else {
+                def comments = CannedComment.all
+
+                log.info "Success showing all canned comments"
+                render comments as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem showing canned comments: ' + e]
+            log.error(error.error)
+            render error as JSON
         }
     }
 }

--- a/grails-app/controllers/org/bbop/apollo/CannedCommentController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/CannedCommentController.groovy
@@ -23,7 +23,7 @@ class CannedCommentController {
 
     def beforeInterceptor = {
         if(!permissionService.isAdmin()){
-            forward action: "notAuthorized" ,controller: "annotator"
+            forward action: "notAuthorized", controller: "annotator"
             return
         }
     }
@@ -269,10 +269,7 @@ class CannedCommentController {
             }
 
             if (commentJson.id || commentJson.comment) {
-                CannedComment comment = CannedComment.findById(commentJson.id)
-                if (!comment) {
-                    comment = CannedComment.findByComment(commentJson.comment)
-                }
+                CannedComment comment = CannedComment.findById(commentJson.id) ?: CannedComment.findByComment(commentJson.comment)
 
                 if (!comment) {
                     JSONObject jsonObject = new JSONObject()

--- a/grails-app/controllers/org/bbop/apollo/CannedKeyController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/CannedKeyController.groovy
@@ -1,10 +1,19 @@
 package org.bbop.apollo
 
 
-
+import grails.converters.JSON
 import static org.springframework.http.HttpStatus.*
 import grails.transaction.Transactional
+import org.bbop.apollo.gwt.shared.PermissionEnum
+import org.codehaus.groovy.grails.web.json.JSONObject
+import org.restapidoc.annotation.RestApi
+import org.restapidoc.annotation.RestApiMethod
+import org.restapidoc.annotation.RestApiParam
+import org.restapidoc.annotation.RestApiParams
+import org.restapidoc.pojo.RestApiParamType
+import org.restapidoc.pojo.RestApiVerb
 
+@RestApi(name = "Canned Keys Services", description = "Methods for managing canned keys")
 @Transactional(readOnly = true)
 class CannedKeyController {
 
@@ -14,7 +23,7 @@ class CannedKeyController {
 
     def beforeInterceptor = {
         if(!permissionService.isAdmin()){
-            forward action: "notAuthorized" ,controller: "annotator"
+            forward action: "notAuthorized", controller: "annotator"
             return
         }
     }
@@ -112,6 +121,181 @@ class CannedKeyController {
                 redirect action: "index", method: "GET"
             }
             '*'{ render status: NOT_FOUND }
+        }
+    }
+
+    @RestApiMethod(description = "Create canned key", path = "/cannedKey/createKey", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "key", type = "string", paramType = RestApiParamType.QUERY, description = "Canned key to add")
+            , @RestApiParam(name = "metadata", type = "string", paramType = RestApiParamType.QUERY, description = "Optional additional information")
+    ]
+    )
+    @Transactional
+    def createKey() {
+        JSONObject keyJson = permissionService.handleInput(request, params)
+        try {
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(keyJson))) {
+                if (!keyJson.key) {
+                    throw new Exception('empty fields detected')
+                }
+
+                if (!keyJson.metadata) {
+                    keyJson.metadata = ""
+                }
+
+                log.debug "Adding canned key ${keyJson.key}"
+                CannedKey key = new CannedKey(
+                        label: keyJson.key,
+                        metadata: keyJson.metadata
+                ).save(flush: true)
+
+                render key as JSON
+            } else {
+                def error = [error: 'not authorized to add CannedKey']
+                render error as JSON
+                log.error(error.error)
+            }
+        } catch (e) {
+            def error = [error: 'problem saving CannedKey: ' + e]
+            render error as JSON
+            e.printStackTrace()
+            log.error(error.error)
+        }
+    }
+
+    @RestApiMethod(description = "Update canned key", path = "/cannedKey/updateKey", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Canned key ID to update (or specify the old_key)")
+            , @RestApiParam(name = "old_key", type = "string", paramType = RestApiParamType.QUERY, description = "Canned key to update")
+            , @RestApiParam(name = "new_key", type = "string", paramType = RestApiParamType.QUERY, description = "Canned key to change to (the only editable option)")
+            , @RestApiParam(name = "metadata", type = "string", paramType = RestApiParamType.QUERY, description = "Optional additional information")
+    ]
+    )
+    @Transactional
+    def updateKey() {
+        try {
+            JSONObject keyJson = permissionService.handleInput(request, params)
+            log.debug "Updating canned key ${keyJson}"
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(keyJson))) {
+
+                log.debug "Canned key ID: ${keyJson.id}"
+                CannedKey key = CannedKey.findById(keyJson.id) ?: CannedKey.findByLabel(keyJson.old_key)
+
+                if (!key) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to update the canned key")
+                    render jsonObject as JSON
+                    return
+                }
+
+                key.label = keyJson.new_key
+
+                if (keyJson.metadata) {
+                    key.metadata = keyJson.metadata
+                }
+
+                key.save(flush: true)
+
+                log.info "Success updating canned key: ${key.id}"
+                render new JSONObject() as JSON
+            } else {
+                def error = [error: 'not authorized to edit canned key']
+                log.error(error.error)
+                render error as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem editing canned key: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Remove a canned key", path = "/cannedKey/deleteKey", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Canned key ID to remove (or specify the name)")
+            , @RestApiParam(name = "key", type = "string", paramType = RestApiParamType.QUERY, description = "Canned key to delete")
+    ])
+    @Transactional
+    def deleteKey() {
+        try {
+            JSONObject keyJson = permissionService.handleInput(request, params)
+            log.debug "Deleting canned key ${keyJson}"
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(keyJson))) {
+
+                CannedKey key = CannedKey.findById(keyJson.id) ?: CannedKey.findByLabel(keyJson.key)
+
+                if (!key) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the canned key")
+                    render jsonObject as JSON
+                    return
+                }
+
+                key.delete()
+
+                log.info "Success deleting canned key: ${keyJson}"
+                render new JSONObject() as JSON
+            } else {
+                def error = [error: 'not authorized to delete canned key']
+                log.error(error.error)
+                render error as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem deleting canned key: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Returns a JSON array of all canned keys, or optionally, gets information about a specific canned key", path = "/cannedKey/showKey", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Key ID to show (or specify a key)")
+            , @RestApiParam(name = "key", type = "string", paramType = RestApiParamType.QUERY, description = "Key to show")
+    ])
+    @Transactional
+    def showKey() {
+        try {
+            JSONObject keyJson = permissionService.handleInput(request, params)
+            log.debug "Showing canned key ${keyJson}"
+            if (!permissionService.hasGlobalPermissions(keyJson, PermissionEnum.ADMINISTRATE)) {
+                render status: UNAUTHORIZED
+                return
+            }
+
+            if (keyJson.id || keyJson.key) {
+                CannedKey key = CannedKey.findById(keyJson.id) ?: CannedKey.findByLabel(keyJson.old_key)
+
+                if (!key) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the canned keys")
+                    render jsonObject as JSON
+                    return
+                }
+
+                log.info "Success showing key: ${keyJson}"
+                render key as JSON
+            }
+            else {
+                def keys = CannedKey.all
+
+                log.info "Success showing all canned keys"
+                render keys as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem showing canned keys: ' + e]
+            log.error(error.error)
+            render error as JSON
         }
     }
 }

--- a/grails-app/controllers/org/bbop/apollo/CannedValueController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/CannedValueController.groovy
@@ -1,10 +1,19 @@
 package org.bbop.apollo
 
 
-
+import grails.converters.JSON
 import static org.springframework.http.HttpStatus.*
 import grails.transaction.Transactional
+import org.bbop.apollo.gwt.shared.PermissionEnum
+import org.codehaus.groovy.grails.web.json.JSONObject
+import org.restapidoc.annotation.RestApi
+import org.restapidoc.annotation.RestApiMethod
+import org.restapidoc.annotation.RestApiParam
+import org.restapidoc.annotation.RestApiParams
+import org.restapidoc.pojo.RestApiParamType
+import org.restapidoc.pojo.RestApiVerb
 
+@RestApi(name = "Canned Values Services", description = "Methods for managing canned values")
 @Transactional(readOnly = true)
 class CannedValueController {
 
@@ -14,7 +23,7 @@ class CannedValueController {
 
     def beforeInterceptor = {
         if(!permissionService.isAdmin()){
-            forward action: "notAuthorized" ,controller: "annotator"
+            forward action: "notAuthorized", controller: "annotator"
             return
         }
     }
@@ -108,6 +117,181 @@ class CannedValueController {
                 redirect action: "index", method: "GET"
             }
             '*'{ render status: NOT_FOUND }
+        }
+    }
+
+    @RestApiMethod(description = "Create canned value", path = "/cannedValue/createValue", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "value", type = "string", paramType = RestApiParamType.QUERY, description = "Canned value to add")
+            , @RestApiParam(name = "metadata", type = "string", paramType = RestApiParamType.QUERY, description = "Optional additional information")
+    ]
+    )
+    @Transactional
+    def createValue() {
+        JSONObject valueJson = permissionService.handleInput(request, params)
+        try {
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(valueJson))) {
+                if (!valueJson.value) {
+                    throw new Exception('empty fields detected')
+                }
+
+                if (!valueJson.metadata) {
+                    valueJson.metadata = ""
+                }
+
+                log.debug "Adding canned value ${valueJson.value}"
+                CannedValue value = new CannedValue(
+                        label: valueJson.value,
+                        metadata: valueJson.metadata
+                ).save(flush: true)
+
+                render value as JSON
+            } else {
+                def error = [error: 'not authorized to add CannedValue']
+                render error as JSON
+                log.error(error.error)
+            }
+        } catch (e) {
+            def error = [error: 'problem saving CannedValue: ' + e]
+            render error as JSON
+            e.printStackTrace()
+            log.error(error.error)
+        }
+    }
+
+    @RestApiMethod(description = "Update canned value", path = "/cannedValue/updateValue", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Canned value ID to update (or specify the old_value)")
+            , @RestApiParam(name = "old_value", type = "string", paramType = RestApiParamType.QUERY, description = "Canned value to update")
+            , @RestApiParam(name = "new_value", type = "string", paramType = RestApiParamType.QUERY, description = "Canned value to change to (the only editable option)")
+            , @RestApiParam(name = "metadata", type = "string", paramType = RestApiParamType.QUERY, description = "Optional additional information")
+    ]
+    )
+    @Transactional
+    def updateValue() {
+        try {
+            JSONObject valueJson = permissionService.handleInput(request, params)
+            log.debug "Updating canned value ${valueJson}"
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(valueJson))) {
+
+                log.debug "Canned value ID: ${valueJson.id}"
+                CannedValue value = CannedValue.findById(valueJson.id) ?: CannedValue.findByLabel(valueJson.old_value)
+
+                if (!value) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to update the canned value")
+                    render jsonObject as JSON
+                    return
+                }
+
+                value.label = valueJson.new_value
+
+                if (valueJson.metadata) {
+                    value.metadata = valueJson.metadata
+                }
+
+                value.save(flush: true)
+
+                log.info "Success updating canned value: ${value.id}"
+                render new JSONObject() as JSON
+            } else {
+                def error = [error: 'not authorized to edit canned value']
+                log.error(error.error)
+                render error as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem editing canned value: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Remove a canned value", path = "/cannedValue/deleteValue", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Canned value ID to remove (or specify the name)")
+            , @RestApiParam(name = "value", type = "string", paramType = RestApiParamType.QUERY, description = "Canned value to delete")
+    ])
+    @Transactional
+    def deleteValue() {
+        try {
+            JSONObject valueJson = permissionService.handleInput(request, params)
+            log.debug "Deleting canned value ${valueJson}"
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(valueJson))) {
+
+                CannedValue value = CannedValue.findById(valueJson.id) ?: CannedValue.findByLabel(valueJson.value)
+
+                if (!value) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the canned value")
+                    render jsonObject as JSON
+                    return
+                }
+
+                value.delete()
+
+                log.info "Success deleting canned value: ${valueJson}"
+                render new JSONObject() as JSON
+            } else {
+                def error = [error: 'not authorized to delete canned value']
+                log.error(error.error)
+                render error as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem deleting canned value: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Returns a JSON array of all canned values, or optionally, gets information about a specific canned value", path = "/cannedValue/showValue", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Value ID to show (or specify a value)")
+            , @RestApiParam(name = "value", type = "string", paramType = RestApiParamType.QUERY, description = "Value to show")
+    ])
+    @Transactional
+    def showValue() {
+        try {
+            JSONObject valueJson = permissionService.handleInput(request, params)
+            log.debug "Showing canned value ${valueJson}"
+            if (!permissionService.hasGlobalPermissions(valueJson, PermissionEnum.ADMINISTRATE)) {
+                render status: UNAUTHORIZED
+                return
+            }
+
+            if (valueJson.id || valueJson.value) {
+                CannedValue value = CannedValue.findById(valueJson.id) ?: CannedValue.findByLabel(valueJson.old_value)
+
+                if (!value) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the canned values")
+                    render jsonObject as JSON
+                    return
+                }
+
+                log.info "Success showing value: ${valueJson}"
+                render value as JSON
+            }
+            else {
+                def values = CannedValue.all
+
+                log.info "Success showing all canned values"
+                render values as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem showing canned values: ' + e]
+            log.error(error.error)
+            render error as JSON
         }
     }
 }


### PR DESCRIPTION
A first try at implementing the REST API we talked about in #1507, for the moment for the Status only.
@nathandunn if you have 5 minutes, maybe you can tell me if it's what you had in mind?
It's not yet working (perm problem on showStatus, other error on createStatus), but I thought I could open the PR now, and see if I'm on the right direction