### PR TITLE
override the default translation table

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -53,6 +53,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
     def sequenceSearchService
     def featureEventService
     def annotationEditorService
+    def organismService
     def brokerMessagingTemplate
 
 
@@ -143,18 +144,10 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         JSONObject returnObject = permissionService.handleInput(request, params)
         log.debug "return object ${returnObject as JSON}"
         Organism organism = preferenceService.getCurrentOrganismForCurrentUser(returnObject.getString(FeatureStringEnum.CLIENT_TOKEN.value))
-        TranslationTable translationTable
         log.debug "has organism ${organism}"
         // use the over-wridden one
-        if(organism?.nonDefaultTranslationTable){
-            log.debug "overriding default translation table for ${organism.commonName} with ${organism.nonDefaultTranslationTable}"
-            translationTable = SequenceTranslationHandler.getTranslationTableForGeneticCode(organism.nonDefaultTranslationTable)
-        }
-            // just use the default
-        else{
-            log.debug "using the default translation table"
-            translationTable = configWrapperService.getTranslationTable()
-        }
+        TranslationTable translationTable = organismService.getTranslationTable(organism)
+
         JSONObject ttable = new JSONObject()
         for (Map.Entry<String, String> t : translationTable.getTranslationTable().entrySet()) {
             ttable.put(t.getKey(), t.getValue())

--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -152,7 +152,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         }
             // just use the default
         else{
-            log.deub "using the default translation table"
+            log.debug "using the default translation table"
             translationTable = configWrapperService.getTranslationTable()
         }
         JSONObject ttable = new JSONObject()

--- a/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
@@ -241,6 +241,7 @@ class OrganismController {
             , @RestApiParam(name = "blatdb", type = "string", paramType = RestApiParamType.QUERY, description = "filesystem path for a BLAT database (e.g. a .2bit file)")
             , @RestApiParam(name = "publicMode", type = "boolean", paramType = RestApiParamType.QUERY, description = "a flag for whether the organism appears as in the public genomes list")
             , @RestApiParam(name = "name", type = "string", paramType = RestApiParamType.QUERY, description = "a common name used for the organism")
+            , @RestApiParam(name = "nonDefaultTranslationTable", type = "string", paramType = RestApiParamType.QUERY, description = "non-default translation table")
             , @RestApiParam(name = "metadata", type = "string", paramType = RestApiParamType.QUERY, description = "organism metadata")
     ])
     @Transactional
