### PR TITLE
started to add fetching preferences from session - not ready to merge

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -77,7 +77,8 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
 
             User user = User.findByUsername(username)
             log.debug "getting user permission for ${user}, returnObject"
-            Organism organism = preferenceService.getOrganismFromPreferences(user,null,returnObject.getString(FeatureStringEnum.CLIENT_TOKEN.value))
+//            Organism organism = preferenceService.getOrganismFromPreferences(user,null,returnObject.getString(FeatureStringEnum.CLIENT_TOKEN.value))
+            Organism organism = preferenceService.getCurrentOrganismForCurrentUser(returnObject.getString(FeatureStringEnum.CLIENT_TOKEN.value))
             if (!organism) {
                 log.error "somehow no organism shown, getting for all"
             }

--- a/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
@@ -60,7 +60,7 @@ class AnnotatorController {
             // check organism first
             if (params.containsKey(FeatureStringEnum.ORGANISM.value)) {
                 String organismString = params[FeatureStringEnum.ORGANISM.value]
-                organism = preferenceService.getOrganismForToken(organismString)
+                organism = preferenceService.getOrganismForTokenInDB(organismString)
             }
             organism = organism ?: preferenceService.getCurrentOrganismForCurrentUser(clientToken)
             def allowedOrganisms = permissionService.getOrganisms(permissionService.currentUser)

--- a/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
@@ -433,7 +433,7 @@ class AnnotatorController {
     @Transactional
     def setCurrentOrganism(Organism organismInstance) {
         // set the current organism
-        preferenceService.setCurrentOrganism(permissionService.currentUser, organismInstance, params[FeatureStringEnum.CLIENT_TOKEN.value])
+        preferenceService.setCurrentOrganism(permissionService.currentUser, organismInstance, params[FeatureStringEnum.CLIENT_TOKEN.value] as String)
         session.setAttribute(FeatureStringEnum.ORGANISM_JBROWSE_DIRECTORY.value, organismInstance.directory)
 
         if (!permissionService.checkPermissions(PermissionEnum.READ)) {
@@ -442,7 +442,7 @@ class AnnotatorController {
             return
         }
 
-        render annotatorService.getAppState(params[FeatureStringEnum.CLIENT_TOKEN.value]) as JSON
+        render annotatorService.getAppState(params[FeatureStringEnum.CLIENT_TOKEN.value] as String) as JSON
     }
 
     /**
@@ -455,10 +455,10 @@ class AnnotatorController {
             return
         }
         // set the current organism and sequence Id (if both)
-        preferenceService.setCurrentSequence(permissionService.currentUser, sequenceInstance, params[FeatureStringEnum.CLIENT_TOKEN.value])
+        preferenceService.setCurrentSequence(permissionService.currentUser, sequenceInstance, params[FeatureStringEnum.CLIENT_TOKEN.value] as String)
         session.setAttribute(FeatureStringEnum.ORGANISM_JBROWSE_DIRECTORY.value, sequenceInstance.organism.directory)
 
-        render annotatorService.getAppState(params[FeatureStringEnum.CLIENT_TOKEN.value]) as JSON
+        render annotatorService.getAppState(params[FeatureStringEnum.CLIENT_TOKEN.value] as String) as JSON
     }
 
     def notAuthorized() {

--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -2,6 +2,8 @@ package org.bbop.apollo
 
 import grails.converters.JSON
 import liquibase.util.file.FilenameUtils
+import org.apache.shiro.SecurityUtils
+import org.bbop.apollo.gwt.shared.ClientTokenGenerator
 import org.bbop.apollo.gwt.shared.FeatureStringEnum
 import org.bbop.apollo.sequence.Range
 import org.codehaus.groovy.grails.web.json.JSONArray
@@ -45,13 +47,14 @@ class JbrowseController {
         }
         // case 3 - validated login (just read from preferences, then
         if (permissionService.currentUser && clientToken) {
-            Organism organism = preferenceService.getOrganismForToken(clientToken)
+//            Organism organism = preferenceService.getOrganismForToken(clientToken)
+            Organism organism = preferenceService.getOrganismForTokenInDB(clientToken)
             if(organism){
                 // we need to generate a client_token and do a redirection
                 paramList = paramList.findAll(){
                     !it.startsWith(FeatureStringEnum.CLIENT_TOKEN.value)
                 }
-                clientToken = org.bbop.apollo.gwt.shared.ClientTokenGenerator.generateRandomString()
+                clientToken = ClientTokenGenerator.generateRandomString()
                 preferenceService.setCurrentOrganism(permissionService.currentUser, organism, clientToken)
                 String paramString = ""
                 paramList.each {
@@ -73,7 +76,7 @@ class JbrowseController {
             if(!availableOrganisms){
                 String urlString = "/jbrowse/index.html?${paramList.join("&")}"
                 String username = permissionService.currentUser.username
-                org.apache.shiro.SecurityUtils.subject.logout()
+                SecurityUtils.subject.logout()
                 forward(controller: "jbrowse", action: "chooseOrganismForJbrowse", params: [urlString: urlString, error: "User '${username}' lacks permissions to view or edit the annotations of any organism."])
                 return
             }

--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -67,7 +67,7 @@ class JbrowseController {
                 return
             }
             else{
-                organism = preferenceService.getOrganismFromPreferences(clientToken)
+                organism = preferenceService.getCurrentOrganismForCurrentUser(clientToken)
             }
             def availableOrganisms = permissionService.getOrganisms(permissionService.currentUser)
             if(!availableOrganisms){

--- a/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
@@ -73,22 +73,6 @@ class SequenceController {
 
         User currentUser = permissionService.currentUser
         preferenceService.setCurrentSequence(currentUser,sequenceInstance,token)
-//        UserOrganismPreference userOrganismPreference = UserOrganismPreference.findByUserAndOrganismAndClientToken(currentUser, organism,token,[max: 1, sort: "lastUpdated", order: "desc"])
-//
-//        if (!userOrganismPreference) {
-//            userOrganismPreference = new UserOrganismPreference(
-//                    user: currentUser
-//                    , organism: organism
-//                    , sequence: sequenceInstance
-//                    , currentOrganism: true
-//                    , clientToken: token
-//            ).save(insert: true, flush: true, failOnError: true)
-//        } else {
-//            userOrganismPreference.sequence = sequenceInstance
-//            userOrganismPreference.currentOrganism = true
-//            userOrganismPreference.save(flush: true, failOnError: true)
-//        }
-//        preferenceService.setOtherCurrentOrganismsFalse(userOrganismPreference, currentUser,token)
 
         Session session = SecurityUtils.subject.getSession(false)
         session.setAttribute(FeatureStringEnum.DEFAULT_SEQUENCE_NAME.value, sequenceInstance.name)
@@ -96,9 +80,6 @@ class SequenceController {
         session.setAttribute(FeatureStringEnum.ORGANISM_JBROWSE_DIRECTORY.value, organism.directory)
         session.setAttribute(FeatureStringEnum.ORGANISM_ID.value, sequenceInstance.organismId)
 
-//        render userOrganismPreference.sequence.name as String
-//        render sequenceInstance.name as String
-//        JSONObject sequenceObject = sequenceInstance as JSONObject
         JSONObject sequenceObject = new JSONObject()
         sequenceObject.put("id", sequenceInstance.id)
         sequenceObject.put("name", sequenceInstance.name)

--- a/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
@@ -5,7 +5,6 @@ import grails.transaction.Transactional
 import org.apache.shiro.SecurityUtils
 import org.apache.shiro.session.Session
 import org.bbop.apollo.gwt.shared.FeatureStringEnum
-import org.bbop.apollo.gwt.shared.PermissionEnum
 import org.bbop.apollo.report.SequenceSummary
 import org.codehaus.groovy.grails.web.json.JSONArray
 import org.codehaus.groovy.grails.web.json.JSONObject

--- a/grails-app/controllers/org/bbop/apollo/UserController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/UserController.groovy
@@ -168,7 +168,7 @@ class UserController {
             UserOrganismPreference userOrganismPreference
             try {
                 // sets it by default
-                userOrganismPreference = preferenceService.getCurrentOrganismPreference(params[FeatureStringEnum.CLIENT_TOKEN.value])
+                userOrganismPreference = preferenceService.getCurrentOrganismPreferenceInDB(params[FeatureStringEnum.CLIENT_TOKEN.value])
             } catch (e) {
                 log.error(e)
             }
@@ -200,7 +200,7 @@ class UserController {
             }
             log.info "updateTrackListPreference"
 
-            UserOrganismPreference uop = preferenceService.getCurrentOrganismPreference(dataObject.getString(FeatureStringEnum.CLIENT_TOKEN.value))
+            UserOrganismPreference uop = preferenceService.getCurrentOrganismPreferenceInDB(dataObject.getString(FeatureStringEnum.CLIENT_TOKEN.value))
 
             uop.nativeTrackList = dataObject.get("tracklist")
             uop.save(flush: true)

--- a/grails-app/jobs/org/bbop/apollo/CleanupPreferencesJob.groovy
+++ b/grails-app/jobs/org/bbop/apollo/CleanupPreferencesJob.groovy
@@ -7,7 +7,8 @@ class CleanupPreferencesJob {
 
     static triggers = {
 //      simple repeatInterval: 30000l // execute job every 30 seconds for testing
-        simple repeatInterval: 24 * 60 * 60 * 1000l ,startDelay: 5 * 60 * 1000l // execute job once a day, delays 5 minutes
+//        simple repeatInterval: 24 * 60 * 60 * 1000l ,startDelay: 5 * 60 * 1000l // execute job once a day, delays 5 minutes
+        simple repeatInterval: 8 * 60 * 60 * 1000l ,startDelay: 5 * 60 * 1000l // execute job three times a day, delays 5 minutes
     }
 
     def execute() {

--- a/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
+++ b/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
@@ -43,7 +43,7 @@ class AnnotatorService {
                 organismArray.add(jsonObject)
             }
             appStateObject.put("organismList", organismArray)
-            UserOrganismPreference currentUserOrganismPreference = preferenceService.getCurrentOrganismPreference(token)
+            UserOrganismPreference currentUserOrganismPreference = preferenceService.getCurrentOrganismPreferenceInDB(token)
             if(currentUserOrganismPreference){
                 Organism currentOrganism = currentUserOrganismPreference?.organism
                 appStateObject.put("currentOrganism", currentOrganism )

--- a/grails-app/services/org/bbop/apollo/DomainMarshallerService.groovy
+++ b/grails-app/services/org/bbop/apollo/DomainMarshallerService.groovy
@@ -36,5 +36,15 @@ class DomainMarshallerService {
             returnArray['end'] = it.end
             return returnArray
         }
+
+        JSON.registerObjectMarshaller(UserOrganismPreference) {
+            def returnArray = [:]
+            returnArray['id'] = it.id
+            returnArray['name'] = it.name
+            returnArray['length'] = it?.length
+            returnArray['start'] = it?.start
+            returnArray['end'] = it.end
+            return returnArray
+        }
     }
 }

--- a/grails-app/services/org/bbop/apollo/DomainMarshallerService.groovy
+++ b/grails-app/services/org/bbop/apollo/DomainMarshallerService.groovy
@@ -40,10 +40,12 @@ class DomainMarshallerService {
         JSON.registerObjectMarshaller(UserOrganismPreference) {
             def returnArray = [:]
             returnArray['id'] = it.id
-            returnArray['name'] = it.name
-            returnArray['length'] = it?.length
-            returnArray['start'] = it?.start
-            returnArray['end'] = it.end
+            returnArray['organism'] = it.organism
+            returnArray['currentOrganism'] = it.currentOrganism
+            returnArray['nativeTrackList'] = it?.nativeTrackList
+            returnArray['sequence'] = it?.sequence
+            returnArray['startbp'] = it?.startbp
+            returnArray['endbp'] = it?.endbp
             return returnArray
         }
     }

--- a/grails-app/services/org/bbop/apollo/JbrowseService.groovy
+++ b/grails-app/services/org/bbop/apollo/JbrowseService.groovy
@@ -11,7 +11,7 @@ class JbrowseService {
         String[] paths1 = path1.split("/")
         String[] paths2 = path2.split("/")
 
-        println "Comparing ${paths1[paths1.length-1]} to ${paths2[0]}"
+        log.debug "Comparing ${paths1[paths1.length-1]} to ${paths2[0]}"
         if(paths1[paths1.length-1]==paths2[0]){
             return true
         }

--- a/grails-app/services/org/bbop/apollo/PermissionService.groovy
+++ b/grails-app/services/org/bbop/apollo/PermissionService.groovy
@@ -3,13 +3,10 @@ package org.bbop.apollo
 import grails.converters.JSON
 import grails.transaction.NotTransactional
 import grails.transaction.Transactional
-import grails.util.Environment
 import org.apache.shiro.SecurityUtils
 import org.apache.shiro.authc.UsernamePasswordToken
 import org.apache.shiro.session.Session
 import org.apache.shiro.subject.Subject
-import org.bbop.apollo.authenticator.AuthenticatorService
-import org.bbop.apollo.gwt.shared.ClientTokenGenerator
 import org.bbop.apollo.gwt.shared.FeatureStringEnum
 import org.bbop.apollo.gwt.shared.PermissionEnum
 import org.codehaus.groovy.grails.web.json.JSONArray
@@ -309,22 +306,22 @@ class PermissionService {
      */
     Sequence checkPermissions(JSONObject inputObject, PermissionEnum requiredPermissionEnum) {
         Organism organism
-        String trackName = getSequenceNameFromInput(inputObject)
+        String sequenceName = getSequenceNameFromInput(inputObject)
 
         User user = getCurrentUser(inputObject)
         organism = getOrganismFromInput(inputObject)
 
         if (!organism) {
-            organism = preferenceService.getOrganismFromPreferences(user, trackName, inputObject.getString(FeatureStringEnum.CLIENT_TOKEN.value))
+            organism = preferenceService.getCurrentOrganismPreference(user, sequenceName, inputObject.getString(FeatureStringEnum.CLIENT_TOKEN.value))?.organism
         }
 
         Sequence sequence
-        if (!trackName) {
-            sequence = UserOrganismPreference.findByClientTokenAndOrganism(trackName, organism, [max: 1, sort: "lastUpdated", order: "desc"])?.sequence
+        if (!sequenceName) {
+            sequence = UserOrganismPreference.findByClientTokenAndOrganism(sequenceName, organism, [max: 1, sort: "lastUpdated", order: "desc"])?.sequence
         } else {
-            sequence = Sequence.findByNameAndOrganism(trackName, organism)
+            sequence = Sequence.findByNameAndOrganism(sequenceName, organism)
             if(!sequence){
-                throw new AnnotationException("No sequence found for name '${trackName}' and organism '${organism?.commonName}'")
+                throw new AnnotationException("No sequence found for name '${sequenceName}' and organism '${organism?.commonName}'")
             }
         }
 
@@ -472,7 +469,7 @@ class PermissionService {
             organism = getOrganismFromInput(jsonObject)
         }
 
-        organism = organism ?: preferenceService.getCurrentOrganismPreference(clientToken)?.organism
+        organism = organism ?: preferenceService.getCurrentOrganismPreferenceInDB(clientToken)?.organism
         // don't set the preferences if it is coming off a script
         if(clientToken!=FeatureStringEnum.IGNORE.value){
             preferenceService.setCurrentOrganism(getCurrentUser(), organism, clientToken)

--- a/grails-app/services/org/bbop/apollo/PreferenceService.groovy
+++ b/grails-app/services/org/bbop/apollo/PreferenceService.groovy
@@ -52,7 +52,7 @@ class PreferenceService {
                 log.debug "No session found"
             }
         } catch (e) {
-            println "faild to get the gession preference objec5 ${e}"
+            log.debug "faild to get the gession preference objec5 ${e}"
         }
         return null
     }

--- a/grails-app/services/org/bbop/apollo/authenticator/UsernamePasswordAuthenticatorService.groovy
+++ b/grails-app/services/org/bbop/apollo/authenticator/UsernamePasswordAuthenticatorService.groovy
@@ -20,7 +20,6 @@ class UsernamePasswordAuthenticatorService implements AuthenticatorService{
     def authenticate(UsernamePasswordToken authToken, HttpServletRequest request) {
         try {
             Subject subject = SecurityUtils.getSubject();
-//            Session session = subject.getSession(true);
             subject.login(authToken)
             if (!subject.authenticated) {
                 log.error "Failed to authenticate user ${authToken.username}"

--- a/src/groovy/org/bbop/apollo/sequence/SequenceLocationDTO.groovy
+++ b/src/groovy/org/bbop/apollo/sequence/SequenceLocationDTO.groovy
@@ -1,0 +1,27 @@
+package org.bbop.apollo.sequence
+
+/**
+ * Created by nathandunn on 5/17/17.
+ */
+class SequenceLocationDTO {
+    String sequenceName
+    Integer startBp
+    Integer endBp
+    String clientToken
+
+    boolean equals(o) {
+        if (this.is(o)) return true
+        if (getClass() != o.class) return false
+
+        SequenceLocationDTO that = (SequenceLocationDTO) o
+
+        if (clientToken != that.clientToken) return false
+
+        return true
+    }
+
+    int hashCode() {
+        int result = clientToken.hashCode()
+        return result
+    }
+}

--- a/src/gwt/org/bbop/apollo/gwt/client/rest/OrganismRestService.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/rest/OrganismRestService.java
@@ -104,7 +104,7 @@ public class OrganismRestService {
             }
         };
 
-        RestService.sendRequest(requestCallback,"annotator/setCurrentOrganism/"+newOrganismId);
+        RestService.sendRequest(requestCallback,"annotator/setCurrentOrganismInDB/"+newOrganismId);
     }
 
     public static void switchSequenceById(String newSequenceId) {

--- a/src/gwt/org/bbop/apollo/gwt/client/rest/OrganismRestService.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/rest/OrganismRestService.java
@@ -104,7 +104,7 @@ public class OrganismRestService {
             }
         };
 
-        RestService.sendRequest(requestCallback,"annotator/setCurrentOrganismInDB/"+newOrganismId);
+        RestService.sendRequest(requestCallback,"annotator/setCurrentOrganism/"+newOrganismId);
     }
 
     public static void switchSequenceById(String newSequenceId) {


### PR DESCRIPTION
Fixing performance and other issues for preferences.

Should grab from session based on the token and not go to the database unless it is not there (and then store it in the session if so).  

These may likely be identical (maybe we don't need to specify the token?) since this may be regenerated each time.  Its a little unclear as we want different tokens between tabs AND browsers. 

This should increase performance and decrease DB load and eliminate query loads.

- [x] get preference from session
- [x] verify that we are always looking into the session first (wire into other methods)
- [x] verify that changes to preference are propagated to the session
- [x] verify behavior between tabs and different screens
- [x] save to database eventually on timer
- [x] verify tokens are separate (and make change if so)
- [x] fix get session error when adding an genomic feature

