### PR TITLE
improve preference behavior and performance

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotatorController.groovy
@@ -425,6 +425,7 @@ class AnnotatorController {
      */
     @Transactional
     def getAppState() {
+        preferenceService.evaluateSaves(true)
         render annotatorService.getAppState(params.get(FeatureStringEnum.CLIENT_TOKEN.value).toString()) as JSON
     }
 
@@ -493,6 +494,9 @@ class AnnotatorController {
     }
 
     def ping() {
+        println "evaluating ssaves: ping"
+        preferenceService.evaluateSaves()
+        println "DONE evaluating ssaves: ping"
         if (permissionService.checkPermissions(PermissionEnum.READ)) {
             log.debug("permissions checked and alive")
             render new JSONObject() as JSON

--- a/grails-app/controllers/org/bbop/apollo/AuthController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AuthController.groovy
@@ -10,6 +10,7 @@ class AuthController {
 
 
     def permissionService
+    def preferenceService
 
     def index = { redirect(action: "login", params: params) }
 
@@ -81,6 +82,7 @@ class AuthController {
     }
 
     def signOut = {
+        preferenceService.evaluateSaves(true)
         // Log the user out of the application.
         SecurityUtils.subject?.logout()
         webRequest.getCurrentRequest().session = null

--- a/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SequenceController.groovy
@@ -52,6 +52,7 @@ class SequenceController {
     def setCurrentSequenceForNameAndOrganism(Organism organism) {
         JSONObject inputObject = permissionService.handleInput(request,params)
         Sequence sequence = Sequence.findByNameAndOrganism(inputObject.sequenceName,organism)
+        println "found a sequence ${sequence}"
         setCurrentSequence(sequence)
     }
 
@@ -64,14 +65,17 @@ class SequenceController {
      * @param sequenceName
      * @return
      */
+
     @Transactional
     def setCurrentSequence(Sequence sequenceInstance) {
         JSONObject inputObject = permissionService.handleInput(request,params)
+        println "setting the current sequence here: ${inputObject}"
         String token = inputObject.getString(FeatureStringEnum.CLIENT_TOKEN.value)
         Organism organism = sequenceInstance.organism
 
         User currentUser = permissionService.currentUser
-        preferenceService.setCurrentSequence(currentUser,sequenceInstance,token)
+        UserOrganismPreference userOrganismPreference = preferenceService.setCurrentSequence(currentUser,sequenceInstance,token)
+        println "set current sequence and found: ${userOrganismPreference} start /stop ${userOrganismPreference?.startbp} / ${userOrganismPreference?.endbp}"
 
         Session session = SecurityUtils.subject.getSession(false)
         session.setAttribute(FeatureStringEnum.DEFAULT_SEQUENCE_NAME.value, sequenceInstance.name)
@@ -85,7 +89,6 @@ class SequenceController {
         sequenceObject.put("length", sequenceInstance.length)
         sequenceObject.put("start", sequenceInstance.start)
         sequenceObject.put("end", sequenceInstance.end)
-        UserOrganismPreference userOrganismPreference = preferenceService.getCurrentOrganismPreference(currentUser,sequenceInstance.name,token)
         sequenceObject.startBp = userOrganismPreference.startbp
         sequenceObject.endBp = userOrganismPreference.endbp
 

--- a/grails-app/controllers/org/bbop/apollo/UserController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/UserController.groovy
@@ -145,6 +145,7 @@ class UserController {
     @Transactional
     def checkLogin() {
         def currentUser = permissionService.currentUser
+        preferenceService.evaluateSaves(true)
 
 
         // grab from session

--- a/grails-app/services/org/bbop/apollo/PreferenceService.groovy
+++ b/grails-app/services/org/bbop/apollo/PreferenceService.groovy
@@ -203,6 +203,7 @@ class PreferenceService {
         }
         userOrganismPreference.startbp = startBp
         userOrganismPreference.endbp = endBp
+        userOrganismPreference.currentOrganism = true
         setSessionPreference(clientToken, userOrganismPreference)
 
         SequenceLocationDTO sequenceLocationDTO = new SequenceLocationDTO(


### PR DESCRIPTION
fixes #1663 

There was a problem with the defaults not being set properly for other sequences / organism preferences, which may be now fixed, but its also possible that it worked the way it was supposed to.

The way it works now is very performant in that movement triggers ignoring a preference save, which is correct.   However, not moving for several seconds should trigger a preference save as well. 

- [x] when changing sequences automatically save the current sequence location if no location is present in the server 
- [x] trigger save of last location when NOT moving (say after 30 seconds or once every minute no matter what)?
   - [x] implement a timer array for this 
- [ ] add Geb?
- [ ] create preference when switching organism / sequence unless one with an existing token (that is inactive) is not there
   - [ ] failing that try detaching the preference from the database 
   - [ ] failing that make the internal session object a JSON object marshaled from the preference, instead
- [ ] when switching organisms, should find the "best" sequence and location
- [ ] when switching sequences on the organism, should find the last good location
- [ ] check that other sequence / organism preferences are respected in other windows (i.e., did my fix break anything)? 
