### PR TITLE
Svg v1

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -71,6 +71,11 @@ grails.project.dependency.resolution = {
         compile 'commons-codec:commons-codec:1.2'
         compile 'commons-collections:commons-collections:3.2.1'
 
+        // svg generation
+        compile group: 'org.apache.xmlgraphics', name: 'batik-svg-dom', version: '1.9'
+        compile group: 'org.apache.xmlgraphics', name: 'batik-svggen', version: '1.7'
+
+
         compile 'org.json:json:20140107'
         compile 'org.hibernate:hibernate-tools:3.2.0.ga'
         //compile 'asm:asm:3.1'

--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -18,9 +18,9 @@ class UrlMappings {
         "/track/nclist/${organismString}/${trackName}/?loc=${sequence}:${fmin}..${fmax}"(controller: "track", action: "nclist")
 
 //        "/trackForName/${organismString}/${trackName}/${sequence}/${featureName}.json"(controller: "track", action: "jsonName")
-        "/track/${organismString}/${trackName}/${sequence}/${featureName}.json"(controller: "track", action: "featuresByName",[params:params])
-        "/track/${organismString}/${trackName}/${sequence}:${fmin}..${fmax}.json"(controller: "track", action: "featuresByLocation",[params:params])
-        "/track/${organismString}/${trackName}/?loc=${sequence}:${fmin}..${fmax}.json"(controller: "track", action: "featuresByLocation",[params:params])
+        "/track/${organismString}/${trackName}/${sequence}/${featureName}.${type}"(controller: "track", action: "featuresByName",[params:params])
+        "/track/${organismString}/${trackName}/${sequence}:${fmin}..${fmax}.${type}"(controller: "track", action: "featuresByLocation",[params:params])
+        "/track/${organismString}/${trackName}/?loc=${sequence}:${fmin}..${fmax}.${type}"(controller: "track", action: "featuresByLocation",[params:params])
         "/track/cache/clear/${organismName}/${trackName}"(controller: "track", action: "clearTrackCache")
         "/track/cache/clear/${organismName}"(controller: "track", action: "clearOrganismCache")
 

--- a/grails-app/controllers/org/bbop/apollo/TrackController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/TrackController.groovy
@@ -1,7 +1,6 @@
 package org.bbop.apollo
 
 import grails.converters.JSON
-import grails.converters.XML
 import grails.transaction.Transactional
 import org.bbop.apollo.gwt.shared.PermissionEnum
 import org.bbop.apollo.sequence.SequenceDTO
@@ -74,7 +73,7 @@ class TrackController {
             , @RestApiParam(name = "type", type = "json/svg", paramType = RestApiParamType.QUERY, description = ".json or .svg")
     ])
     @Transactional
-    def featuresByName(String organismString, String trackName, String sequence, String featureName,String type) {
+    def featuresByName(String organismString, String trackName, String sequence, String featureName, String type) {
         if (!checkPermission(organismString)) return
 
         Boolean ignoreCache = params.ignoreCache != null ? Boolean.valueOf(params.ignoreCache) : false
@@ -107,13 +106,12 @@ class TrackController {
                 returnArray.add(returnObject)
             }
         }
+
         trackService.cacheRequest(returnArray, organismString, trackName, sequence, featureName, paramMap)
 
-        if(type=="json"){
+        if (type == "json") {
             render returnArray as JSON
-        }
-        else
-        if(type=="svg"){
+        } else if (type == "svg") {
             render svgService.renderSVGFromJSONArray(returnArray)
         }
 
@@ -133,7 +131,7 @@ class TrackController {
             , @RestApiParam(name = "type", type = "json/svg", paramType = RestApiParamType.QUERY, description = ".json or .svg")
     ])
     @Transactional
-    def featuresByLocation(String organismString, String trackName, String sequence, Long fmin, Long fmax,String type) {
+    def featuresByLocation(String organismString, String trackName, String sequence, Long fmin, Long fmax, String type) {
         if (!checkPermission(organismString)) return
 
         String name = params.name ? params.name : ""
@@ -169,24 +167,23 @@ class TrackController {
             if (name) {
                 if (returnObject?.name == name) {
                     returnObject.selected = true
-                    if(onlySelected) {
+                    if (onlySelected) {
                         returnArray.add(returnObject)
                     }
                 }
             }
         }
 
-        if(onlySelected){
-            trackService.cacheRequest(returnArray, organismString, trackName, sequence, fmin, fmax, paramMap)
-        } else {
-            trackService.cacheRequest(renderedArray, organismString, trackName, sequence, fmin, fmax, paramMap)
+        if (onlySelected) {
+            renderedArray = returnArray
         }
-        if(type=="json"){
-            render returnArray as JSON
-        }
-        else
-        if(type=="svg"){
-            render svgService.renderSVGFromJSONArray(returnArray)
+
+        trackService.cacheRequest(renderedArray, organismString, trackName, sequence, fmin, fmax, paramMap)
+
+        if (type == "json") {
+            render renderedArray as JSON
+        } else if (type == "svg") {
+            render svgService.renderSVGFromJSONArray(renderedArray)
         }
     }
 

--- a/grails-app/controllers/org/bbop/apollo/TrackController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/TrackController.groovy
@@ -81,10 +81,17 @@ class TrackController {
         paramMap.put("name", featureName)
         paramMap.put("onlySelected", true)
         if (!ignoreCache) {
-            JSONArray responseArray = trackService.checkCache(organismString, trackName, sequence, featureName, paramMap)
-            if (responseArray != null) {
-                render responseArray as JSON
-                return
+            String responseString = trackService.checkCache(organismString, trackName, sequence, featureName, type, paramMap)
+            if (responseString) {
+                if (type == "json") {
+                    render JSON.parse(responseString)  as JSON
+                    return
+                }
+                else
+                if (type == "svg") {
+                    render responseString
+                    return
+                }
             }
         }
 
@@ -107,12 +114,14 @@ class TrackController {
             }
         }
 
-        trackService.cacheRequest(returnArray, organismString, trackName, sequence, featureName, paramMap)
 
         if (type == "json") {
+            trackService.cacheRequest(returnArray.toString(), organismString, trackName, sequence, featureName, type, paramMap)
             render returnArray as JSON
         } else if (type == "svg") {
-            render svgService.renderSVGFromJSONArray(returnArray)
+            String xmlString = svgService.renderSVGFromJSONArray(returnArray)
+            trackService.cacheRequest(xmlString, organismString, trackName, sequence, featureName, type, paramMap)
+            render xmlString
         }
 
     }
@@ -138,15 +147,23 @@ class TrackController {
         Boolean onlySelected = params.onlySelected != null ? params.onlySelected : false
         Boolean ignoreCache = params.ignoreCache != null ? Boolean.valueOf(params.ignoreCache) : false
         Map paramMap = new TreeMap<>()
+        paramMap.put("type", type)
         if (name) {
             paramMap.put("name", name)
             paramMap.put("onlySelected", onlySelected)
         }
         if (!ignoreCache) {
-            JSONArray responseArray = trackService.checkCache(organismString, trackName, sequence, fmin, fmax, paramMap)
-            if (responseArray != null) {
-                render responseArray as JSON
-                return
+            String responseString = trackService.checkCache(organismString, trackName, sequence, fmin, fmax, type, paramMap)
+            if (responseString) {
+                if (type == "json") {
+                    render JSON.parse(responseString) as JSON
+                    return
+                }
+                else
+                if (type == "svg") {
+                    render responseString
+                    return
+                }
             }
         }
         JSONArray filteredList = trackService.getNCList(trackName, organismString, sequence, fmin, fmax)
@@ -178,12 +195,13 @@ class TrackController {
             renderedArray = returnArray
         }
 
-        trackService.cacheRequest(renderedArray, organismString, trackName, sequence, fmin, fmax, paramMap)
-
         if (type == "json") {
+            trackService.cacheRequest(renderedArray.toString(), organismString, trackName, sequence, fmin, fmax, type, paramMap)
             render renderedArray as JSON
         } else if (type == "svg") {
-            render svgService.renderSVGFromJSONArray(renderedArray)
+            String xmlString = svgService.renderSVGFromJSONArray(returnArray)
+            trackService.cacheRequest(xmlString, organismString, trackName, sequence, fmin, fmax, type, paramMap)
+            render xmlString
         }
     }
 
@@ -194,17 +212,17 @@ class TrackController {
         render renderdObject as JSON
     }
 
-    /**
-     *
-     * @param trackName
-     * @param organism
-     * @param sequence
-     * @param fmin
-     * @param fmax
-     * @return
-     */
-    // TODO: this is just for debuggin
-    // track < organism ID or name > / <track name > /  < sequence name > / min / max
+/**
+ *
+ * @param trackName
+ * @param organism
+ * @param sequence
+ * @param fmin
+ * @param fmax
+ * @return
+ */
+// TODO: this is just for debuggin
+// track < organism ID or name > / <track name > /  < sequence name > / min / max
     def nclist(String organismString, String trackName, String sequence, Long fmin, Long fmax) {
         if (!checkPermission(organismString)) return
         JSONArray filteredList = trackService.getNCList(trackName, organismString, sequence, fmin, fmax)
@@ -223,4 +241,5 @@ class TrackController {
         }
 
     }
+
 }

--- a/grails-app/domain/org/bbop/apollo/TrackCache.groovy
+++ b/grails-app/domain/org/bbop/apollo/TrackCache.groovy
@@ -5,6 +5,7 @@ class TrackCache {
     String trackName
     String sequenceName
     String organismName
+    String type
 
 
     Long fmin
@@ -18,6 +19,7 @@ class TrackCache {
         trackName nullable: false, blank: false
         sequenceName nullable: false, blank: false
         organismName nullable: false, blank: false
+        type nullable: true, blank: false
 
         fmin nullable: true
         fmax nullable: true

--- a/grails-app/services/org/bbop/apollo/SvgService.groovy
+++ b/grails-app/services/org/bbop/apollo/SvgService.groovy
@@ -4,6 +4,7 @@ import grails.transaction.Transactional
 import org.apache.batik.dom.GenericDOMImplementation
 import org.apache.batik.ext.awt.geom.Polygon2D
 import org.apache.batik.svggen.SVGGraphics2D
+import org.bbop.apollo.track.RenderObject
 import org.codehaus.groovy.grails.web.json.JSONArray
 import org.codehaus.groovy.grails.web.json.JSONObject
 import org.w3c.dom.DOMImplementation
@@ -16,6 +17,7 @@ class SvgService {
 
     final Integer GLOBAL_HEIGHT = 30
     final Integer GLOBAL_WIDTH = 500
+    final Integer HORIZONTAL_PADDING= 50
     final Integer TOP_PADDING = 10
     final Integer LEFT_PADDING = 10
 
@@ -48,18 +50,20 @@ class SvgService {
     def generateFeatures(SVGGraphics2D svgGraphics2D, JSONArray jsonArray) {
         if (!jsonArray) return
 
-        long globalFmin = jsonArray.first().fmin
-        long globalFmax = jsonArray.last().fmax
+        RenderObject renderObject = new RenderObject(
+               globalFmin:jsonArray.first().fmin,
+               globalFmax:jsonArray.first().fmax,
+        )
         for (JSONObject jsonObject in jsonArray) {
-            generateFeature(svgGraphics2D, jsonObject, globalFmin, globalFmax)
+            generateFeature(svgGraphics2D, jsonObject, renderObject)
         }
     }
 
-    def generateFeature(SVGGraphics2D svgGraphics2D, JSONObject jsonObject, long globalFmin, long globalFmax) {
+    def generateFeature(SVGGraphics2D svgGraphics2D, JSONObject jsonObject, RenderObject renderObject) {
         // assume type is mRNA for type
-        int globalWidth = globalFmax - globalFmin
-        int internalFmin = GLOBAL_WIDTH * ((jsonObject.fmin - globalFmin) / globalWidth)
-        int internalFmax = GLOBAL_WIDTH * ((jsonObject.fmax - globalFmin) / globalWidth)
+        int globalWidth = renderObject.globalWidth
+        int internalFmin = GLOBAL_WIDTH * ((jsonObject.fmin - renderObject.globalFmin) / globalWidth)
+        int internalFmax = GLOBAL_WIDTH * ((jsonObject.fmax - renderObject.globalFmin) / globalWidth)
         int height = GLOBAL_HEIGHT / 2.0
 
         // this will go away once we start working with introns
@@ -67,6 +71,21 @@ class SvgService {
         svgGraphics2D.setPaint(Color.black)
         svgGraphics2D.drawLine(internalFmin, height, internalFmax, height)
 
+        int stepHeight = 0
+        for(JSONArray children in jsonObject.children){
+            renderChildren(svgGraphics2D,children,renderObject,stepHeight)
+            stepHeight += GLOBAL_HEIGHT
+        }
+
+        drawStrand(svgGraphics2D,jsonObject,renderObject)
+    }
+
+    def drawStrand(SVGGraphics2D svgGraphics2D, JSONObject jsonObject,RenderObject renderObject) {
+        svgGraphics2D.setColor(Color.BLACK)
+        int globalWidth = renderObject.globalWidth
+        int internalFmin = GLOBAL_WIDTH * ((jsonObject.fmin - renderObject.globalFmin) / globalWidth)
+        int internalFmax = GLOBAL_WIDTH * ((jsonObject.fmax - renderObject.globalFmin) / globalWidth)
+        int height = GLOBAL_HEIGHT / 2.0
         // draw an arrow to do with strand now
         if(jsonObject.strand==-1){
             println "doing negative strand ${jsonObject.strand}"
@@ -89,7 +108,61 @@ class SvgService {
             svgGraphics2D.fill(shape)
         }
 
-
     }
 
+    def renderChildren(SVGGraphics2D svgGraphics2D, JSONArray children, RenderObject renderObject, int stepHeight) {
+        int globalWidth = renderObject.globalWidth
+
+        // sorted by FMIN and the type (CDS to exon)
+        for(JSONObject childObject in children.sort(){ a,b ->
+            if(a.type != b.type ){
+                if(a.type == "exon"){
+                  return -1
+                }
+                else{
+                    return a.type <=> b.type
+                }
+            }
+            return a.fmin <=> b.fmin
+        }){
+            String type = childObject.type
+            Integer phase = childObject.phase  // if a CDS
+            int internalFmin = GLOBAL_WIDTH * ((childObject.fmin - renderObject.globalFmin) / globalWidth)
+            int internalFmax = GLOBAL_WIDTH * ((childObject.fmax - renderObject.globalFmin) / globalWidth)
+            int height = GLOBAL_HEIGHT / 2.0
+//            svgGraphics2D.drawRect(internalFmin,stepHeight,(internalFmax-internalFmin),GLOBAL_HEIGHT)
+            println "type: ${type}"
+            if(type=="CDS"){
+                Polygon2D shape = new Polygon2D()
+                shape.addPoint(internalFmin,stepHeight+10)
+                shape.addPoint(internalFmax,stepHeight+10)
+                shape.addPoint(internalFmax,stepHeight+GLOBAL_HEIGHT-10)
+                shape.addPoint(internalFmin,stepHeight+GLOBAL_HEIGHT-10)
+                switch (phase){
+                    case 0:
+                        svgGraphics2D.setColor(Color.RED)
+                        break
+                    case 1:
+                        svgGraphics2D.setColor(Color.BLUE)
+                        break
+                    case 2:
+                        svgGraphics2D.setColor(Color.GREEN)
+                        break
+                }
+                svgGraphics2D.fill(shape)
+            }
+            else
+            if(type=="exon"){
+                Polygon2D shape = new Polygon2D()
+                svgGraphics2D.setColor(Color.BLACK)
+                shape.addPoint(internalFmin,stepHeight+10)
+                shape.addPoint(internalFmax,stepHeight+10)
+                shape.addPoint(internalFmax,stepHeight+GLOBAL_HEIGHT-10)
+                shape.addPoint(internalFmin,stepHeight+GLOBAL_HEIGHT-10)
+                svgGraphics2D.draw(shape)
+                svgGraphics2D.setColor(Color.WHITE)
+                svgGraphics2D.fill(shape)
+            }
+        }
+    }
 }

--- a/grails-app/services/org/bbop/apollo/SvgService.groovy
+++ b/grails-app/services/org/bbop/apollo/SvgService.groovy
@@ -1,0 +1,95 @@
+package org.bbop.apollo
+
+import grails.transaction.Transactional
+import org.apache.batik.dom.GenericDOMImplementation
+import org.apache.batik.ext.awt.geom.Polygon2D
+import org.apache.batik.svggen.SVGGraphics2D
+import org.codehaus.groovy.grails.web.json.JSONArray
+import org.codehaus.groovy.grails.web.json.JSONObject
+import org.w3c.dom.DOMImplementation
+import org.w3c.dom.Document
+
+import java.awt.*
+
+@Transactional(readOnly = true)
+class SvgService {
+
+    final Integer GLOBAL_HEIGHT = 30
+    final Integer GLOBAL_WIDTH = 500
+    final Integer TOP_PADDING = 10
+    final Integer LEFT_PADDING = 10
+
+    void paint(Graphics2D g2d) {
+        g2d.setPaint(Color.red);
+        g2d.fill(new Rectangle(10, 10, 100, 100));
+    }
+
+    def renderSVGFromJSONArray(JSONArray jsonArray) {
+        DOMImplementation domImpl =
+                GenericDOMImplementation.getDOMImplementation();
+
+        // Create an instance of org.w3c.dom.Document.
+        String svgNS = "http://www.w3.org/2000/svg";
+        Document document = domImpl.createDocument(svgNS, "svg", null);
+
+        // Create an instance of the SVG Generator.
+        SVGGraphics2D svgGenerator = new SVGGraphics2D(document);
+        svgGenerator.setClip(0,0,GLOBAL_WIDTH,GLOBAL_HEIGHT)
+
+        generateFeatures(svgGenerator, jsonArray)
+
+        StringWriter stringWriter = new StringWriter()
+        svgGenerator.stream(stringWriter, true, false)
+        stringWriter.close()
+        println "should be returning ${stringWriter.toString()}"
+        return stringWriter.toString()
+    }
+
+    def generateFeatures(SVGGraphics2D svgGraphics2D, JSONArray jsonArray) {
+        if (!jsonArray) return
+
+        long globalFmin = jsonArray.first().fmin
+        long globalFmax = jsonArray.last().fmax
+        for (JSONObject jsonObject in jsonArray) {
+            generateFeature(svgGraphics2D, jsonObject, globalFmin, globalFmax)
+        }
+    }
+
+    def generateFeature(SVGGraphics2D svgGraphics2D, JSONObject jsonObject, long globalFmin, long globalFmax) {
+        // assume type is mRNA for type
+        int globalWidth = globalFmax - globalFmin
+        int internalFmin = GLOBAL_WIDTH * ((jsonObject.fmin - globalFmin) / globalWidth)
+        int internalFmax = GLOBAL_WIDTH * ((jsonObject.fmax - globalFmin) / globalWidth)
+        int height = GLOBAL_HEIGHT / 2.0
+
+        // this will go away once we start working with introns
+        svgGraphics2D.setStroke(new BasicStroke(2.0))
+        svgGraphics2D.setPaint(Color.black)
+        svgGraphics2D.drawLine(internalFmin, height, internalFmax, height)
+
+        // draw an arrow to do with strand now
+        if(jsonObject.strand==-1){
+            println "doing negative strand ${jsonObject.strand}"
+            Polygon2D shape = new Polygon2D()
+            shape.addPoint(0,height)
+            shape.addPoint(10,(int) GLOBAL_HEIGHT * 3 / 4)
+            shape.addPoint(10,(int) 0 + (GLOBAL_HEIGHT / 4) )
+            svgGraphics2D.draw(shape)
+            svgGraphics2D.fill(shape)
+        }
+        else
+        if(jsonObject.strand==1){
+            println "doing positive strand ${jsonObject.strand}"
+            Polygon2D shape = new Polygon2D()
+            // TODO: not sure why those numbers work, why we need substract 200?
+            shape.addPoint(internalFmax-200,height)
+            shape.addPoint(internalFmax-210,(int) GLOBAL_HEIGHT * 3 / 4)
+            shape.addPoint(internalFmax-210,(int) 0 + (GLOBAL_HEIGHT / 4) )
+            svgGraphics2D.draw(shape)
+            svgGraphics2D.fill(shape)
+        }
+
+
+    }
+
+}

--- a/grails-app/services/org/bbop/apollo/SvgService.groovy
+++ b/grails-app/services/org/bbop/apollo/SvgService.groovy
@@ -48,6 +48,8 @@ class SvgService {
                globalFmin:jsonArray.first().fmin,
                globalFmax:jsonArray.first().fmax,
         )
+
+        // Renders in the X-axis, multiple feature roots
         for (JSONObject jsonObject in jsonArray) {
             generateFeature(svgGraphics2D, jsonObject, renderObject)
         }
@@ -66,12 +68,13 @@ class SvgService {
         svgGraphics2D.drawLine(internalFmin, height, internalFmax, height)
 
         int stepHeight = 0
+        // render multiple isofrms
         for(JSONArray children in jsonObject.children){
+            // Renders in the Y-axis
             renderChildren(svgGraphics2D,children,renderObject,stepHeight)
             stepHeight += GLOBAL_HEIGHT
         }
 
-        drawStrand(svgGraphics2D,jsonObject,renderObject)
     }
 
     def drawStrand(SVGGraphics2D svgGraphics2D, JSONObject jsonObject,RenderObject renderObject) {
@@ -117,6 +120,7 @@ class SvgService {
             }
             return a.fmin <=> b.fmin
         }){
+            drawStrand(svgGraphics2D,childObject,renderObject)
             String type = childObject.type
             Integer phase = childObject.phase  // if a CDS
             int internalFmin = GLOBAL_WIDTH * ((childObject.fmin - renderObject.globalFmin) / globalWidth) ?: 1

--- a/grails-app/services/org/bbop/apollo/SvgService.groovy
+++ b/grails-app/services/org/bbop/apollo/SvgService.groovy
@@ -9,6 +9,7 @@ import org.codehaus.groovy.grails.web.json.JSONArray
 import org.codehaus.groovy.grails.web.json.JSONObject
 import org.w3c.dom.DOMImplementation
 import org.w3c.dom.Document
+import org.w3c.dom.Element
 
 import java.awt.*
 
@@ -16,27 +17,20 @@ import java.awt.*
 class SvgService {
 
     final Integer GLOBAL_HEIGHT = 30
-    final Integer GLOBAL_WIDTH = 500
-    final Integer HORIZONTAL_PADDING= 50
-    final Integer TOP_PADDING = 10
-    final Integer LEFT_PADDING = 10
-
-    void paint(Graphics2D g2d) {
-        g2d.setPaint(Color.red);
-        g2d.fill(new Rectangle(10, 10, 100, 100));
-    }
+    final Integer GLOBAL_WIDTH = 400
 
     def renderSVGFromJSONArray(JSONArray jsonArray) {
         DOMImplementation domImpl =
-                GenericDOMImplementation.getDOMImplementation();
+                GenericDOMImplementation.getDOMImplementation()
 
         // Create an instance of org.w3c.dom.Document.
         String svgNS = "http://www.w3.org/2000/svg";
         Document document = domImpl.createDocument(svgNS, "svg", null);
 
+
         // Create an instance of the SVG Generator.
         SVGGraphics2D svgGenerator = new SVGGraphics2D(document);
-        svgGenerator.setClip(0,0,GLOBAL_WIDTH,GLOBAL_HEIGHT)
+        svgGenerator.setSVGCanvasSize(new Dimension(500,500))
 
         generateFeatures(svgGenerator, jsonArray)
 
@@ -62,12 +56,12 @@ class SvgService {
     def generateFeature(SVGGraphics2D svgGraphics2D, JSONObject jsonObject, RenderObject renderObject) {
         // assume type is mRNA for type
         int globalWidth = renderObject.globalWidth
-        int internalFmin = GLOBAL_WIDTH * ((jsonObject.fmin - renderObject.globalFmin) / globalWidth)
-        int internalFmax = GLOBAL_WIDTH * ((jsonObject.fmax - renderObject.globalFmin) / globalWidth)
+        int internalFmin = GLOBAL_WIDTH * ((jsonObject.fmin - renderObject.globalFmin) / globalWidth) ?: 1
+        int internalFmax = GLOBAL_WIDTH * ((jsonObject.fmax - renderObject.globalFmin) / globalWidth)-1
         int height = GLOBAL_HEIGHT / 2.0
 
         // this will go away once we start working with introns
-        svgGraphics2D.setStroke(new BasicStroke(2.0))
+        svgGraphics2D.setStroke(new BasicStroke(2))
         svgGraphics2D.setPaint(Color.black)
         svgGraphics2D.drawLine(internalFmin, height, internalFmax, height)
 
@@ -83,16 +77,16 @@ class SvgService {
     def drawStrand(SVGGraphics2D svgGraphics2D, JSONObject jsonObject,RenderObject renderObject) {
         svgGraphics2D.setColor(Color.BLACK)
         int globalWidth = renderObject.globalWidth
-        int internalFmin = GLOBAL_WIDTH * ((jsonObject.fmin - renderObject.globalFmin) / globalWidth)
+//        int internalFmin = GLOBAL_WIDTH * ((jsonObject.fmin - renderObject.globalFmin) / globalWidth)
         int internalFmax = GLOBAL_WIDTH * ((jsonObject.fmax - renderObject.globalFmin) / globalWidth)
         int height = GLOBAL_HEIGHT / 2.0
         // draw an arrow to do with strand now
         if(jsonObject.strand==-1){
             println "doing negative strand ${jsonObject.strand}"
             Polygon2D shape = new Polygon2D()
-            shape.addPoint(0,height)
-            shape.addPoint(10,(int) GLOBAL_HEIGHT * 3 / 4)
-            shape.addPoint(10,(int) 0 + (GLOBAL_HEIGHT / 4) )
+            shape.addPoint(2,height)
+            shape.addPoint(12,(int) GLOBAL_HEIGHT * 3 / 4)
+            shape.addPoint(12,(int) 0 + (GLOBAL_HEIGHT / 4) )
             svgGraphics2D.draw(shape)
             svgGraphics2D.fill(shape)
         }
@@ -101,9 +95,9 @@ class SvgService {
             println "doing positive strand ${jsonObject.strand}"
             Polygon2D shape = new Polygon2D()
             // TODO: not sure why those numbers work, why we need substract 200?
-            shape.addPoint(internalFmax-200,height)
-            shape.addPoint(internalFmax-210,(int) GLOBAL_HEIGHT * 3 / 4)
-            shape.addPoint(internalFmax-210,(int) 0 + (GLOBAL_HEIGHT / 4) )
+            shape.addPoint(internalFmax,height)
+            shape.addPoint(internalFmax-10,(int) GLOBAL_HEIGHT * 3 / 4)
+            shape.addPoint(internalFmax-10,(int) 0 + (GLOBAL_HEIGHT / 4) )
             svgGraphics2D.draw(shape)
             svgGraphics2D.fill(shape)
         }
@@ -127,7 +121,7 @@ class SvgService {
         }){
             String type = childObject.type
             Integer phase = childObject.phase  // if a CDS
-            int internalFmin = GLOBAL_WIDTH * ((childObject.fmin - renderObject.globalFmin) / globalWidth)
+            int internalFmin = GLOBAL_WIDTH * ((childObject.fmin - renderObject.globalFmin) / globalWidth) ?: 1
             int internalFmax = GLOBAL_WIDTH * ((childObject.fmax - renderObject.globalFmin) / globalWidth)
             int height = GLOBAL_HEIGHT / 2.0
 //            svgGraphics2D.drawRect(internalFmin,stepHeight,(internalFmax-internalFmin),GLOBAL_HEIGHT)

--- a/grails-app/services/org/bbop/apollo/SvgService.groovy
+++ b/grails-app/services/org/bbop/apollo/SvgService.groovy
@@ -37,7 +37,7 @@ class SvgService {
         StringWriter stringWriter = new StringWriter()
         svgGenerator.stream(stringWriter, true, false)
         stringWriter.close()
-        println "should be returning ${stringWriter.toString()}"
+        log.debug "should be returning ${stringWriter.toString()}"
         return stringWriter.toString()
     }
 
@@ -82,7 +82,6 @@ class SvgService {
         int height = GLOBAL_HEIGHT / 2.0
         // draw an arrow to do with strand now
         if(jsonObject.strand==-1){
-            println "doing negative strand ${jsonObject.strand}"
             Polygon2D shape = new Polygon2D()
             shape.addPoint(2,height)
             shape.addPoint(12,(int) GLOBAL_HEIGHT * 3 / 4)
@@ -92,7 +91,6 @@ class SvgService {
         }
         else
         if(jsonObject.strand==1){
-            println "doing positive strand ${jsonObject.strand}"
             Polygon2D shape = new Polygon2D()
             // TODO: not sure why those numbers work, why we need substract 200?
             shape.addPoint(internalFmax,height)
@@ -125,7 +123,6 @@ class SvgService {
             int internalFmax = GLOBAL_WIDTH * ((childObject.fmax - renderObject.globalFmin) / globalWidth)
             int height = GLOBAL_HEIGHT / 2.0
 //            svgGraphics2D.drawRect(internalFmin,stepHeight,(internalFmax-internalFmin),GLOBAL_HEIGHT)
-            println "type: ${type}"
             if(type=="CDS"){
                 Polygon2D shape = new Polygon2D()
                 shape.addPoint(internalFmin,stepHeight+10)

--- a/grails-app/services/org/bbop/apollo/SvgService.groovy
+++ b/grails-app/services/org/bbop/apollo/SvgService.groovy
@@ -50,6 +50,7 @@ class SvgService {
         )
 
         // Renders in the X-axis, multiple feature roots
+        println "# of feature regions: ${jsonArray?.size()}"
         for (JSONObject jsonObject in jsonArray) {
             generateFeature(svgGraphics2D, jsonObject, renderObject)
         }
@@ -60,6 +61,7 @@ class SvgService {
         int globalWidth = renderObject.globalWidth
         int internalFmin = GLOBAL_WIDTH * ((jsonObject.fmin - renderObject.globalFmin) / globalWidth) ?: 1
         int internalFmax = GLOBAL_WIDTH * ((jsonObject.fmax - renderObject.globalFmin) / globalWidth)-1
+        println "fmin / fmax ${internalFmin}-${internalFmax}"
         int height = GLOBAL_HEIGHT / 2.0
 
         // this will go away once we start working with introns
@@ -69,6 +71,7 @@ class SvgService {
 
         int stepHeight = 0
         // render multiple isofrms
+        println "# of isoforms: ${jsonObject.children?.size()}"
         for(JSONArray children in jsonObject.children){
             // Renders in the Y-axis
             renderChildren(svgGraphics2D,children,renderObject,stepHeight)

--- a/grails-app/services/org/bbop/apollo/TrackService.groovy
+++ b/grails-app/services/org/bbop/apollo/TrackService.groovy
@@ -343,7 +343,7 @@ class TrackService {
 
     JSONArray checkCache(String organismString, String trackName, String sequence, String featureName, Map paramMap) {
         String mapString = paramMap ? (paramMap as JSON).toString() : null
-        String response = TrackCache.findByOrganismNameAndTrackNameAndSequenceNameAndFeatureNameAndParamMap(organismString, trackName, sequence, featureName,mapString)?.response
+        String response = TrackCache.findByOrganismNameAndTrackNameAndSequenceNameAndFeatureNameAndParamMap(organismString, trackName, sequence, featureName, mapString)?.response
         return response != null ? JSON.parse(response) as JSONArray : null
     }
 

--- a/grails-app/services/org/bbop/apollo/TrackService.groovy
+++ b/grails-app/services/org/bbop/apollo/TrackService.groovy
@@ -154,7 +154,7 @@ class TrackService {
         JSONArray returnArray = new JSONArray()
 
         for (def jsonArray in fullArray) {
-            if(jsonArray instanceof JSONArray){
+            if (jsonArray instanceof JSONArray) {
                 returnArray.add(convertIndividualNCListToObject(jsonArray, sequenceDTO))
             }
         }
@@ -343,26 +343,25 @@ class TrackService {
         return jsonObject.toString()
     }
 
-    JSONArray checkCache(String organismString, String trackName, String sequence, String featureName, Map paramMap) {
+    String checkCache(String organismString, String trackName, String sequence, String featureName, String type, Map paramMap) {
         String mapString = paramMap ? (paramMap as JSON).toString() : null
-        String response = TrackCache.findByOrganismNameAndTrackNameAndSequenceNameAndFeatureNameAndParamMap(organismString, trackName, sequence, featureName, mapString)?.response
-        return response != null ? JSON.parse(response) as JSONArray : null
+        return TrackCache.findByOrganismNameAndTrackNameAndSequenceNameAndFeatureNameAndTypeAndParamMap(organismString, trackName, sequence, featureName, type, mapString)?.response
     }
 
-    JSONArray checkCache(String organismString, String trackName, String sequence, Long fmin, Long fmax, Map paramMap) {
+    String checkCache(String organismString, String trackName, String sequence, Long fmin, Long fmax, String type, Map paramMap) {
         String mapString = paramMap ? (paramMap as JSON).toString() : null
-        String response = TrackCache.findByOrganismNameAndTrackNameAndSequenceNameAndFminAndFmaxAndParamMap(organismString, trackName, sequence, fmin, fmax, mapString)?.response
-        return response != null ? JSON.parse(response) as JSONArray : null
+        return TrackCache.findByOrganismNameAndTrackNameAndSequenceNameAndFminAndFmaxAndTypeAndParamMap(organismString, trackName, sequence, fmin, fmax, type, mapString)?.response
     }
 
     @Transactional
-    def cacheRequest(JSONArray jsonArray, String organismString, String trackName, String sequenceName, String featureName, Map paramMap) {
+    def cacheRequest(String responseString, String organismString, String trackName, String sequenceName, String featureName, String type, Map paramMap) {
         TrackCache trackCache = new TrackCache(
-                response: jsonArray.toString()
+                response: responseString
                 , organismName: organismString
                 , trackName: trackName
                 , sequenceName: sequenceName
                 , featureName: featureName
+                , type: type
         )
         if (paramMap) {
             trackCache.paramMap = (paramMap as JSON).toString()
@@ -371,14 +370,15 @@ class TrackService {
     }
 
     @Transactional
-    def cacheRequest(JSONArray jsonArray, String organismString, String trackName, String sequenceName, Long fmin, Long fmax, Map paramMap) {
+    def cacheRequest(String responseString, String organismString, String trackName, String sequenceName, Long fmin, Long fmax, String type, Map paramMap) {
         TrackCache trackCache = new TrackCache(
-                response: jsonArray.toString()
+                response: responseString
                 , organismName: organismString
                 , trackName: trackName
                 , sequenceName: sequenceName
                 , fmin: fmin
                 , fmax: fmax
+                , type: type
         )
         if (paramMap) {
             trackCache.paramMap = (paramMap as JSON).toString()

--- a/grails-app/services/org/bbop/apollo/TrackService.groovy
+++ b/grails-app/services/org/bbop/apollo/TrackService.groovy
@@ -153,8 +153,10 @@ class TrackService {
     JSONArray convertAllNCListToObject(JSONArray fullArray, SequenceDTO sequenceDTO) {
         JSONArray returnArray = new JSONArray()
 
-        for (JSONArray jsonArray in fullArray) {
-            returnArray.add(convertIndividualNCListToObject(jsonArray, sequenceDTO))
+        for (def jsonArray in fullArray) {
+            if(jsonArray instanceof JSONArray){
+                returnArray.add(convertIndividualNCListToObject(jsonArray, sequenceDTO))
+            }
         }
 
         return returnArray

--- a/src/groovy/org/bbop/apollo/track/RenderObject.groovy
+++ b/src/groovy/org/bbop/apollo/track/RenderObject.groovy
@@ -1,0 +1,15 @@
+package org.bbop.apollo.track
+
+/**
+ * Created by nathandunn on 6/8/17.
+ */
+class RenderObject {
+
+    int globalFmin
+    int globalFmax
+
+
+    int getGlobalWidth() {
+        return globalFmax - globalFmin
+    }
+}

--- a/test/unit/org/bbop/apollo/SvgServiceSpec.groovy
+++ b/test/unit/org/bbop/apollo/SvgServiceSpec.groovy
@@ -1,0 +1,20 @@
+package org.bbop.apollo
+
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+
+/**
+ * See the API for {@link grails.test.mixin.services.ServiceUnitTestMixin} for usage instructions
+ */
+@TestFor(SvgService)
+class SvgServiceSpec extends Specification {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+    }
+}

--- a/web-app/js/restapidoc/restapidoc.json
+++ b/web-app/js/restapidoc/restapidoc.json
@@ -2,14 +2,14 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
-         "jsondocId": "a8ab0fb9-a86f-40c8-867c-0410f508c52e",
+         "jsondocId": "297dcead-9023-4d56-b3ee-08418ab8cf74",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0b1e3b5e-2d2d-4e34-b963-0c79e11bbea2",
+                     "jsondocId": "c3cba1b3-cdfc-4d24-8c73-dd975495e95e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -18,7 +18,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a30cf142-8683-4f21-b8b1-61fe5863dcbb",
+                     "jsondocId": "27b7ab02-cf8a-423c-9e77-9931eeb24fd8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -27,7 +27,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "230dd68f-814c-42da-aaf6-c964448486fa",
+                     "jsondocId": "1a4e2060-6977-408d-a783-7cbcbdd10e22",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -36,7 +36,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a464e940-112e-4f60-896f-1e194ba28a61",
+                     "jsondocId": "fa961e8a-f63f-411e-b423-906c25e3bdb9",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -45,7 +45,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45dffc44-b8d0-4672-b34e-48e5f83ccfad",
+                     "jsondocId": "79c9cc19-88dd-4df7-b403-25140de377ce",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
@@ -57,9 +57,9 @@
                "verb": "POST",
                "description": "Set name of a feature",
                "methodName": "setName",
-               "jsondocId": "d30092f1-a017-45f1-9643-714ee5309e59",
+               "jsondocId": "baf7f800-4cce-4587-b2b0-2e17066015fb",
                "bodyobject": {
-                  "jsondocId": "dab22057-5da9-41ff-8490-99f4e3baf491",
+                  "jsondocId": "c2f25ca0-90e8-45ca-97a3-00b5882977ae",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -69,7 +69,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setName",
                "response": {
-                  "jsondocId": "077ac7a8-dbb9-4329-b162-6dcd11755cc6",
+                  "jsondocId": "0534aa8b-86ba-46f4-b303-f27f3aa029fe",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -82,7 +82,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "06b3cce0-8d2c-4363-b848-ec8adb3f793c",
+                     "jsondocId": "bff86a73-07dc-450b-9a24-43bdec5f9a14",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -91,7 +91,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f8244eef-56f6-4eff-ae15-4ee566e15233",
+                     "jsondocId": "53dd5c55-74a9-4340-9257-b774e4240ea6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -100,7 +100,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "17647e4d-0aa4-42f8-b17e-806cefb2a6a5",
+                     "jsondocId": "608aef4d-79d6-4fe9-97b7-e4c22bda75ee",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -109,7 +109,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5dc30ff4-9d9c-4a5f-9d45-05a69faa1d1c",
+                     "jsondocId": "616218b0-0eb1-419a-bfa6-34323dae9fb5",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -118,80 +118,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b1d68f45-1a1f-4d85-a172-99880ec51f1f",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get comments",
-               "methodName": "getComments",
-               "jsondocId": "0bc829ea-e0ee-48a7-b593-7e2acff41a66",
-               "bodyobject": {
-                  "jsondocId": "30b2c7ce-c718-4b7d-8112-60dc63c66cb9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getComments",
-               "response": {
-                  "jsondocId": "6593a373-2f0d-4b9b-b86f-08c5c3eb7f9f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "b0bdbb9f-6361-44b6-8163-46a23313374f",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cf1b9684-3612-4618-8acb-6963c4ab70e6",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a8ed7686-2119-410a-92b8-c5e397de51fb",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "06a748dd-e7a2-44c6-a11f-aa540178d5fb",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3c03aeff-4e9a-424a-b4ed-05d4dc3802e2",
+                     "jsondocId": "b9846c0c-af61-4688-b8d0-3c46bc31e2b6",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
@@ -203,9 +130,9 @@
                "verb": "POST",
                "description": "Set status of a feature",
                "methodName": "setStatus",
-               "jsondocId": "f4e4b606-6acb-4804-a59b-c0da2fcda31e",
+               "jsondocId": "a8250390-0b0b-4c7e-96a5-ee77f1a92576",
                "bodyobject": {
-                  "jsondocId": "761a597e-d645-485a-bf19-a2bc27ba78c6",
+                  "jsondocId": "f98f1363-e730-446b-8231-96191f4cd292",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -215,7 +142,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setStatus",
                "response": {
-                  "jsondocId": "8f6d8b52-8f8e-4c6d-87bf-e86733ff9d96",
+                  "jsondocId": "afbf0662-94a1-4c69-88e1-0d26a6b8376e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -228,7 +155,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "19a3e702-bd5f-45e1-a721-e289890e0535",
+                     "jsondocId": "30e059ad-57e1-43f1-b1c2-80cd431edf43",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -237,7 +164,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dc57a203-dd4c-4dcd-93b4-c72b528f58cb",
+                     "jsondocId": "0cf37d0a-db1d-4622-b08b-1b202f49b78a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -246,7 +173,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a0499dd3-2ab3-45f4-8e47-cb65cc8bee71",
+                     "jsondocId": "39b18a99-4f1d-4f32-b3ff-be70f9640021",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -255,7 +182,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d9f09572-d4be-48b6-9dba-6daa7036e978",
+                     "jsondocId": "f2e5acd6-ede5-403b-8111-7375597e9192",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -264,80 +191,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "961416bf-15be-408b-a775-47d10cc173db",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add attribute (key,value pair) to feature",
-               "methodName": "addAttribute",
-               "jsondocId": "235c2d37-9558-42dd-8ae9-74863cb9f7fd",
-               "bodyobject": {
-                  "jsondocId": "96dffd05-14fc-4d2c-ab4b-74d4408a6dfb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addAttribute",
-               "response": {
-                  "jsondocId": "5e8fda58-7c16-4bfd-b518-c22e6cb54987",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "dba297ff-0329-4d77-9b0f-c521b614205c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "833c518c-a48d-4e28-b9af-14fe445f3ef4",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "546eb7cd-eb95-4129-a4ee-60c4d590a087",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4b5211a0-11ef-4ad6-8d41-7d52a03345c6",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a4f0fc6e-0e43-49cc-b70e-15a8f3c96e10",
+                     "jsondocId": "9c66642e-a664-4caa-b3e3-68fd8cab34de",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
@@ -349,9 +203,9 @@
                "verb": "POST",
                "description": "Set description for a feature",
                "methodName": "setDescription",
-               "jsondocId": "3d5f0c74-ada8-4bc9-91a4-db04f541804b",
+               "jsondocId": "71f3261f-e6d4-4e38-b34f-2f5ba3cfaafc",
                "bodyobject": {
-                  "jsondocId": "a3ac23e0-1959-4c68-8c68-74cc9371a0e5",
+                  "jsondocId": "1d13a6cb-5f11-442c-840b-9230867af0da",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -361,7 +215,226 @@
                "apierrors": [],
                "path": "/annotationEditor/setDescription",
                "response": {
-                  "jsondocId": "09edf3b9-a3ca-4e0a-89a4-bb1d6a28fa98",
+                  "jsondocId": "959128cb-da19-4b79-b7be-bf8931a04e64",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "33ff0c43-1dc8-4111-b5a6-c9a1273a524f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "51109cef-724b-40b8-ab2a-82b531c5a8ae",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "52b897e9-5344-49d4-8e7d-824b8f6e98fc",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0a91ae75-a43f-4b0b-9e94-1cf22e6c6980",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "818b28cd-207f-4f27-9362-70f720963e94",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set symbol of a feature",
+               "methodName": "setSymbol",
+               "jsondocId": "54b66419-4008-4382-81ab-175c268026e2",
+               "bodyobject": {
+                  "jsondocId": "19b95043-64d2-45cc-a6c1-0b2f5b61ef6b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setSymbol",
+               "response": {
+                  "jsondocId": "7c6ea60e-9eb3-4094-ac50-1dd79a52614b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "676a8bd7-3d31-4e39-8dae-ab050153d1e5",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0a184a56-539a-41a3-8f3f-a316c0ee2402",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4db55f2a-abbf-415f-988f-5f819b1f900d",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "15128189-3992-4752-9d7a-71d3c6bab2f3",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "72f419b5-c6c0-4707-b409-44232f2ff117",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add attribute (key,value pair) to feature",
+               "methodName": "addAttribute",
+               "jsondocId": "ca68c428-78de-4c3f-ab3b-f14afcae6026",
+               "bodyobject": {
+                  "jsondocId": "eaaf759c-09fe-4497-b245-b1d620693d51",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addAttribute",
+               "response": {
+                  "jsondocId": "086a65bb-d739-4f26-b1ae-1536ebe23e07",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "a97e2eb1-edcd-4dc6-a730-49690f46fbeb",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "12b4bed3-2fa2-4c95-945b-fb8eb90a83ce",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "df534009-dbff-4e68-9f00-09658392af20",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c5266927-34ff-4246-991c-da5577017367",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "64ee0087-ba84-453e-9e37-957a33341862",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get comments",
+               "methodName": "getComments",
+               "jsondocId": "457f779c-9f96-4c9c-9e3b-81f5936724ab",
+               "bodyobject": {
+                  "jsondocId": "6f743df4-14f8-4e97-b9f8-fabb89cce9de",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getComments",
+               "response": {
+                  "jsondocId": "726298ef-76d8-44f4-a2fd-4c09ac724d7a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -376,9 +449,9 @@
                "verb": "POST",
                "description": "Returns a translation table as JSON",
                "methodName": "getTranslationTable",
-               "jsondocId": "bb067972-6cdd-414a-a0ab-3494b8d8efb2",
+               "jsondocId": "3159697a-bed3-40b5-b443-2a8cbee33131",
                "bodyobject": {
-                  "jsondocId": "e3fcc475-d941-45ae-98fc-5d8810e6f39d",
+                  "jsondocId": "6e8b3dfd-c808-4e57-a377-d2434749eb9a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -388,7 +461,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getTranslationTable",
                "response": {
-                  "jsondocId": "5022fb9f-a708-4401-b9c4-5c0497684bd6",
+                  "jsondocId": "7e8c0ba2-baee-45f7-a78a-4dd875c51741",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -401,7 +474,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6971a701-5487-4803-957b-1e9e1f69aa52",
+                     "jsondocId": "e5b5723b-4f7e-478b-9307-f59d841c5260",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -410,7 +483,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a18dc523-a571-4119-874e-4ab34826484a",
+                     "jsondocId": "3e0c6dd8-44ca-4386-a7fa-7d19790bfab6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -419,7 +492,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c792f2ed-cdcf-44c8-b73b-71bcf1f4e9af",
+                     "jsondocId": "df024e5a-f043-402e-81de-35240254e0a2",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -428,7 +501,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e357324d-2db5-4ac1-9a1e-635a58ad479d",
+                     "jsondocId": "ea6b3a88-daad-450e-940f-e7bdac36159c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -437,7 +510,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e71f0598-bcd0-4a35-ad89-d0ddeb585128",
+                     "jsondocId": "d57b62bf-1e1d-4899-95c5-2bde57cf619f",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -446,7 +519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ca4c90da-fafa-4136-ab0f-e663483702af",
+                     "jsondocId": "ff06f8df-0adc-4bb9-bc94-3e20f7460f9d",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -455,7 +528,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e6d5a5a6-e273-4507-9864-bafac69b8472",
+                     "jsondocId": "59685e22-9b8a-40f2-b0a2-e430a0867fbf",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -467,9 +540,9 @@
                "verb": "POST",
                "description": "Add non-coding genomic feature",
                "methodName": "addFeature",
-               "jsondocId": "d617e1c3-a5ec-4c5d-9e8f-feb6d3145bea",
+               "jsondocId": "2e816e3d-6626-41ec-bbc5-99fc0ddaf737",
                "bodyobject": {
-                  "jsondocId": "0dfec66f-5cf4-4be1-9981-00515bbe16d4",
+                  "jsondocId": "51b147a9-4fd0-4cbd-8b11-1a499349f106",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -479,7 +552,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addFeature",
                "response": {
-                  "jsondocId": "1c3e8968-5b25-48d4-8fbf-e14b1092fa20",
+                  "jsondocId": "bc03ffc1-433f-49e6-a16c-a67dba62cee0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -492,7 +565,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0b9b1e52-df34-4989-aeeb-7f9d610bd446",
+                     "jsondocId": "a9607541-0168-4b22-be11-8615d0eb59fe",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -501,7 +574,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b2fc72ce-7b88-4390-8063-e5462e279b2f",
+                     "jsondocId": "5e6d636e-f654-4011-bb84-d08d01be7911",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -510,7 +583,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "38884d42-035a-4e1b-9f4b-9fd61c13fc97",
+                     "jsondocId": "adafa550-d53a-4e30-8735-3ec8153e37b9",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -519,7 +592,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9145b7da-d483-488a-b146-444483bd60e0",
+                     "jsondocId": "05a882b4-977c-42a9-a86c-ff050ce499b3",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -528,7 +601,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26fb60c2-6c04-475f-8514-39426eeeaffc",
+                     "jsondocId": "36ab73f4-6e61-41c3-8f0c-8b278db9d8b4",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -537,7 +610,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ecf41632-0bdc-443a-90de-0b9ca2401c95",
+                     "jsondocId": "97b34768-7087-4a5f-ba5a-748a40701024",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -546,7 +619,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0ab9648a-08ed-4e12-bf5d-063aa903a416",
+                     "jsondocId": "e387bb60-5759-47af-b2cc-6efc3bf8d874",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -558,9 +631,9 @@
                "verb": "POST",
                "description": "Set exon feature boundaries",
                "methodName": "setExonBoundaries",
-               "jsondocId": "47460d09-900c-440c-9c97-009456aff132",
+               "jsondocId": "28128ab6-e9ba-4616-bbdf-4b20daa26738",
                "bodyobject": {
-                  "jsondocId": "d331c846-fa96-45a5-be7c-49609e5ccfdf",
+                  "jsondocId": "1fb6dec3-73c5-4106-ace4-540f71a162b0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -570,7 +643,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setExonBoundaries",
                "response": {
-                  "jsondocId": "07548b8a-7260-4cd0-b8ac-26eaae1a0ea2",
+                  "jsondocId": "d7870751-2e90-45c3-9444-62c80628e93b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -583,7 +656,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3507173c-f579-40ae-b000-e9eab2345b60",
+                     "jsondocId": "7b638efa-f9cc-4a58-8744-4a25f119cb76",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -592,7 +665,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4a549c25-548e-4799-9397-c3bda3a8d012",
+                     "jsondocId": "22334290-ece5-4803-b62e-cad0bd5e4934",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -601,7 +674,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "51d9d009-85b3-48d5-a440-85e87127f5cc",
+                     "jsondocId": "08d8503d-89a6-42c0-a0c1-4f71c11ed150",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -610,7 +683,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a97eb157-4e8c-46a4-ac6c-51c217344efa",
+                     "jsondocId": "e64ee50a-6558-48db-b9b2-0c109e45c9c4",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -619,7 +692,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "074e65e0-c177-4b66-9986-b1c987864724",
+                     "jsondocId": "08f360b1-728f-452b-95c3-9977493db20e",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -628,7 +701,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "afd1e3a3-589b-4bd4-a128-4cf1a70da16b",
+                     "jsondocId": "c321c272-2037-46b3-82cc-434bd0fae3b9",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -637,7 +710,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "202342a3-adb7-45a6-83f2-4e6b965d1cd8",
+                     "jsondocId": "5aa5550b-ad57-4257-9247-03d3b6eedb4e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -649,9 +722,9 @@
                "verb": "POST",
                "description": "Add an exon",
                "methodName": "addExon",
-               "jsondocId": "b3c76b55-f3b7-412b-92ba-14427088b3cd",
+               "jsondocId": "b1f12f93-ff2d-47a7-856a-547c319c9bdf",
                "bodyobject": {
-                  "jsondocId": "6a9bb9d0-19aa-4494-b97c-b148c16d9a45",
+                  "jsondocId": "3f790a7c-7e61-4b44-bace-f7908965171c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -661,7 +734,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addExon",
                "response": {
-                  "jsondocId": "218ffbee-0113-4f89-9333-4637142f5765",
+                  "jsondocId": "8d2b2d84-62cf-4d0f-9e2d-22577bea17a4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -674,7 +747,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f01d7144-57a4-481e-a1b5-f09895ec5403",
+                     "jsondocId": "61bd00f8-082e-4749-b03d-9651a1a9c2aa",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -683,7 +756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "77edf08a-fd6f-4653-8140-890c665bf703",
+                     "jsondocId": "ae880ae2-461c-41bc-a98c-77ab4834d1cc",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -692,7 +765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "64b46b45-3afc-4497-90fb-a0264c669463",
+                     "jsondocId": "5b5cebb1-f5a4-4737-94ac-5ac53e50f1b5",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -701,7 +774,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a2151597-e1c0-4ef4-9c02-2835534f36b9",
+                     "jsondocId": "5ab204a5-0294-432e-bc68-0101495a200c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -710,7 +783,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "da6104a9-73a8-41b5-937a-5e33915f27e6",
+                     "jsondocId": "2a61d518-48a3-4878-895e-f265ce92350d",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -722,9 +795,9 @@
                "verb": "POST",
                "description": "Add comments",
                "methodName": "addComments",
-               "jsondocId": "3b56d39f-4fb4-4333-8142-d80f878ae6e9",
+               "jsondocId": "a3d78d8f-5dc7-4351-9ce4-11c8c71bce44",
                "bodyobject": {
-                  "jsondocId": "44f823d3-f86f-4b53-861f-3c0c63309bd5",
+                  "jsondocId": "d4cf864e-ff7d-41c7-8f94-62d9c58423b5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -734,7 +807,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addComments",
                "response": {
-                  "jsondocId": "2595b98c-b93a-405b-8930-bb2c71cae1c8",
+                  "jsondocId": "f65404c4-99ad-4a6e-8878-ac80a1eacfb1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -747,7 +820,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ead57887-9a33-4fe6-a208-2c9dbda73840",
+                     "jsondocId": "43029441-3e78-4953-ba62-4081711d5046",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -756,7 +829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5c94834d-db8f-46fd-b557-adcaed3f3cda",
+                     "jsondocId": "30388905-fd00-4623-8309-9fadb46ddcd2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -765,7 +838,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4cda93a2-5147-4304-b72d-33beb6dd0cdb",
+                     "jsondocId": "a33b52ce-22e6-4610-bd52-4cc263a722fa",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -774,7 +847,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6f565b91-731c-4cc3-b5eb-1aeb50fb4d52",
+                     "jsondocId": "ffad469d-daa9-43e4-a794-9b4f4b50994d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -783,7 +856,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "52ba31d7-3f0f-4b06-bbb9-d0519f50df2e",
+                     "jsondocId": "ed579cc1-0fc4-495d-a768-3c70ec365ac6",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -795,9 +868,9 @@
                "verb": "POST",
                "description": "Delete comments",
                "methodName": "deleteComments",
-               "jsondocId": "3d677755-239f-40f8-80e5-e4f8e9ee347f",
+               "jsondocId": "74fe9813-9ff9-4c34-bea4-63c5e915e804",
                "bodyobject": {
-                  "jsondocId": "26e558e0-105a-4e68-958a-6a41b7cf4e33",
+                  "jsondocId": "050fa498-de18-4f33-9abd-56fdf2c267f3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -807,7 +880,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteComments",
                "response": {
-                  "jsondocId": "6c84bd57-9571-4905-91ca-0f7fde851ddd",
+                  "jsondocId": "ec80a7b4-336d-4d95-9ea5-6e85d28d060a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -820,7 +893,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5cb2ab13-6ebc-4b20-9a6a-0c4638aa4d85",
+                     "jsondocId": "26aebe80-65f2-4886-a7ba-ca000458d9a1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -829,7 +902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dca56435-f3ec-4ed5-9685-054b8a1fd2ae",
+                     "jsondocId": "14269a79-547f-467f-8afe-89615a0fa8b6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -838,7 +911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "869a3179-9f16-419a-b438-92ebb991f98b",
+                     "jsondocId": "829219ef-d566-4049-9776-1e7e66ffa269",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -847,7 +920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8f6f3cb5-ab4a-4dde-af9f-c181163e85d7",
+                     "jsondocId": "00b9a7cd-c919-4dd3-aba9-4350bf37ec25",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -856,7 +929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "72ca1962-1bf9-4f41-abf4-c2dd276858d4",
+                     "jsondocId": "f3addfab-393d-45c2-8caf-f51c968547eb",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -868,9 +941,9 @@
                "verb": "POST",
                "description": "Update comments",
                "methodName": "updateComments",
-               "jsondocId": "cd02ce3d-577b-4893-bc2e-58f81017d7a6",
+               "jsondocId": "180aba8e-cb34-487c-9bb6-9901680487f5",
                "bodyobject": {
-                  "jsondocId": "247dea79-0f55-4d07-a828-3747256943ce",
+                  "jsondocId": "d149c624-c753-45ee-a75e-796c986bc6c3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -880,7 +953,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateComments",
                "response": {
-                  "jsondocId": "f9f92971-c5d2-48b8-bb03-cdcf76239d3d",
+                  "jsondocId": "61fcc348-7af9-4bf8-9174-0e549cfcb599",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -893,7 +966,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "37ff4ba0-9a34-441c-bba4-17e6c3dce962",
+                     "jsondocId": "44b4644e-5973-4c1d-b75a-3999e0d21b32",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -902,7 +975,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4a26167a-5ac5-4e69-882d-15518f25e977",
+                     "jsondocId": "d97994b9-6983-4c07-b418-d917fc94f017",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -911,7 +984,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0caa2b9b-6e1b-4182-a501-e700469925f6",
+                     "jsondocId": "41f0f08c-8f9e-415f-b949-258b7c62ed93",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -920,7 +993,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "01ca31d9-72a2-41b9-9a57-84f78c2c2ad7",
+                     "jsondocId": "697b6922-6289-42c8-8ec7-a175eef0a9d1",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -929,7 +1002,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f50d7b5c-394c-4453-bc55-b94dca4d25e6",
+                     "jsondocId": "90639849-3e51-4897-a4de-5d2c04296d2d",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -938,7 +1011,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e32439fa-619f-40d3-9470-b80a7db84005",
+                     "jsondocId": "ec1f1423-7c07-45c6-9c4b-516f8c42b035",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -947,7 +1020,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7cb43bba-552e-4a56-9462-5db2c8fa3112",
+                     "jsondocId": "6203939c-1e0a-4ebc-a1fd-48fbe80be976",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -959,9 +1032,9 @@
                "verb": "POST",
                "description": "Add transcript",
                "methodName": "addTranscript",
-               "jsondocId": "0eb9965e-2b1f-4eea-bc1c-c21512731125",
+               "jsondocId": "4acd9f8d-d15a-472b-8c1d-9655dee9507a",
                "bodyobject": {
-                  "jsondocId": "fff8b60d-d1b8-499c-9034-bbfa19db90b5",
+                  "jsondocId": "640520b3-74e3-45ae-9904-69eeb11c4eb8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -971,7 +1044,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addTranscript",
                "response": {
-                  "jsondocId": "d1a45bf1-8c92-4c9c-8775-df09614b98db",
+                  "jsondocId": "4c62a5e8-16e9-4446-bc16-1a18cfa6e13a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -984,7 +1057,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d198c380-3d36-4524-bf40-f6390b359d8a",
+                     "jsondocId": "67454d84-eccb-4b75-b76b-d7e720c28fac",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -993,7 +1066,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45135305-49a8-4e1c-8427-62107f96ca5b",
+                     "jsondocId": "eafadf6e-02b4-4e83-9944-6a8066e01375",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1002,7 +1075,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7a67ea0d-772f-4014-b4ec-b5c502c07238",
+                     "jsondocId": "1764a0de-b9b5-4be4-9fb8-9a066328f21e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1011,7 +1084,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "36661181-cf92-425e-8442-9f1f85bf85a9",
+                     "jsondocId": "e5878971-2d79-4b5e-83de-03c515fcbd6f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1020,7 +1093,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6928f799-afb9-4ce6-9de4-b65bf81d9b9c",
+                     "jsondocId": "d685ec8d-0475-40da-b743-94ed1a2ea5d1",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1029,7 +1102,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "285ab1b6-ef68-40dd-85ee-04fd71d93db2",
+                     "jsondocId": "34fa9348-c7fd-432b-89e4-03391348fea0",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1038,7 +1111,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "82c7096e-98e5-4b3f-af0f-d27f83aabbb2",
+                     "jsondocId": "8c018883-05f4-4379-b6ab-d90548239fb8",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
@@ -1050,9 +1123,9 @@
                "verb": "POST",
                "description": "Duplicate transcript",
                "methodName": "duplicateTranscript",
-               "jsondocId": "e063b4e9-0e2c-4ca5-a3a5-0830c63115e1",
+               "jsondocId": "ac461446-8b68-4855-97d7-363fe9ea88f3",
                "bodyobject": {
-                  "jsondocId": "800b717a-f570-4f0c-ae12-087f8f501643",
+                  "jsondocId": "c7177729-151a-4432-b5e9-40fe2f1b9f0e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1062,7 +1135,7 @@
                "apierrors": [],
                "path": "/annotationEditor/duplicateTranscript",
                "response": {
-                  "jsondocId": "ced90345-7c47-43e1-8f79-88cf4231e476",
+                  "jsondocId": "490e60d8-85e5-46cf-a730-7fdbf6e14918",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1075,7 +1148,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "837c192f-872c-4f54-87ba-d3764b318592",
+                     "jsondocId": "baa5632b-d6f6-4f2c-afe3-744d223c57f4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1084,7 +1157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7292268c-ac80-4cad-99c0-6e52ed791e97",
+                     "jsondocId": "a53c3d1f-740c-4cfb-96cd-72edf9243ad3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1093,7 +1166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9c0798ba-0f5d-43cd-bf93-6f20b0f81b00",
+                     "jsondocId": "c582d5b8-13e7-4ef1-b231-039e17021e90",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1102,7 +1175,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "47272447-fc1b-4f71-84e4-db458aa6e2db",
+                     "jsondocId": "f3be30f7-98e5-4e53-9f73-2b84b13ada19",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1111,7 +1184,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "32bc0fed-db4b-4284-8162-b9093cb46d59",
+                     "jsondocId": "b788910d-c742-4f45-bc88-b08dd3e71a21",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -1123,9 +1196,9 @@
                "verb": "POST",
                "description": "Set translation start",
                "methodName": "setTranslationStart",
-               "jsondocId": "4e65f49a-0ad7-462f-aadc-7e68571a4c14",
+               "jsondocId": "66c90b63-bc84-4a69-9c02-2ed514330a7b",
                "bodyobject": {
-                  "jsondocId": "091c3608-e61e-44ac-86e1-696385cfe2f7",
+                  "jsondocId": "38eebf6a-1885-40c3-927b-765faf518ee8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1135,7 +1208,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationStart",
                "response": {
-                  "jsondocId": "aeffa45c-fbc8-4d68-9d44-3da76fa6e1e0",
+                  "jsondocId": "6e148f09-f3a5-4cee-82d2-8f7fc58c000a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1148,7 +1221,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "30fae66c-6c6f-4f50-8797-5fd775d3ca53",
+                     "jsondocId": "15e8924e-4d5c-4d86-9679-3c7b6c16cfad",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1157,7 +1230,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "54ce08ec-91e9-4dac-a841-3182517b805a",
+                     "jsondocId": "481d94fe-5fc5-45dc-9c99-8f490a2029da",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1166,7 +1239,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bd2719ab-3896-41ce-81f4-4a8d620b2036",
+                     "jsondocId": "948acd57-f4e7-4c99-8dbd-4eeb73f89d77",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1175,7 +1248,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f2a99164-6868-46e6-b1b5-9c584801f40a",
+                     "jsondocId": "4da58cb9-37c1-4673-a681-e3f2bcf3b656",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1184,7 +1257,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f04f6b4e-6765-4204-a08c-90b1c418a5bd",
+                     "jsondocId": "0315a311-8889-4aa3-b9de-42efdfbd3728",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
@@ -1196,9 +1269,9 @@
                "verb": "POST",
                "description": "Set translation end",
                "methodName": "setTranslationEnd",
-               "jsondocId": "084c7ec9-1de1-4a4d-b5fd-54b269da885a",
+               "jsondocId": "2af22ec8-27a6-4a31-9c8d-3ac2abee11ce",
                "bodyobject": {
-                  "jsondocId": "7577c6a1-0804-4051-b133-f6527c314ef8",
+                  "jsondocId": "6e6554c8-6150-46d0-82d8-12b5a75c1a07",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1208,7 +1281,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationEnd",
                "response": {
-                  "jsondocId": "2db85a4d-b02e-4dd4-9777-423ae5ed961a",
+                  "jsondocId": "683c8256-800e-47a4-bfa7-6c579f913b26",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1221,7 +1294,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "096bfb2a-32d9-458c-b339-81dcaa042c55",
+                     "jsondocId": "c74a770a-bd7a-46ac-b6a0-e58733a38ebb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1230,7 +1303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9cc56099-767e-43e2-b5af-ba1f173aea04",
+                     "jsondocId": "b3f65cae-4a21-46e9-9cd8-37bf0d6f246a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1239,7 +1312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e5ad1f71-b231-45e3-8694-7a18c08da2f5",
+                     "jsondocId": "af75a7bf-e1f6-4a3a-a766-d6f8408b985b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1248,7 +1321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5a79983a-9821-40b4-9388-ce78a4668deb",
+                     "jsondocId": "936e2294-35f2-4293-8f85-5c601e645e81",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1257,7 +1330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "051875e2-ecb8-4a4a-b48b-fed197ccd3d9",
+                     "jsondocId": "b950baf5-11a5-4f7a-8ab3-ab64fb17f9e1",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
@@ -1269,9 +1342,9 @@
                "verb": "POST",
                "description": "Set longest ORF",
                "methodName": "setLongestOrf",
-               "jsondocId": "3a48ba2f-fdcf-42bf-8198-8392735a61f5",
+               "jsondocId": "213c7e5d-5a54-405b-9e24-4f75ba1c6db8",
                "bodyobject": {
-                  "jsondocId": "5606b97c-3d31-4939-b43a-c169c1876a6c",
+                  "jsondocId": "1fb888c2-bea7-4f17-97db-c38b7aced8c5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1281,7 +1354,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setLongestOrf",
                "response": {
-                  "jsondocId": "747a9129-67d3-40a8-a48b-3a7d342d87dc",
+                  "jsondocId": "a5ef0860-3bb8-4226-8ab8-ed2ddf7fac74",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1294,7 +1367,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "27a61f43-b17c-4956-b0e7-c68791a31270",
+                     "jsondocId": "b7a0233d-4488-4516-becf-4e0805f5496a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1303,7 +1376,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6adcdcc2-34d2-470b-9dfb-af69c5be2f98",
+                     "jsondocId": "420d0494-5ecf-4301-b473-452f1ed30339",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1312,7 +1385,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "987cf0bf-f508-404e-a5ed-ae2c0f77aa59",
+                     "jsondocId": "a534ec51-b2ae-4699-af77-d782692c949b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1321,7 +1394,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "daae19cf-d5f1-4501-9a34-c5b89fb5a27c",
+                     "jsondocId": "dad245ef-1cd8-4c5a-a53b-4f4f775b9d14",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1330,7 +1403,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2590c0d9-eda8-4db1-ba1c-3eb1df7bef10",
+                     "jsondocId": "6355792d-adfe-4403-ab11-8e993968ba56",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -1342,9 +1415,9 @@
                "verb": "POST",
                "description": "Set boundaries of genomic feature",
                "methodName": "setBoundaries",
-               "jsondocId": "63f21c61-4c87-4991-9ece-5ff53803364c",
+               "jsondocId": "1b8c54a1-0c76-4716-b9d5-d155c1088e71",
                "bodyobject": {
-                  "jsondocId": "9112498c-4cdd-42c2-8317-0d014322173a",
+                  "jsondocId": "d5956d5b-9db4-4734-a8a3-9fba3f5cb663",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1354,7 +1427,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setBoundaries",
                "response": {
-                  "jsondocId": "0ba6cc08-172e-44be-903b-068386dcf959",
+                  "jsondocId": "f33c5153-61aa-467a-8188-25f2ad32a55b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1367,7 +1440,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "126151c4-7eb0-4276-b33a-fa529d08ea0d",
+                     "jsondocId": "02c42e6e-c646-4636-a475-ff2386a3095e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1376,7 +1449,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dd753dbb-17c1-41c1-8380-ce7441811646",
+                     "jsondocId": "2a084c5c-1ba0-4c3d-acf5-a720a9a1f8e2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1385,7 +1458,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "100972b1-9f7f-4ac2-b6bf-51c332e84e16",
+                     "jsondocId": "e8644435-3ecd-43ec-aefb-8c3ef4b5d70b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1394,7 +1467,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c385c822-c04d-4aa4-ad7f-ad2011583256",
+                     "jsondocId": "d5105533-ec06-4d4c-a815-8e73325a9a3b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1406,9 +1479,9 @@
                "verb": "POST",
                "description": "Get all annotated features for a sequence",
                "methodName": "getFeatures",
-               "jsondocId": "916f4b8a-6825-4bac-af81-df96936a8655",
+               "jsondocId": "455f9816-dfd2-46f6-b88c-3327f92407d0",
                "bodyobject": {
-                  "jsondocId": "88bd799e-b641-4de4-abf6-886dab00fcf8",
+                  "jsondocId": "32be1702-14b3-4308-9292-def6e9c62671",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1418,7 +1491,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getFeatures",
                "response": {
-                  "jsondocId": "eb12ce73-2eed-43e0-90ed-220ffb3cbc47",
+                  "jsondocId": "bf403b09-9fb6-4089-9c70-9d4473fd4aee",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1431,7 +1504,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b0e5a9cf-bba3-4f28-bf0f-9f66ecc49ec2",
+                     "jsondocId": "87d0a0af-64fa-4184-86f7-eb330f8776aa",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1440,7 +1513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3b7c6e23-ac79-4f3d-bb01-540c504301ef",
+                     "jsondocId": "17fd22e6-937c-4215-b89f-29fb96966c2b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1449,7 +1522,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "16665272-6820-4197-b20c-a23ec5f99a65",
+                     "jsondocId": "50edaa42-7a2b-437d-bd82-71badfb5956f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1458,7 +1531,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e2f94401-1518-40fc-ae25-07b578e7cc29",
+                     "jsondocId": "fac35dc5-e0e2-4982-8732-c7029ada26d0",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1470,9 +1543,9 @@
                "verb": "POST",
                "description": "Get sequence alterations for a given sequence",
                "methodName": "getSequenceAlterations",
-               "jsondocId": "0b948fc8-56f2-441a-9c6b-625141d3f124",
+               "jsondocId": "f857d3d0-3af7-4429-bc6e-79efc5251a53",
                "bodyobject": {
-                  "jsondocId": "f72c3840-63f2-42b5-8fa2-ce9303ff0f66",
+                  "jsondocId": "67fbfd78-e2d6-4816-867d-053db67bd6f2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1482,7 +1555,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequenceAlterations",
                "response": {
-                  "jsondocId": "7c5a2ddf-e73d-4b6c-8ab7-8bd237209b33",
+                  "jsondocId": "0712ca15-dc66-4dd5-9d58-bc45c9c9d26c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1495,7 +1568,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2701c808-1796-4e25-979a-90857a1d9315",
+                     "jsondocId": "843cf66b-a50b-42b0-8e78-33710ec21d6d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1504,7 +1577,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "340bb48b-ebd0-4212-bc7b-359543015638",
+                     "jsondocId": "5235ca41-e210-44e7-8888-81875bc4acf3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1513,7 +1586,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5ebf10ef-8043-469a-81fa-b6310b6ed0ec",
+                     "jsondocId": "ebe7f3d6-3512-422c-84a5-5684e4e351b9",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1522,7 +1595,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e0704662-8296-4dc9-92cc-e46db36d5ecf",
+                     "jsondocId": "2449abb6-ac57-4cd7-b453-ed9b1710cea6",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1531,7 +1604,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "043713ff-b3b6-4e03-a9a5-d1f94af8fd35",
+                     "jsondocId": "91c1d2e5-6be7-4a5a-85f6-89b51e96329c",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -1543,9 +1616,9 @@
                "verb": "POST",
                "description": "Delete attribute (key,value pair) for feature",
                "methodName": "deleteAttribute",
-               "jsondocId": "9fe11ca6-4565-4f9e-a401-2b5015917249",
+               "jsondocId": "779a8ec6-21be-42ca-a024-b63cf9c9bc6a",
                "bodyobject": {
-                  "jsondocId": "e071d5f5-cd03-4851-b858-4082fa68c5f0",
+                  "jsondocId": "6575ca15-2620-48f6-8ba8-38479e17bf14",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1555,7 +1628,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteAttribute",
                "response": {
-                  "jsondocId": "40f58e66-27d9-4acc-835b-6c3d32a669ce",
+                  "jsondocId": "32d70e6c-fe6b-4094-be01-12ec1d21c550",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1568,7 +1641,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0ef0e20f-1272-4843-ab24-1e37d680b4e2",
+                     "jsondocId": "5d3f9a6d-3dec-4cdf-b4ef-4367ae7dfb38",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1577,7 +1650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a31ba1b4-0e8a-447e-9d49-bef82395ad60",
+                     "jsondocId": "ab1b5a1c-3851-4ef3-ba8a-eb83031268b3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1586,7 +1659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d05c71c2-695b-44de-93c3-1664c0a595fe",
+                     "jsondocId": "e8a1416a-0caf-4715-8010-14acfe2c120a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1595,7 +1668,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e73ef9e7-6395-4667-a837-f6250272b71f",
+                     "jsondocId": "0848e6ae-37f6-41b8-bf00-1a36145853fc",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1604,7 +1677,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9fcdba15-7b39-4425-9743-ab7bfd761425",
+                     "jsondocId": "6e625061-bb9e-493d-822c-162a2fe08044",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.",
@@ -1616,9 +1689,9 @@
                "verb": "POST",
                "description": "Update attribute (key,value pair) for feature",
                "methodName": "updateAttribute",
-               "jsondocId": "88336993-d534-4671-8636-cccb0de025e3",
+               "jsondocId": "9287cdab-ff8c-4683-8c9e-8e84b1384ec5",
                "bodyobject": {
-                  "jsondocId": "d555eb05-5935-4734-826d-d1bd067a9b66",
+                  "jsondocId": "774a6abe-3469-433c-a54a-3b8e3a4d8b1e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1628,7 +1701,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateAttribute",
                "response": {
-                  "jsondocId": "fcdb3c52-e3d6-4d8e-8518-4ccfd83b9a41",
+                  "jsondocId": "0c8524ad-cb54-450d-9a39-70034e3dbe64",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1641,7 +1714,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5a71140c-0200-4f7f-9c36-570086112174",
+                     "jsondocId": "4ccf54c5-058d-4d9f-966b-47d327624be0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1650,7 +1723,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e53f1668-1914-47d7-aa24-ea9859e26028",
+                     "jsondocId": "33ad146b-b555-4492-9af7-7628a19b1f45",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1659,7 +1732,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5dcbcae6-d52e-438d-a1a5-a06041199510",
+                     "jsondocId": "b8a6d124-ef0b-472d-9c87-6eaf2364da57",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1668,7 +1741,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "81136e7a-c8f0-460b-a7d1-841f8cb62019",
+                     "jsondocId": "6e53edaf-c34b-4284-ab3b-9d7f2a09c2ed",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1677,7 +1750,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8da306be-151e-41df-94db-2a6ded655a42",
+                     "jsondocId": "fe5cf89a-f1e1-48c5-b560-7c664aec9dee",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1689,9 +1762,9 @@
                "verb": "POST",
                "description": "Add dbxref (db,id pair) to feature",
                "methodName": "addDbxref",
-               "jsondocId": "5e4e1dfa-e838-495a-b939-add96b5d82f2",
+               "jsondocId": "e5729270-c646-44e1-8a78-dc3e3707268d",
                "bodyobject": {
-                  "jsondocId": "ba231167-ecbf-4817-9dd7-1c8d6e69ee39",
+                  "jsondocId": "beb9d563-2888-48d9-bfc6-7714a2d9d7b3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1701,7 +1774,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addDbxref",
                "response": {
-                  "jsondocId": "dd64382e-90bb-4d3b-ac51-cebb8b8601a7",
+                  "jsondocId": "69a062e3-be92-4c97-b81a-0023c07c9248",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1714,7 +1787,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "980328ad-9043-4652-bb4f-f6ab148db45c",
+                     "jsondocId": "ee3cb154-f47f-4e8c-9fe0-f1de27cc7a6d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1723,7 +1796,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7aea026b-202e-4151-ae5c-122e97519134",
+                     "jsondocId": "3317c8fe-d2d5-48f7-aef8-693e1644bb6f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1732,7 +1805,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fbf55b81-31b2-46ec-b09d-d7ef18eb0f68",
+                     "jsondocId": "50dd8a3b-6c19-468e-a5ce-cf46794a7471",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1741,7 +1814,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "83bfdd26-aaf8-4a2e-bb43-22a6b394857d",
+                     "jsondocId": "7a9d2166-018a-45f9-9a13-d0d3c6188ecf",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1750,7 +1823,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e18f42ac-965e-4611-839e-b7eac0fe6ed4",
+                     "jsondocId": "ce6ff7b6-f2a6-4f9e-9b49-b76c226a25ba",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.",
@@ -1762,9 +1835,9 @@
                "verb": "POST",
                "description": "Update dbxrefs (db,id pairs) for a feature",
                "methodName": "updateDbxref",
-               "jsondocId": "b0b780c2-3873-461f-b167-2d4e5c5c403c",
+               "jsondocId": "d5cc1092-28da-4a92-9b87-be5ea95785ff",
                "bodyobject": {
-                  "jsondocId": "cd2a35e7-0955-417f-b382-4a90462c6be8",
+                  "jsondocId": "aa5cb565-b46e-48a2-afc2-1a76bb6e1525",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1774,7 +1847,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateDbxref",
                "response": {
-                  "jsondocId": "4f6d70eb-8ae4-4e0e-844b-02f0bb8f09b5",
+                  "jsondocId": "90d4d2ed-69bd-4c8a-99a4-21cdd4a92d61",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1787,7 +1860,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "73505a91-96cd-4dfd-86c5-194d7bab76a5",
+                     "jsondocId": "934e16f8-a58c-44f8-90f9-27e23d070edc",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1796,7 +1869,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d273366-09a8-4420-99a8-cc83b13deed7",
+                     "jsondocId": "01cd3bad-e288-4f50-9f35-d1d5fcbb64d1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1805,7 +1878,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cff9e451-5744-4489-8a42-5fa645263623",
+                     "jsondocId": "36ea8ba6-21e1-4302-a0fe-8fc44ca7137d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1814,7 +1887,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a1f04771-93fb-49ad-ac30-7a08f5e095ac",
+                     "jsondocId": "2945ed2a-9a4e-4af8-904a-94a68c1e3dfd",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1823,7 +1896,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5d503566-6419-44ec-912e-d109795aab13",
+                     "jsondocId": "58df061b-20a8-4b86-8bd1-9c62d16e4719",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1835,9 +1908,9 @@
                "verb": "POST",
                "description": "Delete dbxrefs (db,id pairs) for a feature",
                "methodName": "deleteDbxref",
-               "jsondocId": "ce3a841d-77ab-4c90-b28b-07ac1f8ae316",
+               "jsondocId": "89bfa0ad-5383-4784-910a-1134884acbcf",
                "bodyobject": {
-                  "jsondocId": "f86d35ce-bb28-4b66-8af0-910bf04e0f73",
+                  "jsondocId": "86398504-3d74-4ed0-aab3-22a9f51797ca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1847,7 +1920,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteDbxref",
                "response": {
-                  "jsondocId": "fd49dd92-5221-4364-bf02-840eb7069a15",
+                  "jsondocId": "6bc70295-3523-4ca3-94bd-d2e5ad217a3a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1860,7 +1933,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "776cb471-e8e8-4a53-93fe-511b1f21d827",
+                     "jsondocId": "a5f945a6-5ade-47cd-9f5d-ab7b6968ff56",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1869,7 +1942,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49689fe4-452b-471a-879c-01b82f6cb774",
+                     "jsondocId": "0930f317-3f84-4faa-ac75-1c3d49c0d7ba",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1878,7 +1951,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c61ba619-6f2c-410f-a686-abc8dbfa1751",
+                     "jsondocId": "c7981a4c-3f55-4669-931f-3bcabd6169a7",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1887,7 +1960,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3e611ecd-b49c-42a0-b9ab-b0f25055412b",
+                     "jsondocId": "d700c1b6-d04b-4d78-82cd-98d62fafdd5d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1896,7 +1969,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "120ce69f-e123-4e67-95fc-0654d1896af1",
+                     "jsondocId": "0088c878-8dbf-4a40-90a6-bd0e4a2bd414",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
@@ -1908,9 +1981,9 @@
                "verb": "POST",
                "description": "Set readthrough stop codon",
                "methodName": "setReadthroughStopCodon",
-               "jsondocId": "cd45f655-239f-4af7-9263-ae7b90595180",
+               "jsondocId": "cb4628cf-4b11-44f9-bb0a-17a15c65bc3c",
                "bodyobject": {
-                  "jsondocId": "b026bb8e-3da5-428d-b61f-562b5db82920",
+                  "jsondocId": "02748088-3a6d-47c5-97e2-a4d50e36b6cf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1920,7 +1993,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setReadthroughStopCodon",
                "response": {
-                  "jsondocId": "c93daf33-7b5b-4523-a82f-652dc510d9c0",
+                  "jsondocId": "b21167fa-a230-4436-bf04-1ecd015177df",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1933,7 +2006,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5e9ffd34-437b-4437-a2d3-725f65638a90",
+                     "jsondocId": "6046c8d5-400b-459d-bae8-792d9ecbfe46",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1942,7 +2015,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "861dbfd5-ab5d-4099-9fb0-c5697b22290d",
+                     "jsondocId": "0fe04942-f362-4563-8388-93092c6999b3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1951,7 +2024,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "411b3de9-61bb-44be-95d1-e3bca4effa9f",
+                     "jsondocId": "a44f988c-1be9-466d-94f7-3992ced250cc",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1960,7 +2033,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b46e92f0-733f-4139-9718-0b0c7df866f2",
+                     "jsondocId": "ecbe07d3-0683-43e5-829d-6424436ccdb4",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1969,7 +2042,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e0a4c1b-7144-4c6c-862f-f49fbe9464de",
+                     "jsondocId": "4bc15e09-231c-4858-b3ba-a6a5882fb796",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
@@ -1981,9 +2054,9 @@
                "verb": "POST",
                "description": "Add sequence alteration",
                "methodName": "addSequenceAlteration",
-               "jsondocId": "f6dcfad1-02eb-4430-a21c-10babc714078",
+               "jsondocId": "6b4f1796-0d1c-4359-a6a1-63aa7a06241b",
                "bodyobject": {
-                  "jsondocId": "e0fd9ad3-491b-4e61-aa3f-b6a85b18ed47",
+                  "jsondocId": "df00cf0c-d0a1-4655-aa24-b11b7481b187",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1993,7 +2066,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addSequenceAlteration",
                "response": {
-                  "jsondocId": "486adad7-8973-4a73-9c48-7c2d2825c5a9",
+                  "jsondocId": "98fd7398-5f25-4602-b949-c3d56d905b7a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2006,7 +2079,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a4fca677-f5d8-4506-9397-4baf31e3d047",
+                     "jsondocId": "786c83ab-2753-4e3c-aa3e-e9e30d97b278",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2015,7 +2088,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "252983e8-b7cc-4f96-9f8e-4570f04ac267",
+                     "jsondocId": "e1488a74-b96c-49d7-a3e3-2b218ff5f62e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2024,7 +2097,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "13316a69-fe4b-427c-b763-e8eef104b330",
+                     "jsondocId": "81a87626-0499-47ce-8176-87f4942c608b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2033,7 +2106,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9f1c2280-55b3-48e4-a9a5-b28043d49067",
+                     "jsondocId": "6340fa0b-c23b-4016-b6ea-be1a208ba88c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2042,7 +2115,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fa1889dd-300d-4609-be81-da4ecc4eea41",
+                     "jsondocId": "7b44260f-4b44-463d-ae96-466b338e9d92",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
@@ -2054,9 +2127,9 @@
                "verb": "POST",
                "description": "Delete sequence alteration",
                "methodName": "deleteSequenceAlteration",
-               "jsondocId": "82b22930-9ddf-45f0-9f2e-761b1eb4db3a",
+               "jsondocId": "a9b6cbc1-4770-4ffa-b4b8-430b4295a996",
                "bodyobject": {
-                  "jsondocId": "4f3ed150-e782-40f0-813e-ccfcb0946380",
+                  "jsondocId": "3494fa2b-e52a-4d8a-8a20-d0c42eb00a99",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2066,7 +2139,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteSequenceAlteration",
                "response": {
-                  "jsondocId": "f719b2a0-6755-4e3e-a0db-4fd8e655dd9a",
+                  "jsondocId": "5e101cdb-9822-4b03-81a1-b49aebd85f29",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2079,7 +2152,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1df2ab29-a367-4830-8659-620db0fe8457",
+                     "jsondocId": "0df58e25-2c28-411e-b53c-38054a4eaf9d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2088,7 +2161,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8045ade5-72ac-4a72-8957-1ff8e2ce85d9",
+                     "jsondocId": "c4640392-c458-4db2-b89e-6fce67303294",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2097,7 +2170,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "99fe7c48-a448-4f22-8923-ef7fc2f9d521",
+                     "jsondocId": "0f710948-b957-419a-8a8e-fbcf7be23350",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2106,7 +2179,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4a3b2a9c-7211-45cd-bf99-2324af1163b0",
+                     "jsondocId": "e7543ec2-572b-4fa4-890a-92e24e9c2a91",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2115,7 +2188,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4abe85c5-9208-4a03-bc3b-612c96b05049",
+                     "jsondocId": "b7a711cb-bd2d-4763-adf5-142ca443892c",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
@@ -2127,9 +2200,9 @@
                "verb": "POST",
                "description": "Flip strand",
                "methodName": "flipStrand",
-               "jsondocId": "766da149-9b6f-4492-8a15-7d8fc455428a",
+               "jsondocId": "1e4a775f-79ba-4e9c-842b-addca7d11851",
                "bodyobject": {
-                  "jsondocId": "f152f079-768d-4d2d-a6c3-30e398293c92",
+                  "jsondocId": "0735ba0a-d750-462b-b432-15dcb4cb04e8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2139,7 +2212,7 @@
                "apierrors": [],
                "path": "/annotationEditor/flipStrand",
                "response": {
-                  "jsondocId": "736d1784-0fc6-4a28-ac4c-a6e037b3f803",
+                  "jsondocId": "b1a7b4c2-f4c5-460b-b077-72d03a830d11",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2152,7 +2225,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7c1ce27f-6775-457a-895c-1ac15f80dc90",
+                     "jsondocId": "cfed2130-70ed-4f2b-a21d-3e1a99ba37bc",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2161,7 +2234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65f7da68-8996-42eb-93a2-47c5314ec7a3",
+                     "jsondocId": "342c19b7-623b-41c3-a572-9f3cb13b0c9f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2170,7 +2243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0b030f8b-0f85-41d2-b19f-5d435a3fb24e",
+                     "jsondocId": "86b57f28-9867-4a31-adbb-15f0a55089f2",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2179,7 +2252,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "978b8778-7280-49b5-b083-e1f1c64fd379",
+                     "jsondocId": "6ae82f78-ee4c-456a-9bcd-c50ae66ae49c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2188,7 +2261,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "748fe7e8-76a3-48fe-97ed-5702aea8fe8b",
+                     "jsondocId": "d69dd6f6-b8bd-48fe-b80a-4847c88b5298",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
@@ -2200,9 +2273,9 @@
                "verb": "POST",
                "description": "Merge exons",
                "methodName": "mergeExons",
-               "jsondocId": "b8859b0f-ff36-4e8e-ae25-9d980f892482",
+               "jsondocId": "a976b66a-a49d-4949-a470-89b44e0b2895",
                "bodyobject": {
-                  "jsondocId": "938b0f86-a869-4af3-8e06-1fdb39dd5e4d",
+                  "jsondocId": "a72df1bd-ea8c-45d9-88fa-c7b994a5372d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2212,7 +2285,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeExons",
                "response": {
-                  "jsondocId": "53028212-b8e1-40ff-b9e7-62be06f21717",
+                  "jsondocId": "b251ac86-90d6-4c69-a835-b5b71968fc2a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2225,7 +2298,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "311dad7a-8577-4319-a8c0-a373867328fb",
+                     "jsondocId": "9cfa29d7-6ba8-4065-951f-a112b67c70e0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2234,7 +2307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "af814240-8327-44ee-b650-2827b9bacfcd",
+                     "jsondocId": "1d5f48cb-b775-4d8d-91c1-562d46ffea93",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2243,7 +2316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "61caa6a8-d015-415a-acbb-798b6630048f",
+                     "jsondocId": "fe2f6e53-3bb7-45da-aafc-d4d8dea2ec90",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2252,7 +2325,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e45d799e-0faf-4479-b601-f1bb86b7f491",
+                     "jsondocId": "1ccce7c2-28bf-400d-af6c-4f6077873d5b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2261,7 +2334,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d71bbde6-4a18-4798-9670-7cc4b899fd52",
+                     "jsondocId": "7b8e198f-fd36-4aa2-b095-daebb7fd8691",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -2273,9 +2346,9 @@
                "verb": "POST",
                "description": "Split exons",
                "methodName": "splitExon",
-               "jsondocId": "c0af1eae-146d-4168-8366-9e4d13403fcd",
+               "jsondocId": "200ceebe-b9b0-44d8-b13a-d92d49e26e0e",
                "bodyobject": {
-                  "jsondocId": "c6aa0218-741f-4762-8625-aeb82ab03861",
+                  "jsondocId": "7be6b639-54ac-408d-968f-479242bebe58",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2285,7 +2358,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitExon",
                "response": {
-                  "jsondocId": "ce4669e4-14d4-49c7-bf23-6119ca2f9e17",
+                  "jsondocId": "66309d41-b93b-4068-805e-c87f40e72186",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2298,7 +2371,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3fa47652-57fe-4577-a0e3-2a2cf9747640",
+                     "jsondocId": "26621cb6-d216-4858-bdae-ad7c5899b93f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2307,7 +2380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a7a4cba4-5071-450a-8209-eebe62aee7d6",
+                     "jsondocId": "acd23253-e986-4958-8836-f984985de0a0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2316,7 +2389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e50fe57b-3101-460d-8a08-c05ce1f3cb80",
+                     "jsondocId": "920c1aeb-b233-4d67-883d-0a1e1af095f1",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2325,7 +2398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3ecabba1-301b-4afa-b730-fdea8cc043f3",
+                     "jsondocId": "e187108d-77c3-47db-ba31-7a678478b20f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2334,7 +2407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c31bcb26-37c1-4113-a7d5-7d61db8ac855",
+                     "jsondocId": "30be5fe8-d74f-40cb-9f3b-eed580ac740a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
@@ -2346,9 +2419,9 @@
                "verb": "POST",
                "description": "Delete feature",
                "methodName": "deleteFeature",
-               "jsondocId": "65ec241b-0cb3-4f3c-81d8-ce845d293827",
+               "jsondocId": "d4094dc2-db3f-43e2-b28c-4be663cf6568",
                "bodyobject": {
-                  "jsondocId": "165107a5-b9eb-43e5-8e69-2d151db04e25",
+                  "jsondocId": "1f84f06c-d3d0-422f-8b0b-17797edd1ba1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2358,7 +2431,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeature",
                "response": {
-                  "jsondocId": "a28b0103-ed65-43cb-935e-5c285dd37cb3",
+                  "jsondocId": "bfd8c852-ed32-4a4b-9cc4-87edfe67348d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2371,7 +2444,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2d2febae-1493-44fd-b26d-5d3585de42f7",
+                     "jsondocId": "45a6c983-ac53-4e4c-b97c-0c3a45a172e6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2380,7 +2453,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ffcabff6-64ef-4e9b-9eb9-fe0bcf3234b1",
+                     "jsondocId": "d22d228c-c2c0-428d-8fe9-23df9e8a5a85",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2389,7 +2462,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8c85bea8-adfd-4386-a7ff-373796514df6",
+                     "jsondocId": "aa177b12-b948-4b28-a86f-ab9062c19678",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2398,7 +2471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "06a741eb-8be0-4495-8f2d-88e0c87608ed",
+                     "jsondocId": "b9294ad9-081e-47b2-8886-7969b2e173fa",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2407,7 +2480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a5ede7db-41e2-4e4d-b4b1-d52153e5d694",
+                     "jsondocId": "c93fb5c5-7383-4d7d-a701-eb2f6e3e60f5",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
@@ -2419,9 +2492,9 @@
                "verb": "POST",
                "description": "Delete exons",
                "methodName": "deleteExon",
-               "jsondocId": "369728f9-9556-411e-8ab7-c65d50d859f8",
+               "jsondocId": "2d00d612-916d-4909-8968-8145a1750d32",
                "bodyobject": {
-                  "jsondocId": "a1a6c24a-d447-4fda-b8ae-f003f8d44184",
+                  "jsondocId": "4cd4f283-34a9-41a8-9207-c3024558231e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2431,7 +2504,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteExon",
                "response": {
-                  "jsondocId": "620d29cb-b8cd-4ec5-ad6d-535efd0ae38d",
+                  "jsondocId": "05db90a5-bec9-4f6b-8424-0efce705cf8c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2444,7 +2517,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9b6ef5e9-c8fe-4bbf-97d4-10cd46eaaf2b",
+                     "jsondocId": "85d2c01b-b85e-44e4-8051-3c29413b4415",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2453,7 +2526,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "16d58823-57ce-4231-9579-c21c4948bdca",
+                     "jsondocId": "f85c5da4-a611-44bf-b752-95c167957bdc",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2462,7 +2535,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d27eff1-e4f4-4808-b93e-f67f5fb9becb",
+                     "jsondocId": "da2d3b0e-6325-417f-b488-714ef7cb6f03",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2471,7 +2544,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bc6564b9-01ef-4059-b591-9e2ee080bee4",
+                     "jsondocId": "fc0e7cec-f439-454e-961d-bc134375a629",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2480,7 +2553,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c887344-38ab-4f42-9753-4e5260431fe5",
+                     "jsondocId": "47a126d1-5350-4097-93d9-6a77346e12a3",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -2492,9 +2565,9 @@
                "verb": "POST",
                "description": "Make intron",
                "methodName": "makeIntron",
-               "jsondocId": "d12c7f2b-99c5-4a69-ba42-46ab8279a1e6",
+               "jsondocId": "94854c7c-9442-409b-a645-0bea7a6bb508",
                "bodyobject": {
-                  "jsondocId": "6c237fa0-df8a-44bd-8723-d47ced9e9309",
+                  "jsondocId": "e2cac9ba-e100-4952-9fe9-ae384eb8470a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2504,7 +2577,7 @@
                "apierrors": [],
                "path": "/annotationEditor/makeIntron",
                "response": {
-                  "jsondocId": "d30162ae-a5ba-4ac3-be98-a3c71d7b5f75",
+                  "jsondocId": "5db87690-12bb-46d0-b7b4-053d9dac340a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2517,7 +2590,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ad18bc7d-e011-4448-bbd2-8ec551be5d15",
+                     "jsondocId": "8c8fc79d-3a3b-4029-903b-319b9825c69d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2526,7 +2599,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ed1eeaae-f9d8-4578-8e82-38eea8072816",
+                     "jsondocId": "049f73ac-44ca-438b-acfd-4905677ab464",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2535,7 +2608,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4c3ff007-a3a8-4491-a12e-c5c83c95af84",
+                     "jsondocId": "457d2f92-f0b5-468c-8cd5-3d76e1864030",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2544,7 +2617,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "919d8ed6-90d4-45fb-87f7-0605371c5c2b",
+                     "jsondocId": "469216f8-a173-4773-8506-55b62830f5bf",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2553,7 +2626,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9d9a4f22-7089-47e7-be79-d94f403cb9e8",
+                     "jsondocId": "ed2513ed-8a5f-4c7a-bbd0-d237de037fd2",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2565,9 +2638,9 @@
                "verb": "POST",
                "description": "Split transcript",
                "methodName": "splitTranscript",
-               "jsondocId": "6401165a-e3ac-445c-927d-0ed4bb807441",
+               "jsondocId": "da1015c9-d67a-4350-ac76-f943d1512152",
                "bodyobject": {
-                  "jsondocId": "6fbc733f-9344-489f-8d1e-5db6492c27a5",
+                  "jsondocId": "e4244f5e-266b-452c-afd3-1e86af1706e2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2577,7 +2650,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitTranscript",
                "response": {
-                  "jsondocId": "9061c43f-8e39-4189-814f-fbe006147939",
+                  "jsondocId": "ca5c8cd2-3161-4f59-9f0b-1778c710f95a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2590,7 +2663,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "bfa7e7af-7492-477d-9a8d-2b35673c1001",
+                     "jsondocId": "ee755a51-7846-4fb2-ab8b-7e3d257e060e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2599,7 +2672,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c3155bd5-6ba8-4ff8-97c5-317f861f6be4",
+                     "jsondocId": "41c6cf09-8a5c-4939-85f4-a6bb5882db2b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2608,7 +2681,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "51fd7d96-0016-4ac6-8d44-00ee96cb2908",
+                     "jsondocId": "99fdf6a2-cd43-4179-96c7-165e2c3c9f2c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2617,7 +2690,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f5521627-0524-48e1-bf69-99dfb12b1bed",
+                     "jsondocId": "d3ecc37e-6602-4246-858c-c75abaebfdef",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2626,7 +2699,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e952590d-12c3-49d0-9573-3357655d9313",
+                     "jsondocId": "30bc0458-96fc-4faf-a0da-d81df6d4ccb2",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2638,9 +2711,9 @@
                "verb": "POST",
                "description": "Merge transcripts",
                "methodName": "mergeTranscripts",
-               "jsondocId": "1e9b4c1b-d51b-44aa-97b7-5c0e5c2ee99d",
+               "jsondocId": "b413ee0e-3f87-40bc-80e5-698066b97e26",
                "bodyobject": {
-                  "jsondocId": "7aeadc93-f299-4a6f-96be-cad15d0c8969",
+                  "jsondocId": "3c577cdb-77cc-4009-9ae6-a4f47158e961",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2650,7 +2723,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeTranscripts",
                "response": {
-                  "jsondocId": "d2f9c4a2-67ac-4303-abb3-04329a142796",
+                  "jsondocId": "5afa4c3b-11f4-4165-8c59-5f15fc012fa7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2663,7 +2736,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "891d02b8-9ae3-49cc-ae1a-b08a743f18e1",
+                     "jsondocId": "b42f4d3e-9189-4705-af1f-bb12b031edd6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2672,7 +2745,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3b0cfa52-151b-4830-a636-d02a6280d9e0",
+                     "jsondocId": "1b7519f2-e87a-4bc3-994f-d64206a24500",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2681,7 +2754,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7f6b53a2-dc25-4bba-ac96-20720c58b3e3",
+                     "jsondocId": "5c67c690-62db-479b-bb54-a7a5ebb330ca",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2690,7 +2763,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "15ee632e-1ecd-4828-9111-2e4d094900f6",
+                     "jsondocId": "8bc49ce9-2c9c-41b6-9315-397a80407ce1",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2699,7 +2772,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eafaecab-373a-4f77-aa47-cd764f8fe804",
+                     "jsondocId": "4d24f13c-12a3-438d-8268-1c9c52f3fd77",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2711,9 +2784,9 @@
                "verb": "POST",
                "description": "Get sequences for features",
                "methodName": "getSequence",
-               "jsondocId": "fbff734b-e6d4-43b0-9cc5-e84cace4f822",
+               "jsondocId": "ce27ecff-a079-48e0-804d-01baccc5f9fd",
                "bodyobject": {
-                  "jsondocId": "af98e71e-8927-4549-a900-6133beab4ef9",
+                  "jsondocId": "21164eaf-2e8a-457e-bab5-815e802749f4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2723,7 +2796,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequences",
                "response": {
-                  "jsondocId": "c9f39958-505e-4ae7-b161-a7dfafac6c2b",
+                  "jsondocId": "2c909941-c366-4656-b23f-33de5bda6986",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2732,7 +2805,7 @@
                "consumes": ["application/json"]
             },
             {
-               "jsondocId": "423764ef-ec87-4b60-b6df-3e2fe7326c19",
+               "jsondocId": "b0d0ecab-8896-4d70-bb6c-10c89b85ac9d",
                "bodyobject": null,
                "apierrors": [],
                "path": "/annotationEditor/getSequenceSearchTools",
@@ -2740,7 +2813,7 @@
                "pathparameters": [],
                "queryparameters": [],
                "response": {
-                  "jsondocId": "d1c02ae9-efb1-424c-baec-8dd2d7d8632e",
+                  "jsondocId": "c3184718-1eef-4c48-8815-81e82480c094",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2755,7 +2828,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "57a3d8eb-c42c-4438-a020-758f7c751ec5",
+                     "jsondocId": "db863145-3e6b-4630-8574-e80274ece070",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2764,7 +2837,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "af0e8063-0713-4a39-a20d-069884ac26c2",
+                     "jsondocId": "2d7b496a-8a96-4342-8393-e079bfe53a2b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2776,9 +2849,9 @@
                "verb": "POST",
                "description": "Get canned comments",
                "methodName": "getCannedComments",
-               "jsondocId": "ce86fdf1-c655-458d-ba34-254e40d0292f",
+               "jsondocId": "571fefa0-ee8b-45c1-a6d9-61158fb05aa8",
                "bodyobject": {
-                  "jsondocId": "32c3cd19-940c-418c-8c80-ef6dc0e23ef6",
+                  "jsondocId": "83caa196-4203-4493-ba4f-15ba36e5fede",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2788,7 +2861,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getCannedComments",
                "response": {
-                  "jsondocId": "ba8db414-e556-454b-a63b-88fc3be409f4",
+                  "jsondocId": "b8a69562-9e00-4a5d-ba10-d7bbf6ac0e0b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2801,7 +2874,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9380ab7c-f03e-482a-99b4-9cbb5700ece7",
+                     "jsondocId": "2e04bbe7-35b2-4a0d-a8ca-b7f663ad7a1a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2810,7 +2883,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e838886e-bbcd-4cd8-b586-3e94a24cc772",
+                     "jsondocId": "d6a404b9-61de-4297-b1a1-eedbc7f03ca4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2819,7 +2892,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9e320086-4985-4a21-bb2b-13b52b77484e",
+                     "jsondocId": "a3e7be2b-97de-4d3b-a6be-1352cfd0de5b",
                      "name": "client_token",
                      "format": "",
                      "description": "Organism ID/Name or Client-generated ",
@@ -2828,7 +2901,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0e987635-4d24-4847-8220-330a78e69f9e",
+                     "jsondocId": "928634ab-7a2e-416b-bc78-6d1b68cb8254",
                      "name": "search",
                      "format": "",
                      "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
@@ -2840,9 +2913,9 @@
                "verb": "POST",
                "description": "Search sequences",
                "methodName": "searchSequence",
-               "jsondocId": "e0591e6b-2029-400c-8964-6678f3af8260",
+               "jsondocId": "790abeb8-b272-4270-b6cb-6dbd87a382e2",
                "bodyobject": {
-                  "jsondocId": "05d10fbd-c5db-4205-9a4e-81ed8381d40c",
+                  "jsondocId": "eae4ae45-3966-406c-b38a-84013932c0f4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2852,7 +2925,7 @@
                "apierrors": [],
                "path": "/annotationEditor/searchSequences",
                "response": {
-                  "jsondocId": "dc653cb3-6c37-4984-89d0-d4c78d1edce5",
+                  "jsondocId": "f53442c9-edd6-49d9-892e-40d884ab4220",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2865,7 +2938,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2b4b2f1a-f75c-4c64-9e20-c2b0d77ae24c",
+                     "jsondocId": "980d90ae-3fc0-48c2-8f46-01f55bdd138f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2874,7 +2947,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b75e614b-3777-4bf1-8e68-5ffb4f3fecb9",
+                     "jsondocId": "83792c7f-5974-401b-a1e0-b639e04406e8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2883,7 +2956,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "25b5906d-ab52-4837-a450-cff93f6e5484",
+                     "jsondocId": "2773d4b8-2913-4826-9e58-8817dfdb67be",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2895,9 +2968,9 @@
                "verb": "POST",
                "description": "Get gff3",
                "methodName": "getGff3",
-               "jsondocId": "63529db0-463a-47d1-b3f2-bcf9d492e1eb",
+               "jsondocId": "4055a5c2-748c-472e-b70b-658f11e60e51",
                "bodyobject": {
-                  "jsondocId": "b74484b0-b4e2-4f92-b00f-8d8a6d2503df",
+                  "jsondocId": "4b4ad584-5508-49be-9e15-fdfba5ec965e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2907,80 +2980,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getGff3",
                "response": {
-                  "jsondocId": "c36c2032-2f3a-43a5-a472-55b1d9481100",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "2637909a-213f-4f3a-87fb-baf336ee8f2b",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "304e56d4-6402-4aa4-b646-aec065fb3780",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d58081ec-99f5-4ab7-82c9-b9cf588f5e25",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "88423477-2526-4eaa-bccd-32d25f228875",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b6ff87e7-1144-4aa6-a7eb-94f4ebe4ca7c",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set symbol of a feature",
-               "methodName": "setSymbol",
-               "jsondocId": "57e08d81-072a-4681-b84a-742c4b0f893b",
-               "bodyobject": {
-                  "jsondocId": "dc947d72-ca86-4d05-8cc9-c9237810bf9e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setSymbol",
-               "response": {
-                  "jsondocId": "3cc0a005-8720-4b57-979e-027386e2a94a",
+                  "jsondocId": "e1752295-62aa-4305-9d27-1d2d3ad73214",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2993,14 +2993,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "bc6c66e1-bdd5-481f-b50d-2346f791a8fa",
+         "jsondocId": "7f697e1a-306b-45f8-b0e9-5e86b0adb725",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7f54d126-ec79-4ad2-aff9-dbc1668ad644",
+                     "jsondocId": "2633efe0-421c-41d1-84b8-417d71641e43",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3009,7 +3009,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d0dfaa86-7802-4b57-a8b3-4e4f5475e703",
+                     "jsondocId": "01e7b737-3fde-464f-a8c8-5660cf619d5e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3018,7 +3018,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4319b54b-b7b4-4de1-8284-faee4ba87546",
+                     "jsondocId": "ee3ba37b-edc0-4701-9802-2e94c06d8fc9",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to update (or specify the old_value)",
@@ -3027,7 +3027,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "960da2af-412b-48ed-9b29-708bcc1c8ce2",
+                     "jsondocId": "27377385-a01b-4b67-9d34-e51d13535fd6",
                      "name": "old_value",
                      "format": "",
                      "description": "Status name to update",
@@ -3036,7 +3036,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d51d30d5-7631-4b67-b12b-c3216396e3fc",
+                     "jsondocId": "af4edb7a-2050-406d-bbd1-819e2f93bd81",
                      "name": "new_value",
                      "format": "",
                      "description": "Status name to change to (the only editable option)",
@@ -3048,9 +3048,9 @@
                "verb": "POST",
                "description": "Update status",
                "methodName": "updateStatus",
-               "jsondocId": "a18eae3e-2c4b-451a-9a31-21a1eb00d7d5",
+               "jsondocId": "107bc7bd-d7ed-485b-882c-f1fdfc531813",
                "bodyobject": {
-                  "jsondocId": "d1db77d4-ed02-4d2a-97c9-344ec80bbe95",
+                  "jsondocId": "1444cd90-37c8-45cd-aa76-a0d7e349bc07",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3060,7 +3060,7 @@
                "apierrors": [],
                "path": "/availableStatus/updateStatus",
                "response": {
-                  "jsondocId": "4a403def-7a56-4464-81cc-fe85b0cdfd67",
+                  "jsondocId": "dcf5b026-9cdd-4499-8cfc-07edc60a5fc4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3073,7 +3073,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a04605be-6f3a-484a-9d2f-9b17786a8ac0",
+                     "jsondocId": "602ef494-11d1-4c03-9a85-6550680be86a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3082,7 +3082,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9abc237a-9f2b-49be-a2e4-34f203ab39f8",
+                     "jsondocId": "9020fbbc-e7ed-4412-9052-dd15af102d2c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3091,7 +3091,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5ad287ea-5ea7-4cb5-bd45-1744f2e934f2",
+                     "jsondocId": "a70a3462-46d0-4d09-86c5-034a8fa07c08",
                      "name": "value",
                      "format": "",
                      "description": "Status name to add",
@@ -3103,9 +3103,9 @@
                "verb": "POST",
                "description": "Create status",
                "methodName": "createStatus",
-               "jsondocId": "fa67c211-cf57-4cc4-be5c-08ab13a0e696",
+               "jsondocId": "e11b7685-2285-439c-9271-5cc586240dd8",
                "bodyobject": {
-                  "jsondocId": "2e30d2a0-52b2-4b80-b870-8595c44d0402",
+                  "jsondocId": "b6682704-bd97-4309-8cec-819f69ac5032",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3115,7 +3115,7 @@
                "apierrors": [],
                "path": "/availableStatus/createStatus",
                "response": {
-                  "jsondocId": "0969f5ae-461e-4408-8fb1-f7579e9fe07d",
+                  "jsondocId": "e62adc40-2002-47cd-b3d7-6625b8c56a88",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3128,7 +3128,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "da2fe6fd-8c6c-4016-a2b1-df3185d4383f",
+                     "jsondocId": "3718e1ec-d1e4-4f19-8db8-998d7bc36225",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3137,7 +3137,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cf188015-0c7f-4bf3-9562-70b073f5fcd9",
+                     "jsondocId": "963e50f1-d4ac-4652-a6ea-37832bf171e3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3146,7 +3146,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "95273abf-ed2e-45a4-b2e6-225d92cb79fb",
+                     "jsondocId": "7c6c2b9e-fcc8-4a41-a7bb-a36299a544a0",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to remove (or specify the name)",
@@ -3155,7 +3155,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a4a1bd0f-3846-4ab2-b334-9b47d16cfdfa",
+                     "jsondocId": "87ab0b32-e185-4c79-8ecd-3d4277d8df6c",
                      "name": "value",
                      "format": "",
                      "description": "Status name to delete",
@@ -3167,9 +3167,9 @@
                "verb": "POST",
                "description": "Remove a status",
                "methodName": "deleteStatus",
-               "jsondocId": "251b4e4f-3063-4273-b72e-cec0aa4f2b89",
+               "jsondocId": "682bbb20-b110-4930-8d52-82ddd39490d2",
                "bodyobject": {
-                  "jsondocId": "a0402469-b135-4cae-814f-62620c97f162",
+                  "jsondocId": "c95fec28-12b9-4c69-af0d-badadc9d91c4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3179,7 +3179,7 @@
                "apierrors": [],
                "path": "/availableStatus/deleteStatus",
                "response": {
-                  "jsondocId": "2921ac9d-7c1a-4a50-a8a7-bda85588cbd7",
+                  "jsondocId": "5282d0e2-0025-4ed6-864b-8504291f6a10",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3192,7 +3192,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ac0e36ea-8461-4306-82f8-c9821b6580e3",
+                     "jsondocId": "eb671b1a-4e5b-4d0c-b998-997fcb8fb203",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3201,7 +3201,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a232c282-aef5-4240-8977-6c6de53bc86f",
+                     "jsondocId": "8da194a6-5c83-48b9-b2e9-2ed5ee3ad1cb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3210,7 +3210,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2be98c30-f91e-406e-9ea1-270446e9d80b",
+                     "jsondocId": "aacc7e8e-be20-4a79-b382-44bc20dc4fe6",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to show (or specify a name)",
@@ -3219,7 +3219,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2013f9f2-6b5a-4f31-81fd-e70378286c1c",
+                     "jsondocId": "0fa4edf3-de6a-423e-96b7-fdd9ff098459",
                      "name": "name",
                      "format": "",
                      "description": "Status name to show",
@@ -3231,9 +3231,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all statuses, or optionally, gets information about a specific status",
                "methodName": "showStatus",
-               "jsondocId": "78d43800-9f97-4862-80e2-b95952815cef",
+               "jsondocId": "f2a88a28-9327-43d8-a422-4878b4744f3b",
                "bodyobject": {
-                  "jsondocId": "a7208162-ba4f-45c1-8436-d1e72598f412",
+                  "jsondocId": "0918c9ab-5ffb-4961-85fb-801c5af40061",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3243,7 +3243,7 @@
                "apierrors": [],
                "path": "/availableStatus/showStatus",
                "response": {
-                  "jsondocId": "a1fa6faf-598c-455b-80b1-ccf5363f2bb3",
+                  "jsondocId": "6dcacd78-20c9-4fe4-b9af-5cc97c7dc210",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3256,14 +3256,14 @@
          "description": "Methods for managing available statuses"
       },
       {
-         "jsondocId": "ce5843df-1d52-4c13-a36c-330561bab050",
+         "jsondocId": "8cb3020f-903f-4a42-aaae-ca74ea219021",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "774350ba-9404-471d-a503-00a8e4a46abd",
+                     "jsondocId": "40edc488-bfcc-4697-b92c-926f1f4bdd94",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3272,7 +3272,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5fc6d470-d705-47d8-8429-0abca13cf191",
+                     "jsondocId": "0731af0b-1259-418e-9cef-56b9b7664f69",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3281,7 +3281,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "19853a52-83f4-4935-a5f9-f168e4383db1",
+                     "jsondocId": "11243a53-4471-47b3-9dc0-297c812e06a6",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to add",
@@ -3290,7 +3290,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "61b53454-4d35-489c-92d0-88424f8a87be",
+                     "jsondocId": "a0ba6bc4-0d49-4d7f-b2e6-e232c1a82963",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3302,9 +3302,9 @@
                "verb": "POST",
                "description": "Create canned comment",
                "methodName": "createComment",
-               "jsondocId": "3d13236f-f2fa-40b0-9009-a40540ebcb51",
+               "jsondocId": "4e271b55-e678-4185-b86d-c310a9483089",
                "bodyobject": {
-                  "jsondocId": "a317ea3f-2b37-4ad0-87c9-0e2ebdf6c3d6",
+                  "jsondocId": "3a92542c-9d01-4e1d-8643-6a9e573130bc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3314,7 +3314,7 @@
                "apierrors": [],
                "path": "/cannedComment/createComment",
                "response": {
-                  "jsondocId": "3c037d36-4e0e-4950-b636-10a79b085d4b",
+                  "jsondocId": "becbfa01-f6d2-4864-917c-b0808c569a21",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3327,7 +3327,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c96e879d-cc60-45dd-accd-7c8493d569de",
+                     "jsondocId": "ab22588e-67ff-4115-b6aa-d7031b74d4d7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3336,7 +3336,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6906b24f-fc39-4212-baf5-e6b865205361",
+                     "jsondocId": "39fc08b7-f0be-4d58-a383-e9a877e712e4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3345,7 +3345,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7652f4a-f6f4-4944-b5c4-293a0d3243c4",
+                     "jsondocId": "8c7ad5c1-aa07-41be-819c-2e2ab493de5a",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to update (or specify the old_comment)",
@@ -3354,7 +3354,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b576d820-1287-4a0f-a100-9d6ab2800863",
+                     "jsondocId": "88c92a8f-fca2-4f31-8519-d07b36ce7131",
                      "name": "old_comment",
                      "format": "",
                      "description": "Canned comment to update",
@@ -3363,7 +3363,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4c7716cf-a546-4f6a-8535-3b18be5bc9e9",
+                     "jsondocId": "0f0d5d63-be3a-44f4-9b98-724a669ddba1",
                      "name": "new_comment",
                      "format": "",
                      "description": "Canned comment to change to (the only editable option)",
@@ -3372,7 +3372,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cc2d720e-cd7f-4355-b058-cf6d1ae2b88c",
+                     "jsondocId": "69629952-e604-4593-8b92-beada236f310",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3384,9 +3384,9 @@
                "verb": "POST",
                "description": "Update canned comment",
                "methodName": "updateComment",
-               "jsondocId": "6ce4c60d-44dc-4e13-b557-25f50d850ebc",
+               "jsondocId": "302c342c-d50a-49f5-9cf9-0141e6984963",
                "bodyobject": {
-                  "jsondocId": "7e089117-e504-45e8-a73c-9b335e7b114a",
+                  "jsondocId": "9bdee2d4-4306-4f3f-bfe0-4541d4b86065",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3396,7 +3396,7 @@
                "apierrors": [],
                "path": "/cannedComment/updateComment",
                "response": {
-                  "jsondocId": "dc39a180-bca2-4cd8-ae4d-b1043a62e75a",
+                  "jsondocId": "111203e8-e1c1-47d0-a8dd-2be33548963a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3409,7 +3409,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "820e8524-615f-4dad-99bd-f732be84a354",
+                     "jsondocId": "9e8f890b-314e-4d74-9a51-25d7f8bb3b91",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3418,7 +3418,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "908a49db-bea5-4273-bd63-b3b4a36cd4bf",
+                     "jsondocId": "0b9f05da-dbb7-4ba0-9060-dc02042990b7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3427,7 +3427,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "735e38c3-f26f-4b6e-98b8-e3e2dc498d6a",
+                     "jsondocId": "f226c984-a15e-4a98-bfcc-5bec7cd4bba9",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to remove (or specify the name)",
@@ -3436,7 +3436,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0c47f7b0-b60e-4574-9d80-935e06cbfe92",
+                     "jsondocId": "0abee341-d3f8-4f1f-80cd-4081b7fa94ac",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to delete",
@@ -3448,9 +3448,9 @@
                "verb": "POST",
                "description": "Remove a canned comment",
                "methodName": "deleteComment",
-               "jsondocId": "73649400-67d7-49b9-91f3-2d0925bafe8a",
+               "jsondocId": "982859a1-c311-4be9-adfe-af60f82dfc88",
                "bodyobject": {
-                  "jsondocId": "62393e3a-3908-40e6-b0d5-9371770fceca",
+                  "jsondocId": "2f9852cd-336a-4246-bbba-1de4bc72aeef",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3460,7 +3460,7 @@
                "apierrors": [],
                "path": "/cannedComment/deleteComment",
                "response": {
-                  "jsondocId": "ce223e0b-99a8-4530-bef5-97de04fb3fd1",
+                  "jsondocId": "c4f2425b-2927-49a5-8f60-f4d034d867bb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3473,7 +3473,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9fe6242c-2909-491d-9d6d-a71554e2f230",
+                     "jsondocId": "98283b9f-9909-46f1-b0cd-5dd05716a696",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3482,7 +3482,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ca6f6839-bcf8-4e98-81ee-39b4878f0d11",
+                     "jsondocId": "93e956e6-2e8e-43df-a311-498c98e540b5",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3491,7 +3491,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "141f6375-7586-42cc-a2c2-de392b037723",
+                     "jsondocId": "ed747e94-97b4-46ec-910c-a60a6c45a1d5",
                      "name": "id",
                      "format": "",
                      "description": "Comment ID to show (or specify a comment)",
@@ -3500,7 +3500,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b33a14bc-e457-4f39-84ce-00514330bdc2",
+                     "jsondocId": "834bc9ff-b72d-46ed-93ad-9c8234609947",
                      "name": "comment",
                      "format": "",
                      "description": "Comment to show",
@@ -3512,9 +3512,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned comments, or optionally, gets information about a specific canned comment",
                "methodName": "showComment",
-               "jsondocId": "f0e353e4-a113-42bc-8f7e-2f8a4d708ba6",
+               "jsondocId": "355049cd-b35c-443b-a421-a87c81d710eb",
                "bodyobject": {
-                  "jsondocId": "7affd618-0d55-4081-8646-e166ccd1b222",
+                  "jsondocId": "aa6f615c-adc2-445a-8312-939832166b42",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3524,7 +3524,7 @@
                "apierrors": [],
                "path": "/cannedComment/showComment",
                "response": {
-                  "jsondocId": "d19d2c7a-b1dd-4a61-88d2-002cc7035571",
+                  "jsondocId": "7a8f1ebc-a679-4ec6-9e02-c8f2ef3f3cac",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3537,14 +3537,14 @@
          "description": "Methods for managing canned comments"
       },
       {
-         "jsondocId": "fdaf3d1d-7511-46a5-a5cd-c7adc02e88e0",
+         "jsondocId": "3390e4f9-27ab-4eee-b992-acb6701469dc",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "385113a6-ada0-47d5-8404-96d0d7a9ec5b",
+                     "jsondocId": "360f6e11-2389-4bb7-bf04-37e80ebf6dc8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3553,7 +3553,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d40ed63b-eec1-477b-ab11-a5909bb3deed",
+                     "jsondocId": "6b365007-a693-4d16-8e0b-1e117e37e20c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3562,7 +3562,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "92cc2f40-a769-4f22-b97f-9027f632fec4",
+                     "jsondocId": "52e0a57a-6d7f-4242-b15e-6233a4a2652b",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to update (or specify the old_key)",
@@ -3571,7 +3571,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2748acad-0c3f-45cd-98db-dda84c167a53",
+                     "jsondocId": "3f239f88-253e-4486-a733-83d61b63b75e",
                      "name": "old_key",
                      "format": "",
                      "description": "Canned key to update",
@@ -3580,7 +3580,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0b3dcd1b-f35c-4ac0-916d-458db55f8fbd",
+                     "jsondocId": "60aecf19-7ba9-4d3a-82d7-d9fbd32b578e",
                      "name": "new_key",
                      "format": "",
                      "description": "Canned key to change to (the only editable option)",
@@ -3589,7 +3589,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b7470d71-fff8-4ed6-a15d-38e8158ef631",
+                     "jsondocId": "911e16df-9482-49f8-9291-42bee9689261",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3601,9 +3601,9 @@
                "verb": "POST",
                "description": "Update canned key",
                "methodName": "updateKey",
-               "jsondocId": "fe600b26-efc9-4092-9d98-7ef88f721d82",
+               "jsondocId": "d0d05f3b-3beb-40b2-86c7-1a1772339d4a",
                "bodyobject": {
-                  "jsondocId": "75631181-a657-4d2c-a637-65e50db1c471",
+                  "jsondocId": "244fec44-9b72-4944-af5e-b6be1520f63e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3613,7 +3613,7 @@
                "apierrors": [],
                "path": "/cannedKey/updateKey",
                "response": {
-                  "jsondocId": "b53ee2a2-9a45-45a9-af3e-1c6a656f721b",
+                  "jsondocId": "eb85eed9-7c84-4c08-af88-460bdf64c459",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3626,7 +3626,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "50e42a5e-550e-4dd5-95bb-4a8fa84ffb8f",
+                     "jsondocId": "149ae78e-5aa8-4126-8f78-717929e401ac",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3635,7 +3635,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5bc701f4-9e76-4078-b396-69e35d87d94f",
+                     "jsondocId": "4715362d-1139-408b-a4b5-699029c4322c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3644,7 +3644,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45404fa5-2517-46e0-a88a-ab26475945d2",
+                     "jsondocId": "ffb68457-0e05-4484-bc8f-5698d609e44d",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to add",
@@ -3653,7 +3653,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5aaad947-b30e-4e49-a796-a6cf4483550e",
+                     "jsondocId": "cf41950f-22b9-42c7-85ce-40fff2ed0233",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3665,9 +3665,9 @@
                "verb": "POST",
                "description": "Create canned key",
                "methodName": "createKey",
-               "jsondocId": "646e6610-a5ca-4cab-b2cf-f6e88cad0d38",
+               "jsondocId": "5de23bea-550b-43d0-aeaf-30f696cf40a5",
                "bodyobject": {
-                  "jsondocId": "ed75c648-8b98-4ede-97ff-d455da6cdd63",
+                  "jsondocId": "074cb707-1766-4e1e-ba76-39de5b50922f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3677,7 +3677,7 @@
                "apierrors": [],
                "path": "/cannedKey/createKey",
                "response": {
-                  "jsondocId": "e2aa78cd-a9fc-4bb4-9fcc-e7361ed16364",
+                  "jsondocId": "37d02f0a-fa30-4ea0-a0c0-d3c1eb885def",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3690,7 +3690,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "316cc233-00e2-43b8-bc88-38b7a66d713a",
+                     "jsondocId": "8c02a40c-ca15-40b6-8165-6647615a30a2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3699,7 +3699,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b698cd8c-9478-4823-8ac6-ddec9b20ac1c",
+                     "jsondocId": "27f187a7-5708-48e3-ab26-f64e4d88e966",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3708,7 +3708,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ca7a7cd-1279-498e-9f4b-0252903f0878",
+                     "jsondocId": "d38cd16e-52d5-450d-ba2c-4514ccf58623",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to remove (or specify the name)",
@@ -3717,7 +3717,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ef80ff50-81d5-4113-8604-25ea91a26020",
+                     "jsondocId": "be2fcebd-7e01-46eb-bf58-ab4d442a6b3e",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to delete",
@@ -3729,9 +3729,9 @@
                "verb": "POST",
                "description": "Remove a canned key",
                "methodName": "deleteKey",
-               "jsondocId": "f03acc94-9f64-4d52-bdf2-469cc583935c",
+               "jsondocId": "3c5b3572-e038-4ce5-a5f7-2a6204e3e138",
                "bodyobject": {
-                  "jsondocId": "c96d5010-260f-4316-a08a-87efcd1981bb",
+                  "jsondocId": "f69bde75-d7f0-4f8f-8c44-98f4f461b2ae",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3741,7 +3741,7 @@
                "apierrors": [],
                "path": "/cannedKey/deleteKey",
                "response": {
-                  "jsondocId": "e3081d75-ed9f-4fe3-a051-89c8545fad59",
+                  "jsondocId": "66fb7080-560e-494d-918e-dc06e1c7b52f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3754,7 +3754,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c7cd0e02-842c-4888-acb2-602aa3b5399a",
+                     "jsondocId": "014381f0-7a0c-41bf-9ac8-781d692620e6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3763,7 +3763,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cd55f924-f9ae-4afb-b055-69ff69173720",
+                     "jsondocId": "a0aebd04-f1d1-4304-a244-9ef450d076aa",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3772,7 +3772,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8bf03a21-6318-43f2-bf6e-6b3ac4ee4fd5",
+                     "jsondocId": "b081ec51-c315-4c68-9f51-b5a12c9dd15b",
                      "name": "id",
                      "format": "",
                      "description": "Key ID to show (or specify a key)",
@@ -3781,7 +3781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9da205a9-45bd-4bb0-895d-3465da69dc90",
+                     "jsondocId": "3d486c87-9d95-4cd1-955d-db52fc186682",
                      "name": "key",
                      "format": "",
                      "description": "Key to show",
@@ -3793,9 +3793,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned keys, or optionally, gets information about a specific canned key",
                "methodName": "showKey",
-               "jsondocId": "e69e484b-57e2-4101-9ee9-3f83f296bfcc",
+               "jsondocId": "fe7d2d60-de99-4a78-87fb-bf1dab1e93b6",
                "bodyobject": {
-                  "jsondocId": "57dbcdc7-23e3-4783-a55a-1b6d0c1adfed",
+                  "jsondocId": "8f477161-0ab8-4b16-b3a6-6fff781cdd7b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3805,7 +3805,7 @@
                "apierrors": [],
                "path": "/cannedKey/showKey",
                "response": {
-                  "jsondocId": "6923f4ed-630a-4386-b9a5-45acab786130",
+                  "jsondocId": "5ac7eb19-1c41-442c-9fd3-babc27089036",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3818,14 +3818,14 @@
          "description": "Methods for managing canned keys"
       },
       {
-         "jsondocId": "9d9fc169-32f0-4a91-8a9a-651174d6beb3",
+         "jsondocId": "9ea50f44-f13b-459a-a813-4e5f4a9a2151",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "75f449c3-7ea0-4fcb-9761-ac0d94d0c111",
+                     "jsondocId": "266a6a38-5ee1-4092-8340-80954a536c00",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3834,7 +3834,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "86dfc2a7-be95-47c7-b771-994d635791f1",
+                     "jsondocId": "edb56fbc-3a2c-4e32-aaff-bd63f1f62a17",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3843,71 +3843,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "36a00b2a-d6b4-41ac-b64c-34712e02f3d0",
-                     "name": "value",
-                     "format": "",
-                     "description": "Canned value to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b0a1fc91-ba93-4f83-b360-8d1de444b4a8",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "Optional additional information",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create canned value",
-               "methodName": "createValue",
-               "jsondocId": "8d39d849-7c82-4c71-a671-3f556be859f0",
-               "bodyobject": {
-                  "jsondocId": "f1749e3f-8868-4b14-a0b7-6b507736d7d0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned value"
-               },
-               "apierrors": [],
-               "path": "/cannedValue/createValue",
-               "response": {
-                  "jsondocId": "c8580e22-e81a-4e3e-90a1-ce59a79e217c",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned value"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "a87463ba-d3ba-420d-8f00-6883734af69d",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5fab7da4-9379-48b2-aebf-fef1a91cfff6",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "503484ff-f9c7-47bb-9cc4-e5a3c0ccc2c1",
+                     "jsondocId": "721fc7bd-bafd-4abc-9fff-c90506156f3f",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to update (or specify the old_value)",
@@ -3916,7 +3852,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b8ad20a9-12fe-4e7e-bd2f-a9450470dcb8",
+                     "jsondocId": "e7f7a643-c111-4fcb-8759-8760cc06e855",
                      "name": "old_value",
                      "format": "",
                      "description": "Canned value to update",
@@ -3925,7 +3861,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "418c9534-44e4-491d-86e9-c5d72c61e8d3",
+                     "jsondocId": "8e433733-07db-4751-8b2c-0347f4fa3af1",
                      "name": "new_value",
                      "format": "",
                      "description": "Canned value to change to (the only editable option)",
@@ -3934,7 +3870,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "208ddeca-b060-44a4-9daf-4b232b54e4e1",
+                     "jsondocId": "d89c5728-f6ac-4a4e-ac4e-b42431cd20cf",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3946,9 +3882,9 @@
                "verb": "POST",
                "description": "Update canned value",
                "methodName": "updateValue",
-               "jsondocId": "a35027e7-10fd-4c06-8029-8820f861edd1",
+               "jsondocId": "a1645949-4a98-43f1-b36c-d99b658ad9fa",
                "bodyobject": {
-                  "jsondocId": "b9472e76-e036-40b6-b89b-be01f01f4fc4",
+                  "jsondocId": "a01b6142-81c0-4951-b0e9-28f5269f814a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3958,7 +3894,7 @@
                "apierrors": [],
                "path": "/cannedValue/updateValue",
                "response": {
-                  "jsondocId": "85c75cfc-7465-46ba-b8dc-3c84a2f87804",
+                  "jsondocId": "4310c968-e4ba-4a62-9ada-552ed4455304",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -3971,7 +3907,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7f600b1f-f5fd-4e47-b3e0-c889783d9fea",
+                     "jsondocId": "4585b956-b20b-48d8-af8b-c8fab2f3935f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3980,7 +3916,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fe74539e-fe70-45af-a49a-65d2802aa834",
+                     "jsondocId": "afa6bade-c0a6-402d-bcc2-8d2dc80428ed",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3989,7 +3925,71 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5c669b5b-f6c8-4ea8-b59e-12251e716632",
+                     "jsondocId": "508fe4bb-9031-42a6-85c7-49090824532d",
+                     "name": "value",
+                     "format": "",
+                     "description": "Canned value to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3f71bb55-e071-463e-ae1a-93e8b95a61ab",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create canned value",
+               "methodName": "createValue",
+               "jsondocId": "25cffabf-8a96-480f-8236-53c58a543f66",
+               "bodyobject": {
+                  "jsondocId": "a7ddf2db-135f-421b-ace4-6f222d355abc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned value"
+               },
+               "apierrors": [],
+               "path": "/cannedValue/createValue",
+               "response": {
+                  "jsondocId": "064ae384-68c9-4b04-9cd0-faf8d046ee81",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned value"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "adaca1e5-ad6a-4025-a5db-5434278e1f6e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "860eebde-fa9d-4c5a-885c-4d22f16e1504",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4943bc6d-14bc-48a6-b34b-6f1d1e170b41",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to remove (or specify the name)",
@@ -3998,7 +3998,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "caa52db9-da91-4fa1-9c22-e809a6cbd05e",
+                     "jsondocId": "d2a31554-4b95-44c2-ace6-b5f603a8ab3b",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to delete",
@@ -4010,9 +4010,9 @@
                "verb": "POST",
                "description": "Remove a canned value",
                "methodName": "deleteValue",
-               "jsondocId": "253fe854-8b3f-4da0-91d8-fdc50dacf5e2",
+               "jsondocId": "737ff189-46f7-4e4b-a37d-d2ec773d3c5d",
                "bodyobject": {
-                  "jsondocId": "d920793f-1ea0-484e-a143-43c0fcd95cfe",
+                  "jsondocId": "c93746d7-b1cd-4603-9309-33a1a2e0193f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4022,7 +4022,7 @@
                "apierrors": [],
                "path": "/cannedValue/deleteValue",
                "response": {
-                  "jsondocId": "2c09114e-fddf-40d5-a027-6dbc26d64309",
+                  "jsondocId": "dfc1e38a-30cf-4e73-8d9e-a6a3ac51d0b6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4035,7 +4035,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "edc97677-1820-4895-837a-d22d6924b9d2",
+                     "jsondocId": "f3b300ca-a0c5-41b7-9582-71c2d4c0ae1f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4044,7 +4044,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e1e94cff-9948-4cda-9070-4ae877e8a732",
+                     "jsondocId": "fe076089-b3c6-4d94-a717-6ca81bfec5d8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4053,7 +4053,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "52572076-85dc-40b1-8bc6-5dcea3c36e55",
+                     "jsondocId": "2f6ad463-b2fb-4f37-825b-5ff06e55e4b6",
                      "name": "id",
                      "format": "",
                      "description": "Value ID to show (or specify a value)",
@@ -4062,7 +4062,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e006f42d-8433-43eb-916a-d7006831afc2",
+                     "jsondocId": "410e93be-9f83-4889-a7d8-942ef6b8cd73",
                      "name": "value",
                      "format": "",
                      "description": "Value to show",
@@ -4074,9 +4074,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned values, or optionally, gets information about a specific canned value",
                "methodName": "showValue",
-               "jsondocId": "913323a8-f3e3-4d9a-a65b-ad55d8a8c741",
+               "jsondocId": "515e0ee3-c26f-438b-ad2c-13b74cb57c14",
                "bodyobject": {
-                  "jsondocId": "96d92d35-55f6-4bbf-a7af-727a83a3619f",
+                  "jsondocId": "8e7815a7-4253-4c2d-8488-29489bb6eb6a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4086,7 +4086,7 @@
                "apierrors": [],
                "path": "/cannedValue/showValue",
                "response": {
-                  "jsondocId": "91735d27-8f0f-4894-8364-995e9cadb407",
+                  "jsondocId": "fc21a61b-92c2-4954-b774-bbe9c17ad056",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4099,14 +4099,14 @@
          "description": "Methods for managing canned values"
       },
       {
-         "jsondocId": "dc391af9-9762-4280-bc36-0faedd8da6fa",
+         "jsondocId": "028ea74d-187b-443a-a614-a95508dd1663",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "509e0244-7451-4586-9497-272c0d3a9916",
+                     "jsondocId": "31e1ea66-a01d-4fe9-a738-cafbc7c27038",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4115,7 +4115,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4941d8d-0160-4df6-bb31-01e9987d09a2",
+                     "jsondocId": "dbb8bd35-2b72-403a-9965-c8ec9a1a6c9b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4124,7 +4124,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "61cd52e4-9a92-4cec-b1f3-c87fc7e38611",
+                     "jsondocId": "efacf3ff-fb27-41a2-9132-56fb2fedfa35",
                      "name": "name",
                      "format": "",
                      "description": "Group name to add",
@@ -4136,9 +4136,9 @@
                "verb": "POST",
                "description": "Create group",
                "methodName": "createGroup",
-               "jsondocId": "98f622cf-03cb-4c93-bf6a-437d1ab3b1c0",
+               "jsondocId": "215d8410-b7bd-4fcc-bd18-4a515d75384f",
                "bodyobject": {
-                  "jsondocId": "90cd877b-aa57-431e-872b-50859c6b0ede",
+                  "jsondocId": "5688993f-ab89-4441-831c-f98e9a7f26ca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4148,7 +4148,7 @@
                "apierrors": [],
                "path": "/group/createGroup",
                "response": {
-                  "jsondocId": "a68f7611-11b5-4684-b652-55e329ab2238",
+                  "jsondocId": "036d1a20-3860-454b-b546-e81c8d7367f3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4161,7 +4161,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "98e2a977-7e00-4d8b-b449-bbd5e8a7c895",
+                     "jsondocId": "75dfe195-2faf-412b-8195-6e8b2a8011e6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4170,7 +4170,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cd2e4600-0968-4495-9d23-3aa6e9e3bfa2",
+                     "jsondocId": "6182b9fb-a1f8-4800-a1bf-113cfeb0b786",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4179,7 +4179,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "688c967f-bc1c-476e-8cf2-4b743dd9d074",
+                     "jsondocId": "56fde90e-93ed-4286-8048-bb47dc40e3db",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -4188,7 +4188,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "389381ea-20f1-46ef-9308-fde36fa90c83",
+                     "jsondocId": "2c54b1bf-1f9f-47f4-9a7e-44272899349c",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -4200,9 +4200,9 @@
                "verb": "POST",
                "description": "Get organism permissions for group",
                "methodName": "getOrganismPermissionsForGroup",
-               "jsondocId": "05aa2e08-6555-4fd2-a55a-e3037a2568d4",
+               "jsondocId": "19d4d883-b25f-4ef5-a2b3-a0fd80fd275b",
                "bodyobject": {
-                  "jsondocId": "e231a9d6-302a-4d1c-819f-fd11b4754aed",
+                  "jsondocId": "21fb09a3-95bb-49f0-9e95-adb0d24b2a0e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4212,7 +4212,7 @@
                "apierrors": [],
                "path": "/group/getOrganismPermissionsForGroup",
                "response": {
-                  "jsondocId": "e835ef6a-d1f8-4996-b94d-6ceaea50a4df",
+                  "jsondocId": "1db23625-d53e-4200-9e92-47d8c1088451",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4225,7 +4225,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ef4918cf-a141-496c-bc08-283e9b4b4c98",
+                     "jsondocId": "d8dbbc92-c5cd-4fa0-97df-e7863c3f73ec",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4234,7 +4234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "00678bec-815c-49dd-bc84-54148c9cb583",
+                     "jsondocId": "483a4858-26e3-42a8-8af0-6c012a066616",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4243,7 +4243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3a63b3b7-ee51-4db8-9161-014524251f74",
+                     "jsondocId": "813498c9-7944-4964-9403-9e35c388ba0f",
                      "name": "groupId",
                      "format": "",
                      "description": "Optional only load a specific groupId",
@@ -4255,9 +4255,9 @@
                "verb": "POST",
                "description": "Load all groups",
                "methodName": "loadGroups",
-               "jsondocId": "28907d13-53ae-487a-a753-4d07e36cd52d",
+               "jsondocId": "777fc777-f8bf-458f-ab90-f210aeb0edcd",
                "bodyobject": {
-                  "jsondocId": "b0e1dde3-8795-4776-b5fa-8b5decbcdeee",
+                  "jsondocId": "1ce468d9-5b02-4fe1-ac0b-76fa957a7a71",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4267,7 +4267,7 @@
                "apierrors": [],
                "path": "/group/loadGroups",
                "response": {
-                  "jsondocId": "c7206a0a-c221-4a5a-a81b-7237847fc941",
+                  "jsondocId": "80444eb9-a306-4a61-a4ea-bd45d9ff0a47",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4280,7 +4280,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "63204768-bac6-4987-b5e1-5574b3e5dadf",
+                     "jsondocId": "452a63ee-8329-4774-81fa-7e9ca2682424",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4289,7 +4289,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f0cd1527-de82-46d5-acd8-a54c6b55905f",
+                     "jsondocId": "9fae3aa0-57b7-4d0b-bb0f-79391c407420",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4298,7 +4298,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6449371d-1334-48b5-bbb3-c691ae995936",
+                     "jsondocId": "a236c294-dfc3-4862-a424-69cced10475c",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to remove (or specify the name)",
@@ -4307,7 +4307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97376c87-0391-4490-b484-48b65fd9f06c",
+                     "jsondocId": "78635da6-7f24-490b-8c98-b6c6980953a7",
                      "name": "name",
                      "format": "",
                      "description": "Group name to remove",
@@ -4319,9 +4319,9 @@
                "verb": "POST",
                "description": "Delete a group",
                "methodName": "deleteGroup",
-               "jsondocId": "6e5d75f8-da85-47bd-8866-da81b3ab7043",
+               "jsondocId": "35ff24dc-3b17-4437-aea6-de733c979c95",
                "bodyobject": {
-                  "jsondocId": "0f6a77a3-eccc-4d3a-aa90-915041d771ad",
+                  "jsondocId": "570ebd5a-10fb-4940-98f6-51a88bd5c415",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4331,7 +4331,7 @@
                "apierrors": [],
                "path": "/group/deleteGroup",
                "response": {
-                  "jsondocId": "f77fb99c-b072-4c22-9032-015c34f1843d",
+                  "jsondocId": "7f1455f4-6f16-499d-941f-79dd8f69fd36",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4344,7 +4344,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0993ec76-21a6-4a2f-8921-5d9af97d6cfb",
+                     "jsondocId": "703a45bc-1a92-4532-92ed-962380741b17",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4353,7 +4353,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fc5f130a-777a-4e86-9bc7-1e839f15b1ab",
+                     "jsondocId": "918cc450-057c-4d2c-895b-9926176d507f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4362,7 +4362,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e8e55535-290a-4dac-a86e-a372ff396e5b",
+                     "jsondocId": "d75c6eee-f469-4183-8483-88cf1dc213cf",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to update",
@@ -4371,7 +4371,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "454b1e5e-1ea4-45a0-a897-4488cb418a04",
+                     "jsondocId": "1de26173-1e6f-4a3d-9266-95b9d8e30687",
                      "name": "name",
                      "format": "",
                      "description": "Group name to change to (the only editable optoin)",
@@ -4383,9 +4383,9 @@
                "verb": "POST",
                "description": "Update group",
                "methodName": "updateGroup",
-               "jsondocId": "dec0156c-b40e-4449-b19b-4f4fe3711aa8",
+               "jsondocId": "85f7aed0-547e-4abd-b7a6-7f5ff1996312",
                "bodyobject": {
-                  "jsondocId": "12d24c1a-bd75-4319-8417-e8826e9400a6",
+                  "jsondocId": "59dc8eb6-5644-44ae-a5f2-8a79fe4c0d5e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4395,7 +4395,7 @@
                "apierrors": [],
                "path": "/group/updateGroup",
                "response": {
-                  "jsondocId": "c595b138-422b-49e8-acff-4a5af314a363",
+                  "jsondocId": "5b88edf3-2007-4c88-a8e2-f768c74c0290",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4408,7 +4408,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c4bc5116-c557-4eb3-a647-1cc48c0de848",
+                     "jsondocId": "9e095767-217e-4df9-bf2d-9c6f2e55585d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4417,7 +4417,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a39261d0-9c8e-443a-8339-5de97b4de78d",
+                     "jsondocId": "9f764e38-a515-406d-bdb6-ebe75ba6362b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4426,7 +4426,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fcceddaf-8639-49bc-b72f-b25d4a3f2b62",
+                     "jsondocId": "48e47ef8-2bfa-4f65-bac2-0ae1a6d89f74",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to modify permissions for (must provide this or 'name')",
@@ -4435,7 +4435,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "48bd20ae-79b1-431a-8102-9fc3713091a7",
+                     "jsondocId": "e263ff2b-d829-4d1a-b008-e378cc9fbafa",
                      "name": "name",
                      "format": "",
                      "description": "Group name to modify permissions for (must provide this or 'groupId')",
@@ -4444,7 +4444,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9392b768-6873-4af2-8e95-cc8c16be5e6f",
+                     "jsondocId": "0f5b34cb-249f-41a8-98c2-acab7c1d843a",
                      "name": "organism",
                      "format": "",
                      "description": "Organism common name",
@@ -4453,7 +4453,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fecd0e8c-02d9-4dbc-8483-18ddf74018ae",
+                     "jsondocId": "effa3793-8d30-45c2-ab82-a8ec322fe8cc",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -4462,7 +4462,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d8ad3d86-9bf7-4b4f-be44-dc6d7311d56a",
+                     "jsondocId": "bd12ead0-2c7e-43d1-9e46-7bd91228ff88",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -4471,7 +4471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c5de2fd4-32e8-40aa-ab6e-3be93d350c68",
+                     "jsondocId": "3a85d9bb-ccb3-481e-ac78-38b918ad581b",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -4480,7 +4480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d14c23f3-edc2-429f-8a9e-f20afdf70909",
+                     "jsondocId": "6944a723-c4a4-4c2c-8942-eea8d52761a1",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -4492,9 +4492,9 @@
                "verb": "POST",
                "description": "Update organism permission",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "18308813-517e-4ce0-b9bd-24339132f696",
+               "jsondocId": "1d810c63-0f97-40e8-88a0-aa571eaae4e3",
                "bodyobject": {
-                  "jsondocId": "1ba3b5ac-4c61-48e5-a1de-1984c38518ed",
+                  "jsondocId": "ec39e4ea-fe33-48d5-aaff-3de102fda352",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4504,7 +4504,7 @@
                "apierrors": [],
                "path": "/group/updateOrganismPermission",
                "response": {
-                  "jsondocId": "6685e95f-6278-46e4-9ce3-25579082a23b",
+                  "jsondocId": "0c5698c0-44ff-44cb-98d7-3b0950acc528",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4517,7 +4517,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a49ed934-0e42-45bd-9e90-92a7c1245108",
+                     "jsondocId": "0b332acd-2d60-461e-993c-d82098aee2e9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4526,7 +4526,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cc7f9b2d-c018-4063-b3c7-5da26bbf1daa",
+                     "jsondocId": "2cd654ce-3cfc-4fc0-bf84-0c2c03a1004e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4535,7 +4535,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bedeb94a-5641-4d3c-98bf-9f7cf70f176c",
+                     "jsondocId": "883af859-e0f3-443c-bac3-d7abd1c9ee52",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -4544,7 +4544,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0609245e-d95b-46e0-9eda-49d466481a6e",
+                     "jsondocId": "75d800e8-135c-4125-ac6a-2b3f3ff74b6f",
                      "name": "users",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -4556,9 +4556,9 @@
                "verb": "POST",
                "description": "Update group membership",
                "methodName": "updateMembership",
-               "jsondocId": "103fc546-38fc-4d3a-bf14-5add194978b8",
+               "jsondocId": "f4f00718-97f0-4d6a-ac6d-35bfbd774210",
                "bodyobject": {
-                  "jsondocId": "5d921031-14cf-4ec7-a56c-aa33fc9c89e5",
+                  "jsondocId": "7e792af4-8d74-40d1-9853-35a784aa3f64",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4568,7 +4568,7 @@
                "apierrors": [],
                "path": "/group/updateMembership",
                "response": {
-                  "jsondocId": "dbbe1568-112d-4cd4-9926-3b9f979fe034",
+                  "jsondocId": "7844d7d3-51ad-4547-bff1-2d39d5193ced",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4581,14 +4581,14 @@
          "description": "Methods for managing groups"
       },
       {
-         "jsondocId": "66de4617-0963-4f83-ba29-bd64bacd4926",
+         "jsondocId": "6e3093e8-ac3e-4443-bba1-a7933ba21210",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6c94674c-1a84-461b-aaf8-c8c19ad564c6",
+                     "jsondocId": "bf6406ce-bc66-4e26-825a-5a4da6dfc615",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4597,7 +4597,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4b5d2417-dc17-4f9c-8f2b-7604db1ce738",
+                     "jsondocId": "6d0b74f3-f466-408f-abc0-2bdc006513ac",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4606,7 +4606,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "606a7eff-e97e-4084-ab8b-66d8af959013",
+                     "jsondocId": "1d6ad93c-1cb6-42e9-b661-04b17129649b",
                      "name": "type",
                      "format": "",
                      "description": "Type of annotated genomic features to export 'FASTA','GFF3','CHADO'.",
@@ -4615,7 +4615,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a9980f16-bb74-4e2e-aee4-387ecf931db0",
+                     "jsondocId": "d24a8942-4a4c-4d11-b475-cf802e96c7c2",
                      "name": "seqType",
                      "format": "",
                      "description": "Type of output sequence 'peptide','cds','cdna','genomic'.",
@@ -4624,7 +4624,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "18e63137-7bbf-4f7d-9d24-90c9c49f72d0",
+                     "jsondocId": "5806ea88-ce41-47bd-9fde-bf439cf78cbb",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -4633,7 +4633,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "50b99e05-e4c3-437d-8dc5-8e493ec36ced",
+                     "jsondocId": "5ddc94c8-4b24-4f48-804f-9b4b7e3d2426",
                      "name": "sequences",
                      "format": "",
                      "description": "Names of references sequences to add (default is all).",
@@ -4642,7 +4642,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4637dbe0-25ae-4d6d-a604-7a6058e94c52",
+                     "jsondocId": "21103b70-267b-4240-a2f1-740948b65182",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism that sequences belong to (will default to last organism).",
@@ -4651,7 +4651,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "35d0f6a5-a285-4a80-855d-755de149a309",
+                     "jsondocId": "77c38b9c-2246-4c4f-9e87-f6f5116bcd4a",
                      "name": "output",
                      "format": "",
                      "description": "Output method 'file','text'",
@@ -4660,7 +4660,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8a715b76-f9f0-4e32-a37a-ee6581bfd967",
+                     "jsondocId": "03c24068-4d15-44ad-b1b3-7e7f2d53bd28",
                      "name": "exportAllSequences",
                      "format": "",
                      "description": "Export all reference sequences for an organism (over-rides 'sequences')",
@@ -4669,7 +4669,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9086ff8b-e136-4d46-98d1-1d3e03085338",
+                     "jsondocId": "fd2bfc17-9ab2-4b12-b719-5edc48c1a57a",
                      "name": "exportGff3Fasta",
                      "format": "",
                      "description": "Export reference sequence when exporting GFF3 annotations.",
@@ -4678,7 +4678,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "643d5dbc-b7a7-4274-98ca-6f3a47b7b81c",
+                     "jsondocId": "688867db-7d79-4829-8097-143411298d95",
                      "name": "region",
                      "format": "",
                      "description": "Highlighted genomic region to export in form sequence:min..max  e.g., chr3:1001..1034",
@@ -4690,9 +4690,9 @@
                "verb": "POST",
                "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "methodName": "write",
-               "jsondocId": "1f8a9dfb-421e-4fe0-a1c3-c6b75d8b2049",
+               "jsondocId": "b650b246-dc6c-40ff-9024-e4bd4af55141",
                "bodyobject": {
-                  "jsondocId": "917de4ad-3285-43fa-9d3c-febc5e09c3ac",
+                  "jsondocId": "bf40d840-e7e9-490d-b514-cc4120c76546",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4702,7 +4702,7 @@
                "apierrors": [],
                "path": "/ioService/write",
                "response": {
-                  "jsondocId": "b3d636c9-d8b4-4e62-9a86-d1bebf7b2a4b",
+                  "jsondocId": "aa2ff4fb-a54e-40d8-92ee-0c4b31017919",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -4715,7 +4715,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "08348257-386b-4be6-b779-91da61a4c28e",
+                     "jsondocId": "a8eba510-a96d-4828-b50b-fb2c0b97dced",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4724,7 +4724,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7badeee8-4414-457e-ab0f-1b1a10441bd1",
+                     "jsondocId": "c94b0767-e8be-4b88-b0b4-1ea78a843066",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4733,7 +4733,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "551477e2-17da-4dc5-ba9b-3d4367a3bca9",
+                     "jsondocId": "449a2df8-676d-4180-9637-085dbb0f7822",
                      "name": "uuid",
                      "format": "",
                      "description": "UUID that holds the key to the stored download.",
@@ -4742,7 +4742,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45da79e8-63b2-46b5-b2e6-cb90b65e018b",
+                     "jsondocId": "2faa1849-d717-4809-aecd-c6ffc48f0b21",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -4754,9 +4754,9 @@
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
                "methodName": "download",
-               "jsondocId": "577c7828-1346-4077-94b9-a50c7c656781",
+               "jsondocId": "30a7264a-cb86-4580-be7e-f16f22078181",
                "bodyobject": {
-                  "jsondocId": "41d95360-51b8-4579-8254-a8f029fdda0f",
+                  "jsondocId": "aa0b6b6a-aa46-426f-ac86-7934bd1dbcf6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4766,7 +4766,7 @@
                "apierrors": [],
                "path": "/ioService/download",
                "response": {
-                  "jsondocId": "cc2b4b47-f659-47d1-a165-c0458f31105f",
+                  "jsondocId": "df745410-8501-4503-ad8b-7ca32bcb0d30",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -4779,14 +4779,14 @@
          "description": "Methods for bulk importing and exporting sequence data"
       },
       {
-         "jsondocId": "a14a1265-c073-4841-b91b-12f79c9f07d7",
+         "jsondocId": "91822398-e5eb-45a3-b91b-d78cc58eec51",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "cba8268a-0fc0-42b9-b7ba-b8e8bdba90fc",
+                     "jsondocId": "37d63d07-8d6a-4c49-ba35-be2c39cfb4f1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4795,7 +4795,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "64bd553b-38c5-48d1-a68c-35f84b05c02c",
+                     "jsondocId": "dbfe48a9-9164-4e8b-a749-95e1aef77708",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4804,7 +4804,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0e64a004-4dbb-4f9d-a747-a2672216e2a2",
+                     "jsondocId": "d95e01c8-bd3e-4c77-9f5e-993a450c89c6",
                      "name": "organism",
                      "format": "",
                      "description": "Pass an Organism JSON object with an 'id' that corresponds to the id to delete",
@@ -4816,9 +4816,9 @@
                "verb": "POST",
                "description": "Remove an organism",
                "methodName": "deleteOrganism",
-               "jsondocId": "2c8fd368-0826-41a7-a020-49ca2873f1e9",
+               "jsondocId": "4a1f0424-0471-4195-954d-1f0954f56c7d",
                "bodyobject": {
-                  "jsondocId": "2c6cc7f8-1432-4d8e-a923-527c7920e9bf",
+                  "jsondocId": "90f05738-bcfd-4dde-b3af-a10923221ee0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4828,7 +4828,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganism",
                "response": {
-                  "jsondocId": "c7603e0d-500c-4c5e-b2f4-267504fd405d",
+                  "jsondocId": "c6b0eb0d-9fc8-4158-a4bc-1c17051d1b68",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4841,7 +4841,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "532eddaa-87a4-4c53-a760-b14356817e67",
+                     "jsondocId": "fa5f0dae-e588-4f37-83c7-5251415684bb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4850,7 +4850,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cb95997d-c550-4206-b46a-8e838ccb4db4",
+                     "jsondocId": "ada4a7bf-0498-4a12-84f7-b7c321ce6fdd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4859,7 +4859,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1ed2604-e906-4557-9654-4929fc7c9ac6",
+                     "jsondocId": "ccb69e70-b6dd-4384-9ed6-409881defeed",
                      "name": "organism",
                      "format": "",
                      "description": "An organism json object that has an 'id' or 'commonName' parameter that corresponds to an organism.",
@@ -4871,9 +4871,9 @@
                "verb": "POST",
                "description": "Remove features from an organism",
                "methodName": "deleteOrganismFeatures",
-               "jsondocId": "21b5f78b-423a-4604-85fc-528c4f8a6ecb",
+               "jsondocId": "f04ed32f-acd1-4034-ad3e-e98ed474390d",
                "bodyobject": {
-                  "jsondocId": "9d1c0ac6-410e-4e99-aa88-9bd603806e17",
+                  "jsondocId": "9d2565ea-4821-4844-8752-aca5e23927b6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4883,7 +4883,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
                "response": {
-                  "jsondocId": "268e34a3-fe04-4b63-90a6-0814659d79e7",
+                  "jsondocId": "9ae9364d-8584-482c-a524-33060d2cc302",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4896,7 +4896,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b704e760-40d7-4304-903d-977b7adf1b46",
+                     "jsondocId": "69452188-ae77-4b34-949e-7e3217d5249f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4905,7 +4905,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d850e83f-7827-46a7-b2b5-ce17f79e147d",
+                     "jsondocId": "99efb0f1-2db9-4498-a770-16d978961b74",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4914,7 +4914,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e970a8f6-4c7a-43a8-905f-f436d0c0c962",
+                     "jsondocId": "5369826e-6098-4909-a7cc-959b7f7bf284",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -4923,7 +4923,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02071735-cfe7-41d4-975b-13465f9b3b39",
+                     "jsondocId": "3c2d3f4f-ce31-4fdf-88c3-96b5b594e8b9",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -4932,7 +4932,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7d35e9da-2949-474f-85ad-f5bc4779299e",
+                     "jsondocId": "ce2732fc-a801-4557-bc1a-7554bcf22c1e",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -4941,7 +4941,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "47ff9a20-28a9-46ac-874a-cc09f3b6b476",
+                     "jsondocId": "e972bd9d-3c69-42d2-9788-2e0931717df7",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -4950,7 +4950,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2641d96f-1f1b-4aae-ba33-fb288a2a0a2e",
+                     "jsondocId": "3de34ac9-e135-437f-a72b-526d506fdeeb",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -4959,7 +4959,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8ebc4c44-5b3e-471e-96d1-28c0b44da895",
+                     "jsondocId": "e506391e-7149-4859-8aa5-1a2929c4bdda",
                      "name": "commonName",
                      "format": "",
                      "description": "a name used for the organism",
@@ -4968,7 +4968,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4c7e9fa-35e1-4809-9da1-65bbeb8c59a2",
+                     "jsondocId": "1a793cd7-28fd-4456-80d5-ce7e197efa8e",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -4980,9 +4980,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganism",
-               "jsondocId": "4c12383d-cc4a-4f01-8f7d-6d390324b74d",
+               "jsondocId": "2b13eda8-419c-4147-aa70-1a8459e600ad",
                "bodyobject": {
-                  "jsondocId": "b4864a3b-a791-4741-9831-ab7d6741586b",
+                  "jsondocId": "eef6e0a8-0314-4143-ab8a-b48cc3214df5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4992,7 +4992,7 @@
                "apierrors": [],
                "path": "/organism/addOrganism",
                "response": {
-                  "jsondocId": "d76ab459-9a9b-4beb-aa60-5c3b99458c47",
+                  "jsondocId": "0f81a5a5-e31c-4454-9c61-48f4d2dd9c0f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5005,7 +5005,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7db97e80-6061-4422-b0ea-bdc5bea40510",
+                     "jsondocId": "27b61f28-4c3d-4a7b-b267-38f4e275e925",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5014,7 +5014,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "21d73ec1-a44a-46f6-8904-33d2dbb5302b",
+                     "jsondocId": "902a94b2-d027-4d2b-8d10-d26282be2a50",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5023,7 +5023,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "445f70ab-2123-46d4-b6cb-01d4cf1ecf95",
+                     "jsondocId": "721528a1-2575-4553-ba12-762f4f1735fa",
                      "name": "organism",
                      "format": "",
                      "description": "Common name or ID for the organism",
@@ -5035,9 +5035,9 @@
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
                "methodName": "getSequencesForOrganism",
-               "jsondocId": "d8722dbe-0c63-49fc-9a2e-06e5c8ff529c",
+               "jsondocId": "376cb40d-50e0-47dc-b034-844605bb8f92",
                "bodyobject": {
-                  "jsondocId": "958bcc52-19b3-49a9-a467-f3e7bb4c69cb",
+                  "jsondocId": "c97ac362-9b1b-4e4d-95e0-bf59ba5bf9ed",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5047,7 +5047,7 @@
                "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
                "response": {
-                  "jsondocId": "10303ad0-19de-43f7-a3b1-f381f304670d",
+                  "jsondocId": "a26a084f-d07a-41ef-8994-33882ea4269f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5060,7 +5060,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "25dc7ee7-ca8c-4d12-98f5-a484ac063bb9",
+                     "jsondocId": "5c602142-1c59-423f-a021-5c12611a35f5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5069,7 +5069,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ae2425b2-e0a2-4244-9e4f-93f2cb534ed5",
+                     "jsondocId": "3a47ea69-7c62-42ee-989b-b28720a8149a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5078,7 +5078,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "abbf6599-7dda-47cb-8274-2c4ef3e1915a",
+                     "jsondocId": "c6df1f48-524b-4a61-8904-47d624e92af4",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -5087,7 +5087,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4228bbc3-cfbf-4f96-bf1e-87a19295e3ba",
+                     "jsondocId": "d4b9017d-babe-4792-8bd4-d38096ae9d06",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -5096,7 +5096,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6b9e22e7-bae1-448e-9a8b-2fdad97ab284",
+                     "jsondocId": "e845d517-8741-4dc4-b868-76c5094415b2",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -5105,7 +5105,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1503fd57-8782-4aec-9580-c85af9726a48",
+                     "jsondocId": "19b17c0d-e3e8-47b1-8488-73862b8675d1",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -5114,7 +5114,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "591050b7-6954-42e3-9694-0aa03dc39535",
+                     "jsondocId": "9b90f958-7aa5-4a9f-b4a1-96d122c833c2",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -5123,7 +5123,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9901cbc6-eabc-4a33-b8b9-3d9dc4bb7d8d",
+                     "jsondocId": "befd5410-b83c-4ff6-814d-3e258fe6232c",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5132,7 +5132,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8ae0bf12-873c-4a67-ac49-0870aad8c2d7",
+                     "jsondocId": "69bb1f5b-e7f0-4f6b-a739-4f8771a098d6",
                      "name": "name",
                      "format": "",
                      "description": "a common name used for the organism",
@@ -5141,7 +5141,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5e02678c-32e6-4554-b7ec-a516d065b6ac",
+                     "jsondocId": "ad6e60fa-dc31-46fe-a4aa-4203598ee655",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5153,9 +5153,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "updateOrganismInfo",
-               "jsondocId": "23154e29-e2dd-413c-93e8-fb69d3023ee3",
+               "jsondocId": "328d8c2e-6ca4-4df3-b840-7105a5fd832e",
                "bodyobject": {
-                  "jsondocId": "d9717c96-08ea-4d22-b2f5-8758dc916e47",
+                  "jsondocId": "7c104f90-1f02-4551-a3de-1ab13650a265",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5165,7 +5165,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismInfo",
                "response": {
-                  "jsondocId": "8f3fe7a3-f18c-417f-af72-9ee1d036a495",
+                  "jsondocId": "f31982b7-4ba8-4b72-96c1-bbf67a2d6b94",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5178,7 +5178,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9e573e9e-20d1-413f-a6c0-803a3d9b5b84",
+                     "jsondocId": "ef6ffea7-ae17-4ec6-8903-5c75dffea118",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5187,7 +5187,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "52409ae9-dc7a-4285-9743-3388a188de5c",
+                     "jsondocId": "a4091f13-eef7-40fd-a49d-d2b80b94f44c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5196,7 +5196,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7ac25b2c-9e35-42b2-9b99-5f6a2c8f23e1",
+                     "jsondocId": "c34609f1-709d-4f22-b1e1-1638f8ca92a7",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -5205,7 +5205,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8d971d01-7ec5-4a4e-ba8e-96584f2b7270",
+                     "jsondocId": "cf2779fa-bf15-4848-91c0-30263dda8fe3",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5217,9 +5217,9 @@
                "verb": "POST",
                "description": "Update organism metadata",
                "methodName": "updateOrganismMetadata",
-               "jsondocId": "afaa857f-7de9-4143-a33d-9d5de9a72d58",
+               "jsondocId": "5ba45464-3596-4788-9f8b-92235b6a4d97",
                "bodyobject": {
-                  "jsondocId": "842aae6f-e7be-4ff8-ac89-abc1dbc2f877",
+                  "jsondocId": "643ceb06-5e06-43d1-8d86-b07f31d058d0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5229,7 +5229,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismMetadata",
                "response": {
-                  "jsondocId": "e7ac199d-0770-4d1f-82f3-32b9400a5c44",
+                  "jsondocId": "4834f3b6-9028-4983-8a35-33db9b464483",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5242,7 +5242,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e8173ddb-4385-4a5b-95b5-90def4abd7e3",
+                     "jsondocId": "deb26f81-c2f2-4257-a889-c939ea0d0592",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5251,7 +5251,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4db45699-06b7-49da-bd37-ff45f1a64980",
+                     "jsondocId": "5cac6001-0288-4c91-9173-673a2dd94fa6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5260,7 +5260,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0e5d2dd3-25d9-469d-ad1a-a75655d28aaf",
+                     "jsondocId": "ca4400f3-ac08-414c-8883-5359b1cb574f",
                      "name": "organism",
                      "format": "",
                      "description": "",
@@ -5272,9 +5272,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "methodName": "findAllOrganisms",
-               "jsondocId": "24f36508-cb4c-4021-ba59-acd0a4fed6d4",
+               "jsondocId": "5efc741a-04f9-4e4d-a37f-fadc7412fb65",
                "bodyobject": {
-                  "jsondocId": "783f286a-e25c-4be1-8823-89cf4937e608",
+                  "jsondocId": "8089217f-1b07-44af-aead-70c5cf0af8d2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5284,7 +5284,7 @@
                "apierrors": [],
                "path": "/organism/findAllOrganisms",
                "response": {
-                  "jsondocId": "0a90f5eb-b3d5-4820-b109-3366d02d5abd",
+                  "jsondocId": "f4ca2815-d561-4d3e-aeb6-2d887d25a5ff",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5297,14 +5297,14 @@
          "description": "Methods for managing organisms"
       },
       {
-         "jsondocId": "34889478-e18e-48d1-a822-0d3ec34e4a79",
+         "jsondocId": "f4fbe534-dcea-44e2-b4fd-12b348072633",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3aab12db-4f1c-4e6a-a2c5-d0693e6c6212",
+                     "jsondocId": "298dd539-d8bf-480d-8e9d-92dfe9cb574c",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -5313,7 +5313,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cec09960-4bf6-4afe-95d2-589908cec31b",
+                     "jsondocId": "be61ae4c-8852-4032-bbad-4e3a8f479a46",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name (required)",
@@ -5325,12 +5325,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism and track",
                "methodName": "clearTrackCache",
-               "jsondocId": "6a5c3f58-6732-4a95-bb54-d6b0c319a204",
+               "jsondocId": "f909dd75-2655-4de1-a516-5aae5471e858",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>/<track name>",
                "response": {
-                  "jsondocId": "239e7a56-24d7-4b27-89e7-37fdc7f9fe54",
+                  "jsondocId": "0ec0780d-5830-4d17-818a-98a87eca2e82",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5342,7 +5342,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "b5ebdb47-0d3a-4c0a-9d41-2fe956dce551",
+                  "jsondocId": "95e23db5-4eb3-4182-9245-ae255fa3c410",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required)",
@@ -5353,12 +5353,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "d5492329-5665-46e2-b685-ad7a2be218eb",
+               "jsondocId": "da6b6041-5c0c-40ef-a1ef-9675826f0eb9",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "5e6904c1-ac83-40f8-9ecb-ad6d52dbd628",
+                  "jsondocId": "be872f80-2efe-42da-b593-6871e2d21d59",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5371,7 +5371,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1869123c-f4b1-4721-97da-017ef472faf1",
+                     "jsondocId": "fad6b1da-31ae-4ef0-8ef0-af51664461d1",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -5380,7 +5380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55ca9510-33a9-4a93-88f8-e72bb45bb9ab",
+                     "jsondocId": "e4b9f5df-fa45-4086-9659-95a5427c807d",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -5389,7 +5389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4b193139-9138-43e2-ba7f-523103e0c2e2",
+                     "jsondocId": "cb820153-564f-49ac-a727-4d615295f788",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -5398,7 +5398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "454a4655-1a4a-4fe8-9309-259cb054d918",
+                     "jsondocId": "fd77856e-2e7f-4ae3-b103-1a3e51cd71fb",
                      "name": "featureName",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -5407,11 +5407,20 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a1013c52-03f9-4e3a-b9ca-93c5dcee3330",
+                     "jsondocId": "0958018f-dbcb-4d6b-ace2-1323fefd4bab",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
                      "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1b08d674-3455-4e22-bf2e-0ee3d0574b82",
+                     "name": "type",
+                     "format": "",
+                     "description": ".json or .svg",
+                     "type": "json/svg",
                      "required": "true",
                      "allowedvalues": []
                   }
@@ -5419,12 +5428,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within but only for the selected name",
                "methodName": "featuresByName",
-               "jsondocId": "5828415f-190a-4bf5-a6d4-992e732d3f00",
+               "jsondocId": "23a51f96-b5db-4c8f-b222-835852f28701",
                "bodyobject": null,
                "apierrors": [],
-               "path": "/track/<organism name>/<track name>/<sequence name>/<feature name>.json?ignoreCache=<ignoreCache>",
+               "path": "/track/<organism name>/<track name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "eeddf571-7aa5-4462-b86a-ee0b9c8df24d",
+                  "jsondocId": "f232565c-2ab1-406b-9301-fe43d10ef072",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5437,7 +5446,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9725193b-e9db-4cfd-a376-076a84e4a254",
+                     "jsondocId": "29f1b8b4-54ab-4b5f-9f9d-cc94ce7cbe4e",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -5446,7 +5455,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ec09249a-2248-4af0-9a50-9ef8156968e7",
+                     "jsondocId": "a4f193a7-3990-42f1-adff-c7a9b52e4b6d",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -5455,7 +5464,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1626521a-0603-40c9-818f-8f0f6cca11ea",
+                     "jsondocId": "9b9f71a5-7f00-4409-a667-7813ab153ba8",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -5464,7 +5473,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1abaf044-7473-4744-af81-577ceb5fab96",
+                     "jsondocId": "402dea49-9e01-4543-a6e1-5d342b8ec4d0",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -5473,7 +5482,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1b220472-091f-4aa1-b0e8-d142bfb9a375",
+                     "jsondocId": "7fb81325-9dec-4c3b-852d-3569ddd14971",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -5482,7 +5491,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "437031f6-7b5b-454f-a982-2c433393a36d",
+                     "jsondocId": "207e656d-4569-4c92-acf6-5f5f37e03565",
                      "name": "name",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -5491,7 +5500,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db876670-769f-41d6-842b-659c8c839991",
+                     "jsondocId": "4ab2e2f2-4ceb-4529-bdeb-ef31809ad830",
                      "name": "onlySelected",
                      "format": "",
                      "description": "(default false).  If 'selected'!=1 one, then exclude.",
@@ -5500,11 +5509,20 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "64e62fb4-0793-492d-a5f4-524a3d9bec71",
+                     "jsondocId": "03dace31-0251-44ef-934d-7327509fcd89",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
                      "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9f4363ca-636d-4cfa-a897-07fd73f32deb",
+                     "name": "type",
+                     "format": "",
+                     "description": ".json or .svg",
+                     "type": "json/svg",
                      "required": "true",
                      "allowedvalues": []
                   }
@@ -5512,12 +5530,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within an range",
                "methodName": "featuresByLocation",
-               "jsondocId": "d04fcdb3-02b9-4fb6-abfb-8a3f3f16b11a",
+               "jsondocId": "b4735c55-f084-49b5-918a-0c048aa48053",
                "bodyobject": null,
                "apierrors": [],
-               "path": "/track/<organism name>/<track name>/<sequence name>:<fmin>..<fmax>.json?name=<name>&onlySelected=<onlySelected>&ignoreCache=<ignoreCache>",
+               "path": "/track/<organism name>/<track name>/<sequence name>:<fmin>..<fmax>.<type>?name=<name>&onlySelected=<onlySelected>&ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "cdbd4762-6a9c-403c-b7ce-3e675e0d5656",
+                  "jsondocId": "a3282448-475b-421a-ad41-df1e9fdf8e98",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5530,14 +5548,14 @@
          "description": "Methods for retrieving track data"
       },
       {
-         "jsondocId": "fc4d790f-bcd4-4b2b-b8a7-d6d68f86796f",
+         "jsondocId": "74f93e1b-c46c-4446-9dcf-1d02bc07612c",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9af4b127-50db-413d-b596-62919810c682",
+                     "jsondocId": "ed73d36d-ce03-4c3c-9241-45391fc249e0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5546,7 +5564,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6eebf156-eba5-4858-8710-d1e128bc07d6",
+                     "jsondocId": "c31d8355-7c31-4961-a3f8-ce4c378f8793",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5555,527 +5573,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "87484d62-17ea-4b90-96ce-5d4c833e8cc2",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to fetch",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get organism permissions for user, returns an array of permission objects",
-               "methodName": "getOrganismPermissionsForUser",
-               "jsondocId": "6264c9c9-42f4-49c4-acdc-3d134e2d8529",
-               "bodyobject": {
-                  "jsondocId": "327789e2-90bb-4f71-a578-6fe3356dac73",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/getOrganismPermissionsForUser",
-               "response": {
-                  "jsondocId": "3d39b632-67f7-42e2-bec4-852eaf682692",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "060b4a32-bef9-4094-823a-60bf065e6f08",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e50a0c12-35fc-461b-b449-dbc842cbbe2f",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e960c979-44e5-4a67-8356-b6eae1fcb629",
-                     "name": "userId",
-                     "format": "",
-                     "description": "Optionally only user a specific userId as an integer database id or a username string",
-                     "type": "long / string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Load all users and their permissions",
-               "methodName": "loadUsers",
-               "jsondocId": "f7108aa2-46ef-4c7d-bd27-36f3ad1a0af3",
-               "bodyobject": {
-                  "jsondocId": "829db055-b8a8-4dc7-b303-ad6e8f5e69d6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/loadUsers",
-               "response": {
-                  "jsondocId": "1c17d3d7-da1f-4dd0-ae40-c6f920a7d131",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "5c175500-35c1-4940-b66d-17bc4c81bbbf",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3691be71-09a1-4a0c-ac64-6f8b3338b763",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "63fcbab5-98b3-49dd-9acf-823fcfcb0f43",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "8192e4d0-d265-447f-9bd5-69893227e3dd",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "68cc4a3c-0f73-4dc0-b9f2-27186aacd10d",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add user to group",
-               "methodName": "addUserToGroup",
-               "jsondocId": "073c361c-2ee3-4be0-bc70-2197455d8584",
-               "bodyobject": {
-                  "jsondocId": "1d79cff1-cf83-4ae1-b7bb-448a3b9575eb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/addUserToGroup",
-               "response": {
-                  "jsondocId": "d9350ceb-0d4d-48ed-9acd-ce3e660cd22f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "45b1c052-8bfe-46ef-b807-d7a86c8c786e",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a708463a-81dc-4f75-85fb-445008c32207",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "45299a1e-3622-4cdf-bb80-c11b6f4d198c",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "40d248ea-7fe2-4fa3-9fb0-31b6f1b2c8fe",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3beec88f-d2c5-4636-b96c-36532e2d6764",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Remove user from group",
-               "methodName": "removeUserFromGroup",
-               "jsondocId": "0740dadb-d1be-4ef4-816f-0ff9311badae",
-               "bodyobject": {
-                  "jsondocId": "9bc8b901-5ed0-433e-96aa-c5c94adc77b2",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/removeUserFromGroup",
-               "response": {
-                  "jsondocId": "b78bbadc-4242-49e9-a9c1-ce0fcf40a5c2",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "7dd42da7-c041-4c2a-a6e0-18277543c5e8",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "19aaad12-7e0a-4c77-a4f9-d1559dbaf461",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3a5e5988-33e9-4da3-84c9-dab451466fe6",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to add",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "59521dc0-220e-4207-be65-e952b23f3e68",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0b9a821a-da5e-4969-8907-82380300dcd7",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "507f1a3b-5b30-49cf-89a6-7f9d9f9d839b",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "User metadata (optional)",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9ad9dee2-ab89-4756-9c77-08e6cae0cb45",
-                     "name": "role",
-                     "format": "",
-                     "description": "User role USER / ADMIN (optional: default USER) ",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "dda7ba97-0115-48ee-b0a1-ba1766c4925a",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create user",
-               "methodName": "createUser",
-               "jsondocId": "3356fe0d-d3aa-4244-9af9-5c70aabea9b2",
-               "bodyobject": {
-                  "jsondocId": "24c8ae64-04b3-487f-8eef-2d11dc93a70a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/createUser",
-               "response": {
-                  "jsondocId": "e3419d6e-ee41-487d-a871-739140b26ffb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "73c55875-f98d-437d-a3a7-c84dca5245e6",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "47da5ed3-725a-4880-9aed-5493b69d31fc",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "56d9032a-3dfd-4650-b536-b3e2c32117cf",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to delete",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5eb8bc5c-6e64-48ef-aaf9-e9e127be6464",
-                     "name": "userToDelete",
-                     "format": "",
-                     "description": "Username (email) to delete",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete user",
-               "methodName": "deleteUser",
-               "jsondocId": "f02327a9-a5b5-41a2-abea-85add7388f51",
-               "bodyobject": {
-                  "jsondocId": "a476b620-11eb-4727-8a96-f19e77149342",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/deleteUser",
-               "response": {
-                  "jsondocId": "ef0ee08e-e04e-4dff-9046-36550149a077",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "a845c5cc-5f35-44c7-8789-f44acfca30ed",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "38b90674-7949-4fee-98bd-622c4602011b",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f3008c3c-9b79-428c-8fd9-bf82f0545085",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to update",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ab69de5d-5b2a-453a-a22d-b3c99e224c73",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to update",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4f6e0e72-fdb8-4c59-a49c-93445d5cfbb1",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a7d78d60-aa69-43a6-93e6-9656769b9a35",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9a50e2be-ae4f-407e-9e0d-dc5ba3264fbe",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "User metadata (optional)",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a0032028-4148-45ed-a437-f9ef5cd82f95",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update user",
-               "methodName": "updateUser",
-               "jsondocId": "bafee0e1-8111-43ad-9000-df129564ce19",
-               "bodyobject": {
-                  "jsondocId": "a789edb4-8e79-47ae-babb-68edd3b9603c",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/updateUser",
-               "response": {
-                  "jsondocId": "8cf3a11b-43a7-4bfa-92c0-d49c9c3c49a0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "ae3af88f-f730-4ca3-b501-30fd998ceab0",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6c19d229-b88f-4970-9d8c-415d300816ff",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "18f69234-a569-4a2a-8ddb-e2517fdc7af0",
+                     "jsondocId": "cad630eb-0ab3-4078-9b06-59435300a961",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to modify permissions for",
@@ -6084,7 +5582,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "feedeb8d-1758-422e-8eb2-0b438c1dad2e",
+                     "jsondocId": "f782cd9b-f412-42d3-9d17-6871b2db36b5",
                      "name": "user",
                      "format": "",
                      "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
@@ -6093,7 +5591,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e05e20e4-b057-4a0c-a3de-54a3aad8160f",
+                     "jsondocId": "4c899f1a-41ba-4502-a95a-c0086b2d5560",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism to update",
@@ -6102,7 +5600,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "15b05088-4013-4d72-a66f-733fe0368f33",
+                     "jsondocId": "0cf4cb37-ae3f-4b5c-9678-8314d18ea03f",
                      "name": "id",
                      "format": "",
                      "description": "Permission ID to update (can get from userId/organism instead)",
@@ -6111,7 +5609,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "df362feb-55fa-4bb8-93de-48c545f33dbd",
+                     "jsondocId": "969a6c14-b064-4be8-a32c-0e9f5c6471b9",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -6120,7 +5618,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d044759-edef-4a03-a959-07c621562c21",
+                     "jsondocId": "da23a639-31b7-4953-aa28-8d3793952653",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -6129,7 +5627,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "566f53c3-a2c3-4099-a0f5-de90cc5bd59b",
+                     "jsondocId": "6e4c530b-efed-421f-97ad-f861d9b00b88",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -6138,7 +5636,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02d66d72-baf7-4883-a5e1-9369fb2823ff",
+                     "jsondocId": "a428efac-f489-417e-a68a-df6eba41f428",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -6150,9 +5648,9 @@
                "verb": "POST",
                "description": "Update organism permissions",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "8270ba43-e7b1-48db-b36a-b7cabfc8e5e7",
+               "jsondocId": "12824d80-06e4-49af-ae04-3cd8208247a2",
                "bodyobject": {
-                  "jsondocId": "e1204f7b-78c6-49a1-aabe-4c509c295b94",
+                  "jsondocId": "eb4a8852-cf34-477b-8aa6-4a82e033f3dd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6162,7 +5660,527 @@
                "apierrors": [],
                "path": "/user/updateOrganismPermission",
                "response": {
-                  "jsondocId": "397fd081-cc37-4692-a34a-59bc7383289f",
+                  "jsondocId": "44d0d491-ebaa-4b12-93b1-bb57b71fc1e0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "a29acd0f-f65f-4b4e-a7d0-3ab560cbb6eb",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6484002c-119d-4ef8-a153-fac12e0f9462",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4f8ee4bd-7d0c-4ed3-b7cc-377e39de1248",
+                     "name": "userId",
+                     "format": "",
+                     "description": "Optionally only user a specific userId as an integer database id or a username string",
+                     "type": "long / string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Load all users and their permissions",
+               "methodName": "loadUsers",
+               "jsondocId": "f14d6967-8335-469d-84fc-861e3342057d",
+               "bodyobject": {
+                  "jsondocId": "75950e09-3a14-4b94-b85d-f7b1793a2d4e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/loadUsers",
+               "response": {
+                  "jsondocId": "15cfc108-96f0-4d66-8696-87c7a7cbd078",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6741427e-f0c1-441a-b4ec-37c18ada52b7",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "353017f3-7c3b-4c48-86d7-c02454d72cfc",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bfe674f3-961e-4160-88a3-94ecef666b2b",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1909e517-b74b-4f04-8f1e-1c44f6a8a664",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8c1d520c-e93b-41d6-834a-8a62576eb431",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add user to group",
+               "methodName": "addUserToGroup",
+               "jsondocId": "8eebd8c8-d6fd-448e-8c83-4b7f89c7a451",
+               "bodyobject": {
+                  "jsondocId": "437fca56-b645-45f1-9eff-32a1bf9565a6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/addUserToGroup",
+               "response": {
+                  "jsondocId": "40343689-7d87-4780-a27d-57f3e85b1d20",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "0789ff1c-7cfd-4e76-99c6-41c85e7ebd2e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8bcebba5-ddf8-49fa-a9c1-03c886cf3f04",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fd1d2ee9-98a1-4a11-9795-09ace04b9d2a",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c0b95f1c-bbec-4d20-bf1d-31e38fbf9e6a",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e7c95307-ff18-4c2f-a109-6d6c8cbad4e1",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Remove user from group",
+               "methodName": "removeUserFromGroup",
+               "jsondocId": "51a3388b-25e7-4973-a2ac-805095911169",
+               "bodyobject": {
+                  "jsondocId": "68c4c690-1010-406d-9e68-04c85b1a7036",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/removeUserFromGroup",
+               "response": {
+                  "jsondocId": "93f1c4df-02f0-445a-b083-3569c21daf9a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "d17d490d-b2ea-4970-8f5a-eea76731573c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "131d8d09-1bc0-42aa-82bf-d7c570161bf8",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "597c53fc-f62d-4f6a-be0c-3ddc224ba2f1",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to add",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8d7bb6bb-4ff8-4e89-9cbd-93398565a9ff",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ad51a40c-0218-4a10-abd9-68c1d1dd697e",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "81c9d8cc-6463-46a1-9553-3a7c596fdf7b",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "User metadata (optional)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "36324ec3-1e8c-4414-b580-102da0f2f059",
+                     "name": "role",
+                     "format": "",
+                     "description": "User role USER / ADMIN (optional: default USER) ",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1909fbb9-78c1-4536-97fd-269273271ce8",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create user",
+               "methodName": "createUser",
+               "jsondocId": "b90f0ffc-5d25-4eea-b2bb-99da65043f9c",
+               "bodyobject": {
+                  "jsondocId": "fe251bc7-131a-4897-bbf5-4679fc94f990",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/createUser",
+               "response": {
+                  "jsondocId": "20ec0a78-1088-4852-abc8-c787d2f195dc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4ea23eca-30f9-4474-81d3-f38b69ca8a05",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "194ccdf6-ef32-4aef-b497-f763fb138725",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "19467b93-0159-47b7-9954-b5f46951a1e9",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6c46ff69-220e-4a11-bf65-1ad67d94a9aa",
+                     "name": "userToDelete",
+                     "format": "",
+                     "description": "Username (email) to delete",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete user",
+               "methodName": "deleteUser",
+               "jsondocId": "5335fbb5-a18e-4a14-8687-dbc2f9c15500",
+               "bodyobject": {
+                  "jsondocId": "d2401281-f502-4466-85a9-0d78862880c2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/deleteUser",
+               "response": {
+                  "jsondocId": "16c0f881-eb16-4cf8-9c2e-adc896b1591e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "414c995c-e4a2-4ef6-bb6d-c2f1eb99419b",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2069ffcd-44a9-4aa4-ab87-f8cf876472ca",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e61d85cc-98e6-45d4-9432-627be97e6ddf",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to update",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0c4fe798-0bd1-40fb-bdb6-c75438640cc0",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to update",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1089438b-858b-4548-b452-6e01c0ff3052",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "10fb8042-a81b-4588-8a63-87c4310a7e1e",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d92b1c49-c63f-41a4-84bd-30d0e566965f",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "User metadata (optional)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1e7e463b-f8b3-4e25-a05a-c685a1024c22",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update user",
+               "methodName": "updateUser",
+               "jsondocId": "fea6a573-dffc-4613-829a-1436ba199d2e",
+               "bodyobject": {
+                  "jsondocId": "1acea47e-c091-4add-bee3-a929c856c59e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateUser",
+               "response": {
+                  "jsondocId": "7b6c9e50-6073-45f9-b13d-b3600de07cff",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "127bd256-4ef8-4b34-9ae0-7793489a4bc8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d35dbac9-f5a6-48ce-b0aa-6ea902d02e4e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e12da8b1-35f4-4236-8b5b-0075d58b0a35",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to fetch",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for user, returns an array of permission objects",
+               "methodName": "getOrganismPermissionsForUser",
+               "jsondocId": "4f570a92-7aa1-46ba-8414-80f486efb9f0",
+               "bodyobject": {
+                  "jsondocId": "53ae443b-7b36-493e-84ca-65e2b25f01f3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/getOrganismPermissionsForUser",
+               "response": {
+                  "jsondocId": "4427c46e-b5db-4a2b-9888-c076087b5fb8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"


### PR DESCRIPTION
- [ ] render a region instead of just one name
- [ ] add other isoforms (might already work)

Able to create an SVG from a URL:

http://localhost:8080/apollo/track/Honeybee/Official%20Gene%20Set%20v3.2/Group10.23/GB48355-RA.svg?ignoreCache=true

<img width="481" alt="screen shot 2017-06-08 at 2 16 21 pm" src="https://user-images.githubusercontent.com/751274/26951196-283169bc-4c55-11e7-91cb-3312cd13d622.png">


