### PR TITLE
Dark Theme Touchups + Flat Theme Option

### DIFF
--- a/client/apollo/css/flat.css
+++ b/client/apollo/css/flat.css
@@ -1,0 +1,29 @@
+.Flat div.gridline_minor {
+	border: none
+}
+.Flat div.gridline_major {
+	border: none
+}
+
+.Flat div.overview {
+	background: #f9f9f9;
+}
+.Flat.Dark div.overview {
+	background: #333333;
+	box-shadow: 0 2px 10px 0px #2b2b2b;
+	border: 1px solid black;
+}
+
+.Flat.Dark div.overview-pos{
+	color: white;
+}
+
+.Flat div#static_track{
+	background: #f9f9f9;
+}
+.Flat.Dark div#static_track{
+	color: white;
+	background: #333333;
+	box-shadow: 0 2px 10px 0px black;
+	border: 1px solid black;
+}

--- a/client/apollo/css/main.css
+++ b/client/apollo/css/main.css
@@ -17,3 +17,4 @@
 @import url("confirm_dialog.css");
 @import url("information_editor_panel.css");
 @import url("maker_darkbackground.css");
+@import url("flat.css");

--- a/client/apollo/css/maker_darkbackground.css
+++ b/client/apollo/css/maker_darkbackground.css
@@ -1,10 +1,13 @@
 /* styles for MAKER tracks and additional customization of WebApollo */
 .Dark .track_jbrowse_view_track_wiggle_xyplot .canvas-track {
-    background-color: #DDD;
+    background-color: hsla(240, 2%, 18%, 1);
 }
 
 .Dark .track_jbrowse_view_track_wiggle_density .canvas-track {
-    background-color: #DDD;
+    background-color: hsla(240, 2%, 18%, 1);
+}
+.Dark .wigglePositionIndicator {
+	background: white;
 }
 
 .Dark div.track  {
@@ -47,16 +50,13 @@
     color: #FAFFF9;
 }
 
-.Dark .track_annotations .feature-name {
-    color: #000;
-}
-
 .Dark div.feature-description {
     color: #bbb;
 }
 /* UI elements */
 .Dark div.locationTrap {
-    background-color: white;
+    background-color: #929292;
+	border-bottom-color: #0b2648;
 }
 
 .Dark .pin_underlay.track.block {
@@ -333,11 +333,15 @@
 */
 
 .Dark .left-edge-match  {
-    border-left: solid red 3px;
+    border-left: solid black 2px !important;
 }
 
 .Dark .right-edge-match  {
-    border-right: solid red 3px;
+    border-right: solid black 2px !important;
+}
+
+.Dark .selected-annotation {
+	outline-color: black;
 }
 
 /* start NeatHTMLFeatures styles */

--- a/client/apollo/css/webapollo_track_styles.css
+++ b/client/apollo/css/webapollo_track_styles.css
@@ -34,6 +34,10 @@
     background-color: #FFFFDD;
 }
 
+.Dark .track.track_annotations {
+    background-color: #676767;
+}
+
 div.track_localannot {
     background-color: #DDDDCC;
 }
@@ -73,6 +77,9 @@ div.wa-sequence .dna-residues.forward-strand {
     color: black;
     z-index: 5;
 }
