### PR TITLE
added better coloring for strand matches

### DIFF
--- a/client/apollo/css/webapollo_track_styles.css
+++ b/client/apollo/css/webapollo_track_styles.css
@@ -22,11 +22,22 @@
     background-color: rgb(173, 92, 194);
 }
 
-.mRNA, 
-.plus-mRNA, 
-.minus-mRNA  {
-    height: 14px;
-    background-color: transparent;
+.bam-read{
+    height: 5px;
+    background-color: #AACDDC;
+    z-index: 8;
+}
+
+.plus-bam-read {
+    height: 5px;
+    background-color: lightblue;
+    z-index: 8;
+}
+
+.minus-bam-read {
+    height: 5px;
+    background-color: lightcoral;
+    z-index: 8;
 }
 
 
@@ -340,26 +351,27 @@ div.annot-sequence  {
     top: 10%;
 }
 
-/* defaults for rendering aligned read from BAM files */
-.bam-read, 
-.plus-bam-read, 
-.minus-bam-read {
-    height: 5px; 
-    background-color: #AACDDC;
-    z-index: 8;
-}
-
 /* CIGAR string "M" subfeature, indicating "alignment match" (can be a sequence match or mismatch) of aligned sequence relative to viewed sequence */
-.cigarM, 
-.plus-cigarM, 
-.minus-cigarM  {
+.cigarM {
     height: 100%; 
     background-color: #1B8A99;
     z-index: 8;   /* rendered below most other subfeatures */
     min-width: 1px;
 }
 
+.plus-cigarM {
+    height: 100%;
+    background-color: navy;
+    z-index: 8;   /* rendered below most other subfeatures */
+    min-width: 1px;
+}
 
+.minus-cigarM  {
+    height: 100%;
+    background-color: darkred;
+    z-index: 8;   /* rendered below most other subfeatures */
+    min-width: 1px;
+}
 
 /* CIGAR string "=" (or "E") subfeature, indicating exact sequence match of aligned sequence relative to viewed sequence */
 .cigarEQ, 


### PR DESCRIPTION
Fixes #412 

@childers  If you have a chance to look at this and let us know if similar matches for .cigarE / .cigar? would be helpful. 

This is a pretty simple fix.  You can also issue a separate PR / patch. 

@deepakunni3  I think this is ready for review.   Not sure what the history of why this wasn't done in the first place (in WA1) as it was pretty easy. 