### PR TITLE
Fix redundant update operation when adding sequence alterations

### DIFF
--- a/client/apollo/js/View/Track/SequenceTrack.js
+++ b/client/apollo/js/View/Track/SequenceTrack.js
@@ -1105,9 +1105,6 @@ var SequenceTrack = declare( "SequenceTrack", DraggableFeatureTrack,
                         "clientToken": track.annotTrack.getClientToken()
                     };
                     track.annotTrack.executeUpdateOperation(JSON.stringify(postData));
-
-
-                    track.annotTrack.executeUpdateOperation(postData);
                     track.annotTrack.closeDialog();
                 }
             }


### PR DESCRIPTION
Fixes `optimistic locking failed` error, as reported in #1665.

This was due to the add operation being called twice.