@@ -259,6 +260,7 @@ class OrganismController {
                 organism.metadata = organismJson.metadata
                 organism.directory = organismJson.directory
                 organism.publicMode = organismJson.publicMode
+                organism.nonDefaultTranslationTable = organismJson.nonDefaultTranslationTable ?: null
 
                 if (checkOrganism(organism)) {
                     organism.save(flush: true, insert: false, failOnError: true)
@@ -268,7 +270,7 @@ class OrganismController {
             } else {
                 throw new Exception('organism not found')
             }
-            render new JSONObject() as JSON
+            render findAllOrganisms() as JSON
         }
         catch (e) {
             def error = [error: 'problem saving organism: ' + e]
@@ -376,6 +378,7 @@ class OrganismController {
                         species        : organism.species,
                         valid          : organism.valid,
                         publicMode     : organism.publicMode,
+                        nonDefaultTranslationTable : organism.nonDefaultTranslationTable,
                         metadata       : organism.metadata,
                         currentOrganism: defaultOrganismId != null ? organism.id == defaultOrganismId : false
                 ] as JSONObject

--- a/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
@@ -123,6 +123,7 @@ class OrganismController {
             , @RestApiParam(name = "blatdb", type = "string", paramType = RestApiParamType.QUERY, description = "filesystem path for a BLAT database (e.g. a .2bit file)")
             , @RestApiParam(name = "publicMode", type = "boolean", paramType = RestApiParamType.QUERY, description = "a flag for whether the organism appears as in the public genomes list")
             , @RestApiParam(name = "commonName", type = "string", paramType = RestApiParamType.QUERY, description = "a name used for the organism")
+            , @RestApiParam(name = "nonDefaultTranslationTable", type = "string", paramType = RestApiParamType.QUERY, description = "non-default translation table")
             , @RestApiParam(name = "metadata", type = "string", paramType = RestApiParamType.QUERY, description = "organism metadata")
     ])
     @Transactional
@@ -143,6 +144,7 @@ class OrganismController {
                         , species: organismJson.species
                         , genus: organismJson.genus
                         , metadata: organismJson.metadata
+                        , nonDefaultTranslationTable:  organismJson.nonDefaultTranslationTable ?: null
                         , publicMode: organismJson.publicMode
                 )
                 log.debug "organism ${organism as JSON}"

--- a/grails-app/domain/org/bbop/apollo/Organism.groovy
+++ b/grails-app/domain/org/bbop/apollo/Organism.groovy
@@ -16,6 +16,7 @@ class Organism {
         blatdb nullable: true
         metadata nullable: true
         commonName nullable: false
+        nonDefaultTranslationTable nullable: true,blank: false
     }
 
     String abbreviation;
@@ -27,6 +28,7 @@ class Organism {
     boolean publicMode;
     String blatdb;
     String directory
+    String nonDefaultTranslationTable
 
     String metadata
 

--- a/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
+++ b/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
@@ -48,6 +48,7 @@ class AnnotatorService {
                         species        : organism.species,
                         valid          : organism.valid,
                         publicMode     : organism.publicMode,
+                        nonDefaultTranslationTable : organism.nonDefaultTranslationTable,
                         currentOrganism: defaultOrganismId != null ? organism.id == defaultOrganismId : false,
                         editable       : organismBooleanMap.get(organism) ?: false
 

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -29,6 +29,7 @@ class FeatureService {
     def sequenceService
     def permissionService
     def overlapperService
+    def organismService
     def sessionFactory
 
     public static final def rnaFeatureTypes = [MRNA.alternateCvTerm,MiRNA.alternateCvTerm,NcRNA.alternateCvTerm, RRNA.alternateCvTerm, SnRNA.alternateCvTerm, SnoRNA.alternateCvTerm, TRNA.alternateCvTerm, Transcript.alternateCvTerm]
@@ -574,12 +575,6 @@ class FeatureService {
  * @param transcript - Transcript to set the longest ORF to
  */
     @Transactional
-    void setLongestORF(Transcript transcript, boolean readThroughStopCodon) {
-        log.debug "setLongestORF(transcript,readThroughStopCodon) ${transcript} ${readThroughStopCodon}"
-        setLongestORF(transcript, configWrapperService.getTranslationTable(), false, readThroughStopCodon);
-    }
-
-    @Transactional
     void setLongestORF(Transcript transcript) {
         log.debug "setLongestORF(transcript) ${transcript}"
         setLongestORF(transcript, false);
@@ -624,7 +619,7 @@ class FeatureService {
     @Transactional
     void setTranslationStart(Transcript transcript, int translationStart, boolean setTranslationEnd, boolean readThroughStopCodon) {
         log.debug "setTranslationStart(transcript,translationStart,translationEnd,readThroughStopCodon)"
-        setTranslationStart(transcript, translationStart, setTranslationEnd, setTranslationEnd ? configWrapperService.getTranslationTable() : null, readThroughStopCodon);
+        setTranslationStart(transcript, translationStart, setTranslationEnd, setTranslationEnd ? organismService.getTranslationTable(transcript.featureLocation.sequence.organism) : null, readThroughStopCodon);
     }
 
     /** Convert local coordinate to source feature coordinate.
@@ -849,7 +844,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
     @Transactional
     void setTranslationEnd(Transcript transcript, int translationEnd, boolean setTranslationStart) {
         setTranslationEnd(transcript, translationEnd, setTranslationStart,
-                setTranslationStart ? configWrapperService.getTranslationTable() : null
+                setTranslationStart ? organismService.getTranslationTable(transcript.featureLocation.sequence.organism) : null
         );
     }
 
@@ -965,11 +960,6 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
 
     }
 
-
-    void setLongestORF(Transcript transcript, TranslationTable translationTable, boolean allowPartialExtension) {
-        log.debug "setLongestORF(transcript,translationTable,allowPartialExtension)"
-        setLongestORF(transcript, translationTable, allowPartialExtension, false);
-    }
 
     /** Get the residues for a feature with any alterations and frameshifts.
      *
@@ -1091,7 +1081,9 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
  */
     @Timed
     @Transactional
-    void setLongestORF(Transcript transcript, TranslationTable translationTable, boolean allowPartialExtension, boolean readThroughStopCodon) {
+    void setLongestORF(Transcript transcript, boolean readThroughStopCodon) {
+        Organism organism = transcript.featureLocation.sequence.organism
+        TranslationTable translationTable = organismService.getTranslationTable(organism)
         String mrna = getResiduesWithAlterationsAndFrameshifts(transcript);
         if (!mrna) {
             return;

--- a/grails-app/services/org/bbop/apollo/OrganismService.groovy
+++ b/grails-app/services/org/bbop/apollo/OrganismService.groovy
@@ -2,10 +2,14 @@ package org.bbop.apollo
 
 import grails.transaction.NotTransactional
 import grails.transaction.Transactional
+import org.bbop.apollo.sequence.SequenceTranslationHandler
+import org.bbop.apollo.sequence.TranslationTable
 
 @Transactional
 class OrganismService {
+
     def featureService
+    def configWrapperService
 
     int TRANSACTION_SIZE = 30
 
@@ -58,5 +62,19 @@ class OrganismService {
             println "Deleted ${rate} features / sec"
         }
         return featurePairs.size()
+    }
+
+
+    TranslationTable getTranslationTable(Organism organism) {
+        if(organism?.nonDefaultTranslationTable){
+            log.debug "overriding default translation table for ${organism.commonName} with ${organism.nonDefaultTranslationTable}"
+            return SequenceTranslationHandler.getTranslationTableForGeneticCode(organism.nonDefaultTranslationTable)
+        }
+        // just use the default
+        else{
+            log.debug "using the default translation table"
+            return  configWrapperService.getTranslationTable()
+        }
+
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
@@ -76,6 +76,8 @@ public class OrganismPanel extends Composite {
     Button deleteButton;
     @UiField(provided = true)
     WebApolloSimplePager pager = new WebApolloSimplePager(WebApolloSimplePager.TextLocation.CENTER);
+    @UiField
+    TextBox nonDefaultTranslationTable;
 
     boolean creatingNewOrganism = false; // a special flag for handling the clearSelection event when filling out new organism info
     boolean savingNewOrganism = false; // a special flag for handling the clearSelection event when filling out new organism info
@@ -224,6 +226,9 @@ public class OrganismPanel extends Composite {
         publicMode.setValue(organismInfo.getPublicMode());
         publicMode.setEnabled(isEditable);
 
+        nonDefaultTranslationTable.setText(organismInfo.getNonDefaultTranslationTable());
+        nonDefaultTranslationTable.setEnabled(isEditable);
+
         deleteButton.setVisible(isEditable);
         deleteButton.setEnabled(isEditable);
     }
@@ -309,6 +314,7 @@ public class OrganismPanel extends Composite {
         organismInfo.setGenus(genus.getText());
         organismInfo.setSpecies(species.getText());
         organismInfo.setBlatDb(blatdb.getText());
+        organismInfo.setNonDefaultTranslationTable(nonDefaultTranslationTable.getText());
         organismInfo.setPublicMode(publicMode.getValue());
 
         createButton.setEnabled(false);
@@ -364,6 +370,14 @@ public class OrganismPanel extends Composite {
     public void handleBlatDbChange(ChangeEvent changeEvent) {
         if (singleSelectionModel.getSelectedObject() != null) {
             singleSelectionModel.getSelectedObject().setBlatDb(blatdb.getText());
+            updateOrganismInfo();
+        }
+    }
+
+    @UiHandler("nonDefaultTranslationTable")
+    public void handleNonDefaultTranslationTable(ChangeEvent changeEvent) {
+        if (singleSelectionModel.getSelectedObject() != null) {
+            singleSelectionModel.getSelectedObject().setNonDefaultTranslationTable(nonDefaultTranslationTable.getText());
             updateOrganismInfo();
         }
     }
@@ -426,12 +440,12 @@ public class OrganismPanel extends Composite {
         deleteButton.setVisible(false);
     }
 
-    public void changeButtonSelection() {
+    private void changeButtonSelection() {
         changeButtonSelection(singleSelectionModel.getSelectedObject() != null);
     }
 
     // Set the button states/visibility depending on whether there is a selection or not
-    public void changeButtonSelection(boolean selection) {
+    private void changeButtonSelection(boolean selection) {
         Boolean isAdmin = MainPanel.getInstance().isCurrentUserAdmin();
         if (selection) {
             newButton.setEnabled(isAdmin);
@@ -449,22 +463,24 @@ public class OrganismPanel extends Composite {
     }
 
     //Utility function for toggling the textboxes (gray out)
-    public void setTextEnabled(boolean enabled) {
+    private void setTextEnabled(boolean enabled) {
         sequenceFile.setEnabled(enabled);
         organismName.setEnabled(enabled);
         genus.setEnabled(enabled);
         species.setEnabled(enabled);
         blatdb.setEnabled(enabled);
+        nonDefaultTranslationTable.setEnabled(enabled);
         publicMode.setEnabled(enabled);
     }
 
     //Utility function for clearing the textboxes ("")
-    public void clearTextBoxes() {
+    private void clearTextBoxes() {
         organismName.setText("");
         sequenceFile.setText("");
         genus.setText("");
         species.setText("");
         blatdb.setText("");
+        nonDefaultTranslationTable.setText("");
         publicMode.setValue(false);
     }
 

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.ui.xml
@@ -29,6 +29,9 @@
             margin-left: auto;
             margin-right: auto;
         }
+        .inline-button{
+            display: inline;
+        }
 
     </ui:style>
     <gwt:DockLayoutPanel>
@@ -42,7 +45,7 @@
                 </gwt:center>
             </gwt:DockLayoutPanel>
         </gwt:center>
-        <gwt:south size="300">
+        <gwt:south size="350">
             <gwt:TabLayoutPanel barHeight="35">
                 <gwt:tab>
                     <gwt:header>Details</gwt:header>
@@ -84,6 +87,14 @@
                                 <b:InputGroup>
                                     <b:InputGroupAddon>Search database</b:InputGroupAddon>
                                     <b:TextBox autoComplete="false" ui:field="blatdb" enabled="false"/>
+                                </b:InputGroup>
+                            </b:Column>
+                        </b:Row>
+                        <b:Row styleName="{style.row}">
+                            <b:Column size="XS_12" styleName="{style.widgetPanel}">
+                                <b:InputGroup>
+                                    <b:InputGroupAddon>Non-default Translation Table</b:InputGroupAddon>
+                                    <b:TextBox autoComplete="false" ui:field="nonDefaultTranslationTable" enabled="false"/>
                                 </b:InputGroup>
                             </b:Column>
                         </b:Row>

--- a/src/gwt/org/bbop/apollo/gwt/client/dto/OrganismInfo.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/dto/OrganismInfo.java
@@ -30,6 +30,7 @@ public class OrganismInfo implements HasJSON{
     private Boolean publicMode;
     private Boolean canEdit ;
     private boolean editable;
+    private String nonDefaultTranslationTable ;
 
 
     public OrganismInfo(){
@@ -129,6 +130,14 @@ public class OrganismInfo implements HasJSON{
         return current;
     }
 
+    public String getNonDefaultTranslationTable() {
+        return nonDefaultTranslationTable;
+    }
+
+    public void setNonDefaultTranslationTable(String nonDefaultTranslationTable) {
+        this.nonDefaultTranslationTable = nonDefaultTranslationTable;
+    }
+
     public JSONObject toJSON() {
         JSONObject payload = new JSONObject();
 
@@ -155,6 +164,9 @@ public class OrganismInfo implements HasJSON{
         }
         if(valid!=null){
             payload.put("valid",JSONBoolean.getInstance(valid));
+        }
+        if(nonDefaultTranslationTable!=null){
+            payload.put("nonDefaultTranslationTable",new JSONString(nonDefaultTranslationTable));
         }
 
         payload.put("publicMode",JSONBoolean.getInstance(publicMode != null ? publicMode : false));

--- a/src/gwt/org/bbop/apollo/gwt/client/dto/OrganismInfoConverter.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/dto/OrganismInfoConverter.java
@@ -28,9 +28,6 @@ public class OrganismInfoConverter {
         } else {
             organismInfo.setNumFeatures(0);
         }
-        if (object.get("blatdb") != null && object.get("blatdb").isString() != null) {
-            organismInfo.setBlatDb(object.get("blatdb").isString().stringValue());
-        }
         organismInfo.setDirectory(object.get("directory").isString().stringValue());
         if (object.get("valid") != null) {
             organismInfo.setValid(object.get("valid").isBoolean().booleanValue());
@@ -43,6 +40,9 @@ public class OrganismInfoConverter {
         }
         if (object.get("blatdb") != null && object.get("blatdb").isString() != null) {
             organismInfo.setBlatDb(object.get("blatdb").isString().stringValue());
+        }
+        if (object.get("nonDefaultTranslationTable") != null && object.get("nonDefaultTranslationTable").isString() != null) {
+            organismInfo.setNonDefaultTranslationTable(object.get("nonDefaultTranslationTable").isString().stringValue());
         }
         if (object.get("publicMode") != null) {
             organismInfo.setPublicMode(object.get("publicMode").isBoolean().booleanValue());
@@ -90,6 +90,9 @@ public class OrganismInfoConverter {
         }
         if (organismInfo.getBlatDb() != null) {
             object.put("blatdb", new JSONString(organismInfo.getBlatDb()));
+        }
+        if (organismInfo.getNonDefaultTranslationTable() != null) {
+            object.put("nonDefaultTranslationTable", new JSONString(organismInfo.getNonDefaultTranslationTable()));
         }
 
         GWT.log("convertOrganismInfoToJSONObject "+organismInfo.getPublicMode());

--- a/web-app/js/restapidoc/restapidoc.json
+++ b/web-app/js/restapidoc/restapidoc.json
@@ -2,14 +2,14 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
-         "jsondocId": "38d078f5-ec8b-4042-860d-018a93d56541",
+         "jsondocId": "f9ab560c-4f3d-4035-9927-f8681f85323f",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2d1ca890-5686-402d-9db8-eedffca07c44",
+                     "jsondocId": "5e0664bb-2e58-4e21-bf30-a67d7a224afe",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -18,7 +18,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3a048873-4ca4-42cc-91e2-dec77e368993",
+                     "jsondocId": "bdc85ac2-bd75-43e4-a85b-ac55956c65c8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -27,7 +27,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1b183e6c-1f6f-42ae-b79a-5ed67d0d442f",
+                     "jsondocId": "a8f9de7f-8c50-4c8c-b0b5-0966d5383b82",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -36,7 +36,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fb289ecb-2a06-4a08-ab99-415874cf4048",
+                     "jsondocId": "4db0e7fd-73eb-4561-8164-8994d80e6866",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -45,7 +45,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d6d7f8ec-ad5e-4e60-b97a-c653f89e5b39",
+                     "jsondocId": "9b525cf9-ae08-44c0-90e9-b98b52cebf89",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
@@ -57,9 +57,9 @@
                "verb": "POST",
                "description": "Set name of a feature",
                "methodName": "setName",
-               "jsondocId": "d8ec2ba4-6d7e-44f1-9460-20c6ad34686a",
+               "jsondocId": "2614c58a-8e83-46a7-b922-70dc76cf3e9b",
                "bodyobject": {
-                  "jsondocId": "167b2c56-282f-4be3-aae8-d83dc5568efc",
+                  "jsondocId": "2e474f36-bc11-4ad8-8e57-a7d6a91ae1f8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -69,7 +69,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setName",
                "response": {
-                  "jsondocId": "bfbe7829-5bfa-41d2-b278-c88ee64e4401",
+                  "jsondocId": "060ca269-f77e-4efa-84de-515d8f43994f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -82,7 +82,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "62de1d16-e55f-45ee-ba58-33980561d72d",
+                     "jsondocId": "e89ab6da-60a4-4aa2-a3a6-f3ad995251df",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -91,7 +91,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7cac1473-36b0-4c96-8378-6abbe1021b7a",
+                     "jsondocId": "ad534685-b965-40a3-b97b-96223e6e7975",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -100,7 +100,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d4aad1a0-5338-4cfa-aace-75a506d55b36",
+                     "jsondocId": "44e3d65d-25f7-4791-ba36-cf44cbbd7bba",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -109,7 +109,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7680235d-dc95-4854-aea9-571bcecf9501",
+                     "jsondocId": "21283077-64c6-4bd3-ba6c-581d7c037899",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -118,80 +118,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2b72c255-0d4e-4466-b7fb-a9f1738b5b78",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set description for a feature",
-               "methodName": "setDescription",
-               "jsondocId": "4ff2724e-852f-4245-aa07-44232978ef47",
-               "bodyobject": {
-                  "jsondocId": "70260714-f4ba-4fa6-91f3-c86652bb20f4",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setDescription",
-               "response": {
-                  "jsondocId": "eb29ca99-2473-4d90-ae08-8a463ca96c1f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "6c7c742f-acef-4a69-9808-a30701d18d04",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f63917c0-59f4-4774-b3c1-f0d8c27413d0",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7e7c539f-07f3-4d4d-be94-cf3705195bae",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b1843719-a031-428f-9de4-f6a27dbed83b",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4281fe63-adc7-4ada-9720-43f9c94b87f3",
+                     "jsondocId": "16fc0e7d-f6e3-40c9-8eb6-1fd6959547f6",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
@@ -203,9 +130,9 @@
                "verb": "POST",
                "description": "Set status of a feature",
                "methodName": "setStatus",
-               "jsondocId": "3d876088-a228-4410-b44d-5ad39d633efb",
+               "jsondocId": "e33c9a37-55f1-42ee-94c3-3bababfb4e86",
                "bodyobject": {
-                  "jsondocId": "93597b49-0686-4015-90f0-f1de00b88fa6",
+                  "jsondocId": "aaa26159-9991-4e96-b1f3-413ff1798611",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -215,7 +142,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setStatus",
                "response": {
-                  "jsondocId": "b3bf8f4d-01aa-44df-afa7-84b0fa3e3742",
+                  "jsondocId": "a7d2c860-d8f5-449d-a633-3835c9381898",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -228,7 +155,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4c80365b-4b7b-4141-8af1-436f48b6a6cc",
+                     "jsondocId": "17670d15-0b19-48cd-824b-92d8dfef7486",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -237,7 +164,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0eac0bff-e3f6-47ca-9590-d62c5707a29c",
+                     "jsondocId": "448a73f9-7eae-48e5-a0d7-35c133304f37",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -246,7 +173,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ce2e8a83-eac5-403a-bb23-f754039fa082",
+                     "jsondocId": "c8d42024-160b-41b5-adfd-4b4655562bb4",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -255,7 +182,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7a029cf2-ba31-4aeb-a3b3-c413a90741a7",
+                     "jsondocId": "4322d452-5860-4f3e-b5e2-1043a7db0dbc",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -264,80 +191,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "60b4b4b4-be99-47a3-936f-0889d43ba3f9",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add attribute (key,value pair) to feature",
-               "methodName": "addAttribute",
-               "jsondocId": "d4749596-dfaf-41a3-ad3d-1204065688c3",
-               "bodyobject": {
-                  "jsondocId": "b013fda1-101e-4711-bc7d-16cb7a014719",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addAttribute",
-               "response": {
-                  "jsondocId": "b6c0fd1b-f5d4-4285-9f84-bfc27fbe2f44",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "3eb3e509-d76a-4c3e-8fe9-db93010854db",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9ac19f6e-4867-4457-bdc4-ab785204ecf4",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "fd716e69-1a57-47b8-aee4-4602527105fa",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f36d6166-8b7a-4cdc-ace8-b7f8b917b9c4",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "39c7fb3a-1735-4c9d-b3b7-995b70fa231f",
+                     "jsondocId": "7ebcefe2-977e-4bcd-aaa3-889ae96f325e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -349,9 +203,9 @@
                "verb": "POST",
                "description": "Get comments",
                "methodName": "getComments",
-               "jsondocId": "9f6885e6-f69e-4287-bebb-6ffa6f3a2c0e",
+               "jsondocId": "fd18e8d1-6f29-443c-a4c7-4b4fa9fd1819",
                "bodyobject": {
-                  "jsondocId": "516c83c0-f0f7-4187-9797-7eb81ee8e7f0",
+                  "jsondocId": "369ab7a3-cb5c-4a41-9f84-bcfae0b1c923",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -361,7 +215,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getComments",
                "response": {
-                  "jsondocId": "6b8a0ed3-7c1c-4abb-872c-e48e8062d7c7",
+                  "jsondocId": "cc16adc4-0dc8-4338-a7ef-3690453c25cb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -374,7 +228,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2ed0a706-3942-47e5-a25d-9368d9fff429",
+                     "jsondocId": "b9f3ff13-469a-47c1-bb8f-fa0c6eb2b994",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -383,7 +237,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "affd0066-23f4-4d08-98dc-d1c55e9a52fe",
+                     "jsondocId": "50340bd2-00f8-49a0-b3eb-f9fce2dc1f9b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -392,7 +246,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2a4cda6a-03b2-448d-abd0-cd98e4e32fc2",
+                     "jsondocId": "fd38e296-842a-48ae-8363-513b9ed04da0",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -401,7 +255,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66025c9b-9e4c-471f-b3f1-9cc8dd24d92e",
+                     "jsondocId": "f0fedb8a-90c0-47fe-80fe-186c332f560a",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -410,21 +264,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fe4dc9e8-e0c2-4bc3-a544-c5e8682451e7",
+                     "jsondocId": "4445fcc9-e3be-41ce-b66e-90a3e6d9fa5e",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Set symbol of a feature",
-               "methodName": "setSymbol",
-               "jsondocId": "ce688f9c-13a0-4d2f-ab4d-4b83d277adf2",
+               "description": "Set description for a feature",
+               "methodName": "setDescription",
+               "jsondocId": "a454ca64-0560-4477-88b1-bc80f190e4ef",
                "bodyobject": {
-                  "jsondocId": "51464bf9-dd87-47f6-ae5e-73d647252735",
+                  "jsondocId": "3750ed38-d830-4449-a194-da02ad8e1e17",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -432,9 +286,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setSymbol",
+               "path": "/annotationEditor/setDescription",
                "response": {
-                  "jsondocId": "6e0e6886-c57b-4f98-91d1-ca69441cae2e",
+                  "jsondocId": "f8fbe30e-1a5c-4122-9eb8-bd5a2f26a771",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -449,9 +303,9 @@
                "verb": "POST",
                "description": "Returns a translation table as JSON",
                "methodName": "getTranslationTable",
-               "jsondocId": "884644fc-03f6-4e5a-8489-3ba03309edf3",
+               "jsondocId": "e142d718-fff5-42cf-b326-f0f72f2c5c62",
                "bodyobject": {
-                  "jsondocId": "d26eeede-9bf1-4719-b61a-7908e9349ae6",
+                  "jsondocId": "1e4c2c7a-7f58-40ee-a58e-d2bf97cc6cb7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -461,7 +315,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getTranslationTable",
                "response": {
-                  "jsondocId": "d305f022-acc7-4b86-b731-6e493a391af4",
+                  "jsondocId": "62ef356c-b39b-495d-b2a1-50ece180afc8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -474,7 +328,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4ca7a72e-7f82-4f70-b55a-96c54cfcc48e",
+                     "jsondocId": "d9c2f4a4-03be-457b-98fb-2bfb6a804f15",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -483,7 +337,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "df31d9e9-bb7b-469f-9898-061ac08c36d1",
+                     "jsondocId": "b5be0eec-3017-43c7-97b0-d4e77f24c7f4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -492,7 +346,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "df05d66b-3a5a-4853-b7ad-3c4a7cc9040e",
+                     "jsondocId": "c2145594-ab2d-4076-87ff-a6f7d899fc61",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -501,7 +355,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1c41e37-ba7d-4d84-88d9-88d919315a5f",
+                     "jsondocId": "0c2629b7-5c2c-4b11-9ec2-10ef9bbc746b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -510,7 +364,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49cec4f7-a400-42d2-a45c-84ba00a10638",
+                     "jsondocId": "b30e847c-4393-48ed-acd3-d7371ee454de",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -519,7 +373,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "415f97f6-792e-4b3f-8b7e-7786656ff99d",
+                     "jsondocId": "1599b7aa-aa34-4751-a875-e68727c8770c",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -528,7 +382,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d10b47db-0533-4e09-8644-1a6aee9796ef",
+                     "jsondocId": "aeecb653-e002-4b93-be87-6475c33c0c84",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -540,9 +394,9 @@
                "verb": "POST",
                "description": "Add non-coding genomic feature",
                "methodName": "addFeature",
-               "jsondocId": "21948b8c-4df7-4d92-8301-71f1a4b0f62d",
+               "jsondocId": "35f40350-ff09-4732-adbd-41cfbaed52bf",
                "bodyobject": {
-                  "jsondocId": "98f7061b-0afe-4420-be81-339c62a42a95",
+                  "jsondocId": "63a412db-ec23-49fb-986d-de3ee6e116f0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -552,7 +406,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addFeature",
                "response": {
-                  "jsondocId": "e7c20160-fb15-431f-9ae3-e20a7b5c630a",
+                  "jsondocId": "10eb4665-14d0-4ae8-8f85-4e9f9e6a8f9e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -565,7 +419,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "cf01c58c-db74-422c-ac3a-972c08f5542e",
+                     "jsondocId": "666d586c-4aa5-4370-982f-e1480be278ea",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -574,7 +428,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0fef86ac-b893-47a2-9e05-15124e0e169a",
+                     "jsondocId": "6f004b59-af52-41e5-af35-d33b39ace247",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -583,7 +437,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "478d7c02-f738-4d83-9418-226a187ff197",
+                     "jsondocId": "93cb740e-6c08-42d9-8288-ec940ed69ec9",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -592,7 +446,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a713a3bd-88e8-42b7-acea-3f941352b4fd",
+                     "jsondocId": "797958be-6ee8-4f06-926b-c091ee21f799",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -601,7 +455,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ed5ae47d-e8d3-4c59-9d7c-0d00c2a83bd4",
+                     "jsondocId": "61ee768e-f591-463f-ad26-ecd882f442a6",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -610,7 +464,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b18e1eca-b555-408a-8088-7c4aca649584",
+                     "jsondocId": "94012c2b-39a0-4483-b78a-03b0336d3206",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -619,7 +473,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b3d8f83d-27bb-4e40-b41b-aceedc81c026",
+                     "jsondocId": "3f2ec6db-ebbf-413b-a1ac-88c6fe401359",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -631,9 +485,9 @@
                "verb": "POST",
                "description": "Set exon feature boundaries",
                "methodName": "setExonBoundaries",
-               "jsondocId": "4c3708e5-4775-4d85-96d5-08d790306bf8",
+               "jsondocId": "5d22806f-02ab-4f04-9b06-6d22f7b73f63",
                "bodyobject": {
-                  "jsondocId": "b0405049-6030-4f58-bfa2-b31bb2454484",
+                  "jsondocId": "038b3cad-1a9b-4455-b234-050208d7ae34",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -643,7 +497,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setExonBoundaries",
                "response": {
-                  "jsondocId": "990573c8-93aa-46f4-bd2a-45d755f33b5a",
+                  "jsondocId": "c6718e01-52a3-4766-b5ef-0a7eace0d5e4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -656,7 +510,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "764efdc8-8dd3-4f66-ae5d-7a8c225574fd",
+                     "jsondocId": "6c8e5a19-4fd0-40e5-b8e4-9510040ac2d9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -665,7 +519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bfc63836-cb0b-4492-9568-58b7d67cacc5",
+                     "jsondocId": "c0c0e645-b4b4-4f07-ac7b-24f521195acb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -674,7 +528,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4892defe-dfbe-479a-b854-1a20805dc6b9",
+                     "jsondocId": "99e50252-e2ce-4f9b-b9cf-3ac5c81843f0",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -683,7 +537,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f68ce036-b23c-4fa4-b339-4db672e94851",
+                     "jsondocId": "1eae2f70-3f18-4f55-b7db-e5fee3b6a8e8",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -692,7 +546,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "955771a3-fd43-4ed9-b79b-4c8fac24f866",
+                     "jsondocId": "c9fb4793-3cc8-4ab0-b165-c88f133b7271",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -701,7 +555,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14f0dabd-ba0a-4647-bdef-d880967b4310",
+                     "jsondocId": "d21db00c-65b7-4e43-9a5e-e92a28f7cecb",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -710,7 +564,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "19acb3b3-247b-430c-8294-55e68fa7425d",
+                     "jsondocId": "da0b0632-740f-4b18-b548-04698eab7705",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -722,9 +576,9 @@
                "verb": "POST",
                "description": "Add an exon",
                "methodName": "addExon",
-               "jsondocId": "2e6ab2ca-6d61-421c-aacb-66e758a14742",
+               "jsondocId": "d9118d03-b34e-43b9-919f-76bbb8e8bb76",
                "bodyobject": {
-                  "jsondocId": "bfb20fb4-4958-4c82-8fb6-5413f2b67924",
+                  "jsondocId": "d7a49b44-910f-4692-b2d8-8550a25415f7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -734,7 +588,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addExon",
                "response": {
-                  "jsondocId": "97bba334-f05a-4684-bad1-056b3cc14f6b",
+                  "jsondocId": "c4e533bd-47dc-4599-99c7-d3dd873b906b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -747,7 +601,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "32d09fd0-76a9-44f4-be76-17c8468fe2ba",
+                     "jsondocId": "52c215af-67e2-43b8-8c0b-b2197c7b7fa8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -756,7 +610,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "22f03756-92d6-4add-8b70-15e47de26da8",
+                     "jsondocId": "0b94ecc5-9dd0-4bcf-b94c-68a2538d35bf",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -765,7 +619,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "46f111e1-2ee4-4c5b-944f-247da49cec8f",
+                     "jsondocId": "20b36032-65c6-48c7-9d83-19ec2fcdcabf",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -774,7 +628,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ea186f6f-7c39-45da-98e0-9430a4d062f7",
+                     "jsondocId": "f4340ba8-8919-4422-a798-703f6ff6853b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -783,7 +637,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "47b81713-74a4-49bd-a137-80de68df2928",
+                     "jsondocId": "3247f606-f4ad-4c1d-9fda-f43ec857eefb",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -795,9 +649,9 @@
                "verb": "POST",
                "description": "Add comments",
                "methodName": "addComments",
-               "jsondocId": "15b6594c-2fa8-4384-9a85-1f5dfdc3758e",
+               "jsondocId": "a4e8c16a-efb0-4b43-882c-6ab3d5b5c0c4",
                "bodyobject": {
-                  "jsondocId": "d2296eae-0c10-4c33-bf45-15dba7709586",
+                  "jsondocId": "79ce009b-3e2c-460e-8050-f0fa41e5b4fe",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -807,7 +661,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addComments",
                "response": {
-                  "jsondocId": "b11c57f2-2132-4534-9f61-da4e3090ad49",
+                  "jsondocId": "6ef84d86-ac8c-4388-bbbe-dbd87bfd7c99",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -820,7 +674,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3fb2cceb-91b0-462f-a377-95677e38c1c9",
+                     "jsondocId": "aae35953-f051-4708-a217-5c1aeb70f09d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -829,7 +683,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3329c06d-5bce-4092-9851-9664894c6728",
+                     "jsondocId": "f22c3d84-b8a0-4322-9f82-d01006cd5f7c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -838,7 +692,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aa3d6f02-ccb0-49c0-8e03-03e83eba360a",
+                     "jsondocId": "9a867ce4-cc75-4c3f-bbe9-387ee873574a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -847,7 +701,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7955a5a7-4946-48db-b58a-511a6b5deb64",
+                     "jsondocId": "772ff55f-024d-484f-812e-2f286e4497de",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -856,7 +710,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e2c5f706-9d95-49bc-ae5c-a1af6ad2e935",
+                     "jsondocId": "fd560228-abd5-42c3-ad35-54810649fc6b",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -868,9 +722,9 @@
                "verb": "POST",
                "description": "Delete comments",
                "methodName": "deleteComments",
-               "jsondocId": "92766f60-1281-4459-9cd6-64a31b6166f7",
+               "jsondocId": "5f7a4709-839b-400c-8200-7f7034f3f896",
                "bodyobject": {
-                  "jsondocId": "5b8d49fc-e580-468f-ae52-843c0b9d322b",
+                  "jsondocId": "4083b79a-8574-41c7-8dc8-2b09548bc886",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -880,7 +734,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteComments",
                "response": {
-                  "jsondocId": "146b5a87-ccee-4f51-9fd6-807476b9e748",
+                  "jsondocId": "bd1b7758-9fd7-4319-8b4d-53158b032ab0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -893,7 +747,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "202d8723-8211-4334-87ce-896759b81d5d",
+                     "jsondocId": "018472e2-973c-47ff-9985-932246ab4f94",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -902,7 +756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1c68cafb-1e88-4343-bc32-a4606fb34210",
+                     "jsondocId": "7c3f8194-2308-483d-83a0-d4b0654427bf",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -911,7 +765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6fdb675f-ae29-4325-a46d-e2139dbcea4b",
+                     "jsondocId": "72196710-5916-4fd8-b8a3-f4fcd546a9da",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -920,7 +774,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1081332-051a-41dc-9b2f-be047b612c38",
+                     "jsondocId": "9ca52685-fdf5-4a97-a9a3-4dc772d722d1",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -929,7 +783,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7e54a235-b60f-4ebd-bab6-2ac9888bb20f",
+                     "jsondocId": "984a24b1-a756-46fc-bd6c-e31fc40c2871",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -941,9 +795,9 @@
                "verb": "POST",
                "description": "Update comments",
                "methodName": "updateComments",
-               "jsondocId": "75aa26f5-ce74-4e17-9d20-3bbaee2b1e63",
+               "jsondocId": "7abe652c-8d16-45fb-930f-5cc9f5cb3c96",
                "bodyobject": {
-                  "jsondocId": "ce27c54b-2a85-4eba-b8ab-11eb773af8e6",
+                  "jsondocId": "382f52e8-267b-496b-9cad-d412dceebd69",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -953,7 +807,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateComments",
                "response": {
-                  "jsondocId": "99c3ea41-ce37-4d35-91ea-aba179f96c9a",
+                  "jsondocId": "8c3c8ebe-0ff9-4c5c-93b3-3d9216ab34fd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -966,7 +820,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "03f5c861-b9d4-4810-b3c2-a2bd496bbfab",
+                     "jsondocId": "dda36841-f92b-48e3-b7d9-c0ba1cbf2ce0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -975,7 +829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e9ae35c-9ef7-4b2d-b858-1950e30fea66",
+                     "jsondocId": "9c6ef9ac-2249-45c7-af45-9830f6f7deef",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -984,7 +838,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "03be52ef-c74d-4801-bce9-072816cec166",
+                     "jsondocId": "13d99b41-ad89-44bb-8036-440ff091c99c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -993,7 +847,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eeb2d92c-39a0-4134-a742-afe1ebaab4c2",
+                     "jsondocId": "3e6849e8-e9c8-4411-8d71-f2ea9b1c28fb",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1002,7 +856,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "10ea4064-db5f-47e0-ae5d-e04d521357f0",
+                     "jsondocId": "08a657e5-997c-4f7c-a2d1-15cd918f2281",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1011,7 +865,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b9592d7c-6243-4718-9148-1c155e6cc64c",
+                     "jsondocId": "4ca1500a-e2f8-460c-82b2-8ca6e919b62f",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1020,7 +874,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "80951556-7a48-493a-83de-adf50dde61f0",
+                     "jsondocId": "6dc7236f-03da-4d44-a000-1b39516f8105",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -1032,9 +886,9 @@
                "verb": "POST",
                "description": "Add transcript",
                "methodName": "addTranscript",
-               "jsondocId": "cfd04171-bbd5-4230-84c9-4d0b560beb25",
+               "jsondocId": "23cc6db3-0ecf-4901-8cf5-2f37fed78cf6",
                "bodyobject": {
-                  "jsondocId": "bc4b72c5-7020-440b-b372-065caffa4ba4",
+                  "jsondocId": "3c7ec699-2495-4ef4-bb75-1c11b7bdc759",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1044,7 +898,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addTranscript",
                "response": {
-                  "jsondocId": "1abf0f9c-6197-47b5-a2fe-30c54d700ea6",
+                  "jsondocId": "37238092-a6a9-4ff4-9c5d-8bd25679deea",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1057,7 +911,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "24fc7b70-0ab9-4c6d-ac6a-b001565ccbb1",
+                     "jsondocId": "83222301-63ea-4d74-9a2c-1d00c9879ded",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1066,7 +920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6226dc14-e8d6-490f-a4fc-531f1155066f",
+                     "jsondocId": "c4bee1e1-6be8-4696-9b6f-b812db1a273d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1075,7 +929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5fd4ad54-5810-4c15-84b4-7c8e50242d66",
+                     "jsondocId": "02d1328f-038a-459d-af57-3e1cdf4ba46a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1084,7 +938,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6998553f-1187-4946-acea-c05d765d75ee",
+                     "jsondocId": "58aca0ec-0efd-4219-b20e-9cc2ff5c4c36",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1093,7 +947,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d7d95c8e-2df3-4610-b4fe-caadf98cb780",
+                     "jsondocId": "93090835-e754-43e7-9f13-8740a63ab53c",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1102,7 +956,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b60e9298-ffaf-4e0a-a087-09abc16e8444",
+                     "jsondocId": "5d51d185-ebf7-453c-a8f9-450e12df014e",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1111,7 +965,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "90d108af-df15-4d75-b002-e45bf6a8f148",
+                     "jsondocId": "c6f4b5dc-dfdb-4fe4-ba17-e26ae749ca09",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
@@ -1123,9 +977,9 @@
                "verb": "POST",
                "description": "Duplicate transcript",
                "methodName": "duplicateTranscript",
-               "jsondocId": "2a4ccef0-3238-48af-b30a-48e21e14806a",
+               "jsondocId": "0ac93c9e-1e03-4359-85e4-037b823cd56d",
                "bodyobject": {
-                  "jsondocId": "0e55cae3-18a4-4bb1-8b6d-b9ffd0fbed8d",
+                  "jsondocId": "5ff5bbf4-672f-4111-bfd0-837da7828970",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1135,7 +989,7 @@
                "apierrors": [],
                "path": "/annotationEditor/duplicateTranscript",
                "response": {
-                  "jsondocId": "dd7d2ede-5324-46ae-8172-140b76ddc009",
+                  "jsondocId": "010aaa1e-0e57-4bea-8354-3e18089ad644",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1148,7 +1002,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "aaff5a6b-66d7-43d8-a27e-88a19643333d",
+                     "jsondocId": "ee3797d0-33ba-4b48-bacb-cfd5922cda5c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1157,7 +1011,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "78477aba-3e1f-4718-a77a-12815ca9ec47",
+                     "jsondocId": "197255f2-1dde-4a63-9ca9-4f83eae826d2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1166,7 +1020,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6a9dc815-c7c6-427b-9f98-054fcd5caa28",
+                     "jsondocId": "c036b133-773b-46c6-9c71-723e2ce0a364",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1175,7 +1029,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b25bd99f-0397-4033-870c-0c9a421dea98",
+                     "jsondocId": "dfb3c855-4694-4ed0-b7d4-2a0118a420f7",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1184,7 +1038,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "87ade196-fb38-4cf1-97c0-2c72f13cb611",
+                     "jsondocId": "f700f552-6454-4b60-952f-c0950f948de5",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -1196,9 +1050,9 @@
                "verb": "POST",
                "description": "Set translation start",
                "methodName": "setTranslationStart",
-               "jsondocId": "3f5d7fed-1f31-41db-90f9-b70d7d40ce5b",
+               "jsondocId": "01f6c40f-ac79-4452-9f50-b30bd12c4055",
                "bodyobject": {
-                  "jsondocId": "ae05e421-b322-4916-bfe1-fe3bb308f805",
+                  "jsondocId": "ef4f57c7-7546-4b89-99ca-25f65799bccf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1208,7 +1062,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationStart",
                "response": {
-                  "jsondocId": "3ff1873c-faf5-46ff-982f-40e348f13d3d",
+                  "jsondocId": "4e236d6f-6712-45ad-a90a-e5331b43d2d2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1221,7 +1075,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "107a8863-a1c6-4e07-be2e-a0ad13947d66",
+                     "jsondocId": "5b765f0a-1b73-4d4f-aedf-0c562e6e96be",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1230,7 +1084,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b5a075cc-a1c8-4011-b85b-6a12a98d0e88",
+                     "jsondocId": "1e732ac6-2b5c-4a75-bbdb-a049b54129c0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1239,7 +1093,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b06f3add-4626-42c4-b613-dd477d82283a",
+                     "jsondocId": "bdf521e8-040f-478e-9a7e-d454b2202d40",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1248,7 +1102,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44457899-22b0-4a64-9896-537cebe66796",
+                     "jsondocId": "8328fe53-52da-4712-b256-7044eef4fcce",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1257,7 +1111,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3f55745c-d516-42c0-806a-4be0ddbcd8d0",
+                     "jsondocId": "1c4ebe51-0c54-45a2-9dfa-0fab812076b1",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
@@ -1269,9 +1123,9 @@
                "verb": "POST",
                "description": "Set translation end",
                "methodName": "setTranslationEnd",
-               "jsondocId": "8718c409-03af-4387-bc84-6624231ccdf6",
+               "jsondocId": "9055f242-6510-48c1-b4f0-e8acaa92efb0",
                "bodyobject": {
-                  "jsondocId": "48b9f893-d1b8-4e7f-8d6a-93c48dbb433b",
+                  "jsondocId": "b99dcb56-9d4c-4f70-addf-607c8da8b888",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1281,7 +1135,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationEnd",
                "response": {
-                  "jsondocId": "94ea7314-2449-40ea-afcd-0957792c8146",
+                  "jsondocId": "265c37e5-f592-459e-a845-fb2339b60a46",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1294,7 +1148,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a597d5e2-80de-47df-96f5-672c7753cb48",
+                     "jsondocId": "9d8f9219-1211-4f46-986a-cf1d4a9ae631",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1303,7 +1157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "326b4773-c9f2-4398-9e83-a70121db24fe",
+                     "jsondocId": "94689710-2a62-4a35-b505-b5a934d08e58",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1312,7 +1166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "21ba4350-8f69-42a2-8e45-2d301a2347c0",
+                     "jsondocId": "2c808267-98d2-4808-9b77-57f41ddfdc98",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1321,7 +1175,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b0bd06ae-6c6f-42db-8acb-0cc9de6717ad",
+                     "jsondocId": "7d6360b6-9fd9-4d84-94d2-bf5f21edd4f3",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1330,7 +1184,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6b3f7c24-3834-490d-a51c-b138b94c1786",
+                     "jsondocId": "9b8a80d7-7a07-4c07-9a1e-8541d3922af7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
@@ -1342,9 +1196,9 @@
                "verb": "POST",
                "description": "Set longest ORF",
                "methodName": "setLongestOrf",
-               "jsondocId": "d4708c54-cceb-4dd6-bf96-62462755343b",
+               "jsondocId": "fc4eeb8b-663e-4c37-bbd8-e32c4e4fd374",
                "bodyobject": {
-                  "jsondocId": "f9653bd7-f6ca-4277-8815-74efdcd70137",
+                  "jsondocId": "c3ac0256-6ce4-4d1f-afbe-5ef50be32427",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1354,7 +1208,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setLongestOrf",
                "response": {
-                  "jsondocId": "7903c306-5dcf-4c41-87b2-d9693eb2de60",
+                  "jsondocId": "4cf65d8c-9d65-4671-8833-fc76ed2c5137",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1367,7 +1221,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2164266b-d10e-4ec8-b978-785bbe7a7301",
+                     "jsondocId": "86e9637a-83f5-4b61-a3b2-261ef07bd0e7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1376,7 +1230,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "90604dc3-dfa3-4a48-ad8c-6759171907d1",
+                     "jsondocId": "404e4406-ba35-4ad8-a1b0-5b0643886f7f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1385,7 +1239,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2a52c023-4c7d-4f3e-afd3-585cd18a5972",
+                     "jsondocId": "7af9da79-6e33-483d-ada2-d5422f98ba25",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1394,7 +1248,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "828965cf-48c6-4f2e-8e84-fae8daf750fb",
+                     "jsondocId": "a1156244-81ea-425c-871b-7f70501bdb1d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1403,7 +1257,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d43a5f62-91ad-4a86-a152-aaef742b48a6",
+                     "jsondocId": "4dbe978a-2db4-4d8d-94ba-490cd1aa4574",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -1415,9 +1269,9 @@
                "verb": "POST",
                "description": "Set boundaries of genomic feature",
                "methodName": "setBoundaries",
-               "jsondocId": "ee74569e-fb8b-4c26-a6f6-d0ee80824609",
+               "jsondocId": "e19e2b51-ff87-4894-9416-f3c9b73fef3e",
                "bodyobject": {
-                  "jsondocId": "077f5625-dbce-4f97-9bc5-36a61d5b0537",
+                  "jsondocId": "59612cd4-9e20-4fe9-b98a-c717a5e57771",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1427,7 +1281,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setBoundaries",
                "response": {
-                  "jsondocId": "efa59b60-dd4b-4422-8bbe-d17bc9dc1445",
+                  "jsondocId": "556c7ba1-f527-4360-9d02-4820c1d25725",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1440,7 +1294,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "56664d36-b4e8-41eb-826b-0758f10092db",
+                     "jsondocId": "df78d7c9-6649-43f8-8794-b27a06e6832b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1449,7 +1303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db429942-6cba-45a4-b81d-15bf865400ee",
+                     "jsondocId": "1ef68424-5ccf-45d3-b57d-738d83438bf0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1458,7 +1312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "036a9d5b-0e4c-46c9-ab16-c9aff30824a2",
+                     "jsondocId": "9eafaf6b-23cb-4717-832c-2016e6fc816c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1467,7 +1321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0c8a91e2-0d4b-439e-be9a-62a9211aca90",
+                     "jsondocId": "a21a4bd3-3af0-4ccd-a750-832f9b9f3795",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1479,9 +1333,9 @@
                "verb": "POST",
                "description": "Get all annotated features for a sequence",
                "methodName": "getFeatures",
-               "jsondocId": "debef59c-7e80-4255-9590-25a4689c3c32",
+               "jsondocId": "75b994ca-603f-4a3a-b7fb-af80605259b2",
                "bodyobject": {
-                  "jsondocId": "7be1325d-c1d1-4686-9500-640a18802560",
+                  "jsondocId": "e84411cf-6be6-40cb-9cfe-6c78faeddcd6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1491,7 +1345,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getFeatures",
                "response": {
-                  "jsondocId": "d839cf64-226d-482e-952b-328d0c83f80a",
+                  "jsondocId": "9ec88e74-71a5-40f5-9f94-e56d18dc64e1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1504,7 +1358,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "958d133f-76df-4c3e-bb2b-27c208d863d5",
+                     "jsondocId": "3e8d9f63-06d1-477c-bd67-179afdd1f1bb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1513,7 +1367,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "335b8494-e32f-4fe6-a44a-9a7566933f35",
+                     "jsondocId": "bff40d30-0dd9-46e2-99d3-8741669a2a13",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1522,7 +1376,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "873373fa-c47a-4aea-ad1b-48849db716d6",
+                     "jsondocId": "eaa6abbd-bcf8-44bd-9ef3-0a9fdca794e3",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1531,7 +1385,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "39380eb5-fd4f-4967-9d6c-2add78cbbebb",
+                     "jsondocId": "fd7ca050-6d7c-4cad-b3bb-92a2a2508f08",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1543,9 +1397,9 @@
                "verb": "POST",
                "description": "Get sequence alterations for a given sequence",
                "methodName": "getSequenceAlterations",
-               "jsondocId": "e8201df1-0115-48bf-88a6-3318d1f4daaa",
+               "jsondocId": "39d097b1-8d18-4bc8-8bd2-0989d586a40a",
                "bodyobject": {
-                  "jsondocId": "8fc056a4-54a9-4d77-9473-fb1b4125efe8",
+                  "jsondocId": "8c94ebb2-bda1-4fd1-a45e-15dc9e91d4e6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1555,7 +1409,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequenceAlterations",
                "response": {
-                  "jsondocId": "6e815d66-8c74-432f-91b3-4e7a5c1c656d",
+                  "jsondocId": "467ee220-d746-4958-b29b-69d655f8d736",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1568,7 +1422,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "02de22e5-cd1e-4090-ab7e-d0d5a19b6d07",
+                     "jsondocId": "01c3d379-8c4f-41db-9901-40eb7adb971f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1577,7 +1431,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a655fb62-22ab-4fea-ab56-a0fa64aaa9f3",
+                     "jsondocId": "a0feb2e5-29f5-4dac-9046-a0140883826a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1586,7 +1440,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6bd0f225-31be-4adf-89d9-30c886773995",
+                     "jsondocId": "9371c6e4-1936-40f5-a697-74dd7d6e038a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1595,7 +1449,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "48ccfe05-4499-4896-ac3b-5fe6cf5361a3",
+                     "jsondocId": "a5dfb4c5-2cbf-4279-a33d-2a0c11ef0992",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1604,7 +1458,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0892da0a-83ad-4c79-a672-742324872a22",
+                     "jsondocId": "932e5dd5-4882-4566-a115-014ad39e2f05",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -1616,9 +1470,9 @@
                "verb": "POST",
                "description": "Delete attribute (key,value pair) for feature",
                "methodName": "deleteAttribute",
-               "jsondocId": "2c16c67e-c761-4fe7-b2fb-ad88ce3b30ae",
+               "jsondocId": "2b2d4b90-0980-4934-90be-ca25a70934ce",
                "bodyobject": {
-                  "jsondocId": "4b5aa083-a5b9-4874-a98b-7bbd3923fb2e",
+                  "jsondocId": "28b58b86-eb69-45da-9bd6-66bf2b961632",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1628,7 +1482,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteAttribute",
                "response": {
-                  "jsondocId": "b59d1d99-7ce0-499a-9daa-0087b98b4c2a",
+                  "jsondocId": "25b1cc1b-9bc9-4d9e-b3c8-600dd5d8119a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1641,7 +1495,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "83282f8d-4a8e-4ded-9546-2dbd3f30d49f",
+                     "jsondocId": "4b97d89c-62bb-4ff8-93d6-16014094ac86",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1650,7 +1504,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "69d8e2c0-d0c5-4b88-9451-4ca0869db32f",
+                     "jsondocId": "c03fd4cc-f347-4c4c-9792-c9bc180be727",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1659,7 +1513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dfdb49d0-7040-4dc8-809e-9a30547a32d2",
+                     "jsondocId": "62280cc6-7b80-4dba-bf97-f6516713845e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1668,7 +1522,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a04073cb-ab88-4b7f-a5b3-254ec71336b6",
+                     "jsondocId": "8d02cafb-53db-4531-ba54-c672b9b81df4",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1677,7 +1531,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49869e78-959d-4893-b2a1-b1b70666cc61",
+                     "jsondocId": "acc4cd7f-6428-4bda-98c1-5b38d1d7366d",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.",
@@ -1689,9 +1543,9 @@
                "verb": "POST",
                "description": "Update attribute (key,value pair) for feature",
                "methodName": "updateAttribute",
-               "jsondocId": "c091ec52-6b17-4234-9917-0ea012071c75",
+               "jsondocId": "3f8748fa-621c-48d2-9aea-bbbb260a3ca2",
                "bodyobject": {
-                  "jsondocId": "0b59508a-945e-41c1-adb3-8eedb2c826ae",
+                  "jsondocId": "4b1c8208-21ac-414c-b0a7-9673dc19e9bf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1701,7 +1555,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateAttribute",
                "response": {
-                  "jsondocId": "ad886e33-282f-4d8b-b0b4-cfaaf0128236",
+                  "jsondocId": "5f75bc4b-0a36-4f62-8c18-3c81f5bf9570",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1714,7 +1568,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "81753050-f0a1-4b4a-86bc-70d63a388565",
+                     "jsondocId": "5a3c9588-9e55-48e3-a0d1-06c3ca550524",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1723,7 +1577,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "627a6b29-88fa-4d29-9800-6e5d7a512cf5",
+                     "jsondocId": "e2654155-cf73-44dd-8701-f2478a8f2b3a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1732,7 +1586,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8de49676-ff86-4ecf-98f7-5ed0b62fbccf",
+                     "jsondocId": "5a06c9f7-33b6-4341-8e54-f25d3dfe0244",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1741,7 +1595,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a2914951-d600-45ca-827a-b40d2f4805ca",
+                     "jsondocId": "1bc2fead-0a09-4ca0-9553-cd06dc5796e2",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1750,7 +1604,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "31e8e418-68b3-4dd3-917d-72826bcb588a",
+                     "jsondocId": "8e8c6024-d059-40ef-bfab-73a36b1b3dd8",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1762,9 +1616,9 @@
                "verb": "POST",
                "description": "Add dbxref (db,id pair) to feature",
                "methodName": "addDbxref",
-               "jsondocId": "7b6a2241-fd70-452f-9931-7fd016f5a8ee",
+               "jsondocId": "8af6ee69-f6ce-4d3e-a1de-df31d0bd9d02",
                "bodyobject": {
-                  "jsondocId": "563bca1c-7f28-4624-a2ca-07c5c3d31640",
+                  "jsondocId": "a542b802-28bc-4741-98f4-840baf107e22",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1774,7 +1628,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addDbxref",
                "response": {
-                  "jsondocId": "56570d6e-aff2-453c-b3e6-523e415b3b43",
+                  "jsondocId": "e61dbf8e-ae64-4f2e-b2b8-79cc6458bc36",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1787,7 +1641,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0dfc82ea-a32b-4b23-a418-460a545ea558",
+                     "jsondocId": "953bbf9e-1b0c-47e8-9d5f-af906d5e2bc3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1796,7 +1650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "825ce7b4-67e3-4185-a172-3539c7aac869",
+                     "jsondocId": "2b446bb7-b9c4-4923-b794-c2ad5ee0c5df",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1805,7 +1659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b7da97da-f3ff-4306-9845-182c6441bb00",
+                     "jsondocId": "92580cf3-e2cd-4954-aed8-5039c216e838",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1814,7 +1668,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0014bfd8-7876-4ab6-b4da-5471c7e35e6c",
+                     "jsondocId": "21bee595-1aa3-4d81-b588-c01a1bb0f168",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1823,7 +1677,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7197ad88-3393-49cb-8ab7-37eefdf35567",
+                     "jsondocId": "b33db2eb-d364-4614-afa2-48980eb37c80",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.",
@@ -1835,9 +1689,9 @@
                "verb": "POST",
                "description": "Update dbxrefs (db,id pairs) for a feature",
                "methodName": "updateDbxref",
-               "jsondocId": "5ffcb695-93e1-4c78-b34b-ac61d70223d4",
+               "jsondocId": "6af08578-5893-470f-a9ab-0cd3bcb032bc",
                "bodyobject": {
-                  "jsondocId": "1ead546d-d524-434d-8fa9-92d65fba5fa5",
+                  "jsondocId": "eda7ed17-4335-499c-93bf-3d608eb30ed6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1847,7 +1701,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateDbxref",
                "response": {
-                  "jsondocId": "f2f9ddc8-04aa-4fcc-82b2-8c723ed1c1bc",
+                  "jsondocId": "0cc796d2-de72-44e3-8ee9-20a4cbf22ff1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1860,7 +1714,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6a68c5e4-3f16-48f1-bf08-d41e397e87bd",
+                     "jsondocId": "aa5de5d0-bc6c-4ff4-b43a-47457addaf0b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1869,7 +1723,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4eebd017-0b24-4785-99cf-a30bf5e292ea",
+                     "jsondocId": "8c8d3bcf-0f2b-4849-aee5-8c1e06ea211f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1878,7 +1732,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2917f8de-bd9f-4e9b-b69d-c7bc002afabc",
+                     "jsondocId": "527df8ed-42d5-4cd9-bcf5-c5a64287d20d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1887,7 +1741,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9c78b82c-4b16-4086-a0c3-449c20fa1035",
+                     "jsondocId": "e122bbf2-3c55-474c-b28c-8f94f378e9d3",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1896,7 +1750,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44e7a256-1896-4414-a92c-7cf281b71cf7",
+                     "jsondocId": "3aa6936e-3e30-4582-8114-8558af9cc12e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1908,9 +1762,9 @@
                "verb": "POST",
                "description": "Delete dbxrefs (db,id pairs) for a feature",
                "methodName": "deleteDbxref",
-               "jsondocId": "64f3277a-58f0-437d-b7b8-2f6626be074d",
+               "jsondocId": "5c183db1-4569-4dab-9ba4-3e821a82a6d5",
                "bodyobject": {
-                  "jsondocId": "5d774fc5-f12f-4ce6-b354-9ef4736860d4",
+                  "jsondocId": "668d9b10-086a-46bc-9fe2-13359adbf368",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1920,7 +1774,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteDbxref",
                "response": {
-                  "jsondocId": "97d2412f-7ae3-4e4f-8a15-010a12c35272",
+                  "jsondocId": "19c7b149-bc7e-4f42-a7b4-3790f29a476a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1933,7 +1787,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fc3c63f7-56e9-45c0-a786-2ba2b918d0ab",
+                     "jsondocId": "404450cd-f812-4e39-9fcd-429d11cc8909",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1942,7 +1796,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4cad17c2-c4ed-4adf-a2c5-7f24a1669225",
+                     "jsondocId": "7bf4ee8b-209b-4f34-a998-79c08965441f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1951,7 +1805,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b2f932f9-a3ad-482f-b098-dc9736ee6ecd",
+                     "jsondocId": "db1c850c-f117-4c03-b2c0-b008b84fdc62",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1960,7 +1814,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "43340b56-b161-46c7-ad28-aaa85b841bf8",
+                     "jsondocId": "577a01fe-4e16-44c0-9dfa-5ce931e465be",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1969,7 +1823,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "927935ec-9b41-4d68-accb-903041bbecb8",
+                     "jsondocId": "8b59575a-a361-470a-b2b7-0b7f8ae56259",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
@@ -1981,9 +1835,9 @@
                "verb": "POST",
                "description": "Set readthrough stop codon",
                "methodName": "setReadthroughStopCodon",
-               "jsondocId": "abe6a8e0-9b19-431f-bae1-3fdf96674de4",
+               "jsondocId": "cec717a3-9357-45e5-9543-c3f49166be48",
                "bodyobject": {
-                  "jsondocId": "7029eda6-0eb8-411e-ac38-f9023ba30943",
+                  "jsondocId": "4607611d-77f6-49f4-a88b-2d46c38391a5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1993,7 +1847,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setReadthroughStopCodon",
                "response": {
-                  "jsondocId": "1d8b4f2b-9931-44f7-81d4-36d5c4ae2308",
+                  "jsondocId": "64b5b491-1c23-4d6a-8277-9a8d530249de",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2006,7 +1860,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4de1d284-5b2d-4215-8f3f-072b0a6f934a",
+                     "jsondocId": "d0e48a5e-591f-4400-abe1-aae2dcb3e4f8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2015,7 +1869,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2ecf716f-9583-4c07-8bde-54fe7cc5ac19",
+                     "jsondocId": "d24dde2c-a8b4-4af9-b7b2-60ece825eeba",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2024,7 +1878,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bedd7e34-9430-4c9e-9374-999ec36a0956",
+                     "jsondocId": "966e9c11-81e3-481d-88b0-79d1de565819",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2033,7 +1887,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "46771aaa-1c42-4607-98f8-3348b05bdd30",
+                     "jsondocId": "e79d39e4-c4c5-47e2-858e-97db2994b4cb",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2042,7 +1896,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8606fd62-e2bc-4dca-be7c-0a06a637a043",
+                     "jsondocId": "72f74d56-0054-4634-b7a0-47890ebe9978",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
@@ -2054,9 +1908,9 @@
                "verb": "POST",
                "description": "Add sequence alteration",
                "methodName": "addSequenceAlteration",
-               "jsondocId": "60696e34-0c7c-4a84-bf2d-4022219504c1",
+               "jsondocId": "690e7392-ab1d-4ec9-bec1-1d19420d756d",
                "bodyobject": {
-                  "jsondocId": "3c0aa961-80ad-419f-9856-aee33874b25f",
+                  "jsondocId": "43bc7a4b-6b46-4762-be57-7e2ddf586b8b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2066,7 +1920,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addSequenceAlteration",
                "response": {
-                  "jsondocId": "caf8f447-7196-40d3-bc53-f76bd32e69f5",
+                  "jsondocId": "cc6ec1fb-2abd-4313-9756-879d9d461a81",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2079,7 +1933,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3e60a970-7beb-4dc8-8c6a-1639ca70be4e",
+                     "jsondocId": "e7aa34f0-13ac-4abc-b860-956c77ef629a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2088,7 +1942,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "de67272a-e8eb-432e-bf3c-7f949afc95c2",
+                     "jsondocId": "c54caebf-7784-4bf7-9b31-6fb50cb040a2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2097,7 +1951,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e006aa49-7c9b-40cb-97b6-5837c180f661",
+                     "jsondocId": "a274aad5-db7b-4af8-94da-f2c6863de60e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2106,7 +1960,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "441cc2d7-d269-4c26-a254-9e569584e8d4",
+                     "jsondocId": "ff8371df-42cd-4c73-8eeb-34a99a73d7b7",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2115,7 +1969,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a0aa2e27-7db8-44e4-8a61-dd32e3c2f962",
+                     "jsondocId": "b28a5028-e4f4-49fc-8f18-b70eba9a18f1",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
@@ -2127,9 +1981,9 @@
                "verb": "POST",
                "description": "Delete sequence alteration",
                "methodName": "deleteSequenceAlteration",
-               "jsondocId": "b5e12dec-b68b-46a8-b7ce-f1037607f848",
+               "jsondocId": "71962779-2c41-4bb2-a0ef-8262e29f9bab",
                "bodyobject": {
-                  "jsondocId": "471440ac-306c-42ea-a207-532223806eb4",
+                  "jsondocId": "4e55e430-2591-4c56-82e5-ada246d3adb8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2139,7 +1993,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteSequenceAlteration",
                "response": {
-                  "jsondocId": "21c17e6f-9340-48e8-aa3f-36aafebb4ad6",
+                  "jsondocId": "5a8ab7d9-15c2-4a20-b87f-ea5879d03b77",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2152,7 +2006,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "89a90c1c-cab0-447d-aec3-20c95e98941f",
+                     "jsondocId": "83afa5a0-bcb6-4809-bd0e-89744e1b0f83",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2161,7 +2015,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ef14b4ee-b6ec-4176-b9ca-b808dbf60a85",
+                     "jsondocId": "088c3edf-06d6-4f03-ae0c-81fb677d7800",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2170,7 +2024,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "289d2639-961d-46b5-bd1e-57b778b37572",
+                     "jsondocId": "9300ba4b-a639-4567-a193-0bd0839304f5",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2179,7 +2033,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "577e7efc-a9b3-4163-be90-fb17e1534976",
+                     "jsondocId": "ea5d39d1-901e-4ecb-8b64-0e9c993050a6",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2188,7 +2042,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e7e6006f-717d-4d22-9902-ad13c747df01",
+                     "jsondocId": "3f847ccf-87a2-4e84-b7bc-b0f959703a1e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
@@ -2200,9 +2054,9 @@
                "verb": "POST",
                "description": "Flip strand",
                "methodName": "flipStrand",
-               "jsondocId": "de2e10db-c257-4585-a1f3-81148a6559a0",
+               "jsondocId": "f11a2cf7-0bee-4ec1-b157-938bce30ab41",
                "bodyobject": {
-                  "jsondocId": "d5ffe026-c497-4ffb-a90c-2c1e1f748788",
+                  "jsondocId": "10aec8d3-7bfd-4200-9459-0b22b694c3cc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2212,7 +2066,7 @@
                "apierrors": [],
                "path": "/annotationEditor/flipStrand",
                "response": {
-                  "jsondocId": "3b8b9bf6-fa0c-4827-94cf-54311ea92b8d",
+                  "jsondocId": "1e960330-daae-4008-af2c-b8bf53fb4078",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2225,7 +2079,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c91794c8-475c-40dc-91f0-880d9f2dae2f",
+                     "jsondocId": "437829e8-91e7-44fc-902a-0c614c83b5db",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2234,7 +2088,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8796c177-cbde-4b84-9317-b6309ea3537d",
+                     "jsondocId": "440d90a2-3ed1-4bca-a3ee-966e3bf4e6e6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2243,7 +2097,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "deccfbef-2f8b-4037-90c4-7be64730de76",
+                     "jsondocId": "8bc0b09a-0e14-4b6b-b95a-6b331c76705a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2252,7 +2106,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c5e40546-d67c-4750-bd42-c3a9cb709986",
+                     "jsondocId": "1247bbdf-aa20-472c-aa88-b5bba6ea3670",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2261,7 +2115,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4c9e4986-9894-4098-89c4-2829572ba631",
+                     "jsondocId": "c0970812-5dd3-4046-ae34-953e8bdc597d",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
@@ -2273,9 +2127,9 @@
                "verb": "POST",
                "description": "Merge exons",
                "methodName": "mergeExons",
-               "jsondocId": "8a46c583-f2de-4336-8099-b45734227858",
+               "jsondocId": "41a1baf4-b97c-4c4f-b94f-cf0d742f6cfd",
                "bodyobject": {
-                  "jsondocId": "692b3ccf-2535-447b-adb6-37a8b17a7de4",
+                  "jsondocId": "7c9974e0-f7d6-4132-b285-2257749c66ab",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2285,7 +2139,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeExons",
                "response": {
-                  "jsondocId": "3dcf3e34-e69a-4db0-a638-85f78525d5ac",
+                  "jsondocId": "beb6d3b9-99d4-45ea-ac8e-d63b5ba7ef4e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2298,7 +2152,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "569fd798-4fa2-4774-bae7-e2cb12c5c8c7",
+                     "jsondocId": "f625b61f-99e7-46e0-86c8-460ae2c8845a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2307,7 +2161,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "99e4bac5-b407-4f46-97a8-02197434bc00",
+                     "jsondocId": "3d35d335-81a3-40dd-bc04-30945c7658de",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2316,7 +2170,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "feebcfa0-8473-454b-8e80-de04cc33e52a",
+                     "jsondocId": "04aca6c4-5239-46a5-a303-356ee8582396",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2325,7 +2179,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4252e30f-5c3f-44c9-8a74-585cb2d8b939",
+                     "jsondocId": "e45774d0-04ac-4eb2-bded-cd10bed346b7",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2334,7 +2188,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e7564c87-760a-4752-8484-7be25cf47f10",
+                     "jsondocId": "8cd7ce34-3bc6-4829-9014-723e06512f23",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -2346,9 +2200,9 @@
                "verb": "POST",
                "description": "Split exons",
                "methodName": "splitExon",
-               "jsondocId": "1f38777d-71bd-4bce-961b-f3dd095ba49d",
+               "jsondocId": "e2a24357-7a4d-412e-a00b-e7e8e80828a2",
                "bodyobject": {
-                  "jsondocId": "64edcc5c-1714-48c2-8ec5-797b9345d0ef",
+                  "jsondocId": "92ffa68f-cf68-42d2-9005-4bf1f4078a76",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2358,7 +2212,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitExon",
                "response": {
-                  "jsondocId": "54189659-4807-4504-97c0-5f9463216961",
+                  "jsondocId": "0f6276dd-2d3f-43e7-8e3c-9855801a8f0f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2371,7 +2225,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "dba31723-9b96-4e5e-9cf4-31d29f06c004",
+                     "jsondocId": "12a4f596-9ad5-40dd-9486-491cbaa1a9a0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2380,7 +2234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "be6fe73f-5c8b-4b48-be65-a91b4e55a206",
+                     "jsondocId": "7ca46e26-a944-45ba-adcf-d2f548bf59ff",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2389,7 +2243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5fc092bf-e653-4a36-803b-2d0dc948c376",
+                     "jsondocId": "1468495d-be80-4aaa-94e3-cc9cbe1e647c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2398,7 +2252,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ebde2e97-7858-4cac-a88a-0cd1ef2998ee",
+                     "jsondocId": "761dc302-2593-4a0b-a1ec-6072a8a8f64e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2407,7 +2261,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "50400564-fbb3-4a60-91b5-37351b29f135",
+                     "jsondocId": "b8902049-93ad-4829-b4ac-3ef472a597e4",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
@@ -2419,9 +2273,9 @@
                "verb": "POST",
                "description": "Delete feature",
                "methodName": "deleteFeature",
-               "jsondocId": "5b2e7703-51f8-4925-b5ec-2be1526eddf9",
+               "jsondocId": "c78a102f-eed0-4d3b-8632-36680796db66",
                "bodyobject": {
-                  "jsondocId": "6c683417-c6d8-406e-84d0-cdcc550fba5f",
+                  "jsondocId": "d592db75-b745-4331-bd05-1239a15f37c5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2431,7 +2285,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeature",
                "response": {
-                  "jsondocId": "b541a753-a65a-47f5-aad1-06d6041c0f09",
+                  "jsondocId": "e5ee5b58-00dd-4b0d-82d1-ba5534148806",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2444,7 +2298,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6e70d856-8b57-43a8-844b-8d3fb805753a",
+                     "jsondocId": "5b6b7f95-f04f-4134-b796-b3eab402f19f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2453,7 +2307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f11c8fc-cf51-4bff-a9fe-8f2692f2b5c5",
+                     "jsondocId": "5b889444-19d6-4c72-bb89-5f5eda9f9ab3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2462,7 +2316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "019af454-e97c-434f-8410-0879efef29fd",
+                     "jsondocId": "480e1c14-b27b-480c-b99b-388f48a8f69e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2471,7 +2325,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b840c80d-0f12-4761-9580-3e7843274ff9",
+                     "jsondocId": "fe370f33-e3cc-4f5c-9e90-a4c56420e59d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2480,7 +2334,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26fe80ca-3171-4883-924f-8f36b4e2ad1b",
+                     "jsondocId": "9b3163ac-2027-4a50-8e96-a13637cd8cdb",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
@@ -2492,9 +2346,9 @@
                "verb": "POST",
                "description": "Delete exons",
                "methodName": "deleteExon",
-               "jsondocId": "e5abe0eb-af29-4cec-8a89-19f463bd2e47",
+               "jsondocId": "b7dc0faf-5178-467c-8048-a972145a3f85",
                "bodyobject": {
-                  "jsondocId": "2a8800b9-212f-4478-b518-2f13175d6e67",
+                  "jsondocId": "6f9593a2-6d22-4f52-b403-36b6ff152a1d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2504,7 +2358,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteExon",
                "response": {
-                  "jsondocId": "2106f893-7639-4e2c-873c-4a0ee243a626",
+                  "jsondocId": "d201fdf3-4220-41a9-a805-2cebbc6fbc05",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2517,7 +2371,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3cf86cea-340d-42fb-8633-057150ba76f7",
+                     "jsondocId": "c8bb6d60-597a-41db-9e14-b787c84fbf23",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2526,7 +2380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dc740327-e489-4b06-b02c-ceb25161fca9",
+                     "jsondocId": "d5e1d996-f3c7-41e9-833e-0a4d2b71dbb7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2535,7 +2389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "18677490-befe-4ec6-a1ca-76529f8b3667",
+                     "jsondocId": "b5801419-49a2-4ea8-bdcb-abab651510f8",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2544,7 +2398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "881445ef-b455-4766-a94d-ce5e192f7a80",
+                     "jsondocId": "424fec96-e2f2-45c6-9d8f-c3487ca1fedf",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2553,7 +2407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b98bc03f-ddbe-4937-a2a3-48590c02f764",
+                     "jsondocId": "ce8bda20-73eb-4a47-b646-bb7ac63eaeda",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -2565,9 +2419,9 @@
                "verb": "POST",
                "description": "Make intron",
                "methodName": "makeIntron",
-               "jsondocId": "567d15b6-421b-43a3-879c-1942463e7bfd",
+               "jsondocId": "58783b4c-dd5f-41d4-98be-3ab6155637fe",
                "bodyobject": {
-                  "jsondocId": "9ec33ce5-f339-44fe-99d1-3cf261250d30",
+                  "jsondocId": "1f088789-d5cd-4708-84c1-2737780cf21d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2577,7 +2431,7 @@
                "apierrors": [],
                "path": "/annotationEditor/makeIntron",
                "response": {
-                  "jsondocId": "676a6467-9809-4d4b-af45-823e0d0f0d8c",
+                  "jsondocId": "4454b340-62dd-4d6d-9092-ca133e8657f5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2590,7 +2444,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "612a60b4-47e5-4a25-bd30-6c30c68239fd",
+                     "jsondocId": "dfcfc52d-e3bf-451d-92c9-898c69f1a15f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2599,7 +2453,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cde71374-d570-4cfd-894d-e56dce486f36",
+                     "jsondocId": "078f4145-5e04-4858-8d35-74e4f1b13055",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2608,7 +2462,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "041326da-2b8c-44c9-ba8c-9e29497bba68",
+                     "jsondocId": "a8b42a70-03a5-4cb4-9652-359388f70d82",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2617,7 +2471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7e305c11-8ec5-4f6d-ad70-4c948ff78fb5",
+                     "jsondocId": "9164b667-7838-45b9-96b8-e6f5b2f4ff38",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2626,7 +2480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ab53d667-35bb-4351-88fd-c78d232960b4",
+                     "jsondocId": "dbb2dad8-7d06-4735-84e7-5ec8fc0520fe",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2638,9 +2492,9 @@
                "verb": "POST",
                "description": "Split transcript",
                "methodName": "splitTranscript",
-               "jsondocId": "6edeb0ee-3e10-4fea-aaec-97bb5148835d",
+               "jsondocId": "005e510d-11de-494c-b105-38b8524281ac",
                "bodyobject": {
-                  "jsondocId": "7c0fe187-48d0-42fa-9dcc-4ef7fa3962c1",
+                  "jsondocId": "9223ef8c-9e72-4cd6-bcc9-ee6faaea3132",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2650,7 +2504,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitTranscript",
                "response": {
-                  "jsondocId": "ab675c1b-da33-45ac-bff1-ac2b41bf685e",
+                  "jsondocId": "03f7892b-8351-401c-9dcd-3c10a44a12fb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2663,7 +2517,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "27933249-ec0e-4bdf-85f6-3844bb77cf2a",
+                     "jsondocId": "f2788d38-b4d8-496a-82c7-841e337b3806",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2672,7 +2526,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d28a25ad-3c96-462f-9bbe-15c81397d7ab",
+                     "jsondocId": "e81e488c-858a-47e7-85ef-6f68a0deabf9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2681,7 +2535,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f5e557c-23ca-4ef5-bf65-ea3e11925b19",
+                     "jsondocId": "454639ad-bdb9-4176-bc59-06cf9422e93d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2690,7 +2544,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9a108af-a4f7-453d-a22e-151238aa4227",
+                     "jsondocId": "f1bcae75-b5f4-4ad1-97ac-48f2ee7047c4",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2699,7 +2553,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3dc25f4b-41f9-4b4b-a8a0-544da3efb964",
+                     "jsondocId": "54ab6573-e1db-4458-955d-edf0ab6c3bea",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2711,9 +2565,9 @@
                "verb": "POST",
                "description": "Merge transcripts",
                "methodName": "mergeTranscripts",
-               "jsondocId": "63c502b4-ca1a-4404-a525-75a6b1bbebf3",
+               "jsondocId": "724e632a-1d68-495d-80d5-e20d6dcc92aa",
                "bodyobject": {
-                  "jsondocId": "5a2d2418-efc2-40a7-88d3-87e3be578ae6",
+                  "jsondocId": "b54f8d93-fc1a-45f4-ae43-1f486f21912d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2723,7 +2577,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeTranscripts",
                "response": {
-                  "jsondocId": "89dee87e-6338-4cc6-ac38-840bbe43b68f",
+                  "jsondocId": "dbfb4ca8-19c4-4f1b-a76b-e9ebeb925046",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2736,7 +2590,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "242aeea3-f6f2-4548-8683-a7ca94f6acfb",
+                     "jsondocId": "d65250bc-c135-4be0-b09b-5ddb9aaa449a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2745,7 +2599,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3abfd156-3b1a-4103-957b-a9b2fb6ff0fd",
+                     "jsondocId": "6250609c-e6f9-46ca-81ac-93fc2e51d9c9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2754,7 +2608,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e58b9b7c-bbda-4771-8466-2fb55e1a23e5",
+                     "jsondocId": "570961c8-cab7-4016-a093-09600c81d042",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2763,7 +2617,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "608dd57f-b72e-4dbc-a0a8-88d5b89d9b54",
+                     "jsondocId": "5fcfe163-fdc0-48a3-9c43-ae38e4498f4f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2772,7 +2626,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "358429ad-e0ca-4868-9de3-9064b0a3444f",
+                     "jsondocId": "e4f8a0a5-9c96-4a06-9f06-6cb3b6d9388f",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2784,9 +2638,9 @@
                "verb": "POST",
                "description": "Get sequences for features",
                "methodName": "getSequence",
-               "jsondocId": "64786d19-9078-44f7-8b37-687b561f5c0f",
+               "jsondocId": "2dcc5848-f4be-4b02-b84a-7aa37cf3ce1c",
                "bodyobject": {
-                  "jsondocId": "24660725-96d8-4748-a60e-3893c75eeba0",
+                  "jsondocId": "fe004404-c0f7-4e66-ac06-7b7efbd98afd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2796,7 +2650,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequences",
                "response": {
-                  "jsondocId": "b80f7c95-b8f0-420e-bfd9-99c46df16af9",
+                  "jsondocId": "4b3b1c06-6c10-4a26-8ab9-d195c1186b7d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2805,7 +2659,7 @@
                "consumes": ["application/json"]
             },
             {
-               "jsondocId": "d30df77e-7f3b-488c-835d-3cbeb782cd6b",
+               "jsondocId": "0a1262f8-b193-4df1-aa07-a6d4ebe21d22",
                "bodyobject": null,
                "apierrors": [],
                "path": "/annotationEditor/getSequenceSearchTools",
@@ -2813,7 +2667,7 @@
                "pathparameters": [],
                "queryparameters": [],
                "response": {
-                  "jsondocId": "7baf5563-95ae-4f99-9b9a-14a405b8638e",
+                  "jsondocId": "0cd54cc8-3933-4d5e-a50d-fc871349998d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2828,7 +2682,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2683efcd-9be0-42a5-85e2-bc1666cc2a0b",
+                     "jsondocId": "ab58a480-30b8-4cc8-b626-5807ba498ea7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2837,7 +2691,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "021be69c-e8e5-432c-b965-903c898b51d5",
+                     "jsondocId": "4cebc54e-09d2-447d-bd85-a4ad1e4bb085",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2849,9 +2703,9 @@
                "verb": "POST",
                "description": "Get canned comments",
                "methodName": "getCannedComments",
-               "jsondocId": "0d3c78c3-9cb9-4512-9fa0-0752ce84fbb3",
+               "jsondocId": "192d1ac0-04bb-4eba-8a92-476168e48344",
                "bodyobject": {
-                  "jsondocId": "f44141c1-948d-47ed-876d-fff6c86e36b6",
+                  "jsondocId": "7648ce0e-2e2e-4e01-9057-bee662828ad1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2861,7 +2715,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getCannedComments",
                "response": {
-                  "jsondocId": "231fdcf5-cd14-4b02-b8bb-04c232fcd0da",
+                  "jsondocId": "d899f96a-14eb-40a3-9a92-3349fc6a8490",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2874,7 +2728,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4ca135f2-1442-4af6-aab0-e5ff466ae495",
+                     "jsondocId": "ca747db8-bb38-4c97-8910-0cce17cd4c2c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2883,7 +2737,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b80f218c-cfb0-4c57-a61d-9d7c10c88d81",
+                     "jsondocId": "c31ba0ba-d6c6-4277-a974-769033465968",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2892,7 +2746,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "96af262f-fc71-4af0-acb1-60b9adbbfe41",
+                     "jsondocId": "053ff139-405f-437a-a1f7-e168195485e0",
                      "name": "client_token",
                      "format": "",
                      "description": "Organism ID/Name or Client-generated ",
@@ -2901,7 +2755,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fbf00e5e-27d8-4163-8d3f-ace62d8195b5",
+                     "jsondocId": "ec7e4adb-6ea9-4a50-94b1-b0879c0ca2b8",
                      "name": "search",
                      "format": "",
                      "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
@@ -2913,9 +2767,9 @@
                "verb": "POST",
                "description": "Search sequences",
                "methodName": "searchSequence",
-               "jsondocId": "671172e5-5148-4464-b1c2-54c147ad00a0",
+               "jsondocId": "f7f2fc9c-d006-4fb0-8cb9-51fb2a715af1",
                "bodyobject": {
-                  "jsondocId": "bb274c09-478a-49cb-a4dd-da97638c0f0f",
+                  "jsondocId": "3c7880ce-ef69-419d-87b4-e28049cecc37",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2925,7 +2779,7 @@
                "apierrors": [],
                "path": "/annotationEditor/searchSequences",
                "response": {
-                  "jsondocId": "d2134022-dc3b-4e5b-b203-41c0c90be3d1",
+                  "jsondocId": "9ac1ab95-92aa-418a-aa9d-f637acf45d87",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2938,7 +2792,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b131abb9-6c9e-43a4-afda-bd03cb2adc9b",
+                     "jsondocId": "8707055c-600e-4354-8a15-c5469b9d0449",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2947,7 +2801,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65962cdd-04c2-4adb-b348-22a0d09df466",
+                     "jsondocId": "280bd5d5-f884-4d31-be56-b566972243f7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2956,7 +2810,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5812258f-2c29-4748-b933-196e7f98f7c7",
+                     "jsondocId": "eded95fa-216c-48f1-8722-5d7bda8fc3a3",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2968,9 +2822,9 @@
                "verb": "POST",
                "description": "Get gff3",
                "methodName": "getGff3",
-               "jsondocId": "9a9aba6b-cdb9-442b-b825-4da9efe73256",
+               "jsondocId": "5b28d987-6af5-4941-95b5-d29761f0186e",
                "bodyobject": {
-                  "jsondocId": "1fae810b-dba4-4bd6-9a56-59cb89f1776a",
+                  "jsondocId": "87991de6-f1c4-49d2-ad6f-09c0f62aa6f8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2980,7 +2834,153 @@
                "apierrors": [],
                "path": "/annotationEditor/getGff3",
                "response": {
-                  "jsondocId": "5a1df6b1-635d-4bab-b9a3-dfb101da6196",
+                  "jsondocId": "982b0cf8-3bbc-43c5-8f0c-f4b3417098ef",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "9f027e78-ec03-4990-8c4c-a0f600c32ea0",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "553b4be2-e9bf-4274-b48a-d8ee3369f0a1",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2ae3c024-00fd-41e3-87b9-30156d75da2c",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d6c5a001-1ad4-4a87-98e7-85fb5f4dfd6e",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b2422f2e-d40f-4b87-9501-7d5f5cdc0dbf",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set symbol of a feature",
+               "methodName": "setSymbol",
+               "jsondocId": "49eb24f9-fb7c-4ee5-b39b-d41a353a273a",
+               "bodyobject": {
+                  "jsondocId": "068d1713-0d4a-403c-95ba-ef0d45653aa6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setSymbol",
+               "response": {
+                  "jsondocId": "ca2f5956-62f3-4b2a-bfb6-c77e9a8f2139",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "179c085b-02ba-47e6-9631-261c14e6ee23",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ee3b5a3e-a7de-4e4a-bc2b-299743ad4b19",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "972d0894-1664-4b84-8f82-d9e7ddfc1332",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "83d76ba5-52f3-48be-b34d-45b9eaf92c3d",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3b5d97cc-0a23-499f-86b5-3cb2d8989454",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add attribute (key,value pair) to feature",
+               "methodName": "addAttribute",
+               "jsondocId": "0d1cc5d5-5a01-4ed9-b136-8077bb1c0519",
+               "bodyobject": {
+                  "jsondocId": "f62b1f6b-ba1f-4d2e-9072-c2b6c8838f80",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addAttribute",
+               "response": {
+                  "jsondocId": "ac1c88dd-7eca-43da-948d-ab79cc4f0327",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2993,14 +2993,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "642cffd2-bb38-4237-83b7-9e79656a98cd",
+         "jsondocId": "043a089a-3aa6-4d00-bc8e-273823fa831d",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b5f24b36-d4af-480c-a02b-4fc316fe6cf0",
+                     "jsondocId": "30a8ad97-effe-4796-b5d5-8dbaada395ba",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3009,7 +3009,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1cbbff78-ac26-4558-9a10-46d1677e7ee5",
+                     "jsondocId": "4c8234e9-e4cd-4ecb-bf68-82d32d475f6e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3018,7 +3018,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "098706a2-3c64-481e-aa79-64320b67d481",
+                     "jsondocId": "0bb08f32-3361-4c53-a8f1-47b979a501da",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to update (or specify the old_value)",
@@ -3027,7 +3027,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ce895c8-48ac-4c02-b77d-c45ade759b54",
+                     "jsondocId": "72b7424f-c523-459c-bb01-c71ffa77f51b",
                      "name": "old_value",
                      "format": "",
                      "description": "Status name to update",
@@ -3036,7 +3036,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4a3f5337-78c9-41aa-b4f6-af9303f8abd3",
+                     "jsondocId": "f83f0fa3-4d1d-4a91-9d49-03f7e909a28a",
                      "name": "new_value",
                      "format": "",
                      "description": "Status name to change to (the only editable option)",
@@ -3048,9 +3048,9 @@
                "verb": "POST",
                "description": "Update status",
                "methodName": "updateStatus",
-               "jsondocId": "9958cad6-855a-4a9a-9374-b27d60ac96e4",
+               "jsondocId": "f37a8a68-41ef-447d-84a3-e18d60e1e45b",
                "bodyobject": {
-                  "jsondocId": "9de9952b-e245-478a-9f05-7ac5cd72e55c",
+                  "jsondocId": "2dbd41e1-33ce-40be-95ae-92b7b3aaabde",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3060,7 +3060,7 @@
                "apierrors": [],
                "path": "/availableStatus/updateStatus",
                "response": {
-                  "jsondocId": "70dfb1e8-5126-4e46-8393-0194e664194a",
+                  "jsondocId": "57b074ba-bbfa-4cce-bc82-54742817a259",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3073,7 +3073,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0e813cab-8ed5-48ab-8150-a9bcbec47c0a",
+                     "jsondocId": "fc2be41d-b61a-451d-8474-ef15bbaefdb9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3082,7 +3082,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9ffe1880-0649-44ac-977f-f37ea2dce87f",
+                     "jsondocId": "c5160442-4583-417d-bbe7-2ac23d425e79",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3091,7 +3091,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff545d3d-9d99-467b-8432-8e71ec12c860",
+                     "jsondocId": "e33b4ecd-a395-4174-85b2-de556c12b200",
                      "name": "value",
                      "format": "",
                      "description": "Status name to add",
@@ -3103,9 +3103,9 @@
                "verb": "POST",
                "description": "Create status",
                "methodName": "createStatus",
-               "jsondocId": "c35ddf05-3361-46e3-a6aa-51ba510b5b5b",
+               "jsondocId": "d67da5a9-b11f-4bd8-a3c5-8c1fba9816a2",
                "bodyobject": {
-                  "jsondocId": "40d98f7e-8d94-4921-b984-7427b73d4d3e",
+                  "jsondocId": "70b9f368-40d6-48be-9c9e-27e2853bc863",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3115,7 +3115,7 @@
                "apierrors": [],
                "path": "/availableStatus/createStatus",
                "response": {
-                  "jsondocId": "1468bd57-c14b-4306-b710-8b37a07d47ac",
+                  "jsondocId": "6d4213b4-4932-4bad-a5ac-925966d8f695",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3128,7 +3128,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "10b48748-c194-4dae-a64b-d6cd4385a801",
+                     "jsondocId": "84e06928-7f29-45e3-9d64-9405c0901dba",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3137,7 +3137,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0b29d5fe-38dc-4265-9545-b2487d580405",
+                     "jsondocId": "8d217b9a-793e-4842-9bca-3441fa7dee2f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3146,7 +3146,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "428625e6-dbb7-4d65-a6ea-2ef185d1b2a3",
+                     "jsondocId": "ad7357fb-bb62-4ea3-a764-b8407062d7f5",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to remove (or specify the name)",
@@ -3155,7 +3155,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a175ad41-9db6-45a1-94da-14e6e3594045",
+                     "jsondocId": "f4499999-19a0-4b62-b1c9-42b6c89179a0",
                      "name": "value",
                      "format": "",
                      "description": "Status name to delete",
@@ -3167,9 +3167,9 @@
                "verb": "POST",
                "description": "Remove a status",
                "methodName": "deleteStatus",
-               "jsondocId": "7485076a-d560-4d56-8dc4-53d86c13a0ce",
+               "jsondocId": "9ffac115-517a-43f0-82be-ab0dfd846c42",
                "bodyobject": {
-                  "jsondocId": "1beba542-39fd-4625-9acc-9a0f5cc19158",
+                  "jsondocId": "8cc674fd-c90c-44e6-81b5-e10fa2876251",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3179,7 +3179,7 @@
                "apierrors": [],
                "path": "/availableStatus/deleteStatus",
                "response": {
-                  "jsondocId": "fcc0e793-d874-4124-9d1a-022200aecccd",
+                  "jsondocId": "007cdd78-dec9-4169-b65c-795892d1af3f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3192,7 +3192,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "46d2bea6-6e20-4574-93cb-c3e8cedb7d6e",
+                     "jsondocId": "479c2042-d3e4-4dee-89b0-4ddbdfee2e84",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3201,7 +3201,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "58362b8a-a92d-4161-bf9b-9b7269e0482e",
+                     "jsondocId": "0910338c-afb7-4013-ad35-4ee50a4125f8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3210,7 +3210,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3149fbf8-477e-4aed-876e-b2a2646e3aef",
+                     "jsondocId": "b4352056-2645-402d-8727-e102acc4ceb1",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to show (or specify a name)",
@@ -3219,7 +3219,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0e181b42-a9b4-4f78-9da7-b28d1815db41",
+                     "jsondocId": "680e095c-1801-4bd7-b9f3-47d588a12099",
                      "name": "name",
                      "format": "",
                      "description": "Status name to show",
@@ -3231,9 +3231,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all statuses, or optionally, gets information about a specific status",
                "methodName": "showStatus",
-               "jsondocId": "2af70141-455b-4dc3-b1df-2675bdf59909",
+               "jsondocId": "bc2657ac-e521-4f95-b5e6-76d6754c63bc",
                "bodyobject": {
-                  "jsondocId": "228ff998-ca92-478a-9548-c56123686e4d",
+                  "jsondocId": "a74258dc-edc6-4da7-b647-2fe6259cae35",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3243,7 +3243,7 @@
                "apierrors": [],
                "path": "/availableStatus/showStatus",
                "response": {
-                  "jsondocId": "98204863-99b9-4521-b0ae-299d6d14cf84",
+                  "jsondocId": "31714917-fc73-4cbb-b926-97ad4e51a476",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3256,14 +3256,14 @@
          "description": "Methods for managing available statuses"
       },
       {
-         "jsondocId": "a76b8511-8ee5-485d-b192-823e04437687",
+         "jsondocId": "dff6848f-0585-470a-b645-5b531570a436",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "88d0cfdf-1fbb-4955-aff1-ce02c5396174",
+                     "jsondocId": "cf8d44ff-095c-4b78-ad1a-46405b8ecc39",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3272,7 +3272,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4caa46c6-b36a-49a1-a8fa-d06a14d47a6e",
+                     "jsondocId": "30c814bf-e6b1-48b5-83ba-91044575538d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3281,71 +3281,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1c242cb-8edd-4575-8dc0-8b198e450681",
-                     "name": "comment",
-                     "format": "",
-                     "description": "Canned comment to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "8f3699a7-1a7a-4d25-b7c2-9f4838170b7d",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "Optional additional information",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create canned comment",
-               "methodName": "createComment",
-               "jsondocId": "da3864da-1a97-4c8b-899b-f85fe379ecab",
-               "bodyobject": {
-                  "jsondocId": "6557c3db-10f4-488f-9227-558ac4a05015",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned comment"
-               },
-               "apierrors": [],
-               "path": "/cannedComment/createComment",
-               "response": {
-                  "jsondocId": "c739c752-a2ed-4b51-956a-2d05e8615d60",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned comment"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "60728165-e9fd-4b15-b551-d382cb23eca1",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6e28bed2-f9a1-4b12-82c9-7e94e77b041c",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cba93ba0-c0cd-41ff-9a9f-ee9528327cd8",
+                     "jsondocId": "f474aa65-4b0a-4f40-9f34-cb22f5d82e4a",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to update (or specify the old_comment)",
@@ -3354,7 +3290,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cdbaeeb7-19db-4723-b570-79a9d386d65c",
+                     "jsondocId": "5de2aef8-60eb-4f33-b009-8130696d37a4",
                      "name": "old_comment",
                      "format": "",
                      "description": "Canned comment to update",
@@ -3363,7 +3299,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ee27da8e-56f8-47aa-9b1b-166077cd0f10",
+                     "jsondocId": "1774843f-c19c-4c54-84e7-078c351dc30a",
                      "name": "new_comment",
                      "format": "",
                      "description": "Canned comment to change to (the only editable option)",
@@ -3372,7 +3308,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "39362cfd-eeee-474e-8c25-2c3eafcd8589",
+                     "jsondocId": "ca39acab-11c4-48aa-9c14-5d5282047a33",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3384,9 +3320,9 @@
                "verb": "POST",
                "description": "Update canned comment",
                "methodName": "updateComment",
-               "jsondocId": "f36d5d24-c7da-4bb3-8e1e-0ca55fde4287",
+               "jsondocId": "ee3c3564-30a2-464f-87a4-d3d871ba8a36",
                "bodyobject": {
-                  "jsondocId": "5ab43e19-5b95-400f-bfef-94ceec3c9e10",
+                  "jsondocId": "ffa03d85-07d4-4c9d-9a2d-06977972a5b0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3396,7 +3332,7 @@
                "apierrors": [],
                "path": "/cannedComment/updateComment",
                "response": {
-                  "jsondocId": "b7a8bd32-a7e4-4b84-8e3f-f0921f374d9b",
+                  "jsondocId": "4114b6e3-afcd-4cf2-93d7-6ece83d7a6a5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3409,7 +3345,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "590cba85-cfae-4573-a09d-7ac33b55d364",
+                     "jsondocId": "935c52d8-d805-4022-acfc-7948c7ff5a13",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3418,7 +3354,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "81e4c595-8547-433c-af37-a260f34766eb",
+                     "jsondocId": "95447cae-868a-41e0-8fc0-1220964a9972",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3427,7 +3363,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8db580de-7cde-4974-8274-d664e663c961",
+                     "jsondocId": "b4d3a16f-1a45-4f2c-9226-3ac7ed7d85f5",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to remove (or specify the name)",
@@ -3436,7 +3372,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fea848d8-d57d-4044-83d5-1ecc62c351ed",
+                     "jsondocId": "b4a8b595-1653-4d4a-a285-1764404f9420",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to delete",
@@ -3448,9 +3384,9 @@
                "verb": "POST",
                "description": "Remove a canned comment",
                "methodName": "deleteComment",
-               "jsondocId": "d96dcb19-0147-404e-be13-9da975b7172b",
+               "jsondocId": "bef8e43c-f787-4a18-ac93-a12ac7f39dfb",
                "bodyobject": {
-                  "jsondocId": "58f56d2d-1a6b-4913-b827-d52b0e3ac8d6",
+                  "jsondocId": "191867ac-09bd-47da-b546-9c60670db77b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3460,7 +3396,7 @@
                "apierrors": [],
                "path": "/cannedComment/deleteComment",
                "response": {
-                  "jsondocId": "c6c616fa-cd75-439e-b54f-5a44b2516400",
+                  "jsondocId": "3ed3e19f-a6ed-43a6-a08c-ff093ed9e41a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3473,7 +3409,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f59927a0-79c1-4b45-bc7f-95e8d10ef54f",
+                     "jsondocId": "ebeb7e76-957b-4c51-8606-8c54641a9afc",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3482,7 +3418,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d126c002-9971-4011-b2bc-49a93ac17ae1",
+                     "jsondocId": "27d95d30-2c1d-4e6c-9ea5-a04bb453cfd7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3491,7 +3427,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "38e9dcc0-f784-4303-98ed-a0e9a860acb4",
+                     "jsondocId": "5e8ea59b-7ecf-4f4b-a2fa-d424e2c45d70",
                      "name": "id",
                      "format": "",
                      "description": "Comment ID to show (or specify a comment)",
@@ -3500,7 +3436,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "08804676-fbb4-4afc-9d66-6a75b81d08c5",
+                     "jsondocId": "0748890d-c20c-466f-a563-8f26905151e9",
                      "name": "comment",
                      "format": "",
                      "description": "Comment to show",
@@ -3512,9 +3448,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned comments, or optionally, gets information about a specific canned comment",
                "methodName": "showComment",
-               "jsondocId": "eea4a2c6-2eed-4360-badd-78868948c71c",
+               "jsondocId": "4ebc14e5-0192-40d8-8b06-46178682196f",
                "bodyobject": {
-                  "jsondocId": "d15da31e-9cc3-4a50-ad6c-c02d7fa6333f",
+                  "jsondocId": "746a95a5-387f-4177-91f1-6784eee696bc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3524,7 +3460,71 @@
                "apierrors": [],
                "path": "/cannedComment/showComment",
                "response": {
-                  "jsondocId": "c1248e9a-46b0-49fa-b584-396c2691e640",
+                  "jsondocId": "7c94aa70-b8ef-4420-abc3-01d5deb74b3c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned comment"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "9dd2cfa5-1c49-431e-806e-70e6db31f83f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9437bdfa-9c1a-4317-8593-faff481e5ef9",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "436a2976-ca41-40ce-9317-d2b9ecbed659",
+                     "name": "comment",
+                     "format": "",
+                     "description": "Canned comment to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "75c617a3-9309-4cf2-b724-913a65d490d0",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create canned comment",
+               "methodName": "createComment",
+               "jsondocId": "fd83d73c-c2e4-4973-a081-7b33dc912ac5",
+               "bodyobject": {
+                  "jsondocId": "1cfebf3f-d98b-42fa-ae4d-47d4b5e2e4b0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned comment"
+               },
+               "apierrors": [],
+               "path": "/cannedComment/createComment",
+               "response": {
+                  "jsondocId": "de3a6be3-4b43-48b1-9397-bdb02f5b9739",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3537,14 +3537,14 @@
          "description": "Methods for managing canned comments"
       },
       {
-         "jsondocId": "ba41cb52-aad1-4a91-9583-2b17d857e264",
+         "jsondocId": "bcd8d7bf-b91e-437f-804f-a9178d87f3cb",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "06bfa5c7-5bdf-42c9-b534-c8e63735e80b",
+                     "jsondocId": "4f351fa4-2ff5-4a19-8cae-ea7fb9823fba",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3553,7 +3553,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "757f40c3-46f5-403e-8f1e-203ded2e6805",
+                     "jsondocId": "87cb075a-03b5-4885-86f6-3a3649d93099",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3562,7 +3562,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "94e9a3b6-2826-4dc6-9b92-e703260a996d",
+                     "jsondocId": "241838e1-d934-460b-b220-fb194bf974ab",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to update (or specify the old_key)",
@@ -3571,7 +3571,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63f06038-b172-434e-a17b-a10a96aeb4ef",
+                     "jsondocId": "526cc0bf-b233-40db-8598-0a090b8dc706",
                      "name": "old_key",
                      "format": "",
                      "description": "Canned key to update",
@@ -3580,7 +3580,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1885bdc9-2469-4348-94b1-844060f524e5",
+                     "jsondocId": "1cd52e7c-1b0e-46e5-9433-31e8666784be",
                      "name": "new_key",
                      "format": "",
                      "description": "Canned key to change to (the only editable option)",
@@ -3589,7 +3589,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "beb9f7ed-e38f-4650-b5d6-cfd85b922c83",
+                     "jsondocId": "ed206919-6a6d-47b2-9da9-61cfa7415f4d",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3601,9 +3601,9 @@
                "verb": "POST",
                "description": "Update canned key",
                "methodName": "updateKey",
-               "jsondocId": "a24fd247-0483-477e-b039-37ba9d329344",
+               "jsondocId": "f7d3668a-735a-421e-9972-9a552efceb85",
                "bodyobject": {
-                  "jsondocId": "7da91858-c2d8-43ac-81f7-a6081c361342",
+                  "jsondocId": "41252fe3-e81f-4691-8331-e2e24f595060",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3613,7 +3613,7 @@
                "apierrors": [],
                "path": "/cannedKey/updateKey",
                "response": {
-                  "jsondocId": "10b45186-3fd8-4846-b016-6d9f88e0c011",
+                  "jsondocId": "2890dd00-3128-4594-b281-4e1394c2109f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3626,7 +3626,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "dbd7a0fa-fbcd-4482-90f3-2d6fb43efe1e",
+                     "jsondocId": "40578c77-b972-4831-94a5-6cccbc16e8b9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3635,7 +3635,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5e23755b-9e7b-4a08-93dc-9c741567aae5",
+                     "jsondocId": "e2c1efa1-0f40-46e1-8f16-ab64d5254fa6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3644,7 +3644,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "397ae4fb-a9f9-46a8-88b5-6fe40e47b34d",
+                     "jsondocId": "90bcb75c-c207-4351-8438-f2e17a70b57e",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to add",
@@ -3653,7 +3653,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9c16e3f2-bd16-4d78-a1b7-b925e2797773",
+                     "jsondocId": "4cff0f95-576a-4d4c-80dd-9cc9b9d87c57",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3665,9 +3665,9 @@
                "verb": "POST",
                "description": "Create canned key",
                "methodName": "createKey",
-               "jsondocId": "89cc01f0-a85c-443d-9618-4b72eea55db6",
+               "jsondocId": "70d8c024-dfb3-4ad7-bb97-c2fa9d2970c0",
                "bodyobject": {
-                  "jsondocId": "96e13a1e-15ac-4d3a-be37-67ff8013433e",
+                  "jsondocId": "63f6060a-f7a9-4dcb-ac35-f6dba139bd7b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3677,7 +3677,7 @@
                "apierrors": [],
                "path": "/cannedKey/createKey",
                "response": {
-                  "jsondocId": "13c94d83-9b36-46cb-8698-ab4bd09b46ec",
+                  "jsondocId": "25d77f91-3ae8-4bdf-9b25-b52f99d9d0e0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3690,7 +3690,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f9d23532-ba9f-403b-8b6c-ffc0ffe967ed",
+                     "jsondocId": "de34da62-b154-4aaa-9b2b-eb4a3f3323b5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3699,7 +3699,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "31c493c8-0ade-4d99-9898-0fd227629996",
+                     "jsondocId": "d126a742-14db-4096-a328-b79d14565f40",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3708,7 +3708,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e8d9fb36-391a-4f7e-96a2-f63d7bb5f8af",
+                     "jsondocId": "72679234-1a13-4139-b859-6c499dc9ea1e",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to remove (or specify the name)",
@@ -3717,7 +3717,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e8db6eff-06d5-4684-8373-b86c84ea86af",
+                     "jsondocId": "91721d23-b10a-4967-8485-425e7ccd583f",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to delete",
@@ -3729,9 +3729,9 @@
                "verb": "POST",
                "description": "Remove a canned key",
                "methodName": "deleteKey",
-               "jsondocId": "decb11af-6c0b-4064-ae84-e786a6b7cdc3",
+               "jsondocId": "fca4c244-1e3b-4612-9029-aa6abe63529f",
                "bodyobject": {
-                  "jsondocId": "9cc0b99d-2a94-4b50-98de-fd7a713558bd",
+                  "jsondocId": "99e86272-c02d-43ec-9eb0-513924e7c4d3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3741,7 +3741,7 @@
                "apierrors": [],
                "path": "/cannedKey/deleteKey",
                "response": {
-                  "jsondocId": "83649f1f-2aad-4c97-a2e1-4f72b69524e9",
+                  "jsondocId": "271a76bc-4b9d-4ae4-8088-a83c1411e240",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3754,7 +3754,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4534fa51-a90d-44fe-b6df-7d027727fc0a",
+                     "jsondocId": "2fdcc4ff-eb85-46b0-a73c-6dd37e3e3f2a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3763,7 +3763,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c4012ae1-4d38-441a-9626-62794ed9efc9",
+                     "jsondocId": "b82f6c1f-30ba-40ef-9077-10fcd16facb9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3772,7 +3772,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aa3b1ca1-1c7c-415e-adcf-48d0948790d3",
+                     "jsondocId": "b74f25d1-adcb-423e-b2f6-3fe00dee714d",
                      "name": "id",
                      "format": "",
                      "description": "Key ID to show (or specify a key)",
@@ -3781,7 +3781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "88faff73-36af-4b73-bb5e-a5d6bf512d75",
+                     "jsondocId": "f74e4b17-c229-4198-b919-e51ebe92c1da",
                      "name": "key",
                      "format": "",
                      "description": "Key to show",
@@ -3793,9 +3793,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned keys, or optionally, gets information about a specific canned key",
                "methodName": "showKey",
-               "jsondocId": "19644fb2-016b-496b-a20e-3c2c08197ecb",
+               "jsondocId": "6c91c453-2473-4498-88dc-805b80b91fee",
                "bodyobject": {
-                  "jsondocId": "a2505200-64ea-4b8e-8bf6-c27d6dc87dde",
+                  "jsondocId": "6c11a740-9527-403e-843d-c8894a1919f4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3805,7 +3805,7 @@
                "apierrors": [],
                "path": "/cannedKey/showKey",
                "response": {
-                  "jsondocId": "a19c7812-07fa-4bf6-a49e-a24bc421120d",
+                  "jsondocId": "9c4ca6a6-2398-48af-9028-66575dcb0a13",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3818,14 +3818,14 @@
          "description": "Methods for managing canned keys"
       },
       {
-         "jsondocId": "a7f6809d-7adf-4115-9dc0-e69fcf5c485d",
+         "jsondocId": "65992715-7e08-48dd-877c-1029fc1e1d5b",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f1151413-9489-49cf-9dc3-3f81ad53fee2",
+                     "jsondocId": "0dedfafb-d096-4203-a11d-afdbc7034ead",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3834,7 +3834,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c2fe77e-b4de-4089-99d9-f5be197d475a",
+                     "jsondocId": "e3d9e163-4d6d-4dcc-adf7-c50b03452edb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3843,7 +3843,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "75897738-550a-4ca3-b693-a234cd417125",
+                     "jsondocId": "a86e7016-0488-4efb-a5c9-3cc78b476f34",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to update (or specify the old_value)",
@@ -3852,7 +3852,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "15fe3583-9c96-456a-b997-560815f7725c",
+                     "jsondocId": "1c99e89a-ed74-4bb2-8ece-216bee6103bd",
                      "name": "old_value",
                      "format": "",
                      "description": "Canned value to update",
@@ -3861,7 +3861,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3414dced-1b68-4ab4-a1aa-da88ceba1cce",
+                     "jsondocId": "80339a75-27b7-4534-bc6e-54b86fa5f846",
                      "name": "new_value",
                      "format": "",
                      "description": "Canned value to change to (the only editable option)",
@@ -3870,7 +3870,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c29fecaa-e2da-4f41-9569-189820ff4242",
+                     "jsondocId": "e7b8e79b-60a5-425f-85c8-e76b978d382b",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3882,9 +3882,9 @@
                "verb": "POST",
                "description": "Update canned value",
                "methodName": "updateValue",
-               "jsondocId": "b3696b5f-b975-45c8-b037-bbd9e66ef4aa",
+               "jsondocId": "d1a67f60-ba2a-40e0-b11c-97efc802a0a8",
                "bodyobject": {
-                  "jsondocId": "dd56cde2-d5c7-42f7-99e0-45808fcff81f",
+                  "jsondocId": "db16b54a-c7e0-4e2c-b192-1b1a227f469d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3894,7 +3894,7 @@
                "apierrors": [],
                "path": "/cannedValue/updateValue",
                "response": {
-                  "jsondocId": "955da450-0581-4d45-92b5-bb3cf2be2593",
+                  "jsondocId": "4f05e6d5-f4bb-46d5-9f18-1956642dd0db",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -3907,7 +3907,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e00c6ac5-e0dd-4b03-87e9-7301f7e6b79f",
+                     "jsondocId": "19eeeef2-e0be-481f-8f8a-5b68b9eebc9a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3916,7 +3916,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "704a0a09-a821-47d5-b9e6-7b1ee1ff71dc",
+                     "jsondocId": "e3e294c9-1b88-4ae5-a91f-cde21b850ea7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3925,7 +3925,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3a491415-344f-4e72-aecb-75e97cbc65d0",
+                     "jsondocId": "9d2afc20-62ff-46b7-b9cd-7293fd417183",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to add",
@@ -3934,7 +3934,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0526cd54-fddd-42e4-98b0-5583f124d91f",
+                     "jsondocId": "d407709a-ebf7-4561-bd16-43535c80cda8",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3946,9 +3946,9 @@
                "verb": "POST",
                "description": "Create canned value",
                "methodName": "createValue",
-               "jsondocId": "5f88ab20-d3c2-40c9-8757-85801a58ebf1",
+               "jsondocId": "740eec70-fb2a-46dc-adfb-8b4e79e6a1c7",
                "bodyobject": {
-                  "jsondocId": "69a7f3e1-0b34-4ce8-b3eb-b74983d7d92d",
+                  "jsondocId": "febb174e-1ff2-4474-a08c-588a5e5a39cd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3958,7 +3958,7 @@
                "apierrors": [],
                "path": "/cannedValue/createValue",
                "response": {
-                  "jsondocId": "dcff3c58-55f0-45e3-872a-509280f414da",
+                  "jsondocId": "872de459-e3be-44c0-8e95-92b7b4def01c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -3971,7 +3971,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e2370876-a488-4326-a27f-49b78b00060d",
+                     "jsondocId": "fe157509-d73d-4294-8510-f21215118123",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3980,7 +3980,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e38eba37-7c90-481e-8c78-4fa98197ef55",
+                     "jsondocId": "f632f123-2344-472e-b3fd-0204f90dd445",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3989,7 +3989,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0f7b2ef7-3228-49a6-aba1-b2f3067150ad",
+                     "jsondocId": "58574f0d-ef8f-4001-9b1d-3528dbc87859",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to remove (or specify the name)",
@@ -3998,7 +3998,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "62ec3bd6-b18f-4527-a5ee-10230944c5b1",
+                     "jsondocId": "33105aaf-7519-45dc-988b-0946e04f447c",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to delete",
@@ -4010,9 +4010,9 @@
                "verb": "POST",
                "description": "Remove a canned value",
                "methodName": "deleteValue",
-               "jsondocId": "0db0ef45-76a5-42ec-8a59-e3697c83375d",
+               "jsondocId": "43e2c3fe-af2f-4fbe-8b1f-f3cf676c2469",
                "bodyobject": {
-                  "jsondocId": "de8e096f-63f0-43f4-bd99-cd60fb79952f",
+                  "jsondocId": "a2f8533b-cc23-47f9-ab50-f43d967a4fb2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4022,7 +4022,7 @@
                "apierrors": [],
                "path": "/cannedValue/deleteValue",
                "response": {
-                  "jsondocId": "093ff28a-59ca-4ed2-a8c6-e840dc661632",
+                  "jsondocId": "89e395d0-3f9b-4d19-a755-378ade61ac26",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4035,7 +4035,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1cf9066f-3d7b-4666-91db-3ccd17c67a6f",
+                     "jsondocId": "a345bc21-3467-4e5b-9b15-d8dad9ca0d90",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4044,7 +4044,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b98fb8a2-dc08-426b-a934-a82ee337d2af",
+                     "jsondocId": "79fd2a39-0245-47df-871a-1a6775a49ce3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4053,7 +4053,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aa0fa646-7682-43e7-a059-130ee219252e",
+                     "jsondocId": "7159527d-50ee-49b3-9662-4b146c0ee214",
                      "name": "id",
                      "format": "",
                      "description": "Value ID to show (or specify a value)",
@@ -4062,7 +4062,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4b04341c-89ae-487d-a671-47418672ba84",
+                     "jsondocId": "6f6067f1-5576-47e2-bf84-894b13491298",
                      "name": "value",
                      "format": "",
                      "description": "Value to show",
@@ -4074,9 +4074,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned values, or optionally, gets information about a specific canned value",
                "methodName": "showValue",
-               "jsondocId": "090a3d5e-8a5a-4974-b24b-0d413fb63ade",
+               "jsondocId": "1269bee2-b95a-4933-8148-a0cbf2665e47",
                "bodyobject": {
-                  "jsondocId": "6436affa-b7ed-4881-aaa3-c169273116cc",
+                  "jsondocId": "0c0c9b43-c5e0-46b4-8553-aad70648fe03",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4086,7 +4086,7 @@
                "apierrors": [],
                "path": "/cannedValue/showValue",
                "response": {
-                  "jsondocId": "460f8ec7-0ffe-4587-b90a-63eafc900de1",
+                  "jsondocId": "d8e7b367-1b09-4c0a-b81d-565e597ea6b7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4099,14 +4099,14 @@
          "description": "Methods for managing canned values"
       },
       {
-         "jsondocId": "2338dad7-76d8-4f77-b9ce-5b94bb2210c4",
+         "jsondocId": "5da64924-6b78-4a76-a194-f3ee9540d6d5",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "428e92be-9934-4995-a43c-398c7ccd071b",
+                     "jsondocId": "d0eb5793-0b11-4768-a1c3-39c1795da8bd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4115,7 +4115,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f8ab13cd-eff7-402f-882c-f1efec88ca7d",
+                     "jsondocId": "5c356ef1-7c65-4c2b-926e-ac991272e8a9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4124,62 +4124,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "54ddafbb-dc0f-48f6-aa23-cfb428fdaa25",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create group",
-               "methodName": "createGroup",
-               "jsondocId": "485c6343-f3c1-47d1-af86-e0df12554f5a",
-               "bodyobject": {
-                  "jsondocId": "357478b3-e937-48cf-b447-93194bed2718",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/createGroup",
-               "response": {
-                  "jsondocId": "6af2967c-e16d-4898-b202-56981b4a319b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "2d73a200-93d4-40c1-9d47-ea497a846e76",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0e321a30-9341-4b98-b60a-d7a740a728c7",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "46ada543-a1f3-4222-bd28-a6cff224b107",
+                     "jsondocId": "5f3db4c8-0782-4609-bbe6-6024a3b759c7",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -4188,7 +4133,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c0a1f42-303c-4e84-8a99-b1861a3b6533",
+                     "jsondocId": "506cf5f7-cccc-4e8d-bd1c-527340c8fce5",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -4200,9 +4145,9 @@
                "verb": "POST",
                "description": "Get organism permissions for group",
                "methodName": "getOrganismPermissionsForGroup",
-               "jsondocId": "3904a5fd-8920-43b0-a060-307fb7d30ad1",
+               "jsondocId": "a6738dd0-1121-4ad5-b9f8-361df8eb4b04",
                "bodyobject": {
-                  "jsondocId": "469cc76d-f5d7-4c61-a6d7-4b814de827f8",
+                  "jsondocId": "f9efd85f-e1b7-4b2d-96fa-59e8092671f2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4212,7 +4157,7 @@
                "apierrors": [],
                "path": "/group/getOrganismPermissionsForGroup",
                "response": {
-                  "jsondocId": "6f28ada5-303a-4ffa-b9ea-f90331466e19",
+                  "jsondocId": "479f358e-4812-449a-b6b3-85ae9604efa1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4225,7 +4170,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5429359b-7d86-4eb1-9222-c88695bab51b",
+                     "jsondocId": "3996cffa-dd2a-4796-ac8b-c4ddffc2c628",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4234,7 +4179,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d8189aa-861e-49d7-8d5c-08b2c087ca0c",
+                     "jsondocId": "58172c22-41d9-45a3-bb3e-270c102049ab",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4243,7 +4188,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e27e661-738d-4897-8e5e-073a4ea75cfd",
+                     "jsondocId": "efdbb642-56e9-4011-bb37-8a89e93bac99",
                      "name": "groupId",
                      "format": "",
                      "description": "Optional only load a specific groupId",
@@ -4255,9 +4200,9 @@
                "verb": "POST",
                "description": "Load all groups",
                "methodName": "loadGroups",
-               "jsondocId": "5fc721e3-de0d-424e-b9d0-605537c462e5",
+               "jsondocId": "9f824e5b-70ff-411d-93ff-1f25356ec8aa",
                "bodyobject": {
-                  "jsondocId": "48abf412-b7ea-4563-81c5-536e7233d5a6",
+                  "jsondocId": "f99ed010-9b9f-483f-ba33-f2e1d3b85439",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4267,7 +4212,7 @@
                "apierrors": [],
                "path": "/group/loadGroups",
                "response": {
-                  "jsondocId": "cf3505d9-ee0d-49f6-b4ff-ec3ffac8e74e",
+                  "jsondocId": "f3d1ae16-fa0b-44e2-8c0b-1562d98fd571",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4280,7 +4225,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "15c18fbd-9256-4cd7-8887-b2fbebad366c",
+                     "jsondocId": "71e60d38-ee79-4ee0-86fe-ce84e38908c8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4289,7 +4234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2b0c9ebb-1f85-4ebd-862a-d34f8efac6fb",
+                     "jsondocId": "2861bbdd-355a-439e-8f2e-9a666fb6fe32",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4298,7 +4243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d4d9d4d6-c2f5-4474-928a-280755359f91",
+                     "jsondocId": "182d6a34-9229-449e-b3d8-5acaeb6fba37",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to remove (or specify the name)",
@@ -4307,7 +4252,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "403e77db-5fb4-4de0-b562-792e16ee3d6d",
+                     "jsondocId": "28e14432-ff6e-4fd2-af5b-679fbe59b5f2",
                      "name": "name",
                      "format": "",
                      "description": "Group name to remove",
@@ -4319,9 +4264,9 @@
                "verb": "POST",
                "description": "Delete a group",
                "methodName": "deleteGroup",
-               "jsondocId": "df097079-7027-4307-8803-4e0e17b457c5",
+               "jsondocId": "98701dbe-c253-4d9f-9bb6-2b40dd12ec62",
                "bodyobject": {
-                  "jsondocId": "3de6d211-ba56-4f9d-a3ee-387256f0eb67",
+                  "jsondocId": "bca8bae7-0517-43c3-852b-d341b3de2bc3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4331,7 +4276,7 @@
                "apierrors": [],
                "path": "/group/deleteGroup",
                "response": {
-                  "jsondocId": "efbf7c1f-8dea-47f7-b0a6-6c326d1ccd42",
+                  "jsondocId": "2cb5e065-6a3c-443a-aac2-095b05667ca9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4344,7 +4289,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "49c1ddac-7786-4947-86de-ee9df09ea1f6",
+                     "jsondocId": "0c3af59b-9ee7-47f6-9367-75efd7610369",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4353,7 +4298,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a0f5c68e-bd25-43d8-b0b6-b7b5de3fab72",
+                     "jsondocId": "4a5dcbf2-9559-4693-a2c8-e7ed63375df4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4362,7 +4307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "574be9a5-a5df-484c-848b-f78d56c23f31",
+                     "jsondocId": "10004a2e-7c43-493e-ba83-1288ca4eb7eb",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to update",
@@ -4371,7 +4316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eb172c5c-049a-4259-889f-83100e49651c",
+                     "jsondocId": "9e5a6a65-4256-46cb-9531-d55c898973d5",
                      "name": "name",
                      "format": "",
                      "description": "Group name to change to (the only editable optoin)",
@@ -4383,9 +4328,9 @@
                "verb": "POST",
                "description": "Update group",
                "methodName": "updateGroup",
-               "jsondocId": "be3850ba-a579-4f0c-8d0f-4b3909c0e973",
+               "jsondocId": "e8372c79-88ea-4b74-aef1-5bbb5d67ffe2",
                "bodyobject": {
-                  "jsondocId": "2407945b-4031-47a6-8599-0b543f82ca39",
+                  "jsondocId": "595af670-450a-47f9-8041-4ffbc1dde7b8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4395,7 +4340,7 @@
                "apierrors": [],
                "path": "/group/updateGroup",
                "response": {
-                  "jsondocId": "13e8cab7-0993-49db-84be-7015583f5eeb",
+                  "jsondocId": "f20b51f6-7f69-4a08-b7be-6f1d9382c6b7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4408,7 +4353,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "75c5bc5c-22b6-40a2-857a-aeb6b9541691",
+                     "jsondocId": "d620f36a-389c-4613-b34c-844cf4415c2e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4417,7 +4362,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "12ce8bf7-fe96-46e5-8be9-56b5107559b9",
+                     "jsondocId": "25ba7261-3115-474c-99ec-0a7dd3c3b937",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4426,7 +4371,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5ee07fc7-9416-4b54-9d24-50a4dc733956",
+                     "jsondocId": "7aa5937f-f785-4218-9f68-c0908d788d48",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to modify permissions for (must provide this or 'name')",
@@ -4435,7 +4380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5368c25f-a82e-461d-b2d6-de35f2247f8d",
+                     "jsondocId": "66ad992f-1a7a-4bc0-bbbc-5d54c96a51b4",
                      "name": "name",
                      "format": "",
                      "description": "Group name to modify permissions for (must provide this or 'groupId')",
@@ -4444,7 +4389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e231075-57c5-4427-b29d-3d9e7be58e34",
+                     "jsondocId": "eb3d5355-749c-4180-977d-59c53aacff13",
                      "name": "organism",
                      "format": "",
                      "description": "Organism common name",
@@ -4453,7 +4398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1113ec3a-0f9c-42ed-abc8-6a0318ce6424",
+                     "jsondocId": "36d6ee09-3ac5-4210-9d50-fdaeddf272e5",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -4462,7 +4407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4a9db0aa-d19f-414e-9582-6ea4ec2ee48a",
+                     "jsondocId": "87487338-3e31-44a0-9e95-d3824e03d07d",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -4471,7 +4416,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "00c108c6-1f93-4419-b622-f6e157b4fee1",
+                     "jsondocId": "fc9ea739-8089-497f-b93e-01fecba130c3",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -4480,7 +4425,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44dff4d3-5edb-4f51-b9e0-95d5b32b8914",
+                     "jsondocId": "89c3fdff-3ee4-465c-ab9f-939438185a17",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -4492,9 +4437,9 @@
                "verb": "POST",
                "description": "Update organism permission",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "4a1df784-b69c-4fd2-95f2-d21b2e0cfac9",
+               "jsondocId": "7b4a9657-89b1-42d0-88ff-de07643b9136",
                "bodyobject": {
-                  "jsondocId": "ca714e13-92f5-4db6-81aa-b7785fad522d",
+                  "jsondocId": "c51d4165-4d3f-4905-a68c-d10ae7918157",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4504,7 +4449,7 @@
                "apierrors": [],
                "path": "/group/updateOrganismPermission",
                "response": {
-                  "jsondocId": "25b16f8b-cb3f-4b0b-b4de-e2e59d50354a",
+                  "jsondocId": "98eba64c-c405-4eed-bec6-daada6889f0b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4517,7 +4462,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2313f27b-71d8-4206-8961-c21ca9e5e56e",
+                     "jsondocId": "06f0fa0b-da8a-4aa9-af5d-93c1010c141f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4526,7 +4471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "431e4d07-65c1-49bf-a17a-350cf982c30d",
+                     "jsondocId": "872abb05-57bc-4ec3-99f8-2c0e6294c2e7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4535,7 +4480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65e455b9-ff2f-4db6-8384-ca43bcfaf376",
+                     "jsondocId": "eb57d43c-a8b7-4b0b-8575-dbc910002bdf",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -4544,7 +4489,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8b166ba7-a50a-4634-9bab-1da298a9d8d7",
+                     "jsondocId": "d8cc3bee-3b22-4d33-aae0-39308886d9a9",
                      "name": "users",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -4556,9 +4501,9 @@
                "verb": "POST",
                "description": "Update group membership",
                "methodName": "updateMembership",
-               "jsondocId": "cc759935-b152-478c-8e75-77464d681fa6",
+               "jsondocId": "90e3c8db-6a85-4853-a97a-80543eec4cfb",
                "bodyobject": {
-                  "jsondocId": "2f9e96f4-5b80-403d-9fcd-1496fa00b07e",
+                  "jsondocId": "e3745129-99b2-4901-b19f-824a1b526a79",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4568,7 +4513,62 @@
                "apierrors": [],
                "path": "/group/updateMembership",
                "response": {
-                  "jsondocId": "8136a967-4cc8-4860-b3d0-08bbabd29c7c",
+                  "jsondocId": "4f4e2f0c-91a5-4ea9-84fe-3f41e1412268",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "84e75b98-62ca-4550-8f46-0d5a198bf51e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "41b5ac12-ded0-46ab-9bd9-7a302ca42389",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "01f9f4d7-c9a4-4e5e-9702-86e081f98eca",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create group",
+               "methodName": "createGroup",
+               "jsondocId": "c43034f6-cf1e-43d2-b59e-94ab08248c38",
+               "bodyobject": {
+                  "jsondocId": "64d34c5d-a0b6-47f0-ba22-db5e3bcd7396",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/createGroup",
+               "response": {
+                  "jsondocId": "457a41c9-de28-4e20-8761-9f13a1b16246",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4581,14 +4581,14 @@
          "description": "Methods for managing groups"
       },
       {
-         "jsondocId": "568ed739-b846-486d-b480-3d5ac12b6563",
+         "jsondocId": "2aba5b2d-dc23-4573-8021-0cbb638356ff",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "76b925dc-0e34-405c-8292-4cd4bbe41935",
+                     "jsondocId": "83f06485-b4c0-4983-8658-5ba841bea2de",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4597,7 +4597,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e771663a-caf2-40a8-9977-2352e9d3ec19",
+                     "jsondocId": "8e31946f-5065-4f18-b7a9-85e58e607fbd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4606,7 +4606,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "470cf025-b8ff-4d82-9071-610788fd0485",
+                     "jsondocId": "46e4b8bb-884c-42aa-8a57-fd744dd39708",
                      "name": "type",
                      "format": "",
                      "description": "Type of annotated genomic features to export 'FASTA','GFF3','CHADO'.",
@@ -4615,7 +4615,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f9402839-0ead-4126-b714-0d451823bc2f",
+                     "jsondocId": "dbef197b-f8eb-4522-8d47-36ae7adc848e",
                      "name": "seqType",
                      "format": "",
                      "description": "Type of output sequence 'peptide','cds','cdna','genomic'.",
@@ -4624,7 +4624,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3d95bb2b-4969-47cd-bed7-1b1bca89b29c",
+                     "jsondocId": "2b1a9f93-bd31-4750-bb7e-f2f9199f19ee",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -4633,7 +4633,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f297675d-8dfa-4c1b-96dd-1f4a13dea1b5",
+                     "jsondocId": "3ff050eb-d0f9-463f-8ae2-d33aa0583626",
                      "name": "sequences",
                      "format": "",
                      "description": "Names of references sequences to add (default is all).",
@@ -4642,7 +4642,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "94e5d81c-831c-44ca-a94f-2eb989c24883",
+                     "jsondocId": "fdc6d399-cecf-41d8-a3b8-b69c585c9af0",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism that sequences belong to (will default to last organism).",
@@ -4651,7 +4651,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e3fdf48c-1a81-41d1-9bd6-05a61332a282",
+                     "jsondocId": "8b823ee3-79fe-4421-9c6d-957d8a23b9e0",
                      "name": "output",
                      "format": "",
                      "description": "Output method 'file','text'",
@@ -4660,7 +4660,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "86997495-116e-4566-9430-a8f1867105d0",
+                     "jsondocId": "8e1f2b0f-8f0d-4b72-93fd-71a02f0a7381",
                      "name": "exportAllSequences",
                      "format": "",
                      "description": "Export all reference sequences for an organism (over-rides 'sequences')",
@@ -4669,7 +4669,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9c9b24ea-7e83-4842-92ea-1013a42e7615",
+                     "jsondocId": "08f5a030-3890-4c4c-a962-0b5a559c5b56",
                      "name": "exportGff3Fasta",
                      "format": "",
                      "description": "Export reference sequence when exporting GFF3 annotations.",
@@ -4678,7 +4678,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f146e593-1f05-4c83-ba47-141aa33632ad",
+                     "jsondocId": "4204cfa4-fdc6-40de-a8a2-6692215819ef",
                      "name": "region",
                      "format": "",
                      "description": "Highlighted genomic region to export in form sequence:min..max  e.g., chr3:1001..1034",
@@ -4690,9 +4690,9 @@
                "verb": "POST",
                "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "methodName": "write",
-               "jsondocId": "0f38408a-b52a-49e2-9f7f-7a1f17fafb4e",
+               "jsondocId": "e99b378b-2b72-45c4-b6b3-eb28190927a1",
                "bodyobject": {
-                  "jsondocId": "4208b608-5a70-46f7-b83f-99c256e53e4a",
+                  "jsondocId": "08478bfb-9c7d-4c31-bb9a-c60be91623b7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4702,7 +4702,7 @@
                "apierrors": [],
                "path": "/ioService/write",
                "response": {
-                  "jsondocId": "98f60e96-19b1-4a0c-b740-100cb9b0fd3b",
+                  "jsondocId": "13c5182f-d953-4efc-90ab-6df4caedd2a8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -4715,7 +4715,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "339303cb-596f-4649-aa2c-a425c0bb9a73",
+                     "jsondocId": "ff86df1d-1068-43af-8d14-b56480f0beba",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4724,7 +4724,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "febad9b1-e56f-4da1-a810-b1fe16f0975f",
+                     "jsondocId": "ef8a712e-eccd-4264-b754-eb2613cf2fc1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4733,7 +4733,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26973afe-8a62-41d8-9bfe-a1e05c17d731",
+                     "jsondocId": "f6de92f5-b397-4505-8f98-fbc7afc32dd5",
                      "name": "uuid",
                      "format": "",
                      "description": "UUID that holds the key to the stored download.",
@@ -4742,7 +4742,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "06279bf3-06dc-4a75-8821-54a7b452ad84",
+                     "jsondocId": "b7362a5f-7d41-46f6-bf86-b752d6371e49",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -4754,9 +4754,9 @@
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
                "methodName": "download",
-               "jsondocId": "8c5aaafb-7d0a-4a2e-82f3-37d8a3a7e406",
+               "jsondocId": "af1d7a6f-7272-4b6a-93dd-6a4d0651d513",
                "bodyobject": {
-                  "jsondocId": "766eacdf-63fb-423d-9f19-20c9ce623dde",
+                  "jsondocId": "6e3c2507-627a-4164-985c-c69599ae2737",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4766,7 +4766,7 @@
                "apierrors": [],
                "path": "/ioService/download",
                "response": {
-                  "jsondocId": "3c8a0833-1050-4829-bf30-8a3859bf71ef",
+                  "jsondocId": "f57f43ae-8a39-4a36-ad65-7194abf1cfb0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -4779,14 +4779,14 @@
          "description": "Methods for bulk importing and exporting sequence data"
       },
       {
-         "jsondocId": "a2036b9a-c799-4318-9952-c04a50fb5a93",
+         "jsondocId": "9b93f2ec-30dd-41af-b822-a3c2fc11f7ef",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4cf22185-add3-47c5-822c-5fca95505358",
+                     "jsondocId": "69d89085-eab4-4c2f-a83c-f169076909ec",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4795,7 +4795,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e9489a9-822f-4f64-9100-0a2cc91d7e6d",
+                     "jsondocId": "f7dbc48b-322b-463d-8e99-75886a4b5033",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4804,7 +4804,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fb57f1cb-ecdd-473e-b637-632746bd7088",
+                     "jsondocId": "4ce74b2f-c337-4867-b85c-b634f7cf1376",
                      "name": "organism",
                      "format": "",
                      "description": "Pass an Organism JSON object with an 'id' that corresponds to the id to delete",
@@ -4816,9 +4816,9 @@
                "verb": "POST",
                "description": "Remove an organism",
                "methodName": "deleteOrganism",
-               "jsondocId": "1e313310-8fd2-46ec-a2fa-686fe5f5e297",
+               "jsondocId": "ec065616-a91c-4a4f-a03a-5472effff8b2",
                "bodyobject": {
-                  "jsondocId": "a6a475bb-9cda-46d2-8ef6-2506ed1b85a3",
+                  "jsondocId": "807a5978-e304-4271-9417-94e8700c4686",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4828,7 +4828,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganism",
                "response": {
-                  "jsondocId": "07bd2725-2ec7-4a3a-9d86-89042e157304",
+                  "jsondocId": "6fcfad2b-ccc7-4f41-9089-489a6c5a8a98",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4841,7 +4841,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c0e0a0e8-919a-4d60-bf59-f8b5c6b30f3c",
+                     "jsondocId": "b2c38436-181e-4ed9-8d3d-6954d5d03529",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4850,7 +4850,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "934b77df-4184-45e9-9477-a48b37e0a440",
+                     "jsondocId": "e7107167-5663-41ee-baaa-e23b5fd1fb52",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4859,7 +4859,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ee08f149-535d-4e89-bdf4-5cf92fe4a978",
+                     "jsondocId": "73ae69e6-74dd-40cb-988a-30442c63b2f0",
                      "name": "organism",
                      "format": "",
                      "description": "An organism json object that has an 'id' or 'commonName' parameter that corresponds to an organism.",
@@ -4871,9 +4871,9 @@
                "verb": "POST",
                "description": "Remove features from an organism",
                "methodName": "deleteOrganismFeatures",
-               "jsondocId": "3debebc8-2e12-40c6-9d21-1208d9bfe66d",
+               "jsondocId": "8f33a9a7-d76d-4271-a360-7deaf2fb9879",
                "bodyobject": {
-                  "jsondocId": "b560d53d-4652-4354-8512-a40f22852d01",
+                  "jsondocId": "9e025aae-c3d1-4274-9fa1-c77ffee38b6c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4883,7 +4883,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
                "response": {
-                  "jsondocId": "bb4e6c16-316e-46da-9155-42b5bfe5c437",
+                  "jsondocId": "46a3d39a-d5d9-4334-bd3d-77b0b7daccb9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4896,7 +4896,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f48bd786-1d70-44ab-a95a-115c0fb7c4b7",
+                     "jsondocId": "62b4d852-a2c8-4c8f-8222-5e4cca60a9d8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4905,7 +4905,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c140d8cf-1b06-4a06-bad9-d5843f1e5e39",
+                     "jsondocId": "ff3f1e5e-65b5-4110-9460-b711b2395dfe",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4914,7 +4914,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c0a695fa-ba6c-42d1-8e36-997d31ec1ba8",
+                     "jsondocId": "947e5fd6-bde8-47c2-8ffa-6d507c7eb65e",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -4923,7 +4923,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c6f1a44a-cf29-4ba9-8ec2-0ffdde45809e",
+                     "jsondocId": "8c118455-321f-4dd5-bbee-7575e08c1b28",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -4932,7 +4932,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d818f9a7-87b2-4375-a52f-2c6d028f8a50",
+                     "jsondocId": "3daded5a-6ef5-441c-9ccc-447dade6a28a",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -4941,7 +4941,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66141f57-d0a8-46f1-a301-3699bef83221",
+                     "jsondocId": "651abfe1-1e9b-4d27-b26a-e76faa1f5b60",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -4950,7 +4950,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1c410b0a-582d-40bc-89ce-01b5db48ddd1",
+                     "jsondocId": "5a8161ac-b64c-40ee-bf30-9736e1b72e9d",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -4959,7 +4959,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "de627b45-c314-493b-a159-73c64b75550b",
+                     "jsondocId": "f2ea3202-3c41-4238-a0bc-00160f428f77",
                      "name": "commonName",
                      "format": "",
                      "description": "a name used for the organism",
@@ -4968,7 +4968,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dd250cb1-0277-43f4-b5b3-e519e07ee882",
+                     "jsondocId": "bca43632-9469-48ca-99bb-60a560a24659",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -4980,9 +4980,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganism",
-               "jsondocId": "8ef3e4f8-07bd-4a43-b3e2-0714b66613fb",
+               "jsondocId": "42fbc61d-e80c-4936-9a53-6184e20ea5e3",
                "bodyobject": {
-                  "jsondocId": "c33e922e-9083-4ff5-b4d5-601eaed3353f",
+                  "jsondocId": "4b3bf89d-488f-4f80-b8ea-659fd35ccc70",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4992,7 +4992,7 @@
                "apierrors": [],
                "path": "/organism/addOrganism",
                "response": {
-                  "jsondocId": "560e18f7-cff7-4d43-b54d-c8cf01042deb",
+                  "jsondocId": "46ce9593-29bf-4d06-b701-e0e819986cac",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5005,7 +5005,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0197546b-cc91-4915-aa76-2f47254c75a5",
+                     "jsondocId": "0a9ca8bb-e950-4920-a47d-e9cb82ce705a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5014,7 +5014,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b78570b5-359a-4f11-96a5-7143e9da545d",
+                     "jsondocId": "1e50eb8d-8148-4d6c-a8ff-b8c75b6952d1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5023,7 +5023,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "34666f6e-430b-4fa7-baab-b314170cb041",
+                     "jsondocId": "0cb1ad99-4cad-4ac9-95a7-ca2aeb729f7f",
                      "name": "organism",
                      "format": "",
                      "description": "Common name or ID for the organism",
@@ -5035,9 +5035,9 @@
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
                "methodName": "getSequencesForOrganism",
-               "jsondocId": "16d5b44c-c621-4325-88c4-c6c8615b7fd8",
+               "jsondocId": "e65b27f1-9289-4286-b2f4-c40d44ecfdaa",
                "bodyobject": {
-                  "jsondocId": "93137de6-c004-4b5a-852b-071097c6c41b",
+                  "jsondocId": "4f23ea69-13cf-4f3b-9017-27e7b23d8bf5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5047,7 +5047,7 @@
                "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
                "response": {
-                  "jsondocId": "c37f3f7d-a406-458d-aebd-42ef87830ff0",
+                  "jsondocId": "2e3889bf-661a-4b46-89b7-c5d574b86aaf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5060,7 +5060,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7ac17fce-d841-4f6a-ba48-73ddd8701226",
+                     "jsondocId": "83a1b31d-5cad-4eb0-b9bf-f97e9bb702bf",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5069,7 +5069,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b067b186-ffc8-4fd5-8781-3820b8ba927d",
+                     "jsondocId": "7bf30f22-c909-45b3-9e8f-d2801902c2cc",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5078,7 +5078,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9e7e44bf-8e0b-4f8f-9421-2d5159195624",
+                     "jsondocId": "45202319-6a2d-4a7d-adeb-62f31131b2ca",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -5087,7 +5087,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fc3c2223-39b0-4a93-af4e-64e2415b9036",
+                     "jsondocId": "6c5b9846-227a-4b18-a3cd-c60b055d0a72",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -5096,7 +5096,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "33a2a965-4b92-43df-87ad-e6179dab7faa",
+                     "jsondocId": "f01b3780-9a53-4c88-9a55-cf2750565957",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -5105,7 +5105,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1e95fca9-d020-42b1-b973-89163cc2c746",
+                     "jsondocId": "d603db0a-7327-45b8-9929-659c2b87eb98",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -5114,7 +5114,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ab30dd89-82d8-4a21-8bc8-774137f828ee",
+                     "jsondocId": "21a535c5-0a5d-4835-95e3-eee862daae43",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -5123,7 +5123,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "050035fe-931d-42e6-a67f-96ea0c3b9ca8",
+                     "jsondocId": "7da545b9-b689-4247-8866-417800157adb",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5132,7 +5132,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e2c96215-6c4b-40e7-a761-cf209cf04982",
+                     "jsondocId": "8ab14b2a-1e08-4a75-96ac-40d18033d302",
                      "name": "name",
                      "format": "",
                      "description": "a common name used for the organism",
@@ -5141,7 +5141,16 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b6c79578-10ea-4be3-8571-25afd4f2eb39",
+                     "jsondocId": "15eaa69a-5538-483a-a695-4423fbe87c05",
+                     "name": "nonDefaultTranslationTable",
+                     "format": "",
+                     "description": "non-default translation table",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "addefce6-27ff-4ec1-97f8-e06f7a59d295",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5153,9 +5162,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "updateOrganismInfo",
-               "jsondocId": "50527022-c5eb-4ed1-a4ff-2eaf0df41d65",
+               "jsondocId": "35f6b6fd-5075-4431-a103-0d77a4dcfd11",
                "bodyobject": {
-                  "jsondocId": "62a70d5f-6585-438e-bdda-118254ace2a8",
+                  "jsondocId": "4a15cabd-0c0c-4134-a433-9e939840eb76",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5165,7 +5174,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismInfo",
                "response": {
-                  "jsondocId": "5f49bbf0-1b5a-453f-9acf-a59c282d258f",
+                  "jsondocId": "cca6a908-b45f-4dca-b491-bd6b0095f3c4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5178,7 +5187,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fb8af599-0995-4c68-8e26-4e5a623341fa",
+                     "jsondocId": "17dd354b-0e1e-4b79-81f0-5525fe78ffd9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5187,7 +5196,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ba389c5-35f0-4da1-8cf2-e3a6ac6dc31a",
+                     "jsondocId": "f08e44b7-3a1f-42a8-a996-04aac63c6e12",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5196,7 +5205,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7f62dd11-ea67-4e47-b94f-0683d2516a9b",
+                     "jsondocId": "f083b404-262a-4201-8eea-a8bef8395070",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -5205,7 +5214,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "213c732c-bab5-4981-8b52-43c57ad8a358",
+                     "jsondocId": "8a9fe4bd-dd5e-40e4-ba4a-16b7a246b612",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5217,9 +5226,9 @@
                "verb": "POST",
                "description": "Update organism metadata",
                "methodName": "updateOrganismMetadata",
-               "jsondocId": "2ac4b8e3-8362-4938-bb45-ea386dcaf029",
+               "jsondocId": "6b7b48ef-a129-4214-8b8f-f009eb8f5f56",
                "bodyobject": {
-                  "jsondocId": "81a8b315-51a2-497e-a412-5652f64953aa",
+                  "jsondocId": "4a349b16-f29d-4cb6-98bc-bdf218586939",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5229,7 +5238,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismMetadata",
                "response": {
-                  "jsondocId": "9e910f76-0186-464d-9bc9-b9297aa2f3ab",
+                  "jsondocId": "d0182bf6-bec5-49da-96fb-53e39b90cdac",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5242,7 +5251,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c2c08280-101f-48ef-a65d-863df8611ee3",
+                     "jsondocId": "dcf855a2-07bd-4030-ae21-89754aeaf427",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5251,7 +5260,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7e30283a-7c13-45a1-8df9-162b9aed386d",
+                     "jsondocId": "25aa0494-97a6-4b17-83ca-22f48c54ddac",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5260,7 +5269,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3d408e9a-1235-4a95-ba93-3dad29b950a6",
+                     "jsondocId": "1397c20e-7d81-4ec2-bf23-f05a883b1da7",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) if valid organism id or commonName is supplied show organism if user has permission",
@@ -5272,9 +5281,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "methodName": "findAllOrganisms",
-               "jsondocId": "059f328a-09d0-48e5-a1e0-397ce86d75b8",
+               "jsondocId": "81e790e8-e47f-418e-9281-126d156283a5",
                "bodyobject": {
-                  "jsondocId": "1c00650e-5c23-4d90-bb58-0fa28ba9fdad",
+                  "jsondocId": "82fb8b96-e221-431f-aa69-99950783bc05",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5284,7 +5293,7 @@
                "apierrors": [],
                "path": "/organism/findAllOrganisms",
                "response": {
-                  "jsondocId": "82d04459-9f63-45f9-81b1-2a793ae3405e",
+                  "jsondocId": "a4797a69-c547-4752-a89d-ee2ce28efe92",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5297,14 +5306,14 @@
          "description": "Methods for managing organisms"
       },
       {
-         "jsondocId": "679520c9-2b72-414d-b23e-d5febcde2582",
+         "jsondocId": "57811208-b7fe-4ca4-b783-06f9e1c12b6c",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fa00e94f-600f-4ad9-bdf7-375d6a3e8442",
+                     "jsondocId": "960d7f42-9e52-4790-bdc1-3d5eecd2a8fb",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -5313,7 +5322,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b885e0b4-5abc-4fbd-9ae8-f17b40def920",
+                     "jsondocId": "b2263aca-abd2-450e-8358-62c9e3c74189",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name (required)",
@@ -5325,12 +5334,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism and track",
                "methodName": "clearTrackCache",
-               "jsondocId": "a15bddd2-482b-40dd-81cf-eb6b40f28ae6",
+               "jsondocId": "d4bd5344-3a05-4cbb-b194-b216d592bbab",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>/<track name>",
                "response": {
-                  "jsondocId": "96bdc805-c76d-4d3a-ac73-b66aad5967c5",
+                  "jsondocId": "a8f0d52c-1b75-4282-b5f3-726b601df7c6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5342,7 +5351,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "37245397-bd2b-415f-bff9-9772c459eb80",
+                  "jsondocId": "9dd2536a-09ba-4431-9a5f-20569951fe2e",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required)",
@@ -5353,12 +5362,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "95116c63-4967-4195-b54c-868ec774ebfa",
+               "jsondocId": "27160e12-3de9-4580-bb9c-9e18d27f9c05",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "4b06cce2-3c31-4553-a3a4-3acbddeab3a2",
+                  "jsondocId": "372607cf-5af8-45e2-9be0-ae1c416a24cf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5371,7 +5380,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "09f3d50e-5a81-4812-9cb2-81ce9d7f58a3",
+                     "jsondocId": "4d084770-08b8-4095-83b6-3247c49a6a9a",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -5380,7 +5389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fff207ef-a329-4f2e-ab04-c4547fc6bfb9",
+                     "jsondocId": "0a14979c-8d16-4cea-a636-a89f104e1e5b",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -5389,7 +5398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0e4a46b2-437c-4bee-82d5-57cd6ba7d753",
+                     "jsondocId": "89f8bf29-8ced-4473-a25f-d5ce6c3a2395",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -5398,7 +5407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a77c04ff-29dd-4e97-861e-e2279e89af06",
+                     "jsondocId": "90bcc2d5-72ae-4dbe-b723-ce486649ac9c",
                      "name": "featureName",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -5407,7 +5416,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "da06704e-9c0e-400f-a25d-5ce5813c3feb",
+                     "jsondocId": "f3e88165-226f-4075-80c4-bd0f108ff33f",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -5416,7 +5425,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2e7ec35f-988c-43b4-9093-77d402718f29",
+                     "jsondocId": "d006b8d2-1ed3-41fb-b259-05cdb7d04930",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -5428,12 +5437,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within but only for the selected name",
                "methodName": "featuresByName",
-               "jsondocId": "09a99066-3157-4498-94eb-e6f45cf5384c",
+               "jsondocId": "30425d08-084b-47c1-a5d5-53c88b675ddf",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "768e3cbf-6ad1-4024-bbfc-c7aae871b05c",
+                  "jsondocId": "19ca638c-0947-4762-98b0-84a08b19c232",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5446,7 +5455,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a77daf07-af41-44db-b83e-3bf27f26936e",
+                     "jsondocId": "d52ba81d-774b-4052-8589-0fe0fdf55920",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -5455,7 +5464,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "964e3af7-e7ce-4219-b779-862525ff5cb0",
+                     "jsondocId": "5c8f0106-ac54-4703-8928-80ff90a0e7ed",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -5464,7 +5473,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a9dcf886-07f4-4c78-946c-3a6c806200c4",
+                     "jsondocId": "6b4febd7-6407-42db-ba2e-0b819bd0f9f4",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -5473,7 +5482,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7e3f0c8-2b9a-42c5-abdd-a4d09eed2ccf",
+                     "jsondocId": "952c30ba-bd78-47e4-90e0-2d5aae3c8c08",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -5482,7 +5491,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "21be73d8-4d1b-461e-9b20-5d4c6b8c8016",
+                     "jsondocId": "ccac5b02-4634-4451-bb6e-6de7e081bf78",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -5491,7 +5500,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4dfd6dc8-da8a-44cb-b36c-956d6db9f1b0",
+                     "jsondocId": "a315b239-f7a6-4e0b-b187-6a2e544da583",
                      "name": "name",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -5500,7 +5509,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "919f0a79-f529-4faf-af35-15c6b55784a8",
+                     "jsondocId": "cb029bb6-7f77-4a75-a798-1b2480976291",
                      "name": "onlySelected",
                      "format": "",
                      "description": "(default false).  If 'selected'!=1 one, then exclude.",
@@ -5509,7 +5518,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "399dcf6c-4042-49f1-9bb8-f31f795b6474",
+                     "jsondocId": "c244eeb0-0ca0-473a-88b4-70c3f2b52a1d",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -5518,7 +5527,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e9a3be06-53d8-4246-a6ee-d9da409fd89b",
+                     "jsondocId": "b321eb59-421f-4a4d-84c1-bff35fad4557",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -5530,12 +5539,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within an range",
                "methodName": "featuresByLocation",
-               "jsondocId": "dc1760c9-3580-4259-98d3-e61be3aa646f",
+               "jsondocId": "abb071f4-5afa-43ff-b69c-0f3262e1bf08",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>:<fmin>..<fmax>.<type>?name=<name>&onlySelected=<onlySelected>&ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "6c5d076f-fe08-4803-9d83-77d114a0ee1d",
+                  "jsondocId": "9ec1d060-d84a-4e8f-9994-89e0d3b792d2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5548,14 +5557,14 @@
          "description": "Methods for retrieving track data"
       },
       {
-         "jsondocId": "4444a772-dd65-4c7e-b63c-36e9f5e8923d",
+         "jsondocId": "003f3295-0212-4928-a681-68ec017b0d30",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2c622791-4df9-4990-8f5e-ac4574df889d",
+                     "jsondocId": "dc9a0808-895f-4b3e-a21c-80cd86727c3e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5564,7 +5573,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0fb6fc5b-de84-4f29-b8ab-0950fa38f77d",
+                     "jsondocId": "ba6803a8-7c10-475f-ab61-92f5b81872ea",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5573,62 +5582,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "37e31d31-abcb-48c8-9bdc-95aba028a6b1",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to fetch",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get organism permissions for user, returns an array of permission objects",
-               "methodName": "getOrganismPermissionsForUser",
-               "jsondocId": "8a1a6fe5-26e4-468d-8a64-7b8c9fbe974d",
-               "bodyobject": {
-                  "jsondocId": "2fe0d3fb-81ae-4659-bd6b-2ab3a13af144",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/getOrganismPermissionsForUser",
-               "response": {
-                  "jsondocId": "95e5d298-2585-471a-90b4-b5412266bad3",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "18c4774c-50fb-45ca-a4ec-16094ead1bbc",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "12876d2e-027f-4fb7-933d-013ca6cbae0d",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "95230f92-4716-43d0-b6fb-97abac96cae1",
+                     "jsondocId": "5a23732f-6296-48f6-9cdd-c408aaf2dc4f",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to modify permissions for",
@@ -5637,7 +5591,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "237e64ba-a1f0-4579-8c81-e514da8ecdc5",
+                     "jsondocId": "6b05c020-a3db-4461-9a0f-f3b8124897a7",
                      "name": "user",
                      "format": "",
                      "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
@@ -5646,7 +5600,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "00fbe0ed-3fa5-4d04-afb7-9e192f850a92",
+                     "jsondocId": "d0f6e69b-ff48-4168-9cc1-d00077f4fb7f",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism to update",
@@ -5655,7 +5609,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "241e7974-bb36-4745-9212-8807986218aa",
+                     "jsondocId": "d25fb8a2-f66f-485b-a9fc-b18905d9f732",
                      "name": "id",
                      "format": "",
                      "description": "Permission ID to update (can get from userId/organism instead)",
@@ -5664,7 +5618,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "70904634-752b-4e33-a1f7-280b20237866",
+                     "jsondocId": "2a719ae0-f1e5-4b2f-80b1-6487fb03fcaf",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -5673,7 +5627,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c03aef25-afb4-4eef-b0cf-1677575abf59",
+                     "jsondocId": "4bd7b923-cc7b-48f4-8803-e31eb7d85754",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -5682,7 +5636,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2719df5e-7dad-4972-a28b-20a214806dcd",
+                     "jsondocId": "55dc4e5f-bcca-4375-8aaf-fa272ce4232c",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -5691,7 +5645,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "22546f6e-3796-4c6b-a728-a7a766a5a526",
+                     "jsondocId": "92dfb9f7-9852-453a-993e-2f9788bd6e40",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -5703,9 +5657,9 @@
                "verb": "POST",
                "description": "Update organism permissions",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "7546d9b1-59bd-4c76-8294-7c6153a9cfe1",
+               "jsondocId": "6b5f7a80-e75b-417d-a1cb-fc76fd7a796e",
                "bodyobject": {
-                  "jsondocId": "79406018-efe0-4549-8264-78934c6bd665",
+                  "jsondocId": "11b4ab25-f367-4574-a9f3-c16e4dbc1669",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5715,7 +5669,7 @@
                "apierrors": [],
                "path": "/user/updateOrganismPermission",
                "response": {
-                  "jsondocId": "a8cd3b8a-180f-471c-9109-7e45884d80fd",
+                  "jsondocId": "765c0ec2-b707-4b19-9eb7-85bb977ffc49",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -5728,7 +5682,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c116dd0f-ea14-45e8-b77a-f132be094661",
+                     "jsondocId": "1b34b04c-2518-46f3-bedc-7ef84f102501",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5737,7 +5691,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49b35b33-1ee1-4130-8280-cae4f9af6383",
+                     "jsondocId": "c78ed0a3-c98a-4558-9412-fe2048ff34ad",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5746,7 +5700,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0e774783-8f22-411e-ad37-f35c36b57a06",
+                     "jsondocId": "d9522782-f89c-4510-9aaf-6c882e7ea63a",
                      "name": "userId",
                      "format": "",
                      "description": "Optionally only user a specific userId as an integer database id or a username string",
@@ -5758,9 +5712,9 @@
                "verb": "POST",
                "description": "Load all users and their permissions",
                "methodName": "loadUsers",
-               "jsondocId": "abb2047d-6c32-4a39-aba5-0b620d7f60d8",
+               "jsondocId": "7da8b722-dd17-47a5-b6a6-d8c9192b3955",
                "bodyobject": {
-                  "jsondocId": "e14a3103-8fea-4c63-8ea0-dd6bd2bd8bd0",
+                  "jsondocId": "d2a9f6b2-fa71-4e4b-9bfd-516fcaa24cc0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5770,7 +5724,7 @@
                "apierrors": [],
                "path": "/user/loadUsers",
                "response": {
-                  "jsondocId": "c587687d-e758-47f3-9ac5-a960ea2a102d",
+                  "jsondocId": "7cc09089-c1b0-4fff-bcb6-db6052993f31",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -5783,7 +5737,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b6f05ab0-7898-4e79-bf8a-2a3b7d27c592",
+                     "jsondocId": "a4df3c99-9f3e-4f62-a823-fe24ab8608bd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5792,7 +5746,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "93191893-a472-49d9-be35-6b9973104865",
+                     "jsondocId": "c09d76b2-20e9-437a-958d-320ceac75418",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5801,7 +5755,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a695fc7c-3717-4239-a539-fd1f6b3f6dfe",
+                     "jsondocId": "3a063489-4842-4574-a19a-e2c1f343c3f5",
                      "name": "group",
                      "format": "",
                      "description": "Group name",
@@ -5810,7 +5764,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "785a431a-7781-4e92-ac95-a57e9ef7367f",
+                     "jsondocId": "e4fd7e53-bb37-4861-ab6e-7c9f4b5c07d6",
                      "name": "userId",
                      "format": "",
                      "description": "User id",
@@ -5819,7 +5773,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8fc3ea0c-8254-4faa-932d-7ee74d60e20f",
+                     "jsondocId": "0988b4fe-e8ba-4ea8-9aa1-9012b7595dda",
                      "name": "user",
                      "format": "",
                      "description": "User email/username (supplied if user id unknown)",
@@ -5831,9 +5785,9 @@
                "verb": "POST",
                "description": "Add user to group",
                "methodName": "addUserToGroup",
-               "jsondocId": "4531c07a-a406-4f9a-b932-f5e3d4c85b90",
+               "jsondocId": "ddf7886c-8ff8-44e8-b632-03ebefe84d66",
                "bodyobject": {
-                  "jsondocId": "d59fe8ac-4dc1-4b2a-a7ab-a15e200eda68",
+                  "jsondocId": "e5294373-184a-41bb-ad3e-7660d075ea7a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5843,7 +5797,7 @@
                "apierrors": [],
                "path": "/user/addUserToGroup",
                "response": {
-                  "jsondocId": "0830ff87-c1ca-401c-bdea-7be41a3a33c8",
+                  "jsondocId": "87fa312f-a570-49e9-97bb-9fd549959cb0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -5856,7 +5810,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3d2acb62-84e7-4605-a39a-fc4f64587825",
+                     "jsondocId": "030dff53-8bc7-4ff3-8c64-4e66990b2d8b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5865,7 +5819,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e87c85e3-3fba-4abc-9409-e401fdeaffc9",
+                     "jsondocId": "722c8405-4eea-4fc0-8733-9df10fcb8280",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5874,7 +5828,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8882598f-8741-4842-8605-ff9bb489d359",
+                     "jsondocId": "922fd9b9-d59e-435e-bc3b-5e1c8a47cd2c",
                      "name": "group",
                      "format": "",
                      "description": "Group name",
@@ -5883,7 +5837,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9c74a220-9952-413d-9f4f-4826b3491a74",
+                     "jsondocId": "63aa4b4b-d983-4e5f-9a69-d18c64835047",
                      "name": "userId",
                      "format": "",
                      "description": "User id",
@@ -5892,7 +5846,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff53fd0e-1ca4-4996-9d41-207cb8eada9f",
+                     "jsondocId": "e3af35f6-147f-48d2-9410-9a8ae5e950c4",
                      "name": "user",
                      "format": "",
                      "description": "User email/username (supplied if user id unknown)",
@@ -5904,9 +5858,9 @@
                "verb": "POST",
                "description": "Remove user from group",
                "methodName": "removeUserFromGroup",
-               "jsondocId": "71f9d915-4d1d-4f52-ab8b-124b0c6c592f",
+               "jsondocId": "95d54e98-665d-4f15-8e60-bf445d19e087",
                "bodyobject": {
-                  "jsondocId": "f1330f5e-f163-4752-baef-0bf939616eef",
+                  "jsondocId": "de08e55b-690a-40b2-ad83-1d0661b57bac",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5916,7 +5870,7 @@
                "apierrors": [],
                "path": "/user/removeUserFromGroup",
                "response": {
-                  "jsondocId": "4e7292d9-6204-463a-8137-1ef668949676",
+                  "jsondocId": "5595a095-1a0e-4067-b6ad-708e3b1cb7cb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -5929,7 +5883,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f400af6d-d585-489c-bb6e-0b973f816fd0",
+                     "jsondocId": "39b8112d-9367-401c-a85d-883d4f80bb3d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5938,7 +5892,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "da0f3cd0-a9f5-4b24-898b-0639b3d68c3d",
+                     "jsondocId": "1a9c1ca1-04bb-45c6-8fa8-a7e5fd390e83",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5947,7 +5901,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7d55de44-0b28-473e-bfb7-a5ec96d3b55b",
+                     "jsondocId": "5f8bb4be-2a2d-49ed-bcfb-d1d14ad1faba",
                      "name": "email",
                      "format": "",
                      "description": "Email of the user to add",
@@ -5956,7 +5910,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ca55a12b-1542-4d4c-b31e-b022569cec65",
+                     "jsondocId": "19fade52-dda9-4bd0-95ec-c41ea8d49f39",
                      "name": "firstName",
                      "format": "",
                      "description": "First name of user to add",
@@ -5965,7 +5919,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "468090f6-11c3-424a-b7c1-cf33d89592a8",
+                     "jsondocId": "370cae90-7664-494f-beae-da7df5e31ec1",
                      "name": "lastName",
                      "format": "",
                      "description": "Last name of user to add",
@@ -5974,7 +5928,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "90d0734b-2003-45db-885c-0da3779a2089",
+                     "jsondocId": "2d3be86b-1cea-447b-a5bc-757c7b30347f",
                      "name": "metadata",
                      "format": "",
                      "description": "User metadata (optional)",
@@ -5983,7 +5937,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cd2639ba-608e-409c-a59a-5bde2640fcb9",
+                     "jsondocId": "7c51633d-f38c-487b-af41-813ab34b1f6b",
                      "name": "role",
                      "format": "",
                      "description": "User role USER / ADMIN (optional: default USER) ",
@@ -5992,7 +5946,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1f9af783-dd29-4c93-8d74-cc056a7d5241",
+                     "jsondocId": "cebf4937-4950-43ed-9ec3-387cf5e0bbd6",
                      "name": "newPassword",
                      "format": "",
                      "description": "Password of user to add",
@@ -6004,9 +5958,9 @@
                "verb": "POST",
                "description": "Create user",
                "methodName": "createUser",
-               "jsondocId": "4ee83e52-1e6f-485a-a9c1-bfbe126581c9",
+               "jsondocId": "6cde1716-79ad-415d-b822-0495c16c201e",
                "bodyobject": {
-                  "jsondocId": "426aa992-e85d-4cb1-8cc3-2ba830bc73a5",
+                  "jsondocId": "c28ee8a9-f10f-405a-85c0-396eabacf210",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6016,7 +5970,7 @@
                "apierrors": [],
                "path": "/user/createUser",
                "response": {
-                  "jsondocId": "5910013c-e93d-4b25-913e-f74624807683",
+                  "jsondocId": "231d2492-ae1b-4fd9-a9e0-b069cc1720c3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -6029,7 +5983,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4175b9bc-8bb5-459e-ad66-011ea10e3e9b",
+                     "jsondocId": "c527c8ff-87de-444e-a16f-8f3a8a650180",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6038,7 +5992,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3dbdc379-8eb8-456a-92c3-2049ce987ce0",
+                     "jsondocId": "d411bc79-7db9-4028-97b4-482bc0d169f1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6047,7 +6001,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f9db1a91-852d-4e4b-908f-34297822df2b",
+                     "jsondocId": "b358b695-10c2-46b5-a6fa-e3e2a9e95f83",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to delete",
@@ -6056,7 +6010,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c824c923-333d-46b5-b196-0b1a55ec91ab",
+                     "jsondocId": "230254c8-357e-442f-ad29-0dcbad91eee4",
                      "name": "userToDelete",
                      "format": "",
                      "description": "Username (email) to delete",
@@ -6068,9 +6022,9 @@
                "verb": "POST",
                "description": "Delete user",
                "methodName": "deleteUser",
-               "jsondocId": "313a81ef-1f52-4df2-b339-4fb0321349d1",
+               "jsondocId": "7a233a3a-666c-475b-aacd-43d571491587",
                "bodyobject": {
-                  "jsondocId": "4b362d1d-2cd7-463d-acf6-8ed95f62a083",
+                  "jsondocId": "e0e51c68-0803-4235-a3c0-f9b85e323bc1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6080,7 +6034,7 @@
                "apierrors": [],
                "path": "/user/deleteUser",
                "response": {
-                  "jsondocId": "0345531d-22d9-4b69-8832-aec8fc83002c",
+                  "jsondocId": "224eb1fe-b6f4-486c-b327-7a2b2ba6b21a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -6093,7 +6047,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5b4511a4-b9c5-4749-a209-0a62ee975023",
+                     "jsondocId": "426a07e4-0168-4135-9d8c-1614e848fc65",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6102,7 +6056,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cb3358b3-f896-4c5e-a041-2fef57d82731",
+                     "jsondocId": "89523ad3-1add-4148-989b-cde718b7e954",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6111,7 +6065,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cc78d7b0-219f-40a3-9bae-7ff30717acc1",
+                     "jsondocId": "ae56ebe2-2fe4-462c-a3c7-8437745dd50c",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to update",
@@ -6120,7 +6074,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eb660525-4d42-425d-9fb7-3d5f5418fe23",
+                     "jsondocId": "4370b6cc-3ad2-4779-803b-4e85cfa8b2ce",
                      "name": "email",
                      "format": "",
                      "description": "Email of the user to update",
@@ -6129,7 +6083,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3bbf1404-ef3c-47f5-81ff-d1c950cbbbd0",
+                     "jsondocId": "98c38971-f24b-48fe-860b-b9ef12e4646c",
                      "name": "firstName",
                      "format": "",
                      "description": "First name of user to update",
@@ -6138,7 +6092,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4bcbe11a-0a5d-4cf8-b884-00ad0a338b03",
+                     "jsondocId": "f31e9d77-13eb-4548-80a9-8b21dcbb46f2",
                      "name": "lastName",
                      "format": "",
                      "description": "Last name of user to update",
@@ -6147,7 +6101,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dfe2d12f-dc73-41d0-af20-11d2bffeb190",
+                     "jsondocId": "fe89f5f4-1d1d-4e36-bcc7-6e2370362fc9",
                      "name": "metadata",
                      "format": "",
                      "description": "User metadata (optional)",
@@ -6156,7 +6110,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d8a8cad2-7060-495c-bccd-90c117dd9014",
+                     "jsondocId": "f40e0b7a-4a37-49df-a7db-1baf4d5dabc3",
                      "name": "newPassword",
                      "format": "",
                      "description": "Password of user to update",
@@ -6168,9 +6122,9 @@
                "verb": "POST",
                "description": "Update user",
                "methodName": "updateUser",
-               "jsondocId": "6b103da5-a813-4410-bdb0-4b842be4cfcd",
+               "jsondocId": "1b70387b-b62a-4e14-9be3-319f7f67547c",
                "bodyobject": {
-                  "jsondocId": "79c3cf76-6689-4db9-aa64-d8f37cd190bd",
+                  "jsondocId": "204ca0bb-5dc8-45de-a15c-665b26ff4ba6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6180,7 +6134,62 @@
                "apierrors": [],
                "path": "/user/updateUser",
                "response": {
-                  "jsondocId": "c0a53f6f-796f-4b3a-880f-54950f9ec77f",
+                  "jsondocId": "1cc536c4-0a5d-40a5-8827-9080f8b4cf03",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "bcdc355d-4880-4967-8464-f10884c437d2",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fb2eb4d5-3c1d-4ab4-8f01-d9d854b51661",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5dac5007-f30c-42e0-ba43-a981c77d95b3",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to fetch",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for user, returns an array of permission objects",
+               "methodName": "getOrganismPermissionsForUser",
+               "jsondocId": "824fd92b-21ca-43ee-9a9d-8481ff39a3eb",
+               "bodyobject": {
+                  "jsondocId": "1037fead-4007-429a-a0b0-ae7e17068a85",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/getOrganismPermissionsForUser",
+               "response": {
+                  "jsondocId": "aa892943-6d89-4cd0-a4f7-e81cc6a78f07",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"


### PR DESCRIPTION
Fixes #95  for having a per-organism translation table.

@deepakunni3  Can you review when you have a moment.
