### PR TITLE
initial forrays into fixing this bug by doing upgrades

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -91,6 +91,10 @@ grails.project.dependency.resolution = {
 //        test "org.seleniumhq.selenium:selenium-support:$seleniumVersion"
 //        test "org.gebish:geb-spock:$gebVersion"
         //test "org.spockframework:spock-grails-support:0.7-groovy-2.0"
+//        compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.8.1'
+//        compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.8.8'
+//        compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.8.8'
+
 
         // for coveralls
         build 'org.apache.httpcomponents:httpcore:4.3.2'
@@ -113,7 +117,9 @@ grails.project.dependency.resolution = {
 
 
         compile ':asset-pipeline:2.1.5'
-        compile ":spring-websocket:1.2.0"
+        compile ":spring-websocket:1.3.1"
+
+
         compile (":shiro:1.2.1") {
             excludes([name: 'quartz', group: 'org.opensymphony.quartz'])
         }


### PR DESCRIPTION
Getting this error (maybe fixed something else, somewhere else).   1.3.1 update may have fixed a few things.

2017-06-14 17:34:24,225 [clientInboundChannel-4] ERROR springwebsocket.GrailsSimpAnnotationMethodMessageHandler  - Unhandled exception
org.codehaus.groovy.grails.web.json.JSONException: JSONObject["operation"] not found.
	at org.bbop.apollo.AnnotationEditorController._do_annotationEditor(AnnotationEditorController.groovy:1121)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)