+.Dark div.wa-sequence .dna-residues.forward-strand {
+	color: white;
+}
 
 div.wa-sequence .dna-residues.reverse-strand {
     color: gray;
@@ -80,10 +87,16 @@ div.wa-sequence .dna-residues.reverse-strand {
     z-index: 5;
     /* outline: 1px solid pink; */
 }
+.Dark div.wa-sequence .dna-residues.reverse-strand {
+	color: lightgray;
+}
 
 div.wa-sequence .aa-residues  {
     color: black;
     z-index: 5;
+}
+.Dark div.wa-sequence .aa-residues  {
+    color: white;
 }
 
 .aa-residues.cds-frame0 {
@@ -437,6 +450,14 @@ div.annot-sequence  {
     border: 1px solid #01F;
 }
 
+.Dark .annot-CDS,
+.Dark .plus-annot-CDS,
+.Dark .minus-annot-CDS {
+    height: 16px;
+    background-color: #30AAFF;
+    border: 1px solid hsla(205, 100%, 25%, 1);
+}
+
 .annot-UTR, x
 .plus-annot-UTR, 
 .minus-annot-UTR {
@@ -542,6 +563,45 @@ div.annot-sequence  {
 
 .colorCds .cds-frame2 {
     background-color: #8080FF;
+}
+
+.Dark.colorCds .dna-residues.cds-frame0 {
+	background-color: #902748
+}
+
+.Dark.colorCds .dna-residues.cds-frame1 {
+	background-color: #366f4b;
+}
+
+.Dark.colorCds .dna-residues.cds-frame2 {
+	background-color: #4e408e;
+}
+
+.Dark div.block.height_overflow .height_overflow_message {
+	color: white;
+	text-shadow: none;
+}
+
+.Dark div.ruler svg g line {
+	stroke: white;
+}
+
+.Dark.colorCds .feature .cds-frame0 {
+    border: 1px solid hsla(0, 100%, 25%, 1);
+}
+
+.Dark.colorCds .feature .cds-frame1 {
+    border: 1px solid hsla(120, 100%, 25%, 1);
+}
+
+.Dark.colorCds .feature .cds-frame2 {
+    border: 1px solid hsla(240, 100%, 25%, 1);
+}
+
+
+.Dark .track .loading {
+	background: rgb(59, 59, 61);
+	color: white;
 }
 
 /**

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -97,6 +97,9 @@ return declare( [JBPlugin, HelpMixin],
         if (browser.cookie("Scheme")=="Dark") {
             domClass.add(win.body(), "Dark");
         }
+        if (browser.cookie("Scheme-Flat")=="Flat") {
+            domClass.add(win.body(), "Flat");
+        }
         if (browser.cookie("colorCdsByFrame")=="true") {
             domClass.add(win.body(), "colorCds");
         }
@@ -243,7 +246,7 @@ return declare( [JBPlugin, HelpMixin],
                                         view.oldOnResize();
                                     }
                             };
-            
+
 
         });
         this.monkeyPatchRegexPlugin();
@@ -641,6 +644,28 @@ return declare( [JBPlugin, HelpMixin],
                     onClick: function (event) {
                         browser.cookie("Scheme","Dark");
                         domClass.add(win.body(), "Dark");
+                    }
+                }
+            )
+        );
+
+        css_frame_menu.addChild(new dijitMenuSeparator());
+        css_frame_menu.addChild(
+            new dijitMenuItem({
+                    label: "Non-Flat",
+                    onClick: function (event) {
+                        browser.cookie("Scheme-Flat","");
+                        domClass.remove(win.body(), "Flat");
+                    }
+                }
+            )
+        );
+        css_frame_menu.addChild(
+            new dijitMenuItem({
+                    label: "Flat",
+                    onClick: function (event) {
+                        browser.cookie("Scheme-Flat","Flat");
+                        domClass.add(win.body(), "Flat");
                     }
                 }
             )


### PR DESCRIPTION
Needed a break from the debugging I've done for the past N days so here's a patch for some extra theme options.

## Currently 
Previously the "dark" theme looked like this. The bright yellow annotator bar always somewhat irked me

![utvalg_144](https://cloud.githubusercontent.com/assets/458683/24972598/7b19a1a2-1fab-11e7-86bb-0d0fe663d50c.png)
And the very bright sequence track
![utvalg_147](https://cloud.githubusercontent.com/assets/458683/24972764/1787e224-1fac-11e7-92f3-38f0f5089949.png)


Additionally some labels were hard to read (e.g. Max Height Reached) and the wig track backgrounds was very light.

## Updated dark theme

![utvalg_141](https://cloud.githubusercontent.com/assets/458683/24972622/8f1d68be-1fab-11e7-9d4f-19baeb637e75.png)
And a more muted sequence track:
![utvalg_148](https://cloud.githubusercontent.com/assets/458683/24972807/2e20cc3a-1fac-11e7-92c9-f1a774a20aef.png)


## Flat Theme Options

Additionally I've added a "Flat" theme option (works with dark and light).
![utvalg_145](https://cloud.githubusercontent.com/assets/458683/24972645/a5f47fd2-1fab-11e7-9ae9-bfd5eea27675.png)

This option removes the gridlines (which I personally find distracting but all my coworkers say they cannot live without) and adds some box-shadows

![utvalg_146](https://cloud.githubusercontent.com/assets/458683/24972678/c27ee2d2-1fab-11e7-97bc-6a250079194f.png)
