### PR TITLE
Fix deleteOrganism endpoint in OrganismController

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
@@ -44,15 +44,15 @@ class OrganismController {
     @RestApiParams(params = [
             @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
             , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
-            , @RestApiParam(name = "organism", type = "string", paramType = RestApiParamType.QUERY, description = "ID or commonName that can be used to uniquely identify an organism")
+            , @RestApiParam(name = "organism", type = "json", paramType = RestApiParamType.QUERY, description = "Pass an Organism JSON object with an 'id' that corresponds to the organism to be removed")
     ])
     @Transactional
     def deleteOrganism() {
 
         try {
-            JSONObject requestObject = permissionService.handleInput(request, params)
-            log.debug "deleteOrganism ${requestObject}"
-            if (permissionService.isUserAdmin(permissionService.getCurrentUser(requestObject))) {
+            JSONObject organismJson = permissionService.handleInput(request, params)
+            log.debug "deleteOrganism ${organismJson}"
+            if (permissionService.isUserAdmin(permissionService.getCurrentUser(organismJson))) {
 
                 log.debug "organism ID: ${organismJson.id} vs ${organismJson.organism}"
                 Organism organism = Organism.findById(organismJson.id as Long) ?: Organism.findByCommonName(organismJson.organism)
@@ -60,10 +60,10 @@ class OrganismController {
                     UserOrganismPreference.deleteAll(UserOrganismPreference.findAllByOrganism(organism))
                     OrganismFilter.deleteAll(OrganismFilter.findAllByOrganism(organism))
                     organism.delete()
-                    log.info "Success deleting organism: ${requestObject.organism}"
+                    log.info "Success deleting organism: ${organismJson.organism}"
                 }
                 else {
-                    log.error "Organism ${requestObject.organism} not found"
+                    log.error "Organism ${organismJson.organism} not found"
                 }
                 render findAllOrganisms()
             } else {

--- a/web-app/js/restapidoc/restapidoc.json
+++ b/web-app/js/restapidoc/restapidoc.json
@@ -2,14 +2,14 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
-         "jsondocId": "04eae7a6-d8c6-4c98-a336-0a5e5eadb33a",
+         "jsondocId": "28092e65-3572-4772-a817-6fafebebbdcf",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5ad519e9-227a-4416-810f-30be4ba3becc",
+                     "jsondocId": "3583c150-0ce9-4362-b8c4-540891883607",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -18,7 +18,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "23712b6b-276c-4f59-834e-fd7799c7cc59",
+                     "jsondocId": "d9535edf-3f76-4460-9f1c-ae45ac118e08",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -27,7 +27,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "864eb4d0-4ac2-4bfa-bf5d-fc080830673c",
+                     "jsondocId": "b181b281-5821-4e63-983c-1c6166ed8329",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -36,7 +36,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7cec7f28-33f4-4ee9-bcf2-acc430cf1003",
+                     "jsondocId": "e4113cdb-1559-4aab-9113-99dea5920367",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -45,7 +45,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ed31a93f-c404-46ce-84a1-ca87f17a9158",
+                     "jsondocId": "b0401196-1bbb-4110-b21e-ebefe4a4f4fd",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
@@ -57,9 +57,9 @@
                "verb": "POST",
                "description": "Set name of a feature",
                "methodName": "setName",
-               "jsondocId": "ecebf18c-367d-4de6-98c5-56660bdd363a",
+               "jsondocId": "d36ffceb-8485-4bc3-b958-32e21254c1f1",
                "bodyobject": {
-                  "jsondocId": "82915ce4-15a9-4df2-8582-0bac97f640c7",
+                  "jsondocId": "0edd7e21-b6c0-4eae-b190-532bfc8ea209",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -69,7 +69,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setName",
                "response": {
-                  "jsondocId": "7a85b695-c8df-4cb5-b1d7-a240b263691b",
+                  "jsondocId": "8f9f633d-f6bd-4d01-9ec7-84f1981fe49a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -82,7 +82,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5dbc815e-fdb1-4e1c-b127-6ad1ffc0d538",
+                     "jsondocId": "95934418-8a23-4f92-8903-54fe86af3aca",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -91,7 +91,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5e91277c-d532-4e5f-b96f-171c4cbe69d4",
+                     "jsondocId": "a627584a-b421-4f6b-8e98-dfca550bd2c5",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -100,7 +100,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1ae68c8e-dd09-4ae3-b1ea-3943d5093f21",
+                     "jsondocId": "41c68d9e-972b-4814-9ac7-82d4c0554e5d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -109,7 +109,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e39f189f-be96-4864-8cfc-b31f6c34d3b2",
+                     "jsondocId": "b88e6ea2-49d2-44cf-b589-fb4f4a255443",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -118,7 +118,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9d8f835f-d148-4631-92dd-b93f3a4c955a",
+                     "jsondocId": "aa0674ec-e513-4eb9-967a-145b4c44537e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -130,9 +130,9 @@
                "verb": "POST",
                "description": "Get comments",
                "methodName": "getComments",
-               "jsondocId": "68987718-2cb6-442c-9669-bf3770ae0ceb",
+               "jsondocId": "8079eb91-242d-493d-8013-39bffe161872",
                "bodyobject": {
-                  "jsondocId": "07e7e066-de28-4cac-b586-ed497043f602",
+                  "jsondocId": "2ffe66d9-c0f3-4444-8f92-3bbac7233fa2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -142,7 +142,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getComments",
                "response": {
-                  "jsondocId": "61828a13-e8cb-4ed0-a919-0cd02f6fd586",
+                  "jsondocId": "bdf0fb50-557c-4fdd-b9ea-64a26b3a0bcc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -155,7 +155,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "82aeb5db-3c66-4ead-ada1-5ac7080b7b92",
+                     "jsondocId": "442b8b1e-d473-497c-8c87-de21fb84b175",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -164,7 +164,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1593b22-2254-4be0-815e-b6f72e21c8d2",
+                     "jsondocId": "3355604e-93e0-4bbe-b776-2e57efa53795",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -173,7 +173,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d60f1ab6-e29a-4570-b6db-1bc57602007c",
+                     "jsondocId": "b315de0c-3716-4097-9371-96acd41cb62a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -182,7 +182,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aaa12379-7dc3-4a66-8907-2c875b912dbe",
+                     "jsondocId": "5a360397-d479-4a92-8b6e-6d3cfd70abcd",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -191,7 +191,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6dcc9783-eace-4968-9746-35c8456c1f0a",
+                     "jsondocId": "bc5cf6dd-21c3-48c0-a27a-63619f349439",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
@@ -203,9 +203,9 @@
                "verb": "POST",
                "description": "Set status of a feature",
                "methodName": "setStatus",
-               "jsondocId": "a7402996-3904-44b8-8439-7d201133d9fb",
+               "jsondocId": "92474be7-885d-449c-9bea-20521e05343e",
                "bodyobject": {
-                  "jsondocId": "33abbafa-3bef-4fac-b5a3-ed1de9611fa5",
+                  "jsondocId": "62a82a13-c523-4d6c-9319-30dbd470dc5d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -215,7 +215,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setStatus",
                "response": {
-                  "jsondocId": "82376ae8-08b6-4755-9447-5eeb0852a398",
+                  "jsondocId": "949730a6-b7eb-477d-900d-0486c9b04ff2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -228,7 +228,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "23ac6a83-db80-49c0-a684-27ed8bbfed7a",
+                     "jsondocId": "a89326c8-e0bd-43c7-bd1c-c3ac2f382a2a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -237,7 +237,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a54d4c0c-999e-4f48-9f3e-fa3e0c5d05cd",
+                     "jsondocId": "6382f0ca-d43e-43c6-8a64-4cba386ff1e8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -246,7 +246,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "575116ac-e5d1-4c41-9acd-fc42084993f0",
+                     "jsondocId": "d26b6a9f-96d6-4cc6-a13e-f05e2c0dd722",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -255,7 +255,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b4e68abb-6eb0-4e30-b3da-1ea6707c6230",
+                     "jsondocId": "5f4a800b-7a83-4b2e-b398-a5790d82fa23",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -264,80 +264,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b0bb30d5-90db-4f99-9b62-db18ce05cc6e",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add attribute (key,value pair) to feature",
-               "methodName": "addAttribute",
-               "jsondocId": "d2312555-5175-4765-b610-73ae26d8ac24",
-               "bodyobject": {
-                  "jsondocId": "90380c7c-6a4f-4f50-a840-c784d230fc12",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addAttribute",
-               "response": {
-                  "jsondocId": "dddae704-da60-4b3f-aa21-23b7796727e0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "a8f6093e-6969-4308-b417-5db60e39ea4f",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "562af5a8-2246-4eb3-8a7f-40cf1eb9afea",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e0b1a33a-c0c5-41a2-9067-3bdeab8ce184",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f9ec1866-9666-49ff-8e1d-6ad04d0c67d6",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "23721a1a-425e-4b32-a5a4-1a8443ddd5b4",
+                     "jsondocId": "90782d5d-752b-4347-bf69-cb560005521e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
@@ -349,9 +276,9 @@
                "verb": "POST",
                "description": "Set description for a feature",
                "methodName": "setDescription",
-               "jsondocId": "b4338fe7-2375-400b-898f-db4acc5a1b2c",
+               "jsondocId": "23c6caa2-85f5-49f9-9c17-8a1a08b6a39a",
                "bodyobject": {
-                  "jsondocId": "fd63f057-d347-4b01-ad09-3f6ee6002537",
+                  "jsondocId": "e5e26669-082b-4647-8b13-90c9ac1cf392",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -361,7 +288,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setDescription",
                "response": {
-                  "jsondocId": "b498c6c6-9fc6-43ee-a211-eb5a56d8e4b8",
+                  "jsondocId": "53bd2ef2-4771-4a23-a8b5-3df554bf35fb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -374,7 +301,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "19328ae9-39e5-4aaf-80fa-68c3b6fbc49b",
+                     "jsondocId": "f6dee5c5-49cb-45df-96c9-da3dd2bed51a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -383,7 +310,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e2565ba0-cff3-4017-9663-29c9ca295b1f",
+                     "jsondocId": "30b98f01-5dd5-405e-b7bc-9dfc362863fa",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -392,7 +319,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3b1b1029-71e1-4c17-a49c-13e600147748",
+                     "jsondocId": "7c3b66d1-7793-4a8c-a50a-391daf3686a8",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -401,7 +328,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a96d33ac-dfb3-45ec-86e5-a2b274fff792",
+                     "jsondocId": "ee966636-be8d-486c-990b-2c122b664fc6",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -410,7 +337,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3d91f5f8-caa6-4d8e-96d1-a61715a25a27",
+                     "jsondocId": "b3e6b1e2-5b14-4924-b92f-b18decbf44dc",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
@@ -422,9 +349,9 @@
                "verb": "POST",
                "description": "Set symbol of a feature",
                "methodName": "setSymbol",
-               "jsondocId": "07c5b251-9ee1-482c-9ed2-983908d0befb",
+               "jsondocId": "add896f1-7a17-49ba-873a-10912b4ca258",
                "bodyobject": {
-                  "jsondocId": "8989ee11-6d37-40cb-a3f4-1392a2bff810",
+                  "jsondocId": "81284c63-20d5-4eeb-9771-e27fec832ce8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -434,7 +361,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setSymbol",
                "response": {
-                  "jsondocId": "c9b76e1c-7f44-464c-bb66-812acf40d6a4",
+                  "jsondocId": "21216051-cf51-4481-a034-fac92cf0399d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -449,9 +376,9 @@
                "verb": "POST",
                "description": "Returns a translation table as JSON",
                "methodName": "getTranslationTable",
-               "jsondocId": "e5da4546-2314-440d-9542-2d993e9f236a",
+               "jsondocId": "32f6b3a3-95b1-4161-b4ed-d795c79228a4",
                "bodyobject": {
-                  "jsondocId": "341dc97f-f3fa-4035-b423-a1e185752aa9",
+                  "jsondocId": "ae54194d-ef52-4bde-aec2-369d56896ec7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -461,7 +388,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getTranslationTable",
                "response": {
-                  "jsondocId": "1a788639-cd1b-4439-8aa7-7389147e5c42",
+                  "jsondocId": "f7295775-f565-43fe-b93f-e273704c1d59",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -474,7 +401,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "408c3145-399c-42f4-9d17-7f9015d3fdd6",
+                     "jsondocId": "666bc0be-c44e-4960-b1d5-dcfdc4c1ff10",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -483,7 +410,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c419e8e2-8158-4bd0-8fac-071cb60b36cc",
+                     "jsondocId": "2a47ab82-5984-4e7e-a8c0-00015afc92b9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -492,7 +419,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55e1f2ca-1649-4e56-8c87-7c98ab22c785",
+                     "jsondocId": "446ba2c2-a5f8-48aa-8748-165970da48e3",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -501,7 +428,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "53fcd492-a223-4007-979e-8aaf5a4e7725",
+                     "jsondocId": "6d54172a-b5c2-468f-bbde-aa1df4edb09d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -510,7 +437,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "30fd8750-69c7-460e-b855-db9752d9ebad",
+                     "jsondocId": "9d3398a5-dbb6-47a5-b0d5-67e8fce52131",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -519,7 +446,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "783bb9a3-cbee-476d-a815-1358e6a0ee33",
+                     "jsondocId": "40a9e38c-abbb-4a42-a73d-160a4a4a4944",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -528,7 +455,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1d40f71-6bc9-4929-a566-657ffa2a0830",
+                     "jsondocId": "d1f8338b-b8d1-4f70-a709-beff92929060",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -540,9 +467,9 @@
                "verb": "POST",
                "description": "Add non-coding genomic feature",
                "methodName": "addFeature",
-               "jsondocId": "f1de15a8-5a9a-4cc2-99a9-534819a31de7",
+               "jsondocId": "394cf966-bfb2-43ea-9882-9865b2e0033a",
                "bodyobject": {
-                  "jsondocId": "9ff05e86-f628-4084-aacf-3a132674669d",
+                  "jsondocId": "d80ee019-4343-44a2-b168-b90e946f0e32",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -552,7 +479,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addFeature",
                "response": {
-                  "jsondocId": "c8f8135d-3684-4230-b3a2-1fa0c422313b",
+                  "jsondocId": "486a3b40-0d52-474b-86fa-3ab3d2adf1c8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -565,7 +492,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4be940fa-b187-4c09-b00c-5e8ed9759996",
+                     "jsondocId": "45c4cb7f-d43f-4391-a357-e388f72197dd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -574,7 +501,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "24d3eff5-fa4e-4920-a272-6786af4f87c3",
+                     "jsondocId": "402e5b20-a53a-4812-9dc4-d8d8ab84494d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -583,7 +510,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d5216b90-ecb3-4d41-8b6b-4d634049355c",
+                     "jsondocId": "9408bef7-5e83-4a28-88dd-38d89fffbffa",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -592,7 +519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bdaa2a7c-83b5-40ed-8f20-91506fe6e756",
+                     "jsondocId": "5b62a0cd-8281-457b-b406-d4ed4888f9bb",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -601,7 +528,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8480417d-8674-4934-a322-6c9e14974b9f",
+                     "jsondocId": "dbd24e9c-0143-441b-97d0-578d45ca2e6a",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -610,7 +537,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "34c15d64-1dcf-4468-9844-5f4298d7f252",
+                     "jsondocId": "618940ac-96dd-474f-8879-c24321f6e304",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -619,7 +546,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3c93e8a3-1c81-4b01-b0ff-01df7562ae08",
+                     "jsondocId": "83540906-bf3c-423e-b882-8bcd4076bedf",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -631,9 +558,9 @@
                "verb": "POST",
                "description": "Set exon feature boundaries",
                "methodName": "setExonBoundaries",
-               "jsondocId": "c731c0b3-bc82-49c8-bcf2-d969e57bfd8c",
+               "jsondocId": "40b5fe74-0b8d-42f5-92bf-2a76c08b3712",
                "bodyobject": {
-                  "jsondocId": "043add87-9f45-4773-9d21-89ac524f57a5",
+                  "jsondocId": "3c51d4fd-6a22-4c34-b400-7db6462f6e8f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -643,7 +570,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setExonBoundaries",
                "response": {
-                  "jsondocId": "53a6b4f2-fcf9-4c8e-a971-3f19204f69e6",
+                  "jsondocId": "70380745-89be-472a-ac07-9fb5811db01d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -656,7 +583,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b6ad8855-9b11-4aaa-b9f5-b45e78f1c515",
+                     "jsondocId": "dec43ae3-dbc7-4e2c-9e08-94c83432d9ea",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -665,7 +592,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c02c0d56-6ea5-4a96-9c9f-9abd3dd6045c",
+                     "jsondocId": "01db5c5d-2c47-4c60-b0c3-63c233e0775a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -674,7 +601,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "43e071dd-d75c-4444-b869-9abeff152e07",
+                     "jsondocId": "f1e1ced8-2465-4fcc-97c9-20502e1cd632",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -683,7 +610,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4344a247-3e3d-4f0b-9395-7ea67d30cc6a",
+                     "jsondocId": "0a2b872f-f564-4da1-94e1-55c13214d63f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -692,7 +619,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4380d403-7481-4235-bfb6-6736da4dee67",
+                     "jsondocId": "7e45244e-8867-4df3-9853-72a44d8c7094",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -701,7 +628,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "721336d1-6efe-41c2-baaa-5b14b6d4611d",
+                     "jsondocId": "15813cf9-e8c0-480c-8222-ff2c58da47ea",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -710,7 +637,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f818e86e-4263-43ee-83f2-8ba115125927",
+                     "jsondocId": "11cb5c38-4693-4d43-a0f9-d92bd21c2161",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -722,9 +649,9 @@
                "verb": "POST",
                "description": "Add an exon",
                "methodName": "addExon",
-               "jsondocId": "80f70c9a-420e-4580-af13-52b32b521fec",
+               "jsondocId": "cb64ec60-a307-43be-9753-ff373cbe1f01",
                "bodyobject": {
-                  "jsondocId": "7881c8d2-ead7-4089-8590-b831a6cb0835",
+                  "jsondocId": "fe628b45-8305-49ac-af8e-50628a47fe80",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -734,7 +661,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addExon",
                "response": {
-                  "jsondocId": "ccd87342-be80-4bde-9a9a-777e3a5653b9",
+                  "jsondocId": "7a254709-a4d4-4864-a454-109b0da4bd2b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -747,7 +674,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "21fc8602-34c4-4526-b2c8-7503a5d91293",
+                     "jsondocId": "e50754b3-f791-4e37-ae27-8f1c53a1c3ba",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -756,7 +683,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97484c60-533c-47fc-9a48-9cab2f69e80a",
+                     "jsondocId": "7e08a45f-7cba-44f8-8759-9c5c3726ea02",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -765,7 +692,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eac784c1-4fb5-485c-b238-a658f9a562d4",
+                     "jsondocId": "e86b0ac4-6b40-4f97-a6cc-3c4bb9acfd89",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -774,7 +701,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "93193cd3-4a54-4577-9974-155267e6f6ec",
+                     "jsondocId": "18a36604-ef81-4f80-905d-8e9570ba5d7c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -783,7 +710,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "589a5a51-03dc-4d7f-ab48-1aa8502951d0",
+                     "jsondocId": "298e2f93-4901-4c29-953f-ee98bdaa65e8",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -795,9 +722,9 @@
                "verb": "POST",
                "description": "Add comments",
                "methodName": "addComments",
-               "jsondocId": "8afb1e65-a88f-4ef8-b69d-d748e4b3bb06",
+               "jsondocId": "75750cf7-acc2-4191-a48f-9b7938755846",
                "bodyobject": {
-                  "jsondocId": "c2b863fa-77ac-4360-b7c0-4d98339bd244",
+                  "jsondocId": "90901851-dd52-4505-9cb0-971e2705c6d3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -807,7 +734,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addComments",
                "response": {
-                  "jsondocId": "b31b0746-f849-417f-8899-0dfff57646be",
+                  "jsondocId": "481fc9c2-da74-4691-9e2f-e5d605e5cb44",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -820,7 +747,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9bf4a656-7b92-4a64-8531-dd898dae236b",
+                     "jsondocId": "dd56e6f5-7da7-4ec1-98e4-8bdfd3f1a9f8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -829,7 +756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1ab13528-dfbe-45d4-81c9-c2da4a6cc904",
+                     "jsondocId": "9727ab23-70e4-4820-979d-7bb7d7e1cd1f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -838,7 +765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "87199f74-eb2e-40d3-b417-5e613aae2235",
+                     "jsondocId": "638ab427-7081-45df-8ca9-ab65717d638e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -847,7 +774,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bcb2609f-8408-4054-b0a9-b84ec8a1a100",
+                     "jsondocId": "e8a01e36-c096-4906-b57d-7e41d5482c0f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -856,7 +783,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c4d248cd-ac05-4a70-b780-1543dc4d1d0e",
+                     "jsondocId": "c121ba18-e6e0-4358-b947-5f5167135235",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -868,9 +795,9 @@
                "verb": "POST",
                "description": "Delete comments",
                "methodName": "deleteComments",
-               "jsondocId": "7ab25daf-b067-40bf-b596-596445773f45",
+               "jsondocId": "42bb5605-fb04-4ad5-b26e-c1a62e8a2a0a",
                "bodyobject": {
-                  "jsondocId": "36668e2f-d5c1-4e7c-ab4a-ca7fb79d2a84",
+                  "jsondocId": "6aeeeec5-cfb7-4b07-8c46-5ccb4da3ae12",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -880,7 +807,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteComments",
                "response": {
-                  "jsondocId": "b048d9cf-b50b-4cea-a1df-04a646db02d4",
+                  "jsondocId": "416b0b04-e9ce-4567-9557-ed24f1681e3b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -893,7 +820,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f776fd03-092d-48a0-8f85-64235ce4629f",
+                     "jsondocId": "cdcb218d-a798-4b4d-a9bb-a675b272080c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -902,7 +829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fe010f8a-dba9-4b86-a7bc-cd493bd4d715",
+                     "jsondocId": "ee1ceeb0-c011-4191-867f-cc39c588cced",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -911,7 +838,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9250102a-7eeb-4cfd-8887-8014ac408661",
+                     "jsondocId": "f7b271b6-6f98-412b-a63e-748629666140",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -920,7 +847,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b79aadf-a022-4abf-bd13-34567ae0fe3e",
+                     "jsondocId": "252a9b5c-9f5e-43a4-9a69-f819756f1334",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -929,7 +856,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7ef98b7b-c173-4024-b42f-3109cc875088",
+                     "jsondocId": "80429549-f7f3-4351-afb6-34ebc725e0b7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -941,9 +868,9 @@
                "verb": "POST",
                "description": "Update comments",
                "methodName": "updateComments",
-               "jsondocId": "1c0bd3bc-bc41-4805-a1e0-fab8ae2c229d",
+               "jsondocId": "2da8028a-10ed-43c0-97ff-88b8514a2c29",
                "bodyobject": {
-                  "jsondocId": "30d91599-7106-4ee5-a624-e6515d9ae646",
+                  "jsondocId": "99374df0-b66b-432f-a1cf-a34428f3e56f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -953,7 +880,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateComments",
                "response": {
-                  "jsondocId": "c9014e8a-0287-4aa6-8aba-a434783599e3",
+                  "jsondocId": "55d91959-c2aa-4449-90c4-e4a76f61dc7e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -966,7 +893,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "05f484bb-ee35-4b12-ad4d-235b227d2bed",
+                     "jsondocId": "b2ab4805-c26d-4d2f-b3f2-b3e2a909ebeb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -975,7 +902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "08819d10-ef84-470c-a754-37c53d40a0d3",
+                     "jsondocId": "0d6be0f7-8f09-48be-a09e-f0f27026eea1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -984,7 +911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e3585b7e-4285-4309-bd71-c13d97ea8084",
+                     "jsondocId": "f54d5cc2-cbc3-4a35-8137-60803f759c79",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -993,7 +920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cf93e707-92b6-4651-8010-22cb1034e690",
+                     "jsondocId": "46937bc9-4fc8-43d3-8ffe-adab94513739",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1002,7 +929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8bd5498e-1688-45b9-b28e-fecbc51148f3",
+                     "jsondocId": "92cb6456-6a84-4b4e-8c48-a68783b5f111",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1011,7 +938,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f73b3cd5-8b14-4614-a6b1-9e2c0855bdb2",
+                     "jsondocId": "e69b33a1-e81f-440d-a11a-0dff56321943",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1020,7 +947,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b49e024e-cf69-4e9a-8cbc-e3b0372d9f2e",
+                     "jsondocId": "5ddfcde7-69c4-4947-9944-09e28adaf5b7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -1032,9 +959,9 @@
                "verb": "POST",
                "description": "Add transcript",
                "methodName": "addTranscript",
-               "jsondocId": "11af6cfc-81e4-4c49-813d-2d734af37624",
+               "jsondocId": "ef6fa784-61e4-43ea-9de5-149df5c059ce",
                "bodyobject": {
-                  "jsondocId": "86d43467-649e-4652-a9f0-0cbe25cff2cc",
+                  "jsondocId": "b62b653b-8e48-4cba-b8ee-cfe1e81b91a9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1044,7 +971,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addTranscript",
                "response": {
-                  "jsondocId": "575edb3e-3e41-452e-b57c-1c2354181f0c",
+                  "jsondocId": "7a76596f-3364-46e9-b98a-4cdb383b56a6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1057,7 +984,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "255aba93-dd61-40af-9809-615626bb2a1b",
+                     "jsondocId": "958782ec-a32f-4316-a3c3-fba25863ac24",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1066,7 +993,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "30ac338d-012a-4ade-9432-62445802a7cd",
+                     "jsondocId": "4d376434-53f3-4cfd-aee2-53928b33a07a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1075,7 +1002,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8439555c-6303-4a1c-8b89-51ce50d06e72",
+                     "jsondocId": "34171813-9785-4bcb-94ec-d353daed8633",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1084,7 +1011,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d73d4e46-d1ca-42e8-ab33-9e323e9521bf",
+                     "jsondocId": "52cd6948-3b46-45bc-81fc-4f0bdd53c08c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1093,7 +1020,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8a1e7eea-05b4-4580-9794-07441a72ad64",
+                     "jsondocId": "a881cafc-75e5-436d-8861-ec7e7075f0a8",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1102,7 +1029,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4380321-306c-40cf-bb8d-e721d5d24beb",
+                     "jsondocId": "2ff44202-9abd-4911-b395-704a82557025",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1111,7 +1038,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "46f9bc4b-e8c7-4e4f-b315-6ee09feb41e4",
+                     "jsondocId": "66c2d50a-7de5-49df-b109-8870c5f80e65",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
@@ -1123,9 +1050,9 @@
                "verb": "POST",
                "description": "Duplicate transcript",
                "methodName": "duplicateTranscript",
-               "jsondocId": "a473c699-9d73-4879-a39c-062d628036eb",
+               "jsondocId": "24bdafb1-1784-45f5-89e4-2d272894e728",
                "bodyobject": {
-                  "jsondocId": "7c87af68-8fb0-4459-b60a-a9136f4700d7",
+                  "jsondocId": "c1ef0cda-2dc9-4648-a36a-99fb541442ca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1135,7 +1062,7 @@
                "apierrors": [],
                "path": "/annotationEditor/duplicateTranscript",
                "response": {
-                  "jsondocId": "155c28f8-e24b-4f76-8c17-32cd37f97b11",
+                  "jsondocId": "0a1e9227-afe7-441e-8e30-4f03fe07b637",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1148,7 +1075,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "59586a0b-8d74-4ed7-8846-0f9a5ba89159",
+                     "jsondocId": "3f92928f-279b-4667-9bbb-c4454a0d3109",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1157,7 +1084,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0ace4c8b-ee50-4a1d-badc-da6ec54583aa",
+                     "jsondocId": "467edb99-ea7c-4e1a-a417-4f3ebe761817",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1166,7 +1093,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9e1f1d8d-7b1b-4dfc-9c94-45726043b4ab",
+                     "jsondocId": "8f8dd06f-2641-4b49-98f6-fc81b5e85a56",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1175,7 +1102,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d68d581e-3729-40c2-80e5-d1f322e2d7da",
+                     "jsondocId": "c57d75ce-8976-470f-a1a7-e2bd64e7d9de",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1184,7 +1111,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a24e6e37-d61a-4f3d-a68a-a1f523268dbd",
+                     "jsondocId": "8e955e77-5384-497a-9534-31298e66f5e7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -1196,9 +1123,9 @@
                "verb": "POST",
                "description": "Set translation start",
                "methodName": "setTranslationStart",
-               "jsondocId": "b4a996b5-5c0c-494d-89b6-3d579f2b9bed",
+               "jsondocId": "1f764f3e-d0ac-4aca-b4e2-bd45eaa4a0ba",
                "bodyobject": {
-                  "jsondocId": "1d974aab-b946-493e-8752-f293c85e4e2f",
+                  "jsondocId": "07704871-66f4-4e16-a063-d856a6b4f08d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1208,7 +1135,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationStart",
                "response": {
-                  "jsondocId": "3fa294d1-808b-419d-adca-8bfc5a4eda41",
+                  "jsondocId": "1a8d3ff8-f89b-43a8-8cfb-dc5b8b655d0e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1221,7 +1148,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0485a35c-5f8d-4458-a1e1-520a16d34ecf",
+                     "jsondocId": "b1abd21c-e30d-4b2c-bbd3-546a64c7737a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1230,7 +1157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c51b9518-7ac8-4735-97a0-22a89afca229",
+                     "jsondocId": "98cb045a-e688-4479-8285-fe0dcac6fd0b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1239,7 +1166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0271961c-da28-4cf9-b1c8-49300c6fa4b9",
+                     "jsondocId": "88bd32e9-2e74-43f3-8150-35881a7e8e8f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1248,7 +1175,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b0b8533d-43ec-47c9-93bb-f9570cdbb47c",
+                     "jsondocId": "819e3471-5926-4672-815d-ca5f470f8f7c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1257,7 +1184,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1575fccc-ef3d-4cea-b09b-d8b042aa5937",
+                     "jsondocId": "4a825ea8-4b6c-4905-b736-a49bce6d5c8a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
@@ -1269,9 +1196,9 @@
                "verb": "POST",
                "description": "Set translation end",
                "methodName": "setTranslationEnd",
-               "jsondocId": "5db275b7-37a5-460f-8fbd-b3a682856bd2",
+               "jsondocId": "31652534-5ce0-468f-99e1-f7c4d23a6d59",
                "bodyobject": {
-                  "jsondocId": "d8e75364-e0cb-402f-812b-0d6843eeff80",
+                  "jsondocId": "ff3969b9-487f-46e6-9e60-a151bb7a671f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1281,7 +1208,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationEnd",
                "response": {
-                  "jsondocId": "88ad8e61-e4f0-4ad5-a5e2-978226fe2e6a",
+                  "jsondocId": "f50c79d0-263a-476f-a4db-7b2c2586c14f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1294,7 +1221,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5e437561-1638-4398-a9d7-57053141f2da",
+                     "jsondocId": "421ea109-549c-46c1-bc3e-1dafe74fe209",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1303,7 +1230,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6271bc39-dd3e-49fe-9782-e0cb63c2fd4b",
+                     "jsondocId": "4916ed47-09dd-4708-9462-84460c9767ed",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1312,7 +1239,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "71947720-086e-4228-8835-1d23e732289a",
+                     "jsondocId": "1d0b395e-da78-4017-bdaa-0956360c809d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1321,7 +1248,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "889a491a-293e-4898-bfdd-1d8278e919f7",
+                     "jsondocId": "4cc0fd07-371b-41e5-b5fc-608279a0a0f6",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1330,7 +1257,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1a198f70-ffed-45ad-808d-41022d9474f8",
+                     "jsondocId": "3bee154f-8d7b-4014-bdea-9b2c30051647",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
@@ -1342,9 +1269,9 @@
                "verb": "POST",
                "description": "Set longest ORF",
                "methodName": "setLongestOrf",
-               "jsondocId": "fb1b7308-d32b-4f6b-9e75-258ef64322d6",
+               "jsondocId": "dc9d9753-5b7f-4201-8747-c0e2c395ad62",
                "bodyobject": {
-                  "jsondocId": "45e0c0e4-7ea0-40b0-a94b-5ff9aad1111b",
+                  "jsondocId": "508cb174-351d-43da-bd9b-7946f12b3491",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1354,7 +1281,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setLongestOrf",
                "response": {
-                  "jsondocId": "9cca95a0-4989-4745-af2c-07dafec166f1",
+                  "jsondocId": "bb63b328-b7d5-4a80-8a2c-ca9c5480927f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1367,7 +1294,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e298ee88-9716-48be-a8d1-2c9f0e4ee2de",
+                     "jsondocId": "7dcb9824-20f3-49e5-b585-4523a0a6594b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1376,7 +1303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2fcc4608-aaed-4e28-b705-0f61e4c887b4",
+                     "jsondocId": "cc0f14c5-a4ec-483a-bc87-405d737ccd4c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1385,7 +1312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "20690193-f2ec-4c05-8627-f64fce33e0f7",
+                     "jsondocId": "469c1d48-13c8-42df-8ace-b890a00276c3",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1394,7 +1321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "438b9147-edd1-4c09-b666-cf5bf689b344",
+                     "jsondocId": "d8a9128e-1e20-49bf-b0ee-340ba48e6240",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1403,7 +1330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b20413aa-27cb-4d44-a537-58303e06597e",
+                     "jsondocId": "eebc60b4-3022-4722-9a5a-afb0f18bc141",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -1415,9 +1342,9 @@
                "verb": "POST",
                "description": "Set boundaries of genomic feature",
                "methodName": "setBoundaries",
-               "jsondocId": "e65eb846-9682-41ea-b42a-492e546afc59",
+               "jsondocId": "9da7b071-8918-41a0-bd90-c6695fb266a5",
                "bodyobject": {
-                  "jsondocId": "1d29b183-46a1-4eee-adfc-0feb5ce3aca8",
+                  "jsondocId": "73ac2109-4339-41be-9748-10abfdb1889b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1427,7 +1354,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setBoundaries",
                "response": {
-                  "jsondocId": "361b6cce-348d-4e44-a3c7-d044d1a16086",
+                  "jsondocId": "78db9f08-7ad4-40b9-a2a1-c19890d47d3b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1440,7 +1367,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e4590366-9b6d-48dc-b7a5-81fa9b93b0a6",
+                     "jsondocId": "e295917d-4990-498e-bb37-118ef689819c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1449,7 +1376,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e4c26d8e-b13a-44bf-ac26-45d620fd197d",
+                     "jsondocId": "723b90f5-a695-4310-a6da-19bd77325ef3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1458,7 +1385,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "87e9610e-c84b-4e10-92d2-be7b9d080191",
+                     "jsondocId": "a0691652-9e5e-4b71-8223-1ae9bcb4d3dd",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1467,7 +1394,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a7a1b8b4-519f-4660-94f5-8dac502dc5d5",
+                     "jsondocId": "d91f3340-8f2c-4ec0-9c5e-397f0bf9ba36",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1479,9 +1406,9 @@
                "verb": "POST",
                "description": "Get all annotated features for a sequence",
                "methodName": "getFeatures",
-               "jsondocId": "3ecee7bc-a0b3-4a8a-9906-504dd6e53341",
+               "jsondocId": "2633df92-c252-4d11-acd4-83d82143f475",
                "bodyobject": {
-                  "jsondocId": "7c777e74-0b13-4a1d-8486-54ef0285c7bf",
+                  "jsondocId": "13409d59-63a8-48d1-8580-25e1f396ec2f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1491,7 +1418,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getFeatures",
                "response": {
-                  "jsondocId": "ab51ed94-3945-4db8-bae7-d65c050a3af3",
+                  "jsondocId": "f806ef75-3375-42e3-8f2c-0082ab76779c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1504,7 +1431,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "917d39dc-e445-4b77-9f22-a1f4fb9e58ae",
+                     "jsondocId": "ba32dc98-d462-4a01-9293-d62ac25fa591",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1513,7 +1440,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f35d746-ac13-4e89-b39b-efb759a1d5f5",
+                     "jsondocId": "8cf1531f-d525-4eff-ad8b-13b1a140e7d6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1522,7 +1449,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3770e04a-8045-4f6d-bef5-64d4d74b0363",
+                     "jsondocId": "d8dcb93b-739f-4b5c-91ed-89370c777c22",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1531,7 +1458,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "59d5a2a3-7bbc-4595-b706-d42adb264cf5",
+                     "jsondocId": "dd535a03-7e3a-4bc0-827a-b8fe2069f829",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1543,9 +1470,9 @@
                "verb": "POST",
                "description": "Get sequence alterations for a given sequence",
                "methodName": "getSequenceAlterations",
-               "jsondocId": "039b753c-5cac-4ee8-820b-7c20b4238da4",
+               "jsondocId": "1a764bac-e680-48f2-877a-23a20de871fa",
                "bodyobject": {
-                  "jsondocId": "2f971f16-f10c-467e-854f-451d9ee8e708",
+                  "jsondocId": "437d0174-9525-4db3-b16b-856edf92e18a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1555,7 +1482,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequenceAlterations",
                "response": {
-                  "jsondocId": "a91330c4-6fd4-4594-9a46-1bee72775e84",
+                  "jsondocId": "f0b0c0c2-a056-4ebf-b33e-484fe237325c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1568,7 +1495,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "afdf4482-225e-4fd2-b44b-4bafa749899c",
+                     "jsondocId": "8a89a03d-076c-4d97-8a8a-b8a2b4ea9fc7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1577,7 +1504,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e7a00043-d81d-4dc5-a058-1652787a58d5",
+                     "jsondocId": "2cdf3c0b-944e-445c-bb81-50f370dcd61e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1586,7 +1513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5e10bd07-10d9-40e2-a168-9cb1dc9086f3",
+                     "jsondocId": "704a0aaa-317e-4b96-8032-7c2cd2775a4f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1595,7 +1522,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "05be2cba-c899-45ae-8224-b0e12e2740f7",
+                     "jsondocId": "d088e952-9931-478c-baab-1d880adaf473",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1604,7 +1531,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fedbf8a7-506f-45dc-b11b-45f3153898d6",
+                     "jsondocId": "153c9732-12b1-4d42-ae37-0173a7cfbcfe",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -1616,9 +1543,9 @@
                "verb": "POST",
                "description": "Delete attribute (key,value pair) for feature",
                "methodName": "deleteAttribute",
-               "jsondocId": "e4d5119a-7f63-4f2d-b060-bd3c1feeaab2",
+               "jsondocId": "09d1ced4-d0dd-46d2-8b13-9b7c0e712f21",
                "bodyobject": {
-                  "jsondocId": "c741c5ed-4d46-495d-867e-2ba97d3360cf",
+                  "jsondocId": "ebf1fbfd-3b07-40bc-8992-a05bacd301cd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1628,7 +1555,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteAttribute",
                "response": {
-                  "jsondocId": "bf208790-879b-493f-9424-42fb9d7b7a9c",
+                  "jsondocId": "b2d787a2-0355-4826-a034-375c41838bd4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1641,7 +1568,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3725a208-14ea-4ad0-8a20-343946f8f9a0",
+                     "jsondocId": "7dd2ed7c-e978-4416-8f6b-6f0293690a5f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1650,7 +1577,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1f566cb5-8d10-4a75-aa9f-231aafcdeba1",
+                     "jsondocId": "49424531-1fb1-4bbc-b28c-a9949565a8a3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1659,7 +1586,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2cad5110-1309-485e-9927-e78dc97fc4ef",
+                     "jsondocId": "be065b75-b171-4bb5-8f85-0b038c9a0f6e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1668,7 +1595,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "87f68113-c47e-43b5-8958-1def325a3b07",
+                     "jsondocId": "d95992dd-d2b7-4183-b045-c08f170c38c8",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1677,7 +1604,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2b234e52-9e15-4b7d-bf07-54b419c9b7ff",
+                     "jsondocId": "6f6b5d09-55cc-4c44-8763-61460579cdf9",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.",
@@ -1689,9 +1616,9 @@
                "verb": "POST",
                "description": "Update attribute (key,value pair) for feature",
                "methodName": "updateAttribute",
-               "jsondocId": "3cc0c5ef-ca38-458f-b137-916142c2e6a7",
+               "jsondocId": "d7d77b96-8ae2-4f17-a89a-027223590e2f",
                "bodyobject": {
-                  "jsondocId": "346504fb-8462-4732-80b2-10097d9e9606",
+                  "jsondocId": "5c6253b8-9d94-4706-9205-9eea79fc7c5f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1701,7 +1628,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateAttribute",
                "response": {
-                  "jsondocId": "00867e66-8835-4899-93d5-15c273f0d6eb",
+                  "jsondocId": "6d6eae98-7f9c-42ce-9c6c-36ae77cfad6b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1714,7 +1641,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "eb4a2272-cc5a-4bd9-8af0-a33ad4ab3276",
+                     "jsondocId": "e18edd4c-9647-4f2c-8041-de2e567772cd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1723,7 +1650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "442642b3-91d6-41a0-b362-a01d35b074b6",
+                     "jsondocId": "ca17f843-ac37-4cdf-8876-a9c61ad4db53",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1732,7 +1659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6249c0e9-3321-422f-bb07-a5d0a4b73dce",
+                     "jsondocId": "0f75cb45-ceb8-4093-a235-409e1dc88c5f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1741,7 +1668,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02c3a4f7-98ee-41a5-aea4-b6eda076cff2",
+                     "jsondocId": "b8a47566-e92f-46f9-942a-13bb9dbadad7",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1750,7 +1677,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "701c9a2c-95c8-4e7a-a2c1-18d206bb8ddf",
+                     "jsondocId": "f98b5fe4-3511-4346-bc7d-6000b81fd1f1",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1762,9 +1689,9 @@
                "verb": "POST",
                "description": "Add dbxref (db,id pair) to feature",
                "methodName": "addDbxref",
-               "jsondocId": "0d8069b5-ab2d-4bda-a5bf-aa4ed249004a",
+               "jsondocId": "3a3057f2-e55f-4d40-935e-1904a1cd500c",
                "bodyobject": {
-                  "jsondocId": "8f415fa5-6b49-46f2-8e51-331d90c0b90a",
+                  "jsondocId": "96995c1a-d18b-4955-af07-732ecae72226",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1774,7 +1701,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addDbxref",
                "response": {
-                  "jsondocId": "e1cbb2ff-8bfc-4606-8f71-25b94baf10f9",
+                  "jsondocId": "6028d377-64f4-49ab-b5bc-2ade4a34fadc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1787,7 +1714,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ae5f54ab-94fa-420f-99c9-9210de438280",
+                     "jsondocId": "30b562e0-75d4-416a-8962-0b6070d35093",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1796,7 +1723,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "99d746c7-db60-4216-b24f-f5f959f1438f",
+                     "jsondocId": "4f5d7901-ba5c-4798-b5ac-08c8f93fbc8a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1805,7 +1732,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fe322893-60e8-460a-a652-369829589ac7",
+                     "jsondocId": "b010eb2e-73a1-46aa-8d45-b2fa8ecb424d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1814,7 +1741,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "12296bad-be03-4012-b37d-9b0129faf371",
+                     "jsondocId": "043ee96e-f4d7-470d-92f7-9c6124d6e391",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1823,7 +1750,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1952e5d7-e34d-4d0c-a9ed-c9c58fff3188",
+                     "jsondocId": "8bcab993-9a54-4f10-aa5a-b7570551d993",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.",
@@ -1835,9 +1762,9 @@
                "verb": "POST",
                "description": "Update dbxrefs (db,id pairs) for a feature",
                "methodName": "updateDbxref",
-               "jsondocId": "6bf5c5f6-28c6-4c25-8651-b6b19b0935c0",
+               "jsondocId": "6284af00-6e97-4fc9-a964-026ea19d66d1",
                "bodyobject": {
-                  "jsondocId": "b039de3e-3d76-4c3c-8c67-5a03cdc52099",
+                  "jsondocId": "a0dcce5e-f869-4075-bf25-851df6601e77",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1847,7 +1774,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateDbxref",
                "response": {
-                  "jsondocId": "29513ca4-c62f-44ab-bcde-f5420169ef03",
+                  "jsondocId": "31da4206-774b-45ac-ab18-4f6a92dbdd16",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1860,7 +1787,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ac74431b-62ff-495a-8887-bc3ae3a97d17",
+                     "jsondocId": "9c313c72-2d90-439b-aead-e5a5422bda7a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1869,7 +1796,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a28911db-dba4-4eb5-a75c-495cc7b4e175",
+                     "jsondocId": "865da502-53b1-48a5-8ac4-9feceb71caba",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1878,7 +1805,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "82337042-b58d-4ba4-8ace-36dd29e91617",
+                     "jsondocId": "120afdda-6e8c-44c0-8f75-c9a4e6cc978f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1887,7 +1814,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6dbbf16f-4026-4f8f-aa69-e2307fc26b6a",
+                     "jsondocId": "5df14714-00ee-45c9-8083-23c7c21caa05",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1896,7 +1823,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9b6f9dfb-c19a-4f93-8b47-b961f852588a",
+                     "jsondocId": "433b8a34-3b8f-402a-988a-26694e44e56c",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1908,9 +1835,9 @@
                "verb": "POST",
                "description": "Delete dbxrefs (db,id pairs) for a feature",
                "methodName": "deleteDbxref",
-               "jsondocId": "1d8f1a38-9f9f-4141-89b4-e42aa7950719",
+               "jsondocId": "4da3825b-e57b-453f-a649-58555e3a9a79",
                "bodyobject": {
-                  "jsondocId": "8272998b-2bc5-4ea7-acc4-8e983a99490e",
+                  "jsondocId": "5a78b678-94af-4461-906c-f67a50c34da8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1920,7 +1847,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteDbxref",
                "response": {
-                  "jsondocId": "f421097c-25d9-44be-a12a-7eb3b34ca0f5",
+                  "jsondocId": "9888c291-d042-4adf-99ff-fb30d0a59c61",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1933,7 +1860,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "36d2ddde-f1a5-4538-a7bd-1d00de81c24b",
+                     "jsondocId": "7e3ae052-54d2-4dce-a699-7edaed20609c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1942,7 +1869,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "368bb184-c3dc-40cc-aef7-ac6159fb0535",
+                     "jsondocId": "a895c5bc-0bc5-4c59-b6bb-a7dd6fb23ce1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1951,7 +1878,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7b9fefa6-1935-4637-9982-5102325a9687",
+                     "jsondocId": "1e92ebd9-c6ac-4b34-ba75-c01a2f186f69",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1960,7 +1887,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84243bef-9ab3-4c2c-ab8b-6f4fb0ee9497",
+                     "jsondocId": "18f0b5e7-b0ac-4221-8595-adac239ccad3",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1969,7 +1896,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a17f5b07-999a-4639-9729-5b2d01c8d002",
+                     "jsondocId": "1ef2d640-8eeb-41d8-a720-bd2e58346231",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
@@ -1981,9 +1908,9 @@
                "verb": "POST",
                "description": "Set readthrough stop codon",
                "methodName": "setReadthroughStopCodon",
-               "jsondocId": "63a015a7-15aa-40cc-b48e-cde24c50e11c",
+               "jsondocId": "9802399d-e6bf-4be0-aded-88a2cec2a34e",
                "bodyobject": {
-                  "jsondocId": "d212fefe-2c8c-4f44-828e-5f872a14050c",
+                  "jsondocId": "5c9b9283-2ded-474c-8f0a-1175dc2fa8e6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1993,7 +1920,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setReadthroughStopCodon",
                "response": {
-                  "jsondocId": "87e37bc0-ef9a-4bac-adb0-23a55c593f44",
+                  "jsondocId": "a54e55be-7d18-48f1-98bb-d60cb5c9de38",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2006,7 +1933,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "af744fb9-d682-4f34-8fd6-e9c5dcaf777f",
+                     "jsondocId": "2bbd0ee5-34f8-4d1e-94a7-2ceb7287bd43",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2015,7 +1942,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f58ab679-1c32-477c-8cd7-73c353b2d014",
+                     "jsondocId": "02cfddd2-d901-4949-b336-49b531510d7e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2024,7 +1951,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "626ac80c-2c06-4fa3-92d1-2c95e92336a0",
+                     "jsondocId": "ca68211d-a04b-4439-ae21-ebe53585441a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2033,7 +1960,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b60e612f-5e5c-4f33-a9c0-1366aefe9b83",
+                     "jsondocId": "69ed9933-1527-417d-a804-d801b969bb29",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2042,7 +1969,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3b721f7c-5817-4a64-b748-243649839a15",
+                     "jsondocId": "676c3d99-04f9-4594-8c93-087912d29e14",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
@@ -2054,9 +1981,9 @@
                "verb": "POST",
                "description": "Add sequence alteration",
                "methodName": "addSequenceAlteration",
-               "jsondocId": "5e606294-cd24-4afe-bd30-c53870d22947",
+               "jsondocId": "1b1290ec-0353-4c13-8765-dc7f5515dd83",
                "bodyobject": {
-                  "jsondocId": "46e48ea9-5ed2-4a27-bca8-8cda0bc33246",
+                  "jsondocId": "90e201ee-db82-446f-9d24-ff420c554e0d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2066,7 +1993,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addSequenceAlteration",
                "response": {
-                  "jsondocId": "bc4ea58f-c7a6-46d5-9d4d-4f9da6e9b36c",
+                  "jsondocId": "f9cfff53-486f-4148-93e7-640819bc6abe",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2079,7 +2006,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "303f3881-3322-4684-bbc6-e731c87ae014",
+                     "jsondocId": "53211bef-dd05-46a2-ac45-e65d60c895e8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2088,7 +2015,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "964b1b13-6f05-4161-9110-5f9f34692829",
+                     "jsondocId": "0c342e6f-93f1-4969-a3ce-7240639420c6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2097,7 +2024,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cdecb00b-bc7b-4a92-a81b-28fcb9e698c9",
+                     "jsondocId": "caa72f70-e5d3-432e-a2d9-4ecff0b2eff8",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2106,7 +2033,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bf701525-8638-4c04-989e-6c1a22c97e14",
+                     "jsondocId": "d487a9d7-b8c7-46e0-8f72-92ec605ef4c5",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2115,7 +2042,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eed3844d-c53d-4c20-bbcd-9cc7007a34a7",
+                     "jsondocId": "5cdee329-fcf2-4e25-8400-68be3579c248",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
@@ -2127,9 +2054,9 @@
                "verb": "POST",
                "description": "Delete sequence alteration",
                "methodName": "deleteSequenceAlteration",
-               "jsondocId": "4e375382-59e5-4bd4-921f-5ad03ef79157",
+               "jsondocId": "fc5ca222-8878-4d2f-9756-4e92f3913575",
                "bodyobject": {
-                  "jsondocId": "d0988116-8e95-4378-b193-216503ca31b2",
+                  "jsondocId": "d630c1de-83f3-405e-a3b5-013b3434421e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2139,7 +2066,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteSequenceAlteration",
                "response": {
-                  "jsondocId": "cbed4bb3-08f5-474f-adfc-27d2ada3f3c0",
+                  "jsondocId": "4d7916f1-e44a-4c16-a6b9-9da35fa87e90",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2152,7 +2079,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ee6bed18-db03-4bd0-a51a-de48acb29683",
+                     "jsondocId": "2c0ba7e1-6c63-4cca-9d9c-aad3070b9464",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2161,7 +2088,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2e6a2c46-2075-4253-9732-d39831f74e8d",
+                     "jsondocId": "d568b9ca-1337-4ba5-bbe1-19ebad1c9954",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2170,7 +2097,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "793a617d-c8c0-4e26-9c01-b6c6df85e711",
+                     "jsondocId": "bd054628-9e7a-4a4d-8cbf-ad64c688f595",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2179,7 +2106,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "25cb8ace-364f-49f0-bd04-c57f6f10f183",
+                     "jsondocId": "8e558336-e1ff-4623-89c6-303bc4fc31e0",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2188,7 +2115,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5a685380-b00e-433a-aa27-db2ceca09aa4",
+                     "jsondocId": "dcf215f0-9a30-4123-af1c-d8fe5da44747",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
@@ -2200,9 +2127,9 @@
                "verb": "POST",
                "description": "Flip strand",
                "methodName": "flipStrand",
-               "jsondocId": "baa3beee-a7f3-4ef8-b2c3-eaf574e10c9e",
+               "jsondocId": "3db7cec5-9fdd-4bb8-82d9-e729f6141c37",
                "bodyobject": {
-                  "jsondocId": "d03a4385-1813-41e8-9cb4-8f79aa0b268b",
+                  "jsondocId": "c5a28064-2e90-4a1d-b8f2-69c9635455f6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2212,7 +2139,7 @@
                "apierrors": [],
                "path": "/annotationEditor/flipStrand",
                "response": {
-                  "jsondocId": "256e7822-9477-4e06-bd1b-0cbf08613e2c",
+                  "jsondocId": "066b8287-73d1-462a-91cf-6f1f2a137397",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2225,7 +2152,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5428c450-d7d9-4354-9ccb-e1da43d4dceb",
+                     "jsondocId": "137f9dce-f241-4e21-8558-9995c3112b5f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2234,7 +2161,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f067a6b5-5dfa-41f7-8049-c116ac20eb5a",
+                     "jsondocId": "e3134617-9870-4550-acfc-ad500af05d60",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2243,7 +2170,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b604bef3-856f-45a8-92b1-53ffd9c76f38",
+                     "jsondocId": "60e912d3-52f9-4c8a-9695-669b4a6fc4f5",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2252,7 +2179,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cfb99685-e569-4d5c-ac3f-b3fc89ca4ffa",
+                     "jsondocId": "c51f1f16-c54f-4112-8a19-78eff330ca77",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2261,7 +2188,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "449dacf4-6237-4abe-9045-792d5251ca44",
+                     "jsondocId": "74237787-de5b-443d-8804-45d4580506d0",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
@@ -2273,9 +2200,9 @@
                "verb": "POST",
                "description": "Merge exons",
                "methodName": "mergeExons",
-               "jsondocId": "fb63c47f-8c9f-40c3-ad1b-6857562b6765",
+               "jsondocId": "91c439ea-30bb-4add-bb7a-9b6b03cdd4d8",
                "bodyobject": {
-                  "jsondocId": "3451b72e-18f7-4537-9710-32bc43d3b7bd",
+                  "jsondocId": "8b083de9-9514-4490-a938-9ba12da50524",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2285,7 +2212,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeExons",
                "response": {
-                  "jsondocId": "083a677b-a2fe-4de5-a09a-5f7f99230c1a",
+                  "jsondocId": "3f69187a-9af9-43d2-9edd-8523acc3a2b4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2298,7 +2225,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b092f55f-7512-4e0f-89c5-204b34525bf9",
+                     "jsondocId": "dab762d7-5ed6-4e77-972f-37e53b7295a1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2307,7 +2234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "41057ede-d744-47cd-93d6-d583dffb3da8",
+                     "jsondocId": "ece13f4c-84c2-4493-8522-84af9701350e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2316,7 +2243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0e808d4a-f654-484d-8281-a90ebb9665ff",
+                     "jsondocId": "0ae73d42-e553-464c-adbf-d642e6b6e2c8",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2325,7 +2252,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "46772581-d4b3-451e-939f-ba7f43fc2ffa",
+                     "jsondocId": "6c4a9fbe-1db5-4769-b4b4-17f4dee20da8",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2334,7 +2261,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e10eb86a-5488-4c91-9a76-353b342a1199",
+                     "jsondocId": "1b361c31-3dd0-462f-a90b-cd336eafbe4e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -2346,9 +2273,9 @@
                "verb": "POST",
                "description": "Split exons",
                "methodName": "splitExon",
-               "jsondocId": "0d9bbc05-14bd-46c1-a92a-f967f09748c7",
+               "jsondocId": "7965a67c-9370-47f1-a28d-3c9e2e863f2d",
                "bodyobject": {
-                  "jsondocId": "fb5664bc-b9e7-4cd9-8f16-78e574116f04",
+                  "jsondocId": "4ae56c9c-f796-40a0-9865-fa63cba1418b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2358,7 +2285,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitExon",
                "response": {
-                  "jsondocId": "2ee073bb-dbbc-48c2-a5c4-dc153d768b79",
+                  "jsondocId": "1354704c-5867-41c7-a853-d6b9d6572d9e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2371,7 +2298,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3edcdca5-3944-4c9c-b9a7-35c35f87f355",
+                     "jsondocId": "21de59cb-0aa1-406a-b994-d9a5afda7ad4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2380,7 +2307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d3adb301-f5da-49ae-bbd6-91e7d01b28e8",
+                     "jsondocId": "69ea38d0-7022-4005-b584-1c29f72bcba4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2389,7 +2316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "754711e2-d600-4f92-bea2-746bbd3520ae",
+                     "jsondocId": "d9395615-3127-4bd7-a142-de48a48133dc",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2398,7 +2325,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e2df8e80-97d9-4060-9b1e-90fdfe3eb08a",
+                     "jsondocId": "891911ca-570d-436e-96b5-1f509793e7ac",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2407,7 +2334,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d6c0838-ce93-4805-93c3-156d71860e6d",
+                     "jsondocId": "4601bcde-d982-4188-9445-8e0809d5e090",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
@@ -2419,9 +2346,9 @@
                "verb": "POST",
                "description": "Delete feature",
                "methodName": "deleteFeature",
-               "jsondocId": "ca1d9ab8-292e-49a5-8bd2-3c1424d738f9",
+               "jsondocId": "d10ef7aa-c85a-4c63-9da0-a7af63bacc8e",
                "bodyobject": {
-                  "jsondocId": "9d3cf113-1c02-4794-8b4a-529d81e7c08d",
+                  "jsondocId": "e387ebb4-fc3b-41b4-b1fd-b51737279950",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2431,7 +2358,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeature",
                "response": {
-                  "jsondocId": "8ee41754-cdad-4c3e-bbe4-37aa794c8c9d",
+                  "jsondocId": "a49cc1dc-7440-4280-aaba-6c943c9bf63f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2444,7 +2371,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3c4db44a-58ee-426f-b535-f7b914f4bece",
+                     "jsondocId": "24e5f38a-5b68-4d5e-9c0b-078e6ee0187d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2453,7 +2380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b52f7e8c-6b9f-47fd-854c-fc74527ff3cb",
+                     "jsondocId": "de29d194-1c8b-4c1e-b98f-0c5b368cdf5b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2462,7 +2389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3a337190-0246-4357-a1ac-ee8a9733de21",
+                     "jsondocId": "ebaca849-7393-4039-815f-b704fafaaa5c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2471,7 +2398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2b35e9d3-1991-40dd-8319-478df605f1cf",
+                     "jsondocId": "af8bd1bf-2626-4ded-830f-831591e7c1ee",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2480,7 +2407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b9b81ec9-e33b-41cc-8f9d-5e30c50be004",
+                     "jsondocId": "d8203be4-8928-4284-864d-4b3d75cc5406",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
@@ -2492,9 +2419,9 @@
                "verb": "POST",
                "description": "Delete exons",
                "methodName": "deleteExon",
-               "jsondocId": "1f5259a3-0b9b-412d-ac17-3163a57a25de",
+               "jsondocId": "039550bb-da86-4294-b183-df73f86b1006",
                "bodyobject": {
-                  "jsondocId": "55d329be-e907-4cd0-b2eb-722c680ed61d",
+                  "jsondocId": "092d2697-f2f2-48a3-ab0f-455780e6b052",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2504,7 +2431,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteExon",
                "response": {
-                  "jsondocId": "664c2b52-41e8-4f1c-ae98-06ae4a5136bf",
+                  "jsondocId": "16fb6ab5-2376-4bdf-843e-96f8a5632b5a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2517,7 +2444,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fcd71199-a458-4e50-8ff2-9ee02130ef8d",
+                     "jsondocId": "f1deedfe-166b-4b65-b6b8-ba4468adbfbf",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2526,7 +2453,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5521cdd8-197d-4291-a7c5-c6e2e9d4fca0",
+                     "jsondocId": "83e9b658-6108-470c-87ac-359b330e1634",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2535,7 +2462,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "954cfb3f-402b-49ee-9325-c325665cbe30",
+                     "jsondocId": "116bda12-b458-47f5-a524-7b9b916a7d92",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2544,7 +2471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6c54aef9-64f5-4636-a4e4-2462f023871a",
+                     "jsondocId": "dc8a1bdf-5952-4747-a3d2-81943b93483f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2553,7 +2480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e8881c3d-1b98-4d41-b9ed-2ec60e02a57d",
+                     "jsondocId": "052352f4-f497-4bfb-8711-4f8cdc64df3b",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -2565,9 +2492,9 @@
                "verb": "POST",
                "description": "Make intron",
                "methodName": "makeIntron",
-               "jsondocId": "83ea4d9b-c16b-48e9-9fbb-a9b7d9e0ea39",
+               "jsondocId": "23492334-dfab-49eb-b968-6236ec9f0460",
                "bodyobject": {
-                  "jsondocId": "d7cc122f-a58f-457e-ae85-560b15f5f16c",
+                  "jsondocId": "32107d1b-ae62-41c3-bae0-05631bd80f77",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2577,7 +2504,7 @@
                "apierrors": [],
                "path": "/annotationEditor/makeIntron",
                "response": {
-                  "jsondocId": "8ad442ca-ad8a-4d62-aaf6-12d6c3d5cb7b",
+                  "jsondocId": "2beb03e6-0de0-41bc-b2a8-76e550b93174",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2590,7 +2517,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2de3b071-c529-4ce2-a954-1a4bac276067",
+                     "jsondocId": "db5496be-c3ae-40da-bb65-b8e311cac204",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2599,7 +2526,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e439596-d64b-4c8c-aeba-ee10ade01325",
+                     "jsondocId": "82907c1d-79c2-406a-b415-b83ae7d124d3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2608,7 +2535,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "381b105a-e01f-429f-8d8e-cecea9326174",
+                     "jsondocId": "4915950b-8f21-4c4d-80c3-e62aacf8fb9b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2617,7 +2544,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7f947b5e-c986-4020-be2b-5a5a54648511",
+                     "jsondocId": "60f5a55a-81ac-420c-942e-2d59d77cf0f2",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2626,7 +2553,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dfb4400a-e5b5-4a61-9a90-86f5dc043894",
+                     "jsondocId": "721b9d35-fa91-44d5-95ee-f598a32d9e47",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2638,9 +2565,9 @@
                "verb": "POST",
                "description": "Split transcript",
                "methodName": "splitTranscript",
-               "jsondocId": "4bdba0ff-8122-46b2-b93d-af32e2f68ef7",
+               "jsondocId": "476de46b-9b39-42be-8607-141949fa4c3b",
                "bodyobject": {
-                  "jsondocId": "ae55bbfc-e85d-425f-b5ef-337b310dd8d1",
+                  "jsondocId": "3d6619c8-abda-4521-bce8-567a06761b6b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2650,7 +2577,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitTranscript",
                "response": {
-                  "jsondocId": "153c7c7d-df52-4557-9ab2-f1088f2e6f42",
+                  "jsondocId": "2b6d2e18-1014-4409-9d4a-131fcda3c706",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2663,7 +2590,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "95de48fa-3e52-4539-a420-25381dbe61f1",
+                     "jsondocId": "df6ccf33-27c1-4627-814f-0dca467520c6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2672,7 +2599,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "95e525a6-11bd-4aa8-a512-e047c00f3d45",
+                     "jsondocId": "b86b15c8-b2a5-4b3c-b0aa-4950023c71de",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2681,7 +2608,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d561556-85b8-4885-b8d9-3ae40cd610ca",
+                     "jsondocId": "e1d193c8-2480-4acd-8d6a-9d88bb4bff83",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2690,7 +2617,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "71a1a621-bcc3-42a7-a044-c1d7738c49f6",
+                     "jsondocId": "d9b3942e-b8d7-4c74-b852-c4c568dfb5db",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2699,7 +2626,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a13bd88f-0047-4d1e-9f10-f44f7168cc82",
+                     "jsondocId": "2bd0eef8-8d83-4eeb-b5da-155925b0c5d2",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2711,9 +2638,9 @@
                "verb": "POST",
                "description": "Merge transcripts",
                "methodName": "mergeTranscripts",
-               "jsondocId": "a8aa2af8-4edf-4d77-be3e-fcd0cc9014c4",
+               "jsondocId": "8a87bcce-44a7-4747-9df2-4080e5d4aa65",
                "bodyobject": {
-                  "jsondocId": "cbd604ea-a078-42d2-9ab1-238853988b89",
+                  "jsondocId": "6514ed49-c638-4ea9-8691-fddceadffdab",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2723,7 +2650,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeTranscripts",
                "response": {
-                  "jsondocId": "80a2ee67-02f2-4c43-a623-10752194c679",
+                  "jsondocId": "5eac10fc-835a-426c-b8b8-cadda7c74730",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2736,7 +2663,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "487403dc-e012-495a-9030-e8d1e5444a88",
+                     "jsondocId": "0f2097f0-a1a0-4013-9634-0f5984adf4c9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2745,7 +2672,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f3c65eeb-ed41-43c4-bf06-8762d154d4e6",
+                     "jsondocId": "29be9581-1c71-4cec-8c60-d4829409cc43",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2754,7 +2681,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8e0c8197-2fe7-49ac-b564-6c94c76f237b",
+                     "jsondocId": "e84e6a95-7915-4884-9c52-af85a82a304f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2763,7 +2690,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e9d0bb70-5e7d-48a4-81f6-59fc825eea0f",
+                     "jsondocId": "17a45154-14f6-4970-8607-e291fffe7f19",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2772,7 +2699,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f590155e-fb3a-407f-979a-04696fdc05e2",
+                     "jsondocId": "63375a1d-6d57-4fc2-9cb3-3cf223b425d8",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2784,9 +2711,9 @@
                "verb": "POST",
                "description": "Get sequences for features",
                "methodName": "getSequence",
-               "jsondocId": "d428db14-d8a0-43b2-b415-895579c2129a",
+               "jsondocId": "90a2f832-baee-42a4-b89e-ec3d7ba7d08f",
                "bodyobject": {
-                  "jsondocId": "4a20f0f2-3e75-4974-9405-fbe3cc2659f2",
+                  "jsondocId": "54f00b85-880e-4327-8631-4b8e1f3c5de3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2796,7 +2723,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequences",
                "response": {
-                  "jsondocId": "26fea380-68dd-47dc-9837-e0e6d0dfa83e",
+                  "jsondocId": "901dac35-b575-4068-9e63-ab14ff67a0cd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2805,7 +2732,7 @@
                "consumes": ["application/json"]
             },
             {
-               "jsondocId": "3f866d7e-5c63-4320-8389-4da28072e6a2",
+               "jsondocId": "13da2c34-3b38-4860-a2db-71ae00d4b29d",
                "bodyobject": null,
                "apierrors": [],
                "path": "/annotationEditor/getSequenceSearchTools",
@@ -2813,7 +2740,7 @@
                "pathparameters": [],
                "queryparameters": [],
                "response": {
-                  "jsondocId": "b5ae09d1-38d4-4b14-840b-23f390af07ac",
+                  "jsondocId": "59e85945-7782-475b-b341-c953f473c707",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2828,7 +2755,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "368d32dc-d657-44b3-8658-289321ba9827",
+                     "jsondocId": "262ba792-5fd3-46df-8f85-0a7440a2bb1a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2837,7 +2764,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c98a5833-11b1-41a8-b1cc-50dd57e8b1f3",
+                     "jsondocId": "86c56d96-dbf3-4d81-96c2-643eaf124d87",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2849,9 +2776,9 @@
                "verb": "POST",
                "description": "Get canned comments",
                "methodName": "getCannedComments",
-               "jsondocId": "d45d01ee-745c-4caa-872c-3cce1f6a8f83",
+               "jsondocId": "43ae4e53-c5b8-4810-a225-d45ae90eb174",
                "bodyobject": {
-                  "jsondocId": "f625e5c8-f4c8-428f-b6ba-0cff42f201a0",
+                  "jsondocId": "7f12eeeb-1c45-4503-940e-00a537d70e97",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2861,7 +2788,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getCannedComments",
                "response": {
-                  "jsondocId": "f26b6595-ac02-4bdf-ab7b-b1df5de61d56",
+                  "jsondocId": "4c70ab5d-8605-4cec-bff8-9f476ce11ea8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2874,7 +2801,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "44391268-d106-466f-b955-1dab0bdea076",
+                     "jsondocId": "43aac4bf-43bd-4e4f-8033-75f600596140",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2883,7 +2810,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c533039b-fba4-452f-aa25-569cef98c420",
+                     "jsondocId": "db464c9d-5995-41a1-9520-b3c097fd880e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2892,7 +2819,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "912838e7-7018-439e-a7e7-9c018d405dac",
+                     "jsondocId": "a8d9aa6a-593f-444d-bf9a-79eda6d00ace",
                      "name": "client_token",
                      "format": "",
                      "description": "Organism ID/Name or Client-generated ",
@@ -2901,7 +2828,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "92fad0fd-efaf-4a80-8985-a531a550aee6",
+                     "jsondocId": "71d48b1f-9de7-40a4-adb6-0a4922cc4546",
                      "name": "search",
                      "format": "",
                      "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
@@ -2913,9 +2840,9 @@
                "verb": "POST",
                "description": "Search sequences",
                "methodName": "searchSequence",
-               "jsondocId": "534293dd-dbac-4b2c-9077-34043082f76f",
+               "jsondocId": "12059bd6-52ce-47f3-86f7-b9c6c373ae7f",
                "bodyobject": {
-                  "jsondocId": "4a4a51e8-48f5-449c-b2fa-6a6831047ac7",
+                  "jsondocId": "bfcf8d9b-7b09-4d0d-aa99-9a13e6055528",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2925,7 +2852,7 @@
                "apierrors": [],
                "path": "/annotationEditor/searchSequences",
                "response": {
-                  "jsondocId": "15661eff-f2fe-4492-9851-93518a4c453c",
+                  "jsondocId": "0535998e-ba78-4c75-b4ad-059a41d4faac",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2938,7 +2865,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b7cdd767-28d3-4c2b-a309-63a2e429ae72",
+                     "jsondocId": "7ed6c2c4-8324-4941-aadb-86553d9970e0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2947,7 +2874,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "46148895-c351-4c8d-9a1b-f49c879246c0",
+                     "jsondocId": "acf03e14-c082-4854-88d2-0a90a299d928",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2956,7 +2883,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a447aafb-2b6b-4748-b8ce-cea4ee468b01",
+                     "jsondocId": "f936d2bb-58a1-4a3d-bb66-b9f55efa4dcf",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2968,9 +2895,9 @@
                "verb": "POST",
                "description": "Get gff3",
                "methodName": "getGff3",
-               "jsondocId": "f339dd6b-b784-48ef-ad71-c05fe075fe93",
+               "jsondocId": "7d943720-c2cf-4b17-b6bf-267f3dfd80fd",
                "bodyobject": {
-                  "jsondocId": "4723547c-6391-4001-88b2-609164728a76",
+                  "jsondocId": "f325b82d-8395-45cc-ada4-b8fc7abc21ca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2980,7 +2907,80 @@
                "apierrors": [],
                "path": "/annotationEditor/getGff3",
                "response": {
-                  "jsondocId": "a6cf1600-3b16-4e97-bdcf-eadc36c6f877",
+                  "jsondocId": "a7dca5ec-46b0-4fa5-a7b1-7d2e7052a6c1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "71f05979-3e29-4335-97b5-3650d7ac589f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "20550c44-18b5-4ab9-a751-c8c280eeddd8",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "32ea47e0-8093-4d4c-98fc-383490d558dd",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "494c41a5-ba2b-4293-9463-beb250573a41",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "42083bc9-c382-4099-9c4d-ee6875cbe3b5",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add attribute (key,value pair) to feature",
+               "methodName": "addAttribute",
+               "jsondocId": "425afc33-9b8f-45f3-aff7-91d5fb2a93a9",
+               "bodyobject": {
+                  "jsondocId": "9636eda8-7951-4bfe-8395-c9d53ca224d9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addAttribute",
+               "response": {
+                  "jsondocId": "6e36cca8-30d0-4662-946c-a8bd981afbdc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2993,14 +2993,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "6f0c541c-5372-4b21-827a-89ebfb3f4e09",
+         "jsondocId": "4813e39c-5bd3-49d1-9cc8-30745b27e031",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "eb8ef683-71f6-4fd4-aec3-b0d3bbdfe67b",
+                     "jsondocId": "510979aa-dbef-435d-882c-4dc34d661777",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3009,7 +3009,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "71cc0ce4-0865-4c97-8117-76aa028bbcd4",
+                     "jsondocId": "5c1ff257-9aa4-49ea-9c38-800acabd30d4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3018,7 +3018,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bf56d98f-d2f0-4906-a71f-e6b6c9687149",
+                     "jsondocId": "b747e4d7-37d9-48f1-bf14-f9498a7be702",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to update (or specify the old_value)",
@@ -3027,7 +3027,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a8ff16df-2558-485b-a959-24f26fefb202",
+                     "jsondocId": "f358c0e3-5e0e-4572-844f-632ac14ced32",
                      "name": "old_value",
                      "format": "",
                      "description": "Status name to update",
@@ -3036,7 +3036,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ede31a02-959b-4fcb-8dab-824f13c49963",
+                     "jsondocId": "c051e860-9deb-4801-9136-840c9a5c541a",
                      "name": "new_value",
                      "format": "",
                      "description": "Status name to change to (the only editable option)",
@@ -3048,9 +3048,9 @@
                "verb": "POST",
                "description": "Update status",
                "methodName": "updateStatus",
-               "jsondocId": "dbe2b67c-6e44-4f5d-801c-b47483d126b9",
+               "jsondocId": "edc2590a-4f7d-4d50-90d4-959b2739a03a",
                "bodyobject": {
-                  "jsondocId": "7055c0ad-32c4-48ae-8674-f11afef57266",
+                  "jsondocId": "5fb685f4-5029-4c4c-b236-553ca94d55bf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3060,7 +3060,7 @@
                "apierrors": [],
                "path": "/availableStatus/updateStatus",
                "response": {
-                  "jsondocId": "205030b2-e1ac-46b5-9b00-95add8df31af",
+                  "jsondocId": "69bf1556-e45d-4ebb-a95e-8f4426c14fbb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3073,7 +3073,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a0e6bb62-3577-432b-91d6-993dc5473d96",
+                     "jsondocId": "5b7849bd-326c-4838-b8d2-01f49c5edeae",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3082,7 +3082,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cecc7a45-fcf4-4ed1-a605-79c92e2cf326",
+                     "jsondocId": "d70e96f1-019f-4573-ab52-4a542ec321a0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3091,7 +3091,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "50058dc4-5ed2-4167-a392-0178ffaa26e3",
+                     "jsondocId": "f1bc6b68-93cb-4810-9b7b-20f81ca98a68",
                      "name": "value",
                      "format": "",
                      "description": "Status name to add",
@@ -3103,9 +3103,9 @@
                "verb": "POST",
                "description": "Create status",
                "methodName": "createStatus",
-               "jsondocId": "db936411-c494-4eb7-90e9-500b28005925",
+               "jsondocId": "6e2f37a9-d49c-4704-81cc-e124a61d7ffa",
                "bodyobject": {
-                  "jsondocId": "71be3fda-fe0a-4f8f-9ae0-d99ee7f64922",
+                  "jsondocId": "418c2082-1fbf-4a3a-af9f-34cf592993a6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3115,7 +3115,7 @@
                "apierrors": [],
                "path": "/availableStatus/createStatus",
                "response": {
-                  "jsondocId": "72f08525-1ed7-4a1c-ae52-9c4b2760a6d5",
+                  "jsondocId": "e2469716-640b-4925-860e-a4f02d710d50",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3128,7 +3128,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2be53e45-34be-4338-8706-04293a6e9bb9",
+                     "jsondocId": "b588b399-1cb5-431d-88a8-9eb3f8cee3da",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3137,7 +3137,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ca50c771-c0a6-4042-998f-c2412b82a346",
+                     "jsondocId": "744bef07-feef-4349-959c-c8ea8ad77878",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3146,7 +3146,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7dd9341b-9b47-46f5-a10a-e8a267ba4c21",
+                     "jsondocId": "e8ba922d-6c74-490b-8eea-a5701e7adc3a",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to remove (or specify the name)",
@@ -3155,7 +3155,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "790b23b4-fc03-4a5a-8a21-2d7e05a6ab30",
+                     "jsondocId": "b106ba6e-9039-403d-abe5-b69952017c2f",
                      "name": "value",
                      "format": "",
                      "description": "Status name to delete",
@@ -3167,9 +3167,9 @@
                "verb": "POST",
                "description": "Remove a status",
                "methodName": "deleteStatus",
-               "jsondocId": "e60b3bf6-2cb5-48ec-a238-6d84566cde4d",
+               "jsondocId": "a715c46d-3fb4-43eb-945e-0e2160a0301c",
                "bodyobject": {
-                  "jsondocId": "6e059677-59b4-4c45-9ba7-d4579bb0aca6",
+                  "jsondocId": "80c5f49d-053c-4c3a-903f-d1ed39797428",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3179,7 +3179,7 @@
                "apierrors": [],
                "path": "/availableStatus/deleteStatus",
                "response": {
-                  "jsondocId": "76a2fa64-3505-4fe0-9927-7b7f631843c1",
+                  "jsondocId": "bf738404-0797-48c5-a0cb-7b984b691450",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3192,7 +3192,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "450d53dd-1a9d-455e-b237-05a1835061f4",
+                     "jsondocId": "ef6423c3-2b4a-4735-956f-a3101f1751da",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3201,7 +3201,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c2fe322b-9db4-443a-9383-a4f42bfc4a34",
+                     "jsondocId": "b0403a4d-b51a-4c57-a876-90b490b6e77f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3210,7 +3210,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "333614b6-99fb-4d67-9475-5220c97a385e",
+                     "jsondocId": "78accded-0caa-4ac6-b008-096e7dbb6751",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to show (or specify a name)",
@@ -3219,7 +3219,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2e85b3b7-bc9e-4b13-bd6b-5ca62b8fea90",
+                     "jsondocId": "4ba61349-3784-4350-bc3f-75f3c213e36f",
                      "name": "name",
                      "format": "",
                      "description": "Status name to show",
@@ -3231,9 +3231,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all statuses, or optionally, gets information about a specific status",
                "methodName": "showStatus",
-               "jsondocId": "611332df-92cc-4c93-9e36-164d66de658e",
+               "jsondocId": "2f58005f-a7ee-4b9b-8f96-9bc43f82260c",
                "bodyobject": {
-                  "jsondocId": "10ec798b-b03a-41e0-8a30-c7f2c1a698c9",
+                  "jsondocId": "de17b119-2934-47db-94fe-ea366d5fe6f4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3243,7 +3243,7 @@
                "apierrors": [],
                "path": "/availableStatus/showStatus",
                "response": {
-                  "jsondocId": "aab4cdc0-5c26-4d89-8262-edd5a39b9af2",
+                  "jsondocId": "380d8db7-5aff-4ba6-a237-eb68240c3849",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3256,14 +3256,14 @@
          "description": "Methods for managing available statuses"
       },
       {
-         "jsondocId": "035b4bc6-25b7-4e42-b060-02f1712f232d",
+         "jsondocId": "936e2d9a-0b5c-4ab4-b64f-290cdf359690",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f34c8da4-5573-46d0-843f-c6213e514d1b",
+                     "jsondocId": "86dafac6-0b95-4d18-bf90-f0d6efca3ccd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3272,7 +3272,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4cf55aff-4844-4930-9830-e6cac0d54a95",
+                     "jsondocId": "861cc4d0-dc01-49b0-beaa-17a16884220b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3281,7 +3281,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "50385d33-9396-463f-a644-889134a9ec78",
+                     "jsondocId": "6f6d7d3f-d136-42aa-9600-eab3ff77c9dd",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to add",
@@ -3290,7 +3290,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "68771e1e-d058-4f47-8f30-e9b00be67efe",
+                     "jsondocId": "c98be511-a680-4223-b9e2-4a3c134eb9ff",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3302,9 +3302,9 @@
                "verb": "POST",
                "description": "Create canned comment",
                "methodName": "createComment",
-               "jsondocId": "6e1bcb68-d797-44b5-a1f4-035a2fc48437",
+               "jsondocId": "a52f9f40-c8aa-46f2-80eb-356d7f671a7d",
                "bodyobject": {
-                  "jsondocId": "8df8f307-da60-49b9-a408-37600d3a2b6f",
+                  "jsondocId": "f30321ba-c532-4320-a43e-20b076e6ae64",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3314,7 +3314,7 @@
                "apierrors": [],
                "path": "/cannedComment/createComment",
                "response": {
-                  "jsondocId": "1750d42a-3bc1-4890-baa9-01dd14271a64",
+                  "jsondocId": "479a8a96-dcbe-483d-aa52-1dee76b2a985",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3327,7 +3327,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c2c8c73f-8a40-446f-9f9e-7840af4339ce",
+                     "jsondocId": "219ab4de-c5d0-4d99-9a64-15057d3ad28e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3336,7 +3336,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6762e0a1-2bbf-4c56-a952-5a35aeb321eb",
+                     "jsondocId": "64f8a86d-289e-41fe-9b4f-575895a5686e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3345,7 +3345,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5aca822d-5019-4eb4-8522-ce168f95bd85",
+                     "jsondocId": "5294922b-1a68-4328-aaa8-d9f63c84a051",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to update (or specify the old_comment)",
@@ -3354,7 +3354,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1f476bd5-56a1-4440-9dfc-3f0095fc4873",
+                     "jsondocId": "2ec9697a-0522-4ceb-8731-924a139208cc",
                      "name": "old_comment",
                      "format": "",
                      "description": "Canned comment to update",
@@ -3363,7 +3363,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d0eae07-74a0-43a9-afff-9b0c2d8e9657",
+                     "jsondocId": "5aba1c26-576f-4b63-8e91-eedf45d829a1",
                      "name": "new_comment",
                      "format": "",
                      "description": "Canned comment to change to (the only editable option)",
@@ -3372,7 +3372,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "86fd4b91-116d-417f-88cc-4c69411c2f98",
+                     "jsondocId": "0e9cf9d6-ab81-4b22-835b-6880c455a9a6",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3384,9 +3384,9 @@
                "verb": "POST",
                "description": "Update canned comment",
                "methodName": "updateComment",
-               "jsondocId": "a026aa4d-a967-43df-970c-31cc8ef0b763",
+               "jsondocId": "5c68e651-f1a8-41eb-bb28-50909df3ec6f",
                "bodyobject": {
-                  "jsondocId": "efef0c31-f90c-47ec-aeac-49bbf546bd46",
+                  "jsondocId": "62f5c005-5e57-4ed5-91f4-11372a75ba90",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3396,7 +3396,7 @@
                "apierrors": [],
                "path": "/cannedComment/updateComment",
                "response": {
-                  "jsondocId": "5b2b0c45-ef9a-43e1-8436-912386d17534",
+                  "jsondocId": "7619c35b-e588-4442-841a-96f0fe4ea8d2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3409,7 +3409,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a93cb447-e505-408d-929d-001abe1d51c7",
+                     "jsondocId": "ff36ad26-7909-4e83-be49-5e075ef71e1a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3418,7 +3418,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4296f5df-4ade-405d-badf-d58615368c8f",
+                     "jsondocId": "e82dc370-5a6f-4138-9894-088ac058f1f1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3427,7 +3427,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "79189ebb-e3ed-459c-9e93-6e912d78ca18",
+                     "jsondocId": "23d1e732-ba3a-4240-a9bc-0dbf7d441432",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to remove (or specify the name)",
@@ -3436,7 +3436,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0281e11f-5913-4480-9810-09a061c2b115",
+                     "jsondocId": "cb094fdf-9a60-4cac-b034-16a438c9e6e4",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to delete",
@@ -3448,9 +3448,9 @@
                "verb": "POST",
                "description": "Remove a canned comment",
                "methodName": "deleteComment",
-               "jsondocId": "ac47f5b3-4b68-42ca-b02c-e83fe3c18291",
+               "jsondocId": "bd2f5538-91cd-41ef-a6d1-432a5eb3b147",
                "bodyobject": {
-                  "jsondocId": "e37ba375-b22e-43a3-accb-7a2ffda77dbe",
+                  "jsondocId": "1d3550c0-b48b-438c-844b-5185f4c595d9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3460,7 +3460,7 @@
                "apierrors": [],
                "path": "/cannedComment/deleteComment",
                "response": {
-                  "jsondocId": "a862891a-28f0-49b6-b00b-c04318f9f04a",
+                  "jsondocId": "edc7e9b5-b60c-4125-9393-a40e228de4a2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3473,7 +3473,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3cf10c6e-f12f-4810-a3a2-7d98a868c3b3",
+                     "jsondocId": "5e31ac31-7d58-4cf6-a071-4c6384c70e6b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3482,7 +3482,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d7a5d89-0a35-4217-9d5f-114768624f4f",
+                     "jsondocId": "eb467b71-b486-4dfb-922e-c9759e365cb3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3491,7 +3491,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "19b67174-546f-4aa6-9678-1a994e6d7151",
+                     "jsondocId": "01896ab8-bd05-4d4a-ab7a-6e13cb1713f5",
                      "name": "id",
                      "format": "",
                      "description": "Comment ID to show (or specify a comment)",
@@ -3500,7 +3500,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d2ce2155-0259-436c-b815-33af16ab7e56",
+                     "jsondocId": "f8a715f8-5736-40f7-916f-832c860221cf",
                      "name": "comment",
                      "format": "",
                      "description": "Comment to show",
@@ -3512,9 +3512,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned comments, or optionally, gets information about a specific canned comment",
                "methodName": "showComment",
-               "jsondocId": "63706307-0993-41a3-8e00-b953792e9eab",
+               "jsondocId": "8885e7ad-df61-4398-b5eb-d29a58e3493d",
                "bodyobject": {
-                  "jsondocId": "02606f8e-c85f-4341-b070-cbb6b3b71768",
+                  "jsondocId": "55abc78e-1582-481b-a006-0e5c72910b9e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3524,7 +3524,7 @@
                "apierrors": [],
                "path": "/cannedComment/showComment",
                "response": {
-                  "jsondocId": "ed68e7da-57a7-47ce-a842-b03a93699de6",
+                  "jsondocId": "348bac0c-c49b-4b9f-a922-019738609d2e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3537,14 +3537,14 @@
          "description": "Methods for managing canned comments"
       },
       {
-         "jsondocId": "cb83dd50-1c68-4d34-a216-8ce5575c58d2",
+         "jsondocId": "6124b171-7fe5-4b0a-a115-a4b2cc4fd4b0",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "94effa09-e66f-42cd-aa27-488810bcf51b",
+                     "jsondocId": "f9f840c7-091b-4726-8d54-ef0bb64302a8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3553,7 +3553,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "90e1bc0a-9212-4eb9-a503-0e3f69f01a88",
+                     "jsondocId": "7dfae1aa-b580-4688-b5ae-03343b9f638b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3562,7 +3562,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0f0782a6-c753-4ba5-bda4-4427ede10b96",
+                     "jsondocId": "c208776f-810f-4331-9f1f-dc02743d5000",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to update (or specify the old_key)",
@@ -3571,7 +3571,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7987a789-ff36-422c-a7ab-ba81835a32d3",
+                     "jsondocId": "eac5a8be-6313-4cee-9fdb-b667b2b2160b",
                      "name": "old_key",
                      "format": "",
                      "description": "Canned key to update",
@@ -3580,7 +3580,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9cfac534-53de-4c4f-8797-17fdb37a57e8",
+                     "jsondocId": "4918c6c6-ac6b-4c1b-86be-854fe4edc763",
                      "name": "new_key",
                      "format": "",
                      "description": "Canned key to change to (the only editable option)",
@@ -3589,7 +3589,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "060b91a7-df4d-4fe3-9802-cc4b76534ce1",
+                     "jsondocId": "18224031-0fcb-4339-b154-387af5d26591",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3601,9 +3601,9 @@
                "verb": "POST",
                "description": "Update canned key",
                "methodName": "updateKey",
-               "jsondocId": "7f729ac4-ea3e-429c-806a-f297398e72a3",
+               "jsondocId": "09a958ab-9630-4382-b15f-17685205c4ac",
                "bodyobject": {
-                  "jsondocId": "9fab864c-512b-466d-b2cf-d6b12455a05d",
+                  "jsondocId": "5e22275e-ecda-4e1b-8f13-fd70cb1baec0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3613,7 +3613,7 @@
                "apierrors": [],
                "path": "/cannedKey/updateKey",
                "response": {
-                  "jsondocId": "ed5d1695-1367-4123-a3b9-7f275a376d7f",
+                  "jsondocId": "4a9cf154-0973-4988-81aa-944b3efdae1c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3626,7 +3626,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e906e655-a216-4ea4-bab7-b1b31ba082bf",
+                     "jsondocId": "bf28a1bf-5c8f-47b2-8241-4409c557373a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3635,7 +3635,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "357246f8-d4b5-4e01-8719-fa94b43af65d",
+                     "jsondocId": "9c9fc4f8-1418-49cc-9f5a-0f8fb5d7d92e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3644,7 +3644,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "90aabdc6-d33d-44ef-a5d9-d4d84114f26b",
+                     "jsondocId": "00de0563-640c-4daa-8461-677eacfb3770",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to add",
@@ -3653,7 +3653,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f797a946-5653-456e-a592-5b475520d9b7",
+                     "jsondocId": "0e38ae2a-ca14-4ce2-891d-236d3bf5b68c",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3665,9 +3665,9 @@
                "verb": "POST",
                "description": "Create canned key",
                "methodName": "createKey",
-               "jsondocId": "546b5355-2519-43f4-a141-4b015f094038",
+               "jsondocId": "4a1673a2-dd48-40dc-b6f4-a3f8fa7fbbde",
                "bodyobject": {
-                  "jsondocId": "99bd6f2a-2f77-41eb-9c13-c1aaaace62fb",
+                  "jsondocId": "b6ff7571-93d8-4646-89b9-3eba81be9f98",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3677,7 +3677,7 @@
                "apierrors": [],
                "path": "/cannedKey/createKey",
                "response": {
-                  "jsondocId": "76620b92-8b98-499b-b494-e1c195089e2e",
+                  "jsondocId": "0ea5795b-b6a4-4438-bc8b-2e61aa61a43e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3690,7 +3690,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0c9ee34c-2b3e-41de-86cc-901bbd63c6ee",
+                     "jsondocId": "1f9020c8-e7fc-4a19-b395-976fe9c85865",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3699,7 +3699,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d0b33ae2-1032-4a86-b7b6-8441cacb1b5c",
+                     "jsondocId": "508763fa-131b-4cd9-a30a-9e6e1fa16bc3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3708,7 +3708,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "307c3c55-8f9b-4d2b-b9c7-5e160fb98f0f",
+                     "jsondocId": "bceea10d-eac3-4923-b864-112e448df086",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to remove (or specify the name)",
@@ -3717,7 +3717,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b860c78-2c0e-4861-af2e-894935b441d2",
+                     "jsondocId": "72a2d20e-8d3f-49df-97f7-efef70bd9083",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to delete",
@@ -3729,9 +3729,9 @@
                "verb": "POST",
                "description": "Remove a canned key",
                "methodName": "deleteKey",
-               "jsondocId": "c3fa1fa7-0576-447b-beb5-7f1ac51e0fff",
+               "jsondocId": "bb37db5a-f688-49ca-acc0-02cbec54059d",
                "bodyobject": {
-                  "jsondocId": "4bd8fcd6-f753-43a2-bd4f-9234f5c44d7c",
+                  "jsondocId": "e5bcd8c9-bbf8-47c0-9a9e-33fba34c011f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3741,7 +3741,7 @@
                "apierrors": [],
                "path": "/cannedKey/deleteKey",
                "response": {
-                  "jsondocId": "fa231bc4-b5e0-4b95-b222-3c8dd2d410c0",
+                  "jsondocId": "fc8d4c83-6de3-4044-915d-9ab0567a4460",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3754,7 +3754,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4a9e2a41-a99e-4568-ab15-b93b13c032c4",
+                     "jsondocId": "f8e0698e-18aa-4a34-b6ae-4cab86e88c7e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3763,7 +3763,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6ecb89f1-1a32-4bd9-9d98-c332f295d937",
+                     "jsondocId": "f301fa27-d760-45bf-9f67-90b46fab1c64",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3772,7 +3772,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e3e6600e-1e1e-42dd-9e83-9ed188d8eb83",
+                     "jsondocId": "90688be2-8979-4adb-bafe-90831cc0f81c",
                      "name": "id",
                      "format": "",
                      "description": "Key ID to show (or specify a key)",
@@ -3781,7 +3781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "902ab9bc-00de-48ad-985e-a473aaf491d7",
+                     "jsondocId": "ab94927f-826b-4619-8892-a2f913ac2cb7",
                      "name": "key",
                      "format": "",
                      "description": "Key to show",
@@ -3793,9 +3793,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned keys, or optionally, gets information about a specific canned key",
                "methodName": "showKey",
-               "jsondocId": "5fda7cdc-eedd-4d0e-904f-1edaa1d1e7ea",
+               "jsondocId": "bebbeec9-7599-40e6-9a68-10a281774aaf",
                "bodyobject": {
-                  "jsondocId": "efaa7f9a-c4bf-4446-8fd1-cb28189e88e3",
+                  "jsondocId": "316470de-5551-4269-b265-5055591aec8a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3805,7 +3805,7 @@
                "apierrors": [],
                "path": "/cannedKey/showKey",
                "response": {
-                  "jsondocId": "27031a05-1f3e-4ef4-90ce-c01b556604c7",
+                  "jsondocId": "ccdec0f2-f05d-478e-958f-cb15fb311a26",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3818,14 +3818,14 @@
          "description": "Methods for managing canned keys"
       },
       {
-         "jsondocId": "f5c2dbf1-9752-468d-b982-4c6950903fe2",
+         "jsondocId": "a4755dd1-783a-4424-8ada-3f12197a4c52",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e46a940f-69c9-4fcf-a40b-1502d7e09e94",
+                     "jsondocId": "5bbf7cd8-3636-4e5d-870e-eab564492ad1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3834,7 +3834,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dbde999f-b8f5-4dd2-baf0-f49176c6eea2",
+                     "jsondocId": "449ba5c2-330d-42c9-abf7-7172db96fa1c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3843,153 +3843,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "82360fed-3a49-434d-80c3-fcd834892511",
-                     "name": "id",
-                     "format": "",
-                     "description": "Canned value ID to update (or specify the old_value)",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3281c7ba-19aa-490a-b7fe-ef39e23a33d3",
-                     "name": "old_value",
-                     "format": "",
-                     "description": "Canned value to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3ad30fd0-c657-4284-af23-54dc5deb17ec",
-                     "name": "new_value",
-                     "format": "",
-                     "description": "Canned value to change to (the only editable option)",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c058619e-bffc-498f-b164-fc9941bc8f4c",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "Optional additional information",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update canned value",
-               "methodName": "updateValue",
-               "jsondocId": "374b30cc-4fc1-4ab3-bd06-0453ae3ac6f7",
-               "bodyobject": {
-                  "jsondocId": "af075ac5-f005-45cd-91ca-0b56f3a1317d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned value"
-               },
-               "apierrors": [],
-               "path": "/cannedValue/updateValue",
-               "response": {
-                  "jsondocId": "913dc4cd-8ef7-4ec6-a865-9f84e0f45a73",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned value"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "f4c6cc0b-c6be-47c2-a2fa-de1571be006e",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b16ca572-3827-49f2-842a-c9e4dec11c86",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "414ef2ac-98d1-4400-b5cd-9ebef4879368",
-                     "name": "value",
-                     "format": "",
-                     "description": "Canned value to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3e63e596-6fde-4b31-b316-ef4d882469dd",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "Optional additional information",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create canned value",
-               "methodName": "createValue",
-               "jsondocId": "0e58d929-4e4d-48ae-8da7-19612b7bfd7e",
-               "bodyobject": {
-                  "jsondocId": "77331ee8-9394-4bc4-8c3c-3d6bb22e0250",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned value"
-               },
-               "apierrors": [],
-               "path": "/cannedValue/createValue",
-               "response": {
-                  "jsondocId": "9c7e3d69-61d9-4383-a118-85de5515741c",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned value"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "741e9fa5-984f-4957-b53b-2a4e806d153a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e0cd2a68-4a60-481e-b170-1aaa04edec53",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6b9b7538-5b0d-4929-bba8-5d41a8bc7907",
+                     "jsondocId": "05fbb972-c17d-497d-af8b-f02c6dc25a63",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to remove (or specify the name)",
@@ -3998,7 +3852,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3757b00c-4ef8-412e-a82f-755c68fad660",
+                     "jsondocId": "7d70995b-b898-41a2-b7da-92948611dea3",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to delete",
@@ -4010,9 +3864,9 @@
                "verb": "POST",
                "description": "Remove a canned value",
                "methodName": "deleteValue",
-               "jsondocId": "c8906a51-dfe2-4c97-8016-cd56dbf321ee",
+               "jsondocId": "d57aa9d4-2992-495e-961f-f590bc3b948d",
                "bodyobject": {
-                  "jsondocId": "5ee539b6-3979-4473-93d2-99891f0a29af",
+                  "jsondocId": "b43a53b6-93a8-484f-99f4-5e72c9e988f0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4022,7 +3876,7 @@
                "apierrors": [],
                "path": "/cannedValue/deleteValue",
                "response": {
-                  "jsondocId": "0250bc6b-b190-405e-9677-9f088dea53ee",
+                  "jsondocId": "8dfa1564-0034-4ccb-bd28-20a5e142ce70",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4035,7 +3889,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3d8fb477-cae0-49ef-bbf5-c9c9c8996d1e",
+                     "jsondocId": "ba64a05f-5cf2-4fb2-b294-fd5a9f00be7b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4044,7 +3898,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2e83f49b-104c-4626-ad5f-61bc5661e8a0",
+                     "jsondocId": "dbdd157f-f819-4897-a2f8-1e6fd026435e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4053,7 +3907,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1ab9bc9-ee96-45ab-ba6d-514be70f066d",
+                     "jsondocId": "9c0f8fa1-a9d0-4b45-a003-4d90c0b7707d",
                      "name": "id",
                      "format": "",
                      "description": "Value ID to show (or specify a value)",
@@ -4062,7 +3916,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0090d42e-6991-4471-b4c4-8438d449e8c4",
+                     "jsondocId": "d796d175-994f-4dd2-a5e7-61d81d0160e7",
                      "name": "value",
                      "format": "",
                      "description": "Value to show",
@@ -4074,9 +3928,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned values, or optionally, gets information about a specific canned value",
                "methodName": "showValue",
-               "jsondocId": "833e9994-5399-4191-a83d-21d0bba2f838",
+               "jsondocId": "a1c8911f-43eb-4bc1-a105-f27d9b82f8a3",
                "bodyobject": {
-                  "jsondocId": "ce01a46e-9c23-4feb-92fc-e847e83fa7c8",
+                  "jsondocId": "e066d4a5-c686-47c2-a877-7152415be247",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4086,7 +3940,153 @@
                "apierrors": [],
                "path": "/cannedValue/showValue",
                "response": {
-                  "jsondocId": "a1950569-5fb6-43fc-b951-1a60646fd759",
+                  "jsondocId": "c1cb09be-69d4-4bf0-b2a3-375bd897aa00",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned value"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "231e0932-fbe4-4d19-8d9a-4e48998763f4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4fe75050-6267-4b67-951a-bdc7e75e6030",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "264b61c6-8c3a-475b-826d-b06ed15509ee",
+                     "name": "id",
+                     "format": "",
+                     "description": "Canned value ID to update (or specify the old_value)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "af8b9a07-3c18-49e7-857b-16e512d41263",
+                     "name": "old_value",
+                     "format": "",
+                     "description": "Canned value to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f5066601-11f8-47d9-b976-aa97fe3124b4",
+                     "name": "new_value",
+                     "format": "",
+                     "description": "Canned value to change to (the only editable option)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f4d702d7-7b8b-4b63-a3fc-c156bcd47c4e",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update canned value",
+               "methodName": "updateValue",
+               "jsondocId": "722f5a8b-e165-41d4-b835-38601e8663f6",
+               "bodyobject": {
+                  "jsondocId": "03e1f034-6c5b-48e7-988d-e2ab389a04d2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned value"
+               },
+               "apierrors": [],
+               "path": "/cannedValue/updateValue",
+               "response": {
+                  "jsondocId": "ee668d0c-e395-430f-a68d-7ba552c988c4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned value"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c239d06c-c956-45fb-836e-3c878f743558",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c89ed77a-d916-4439-b499-d83a06cc7cdc",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4e145e5e-eb13-4243-815e-3bb8c66933cb",
+                     "name": "value",
+                     "format": "",
+                     "description": "Canned value to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "eb827dc1-7042-4f89-9c83-c71b955fa849",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create canned value",
+               "methodName": "createValue",
+               "jsondocId": "daaeb0f8-df36-4fa5-a88c-44b615db07e9",
+               "bodyobject": {
+                  "jsondocId": "ff6be4b9-ae5a-4b93-b16c-12f45d78f431",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned value"
+               },
+               "apierrors": [],
+               "path": "/cannedValue/createValue",
+               "response": {
+                  "jsondocId": "63b09d7b-d0b4-40b1-9fec-8b2e5391a9fb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4099,14 +4099,14 @@
          "description": "Methods for managing canned values"
       },
       {
-         "jsondocId": "2ad1d8e5-b28c-42e4-aba8-03a87631d92d",
+         "jsondocId": "c55d5bc2-c608-489f-8412-0a9dac02722e",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "19b3f6a2-9dee-4dbc-9a3d-77c04bd67f14",
+                     "jsondocId": "aeb57711-a516-48f6-be5c-1d299ddc4e0e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4115,7 +4115,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "69b03561-59ec-4885-bbe0-39de7ddb5ecc",
+                     "jsondocId": "58d0cc67-32ad-416a-96c1-074eb8b6fc27",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4124,62 +4124,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "75eeaf85-e042-4c3b-a41a-855ccd119888",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create group",
-               "methodName": "createGroup",
-               "jsondocId": "0fd1b5ef-431e-4233-9952-60fa83201425",
-               "bodyobject": {
-                  "jsondocId": "9053f015-e49a-47ff-8dae-62492686a0e2",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/createGroup",
-               "response": {
-                  "jsondocId": "65a1887e-e43c-4ce4-9424-86004d29b5a8",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "ac6a428e-1cdc-4ec4-bd2f-fbf09172b2be",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d1df8e21-60e0-4458-9529-8f8039c0857a",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b3f70db6-a39f-4355-afe9-4ab7e0e86143",
+                     "jsondocId": "159ebcbe-9246-4fbd-9709-bbce4c55a911",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -4188,7 +4133,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f94987ef-124b-4d93-a320-4ecef976768a",
+                     "jsondocId": "2d501fb5-a96e-4ddb-869c-31e791d04093",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -4200,9 +4145,9 @@
                "verb": "POST",
                "description": "Get organism permissions for group",
                "methodName": "getOrganismPermissionsForGroup",
-               "jsondocId": "e88b42c8-94ac-4206-a4fc-f6cedfa27fdb",
+               "jsondocId": "b64abac1-9a98-4e79-a84f-befe5942d1cb",
                "bodyobject": {
-                  "jsondocId": "751ca368-4205-4b83-8a13-43a0b38721ea",
+                  "jsondocId": "b146fbb6-7003-45e6-98a6-90099638e338",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4212,7 +4157,7 @@
                "apierrors": [],
                "path": "/group/getOrganismPermissionsForGroup",
                "response": {
-                  "jsondocId": "727a201a-418e-4f4f-998d-1d7482df5ae4",
+                  "jsondocId": "06acb321-1619-43ac-9f41-3e020054bdd7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4225,7 +4170,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b5e88c29-ea72-4c15-81bb-a792e7eb1a9e",
+                     "jsondocId": "9b4a78b1-b10d-4f9c-8e07-8ed12805327d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4234,7 +4179,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3da3f5f9-4850-4d4e-be0e-d9dab6169ccc",
+                     "jsondocId": "58767e26-c9cb-4869-ba74-60b3408a2f32",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4243,7 +4188,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7478fd1f-91da-47e8-b0f6-a574eef4e79e",
+                     "jsondocId": "3b55e86c-cae4-4ae4-a823-e987ad4ee646",
                      "name": "groupId",
                      "format": "",
                      "description": "Optional only load a specific groupId",
@@ -4255,9 +4200,9 @@
                "verb": "POST",
                "description": "Load all groups",
                "methodName": "loadGroups",
-               "jsondocId": "bf55e451-8b64-4f0a-ab13-bf24fe313fbf",
+               "jsondocId": "760b89a4-6822-48a8-ad4e-5d51b22fa036",
                "bodyobject": {
-                  "jsondocId": "517c9dec-39f3-4ea4-a088-9ab13a33cc24",
+                  "jsondocId": "a5097927-0c1f-46b8-b45d-7d012db48586",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4267,7 +4212,7 @@
                "apierrors": [],
                "path": "/group/loadGroups",
                "response": {
-                  "jsondocId": "2c49b46c-60b1-49f2-894c-3a19dc027346",
+                  "jsondocId": "9439e007-491b-4b12-b0c3-88b4b6b050ff",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4280,7 +4225,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4c87e966-c794-4f44-9eef-d4f5d19d174b",
+                     "jsondocId": "0b34946b-9191-4220-a34a-034276417f0e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4289,7 +4234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "87a34a6e-36ae-46d7-b65a-a54da2d303b9",
+                     "jsondocId": "8a25ba60-9d11-42c8-8860-88733415c9c0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4298,7 +4243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8c70dbdc-2c77-47b3-9a75-0a9a2bd7652a",
+                     "jsondocId": "e1ba0483-62fc-4239-9d7a-b04087388866",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to remove (or specify the name)",
@@ -4307,7 +4252,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7253da54-f0fb-48a3-8234-d495e9f92339",
+                     "jsondocId": "155b947a-71de-4ac3-b2aa-69b1881141dd",
                      "name": "name",
                      "format": "",
                      "description": "Group name to remove",
@@ -4319,9 +4264,9 @@
                "verb": "POST",
                "description": "Delete a group",
                "methodName": "deleteGroup",
-               "jsondocId": "e0c4955d-f27f-4919-a6aa-5ff92be2cd4b",
+               "jsondocId": "767a9864-448c-4c50-9a13-9eed07f1698f",
                "bodyobject": {
-                  "jsondocId": "70976f5a-3c6f-4f68-9155-6c4416a64246",
+                  "jsondocId": "ed3621d7-67a7-4dbe-8187-aecde7367f45",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4331,7 +4276,7 @@
                "apierrors": [],
                "path": "/group/deleteGroup",
                "response": {
-                  "jsondocId": "02ee04f8-725c-4daa-a003-c846b14c7ee2",
+                  "jsondocId": "eac958ea-5572-4af6-b5a8-4fe04d17fc3d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4344,7 +4289,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "aea3449e-4d6d-4512-94f9-b86b8eb5ba4f",
+                     "jsondocId": "906b1f26-91fb-44e5-8199-5c4a16f9511d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4353,7 +4298,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a7d3e86b-5c8b-43db-97d6-45a37b7620ef",
+                     "jsondocId": "c42241b0-5d9f-464a-9745-df4141f08e5a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4362,7 +4307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "35d36d56-9d0b-455c-893e-8d2085322ead",
+                     "jsondocId": "751c9955-8ac6-406a-ad98-4a1f8aca56eb",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to update",
@@ -4371,7 +4316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3d207b95-489a-4a02-acab-de9163e93633",
+                     "jsondocId": "04635fd8-ad0b-4c68-8271-a550b69565db",
                      "name": "name",
                      "format": "",
                      "description": "Group name to change to (the only editable optoin)",
@@ -4383,9 +4328,9 @@
                "verb": "POST",
                "description": "Update group",
                "methodName": "updateGroup",
-               "jsondocId": "6f75e787-07b4-4baf-94be-da88c974f9fb",
+               "jsondocId": "1d9c554a-4d1f-4ad6-9b13-dc054307738d",
                "bodyobject": {
-                  "jsondocId": "ed5e1030-eee7-4dc2-958d-2401177dac2b",
+                  "jsondocId": "c1734019-f468-40a8-8d21-18ce0bbe7b2e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4395,7 +4340,7 @@
                "apierrors": [],
                "path": "/group/updateGroup",
                "response": {
-                  "jsondocId": "3a6f1ed1-5cfd-4769-a48c-a2a2e739ffc5",
+                  "jsondocId": "a111a5e0-54ae-4acc-88a3-1d750732a98c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4408,7 +4353,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "33e9a34b-aae6-455c-aff2-b90a14f1a953",
+                     "jsondocId": "e782af44-56c0-4634-b49f-daf963342ec0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4417,7 +4362,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "310cd1f1-9d21-4cd9-a1b2-965b92ba2069",
+                     "jsondocId": "54388e5c-d7f9-4682-a57d-c39fe6446fb3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4426,7 +4371,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5d8ab2fb-d88d-4611-a69d-5f16a548b14a",
+                     "jsondocId": "38058732-8da8-49b7-aa9d-11a69a95a1e5",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to modify permissions for (must provide this or 'name')",
@@ -4435,7 +4380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1740e66f-d1ca-44c5-947a-8fc603d05534",
+                     "jsondocId": "67a00735-115a-42b2-beed-f3efdb0753fe",
                      "name": "name",
                      "format": "",
                      "description": "Group name to modify permissions for (must provide this or 'groupId')",
@@ -4444,7 +4389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ad2b1de1-f18c-4141-92b3-e403f059a2d2",
+                     "jsondocId": "1421c091-f56b-44c0-9dce-6340d90690f8",
                      "name": "organism",
                      "format": "",
                      "description": "Organism common name",
@@ -4453,7 +4398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63016492-c4c2-4255-9d94-2c869f0a6ef2",
+                     "jsondocId": "085a7ef9-e7a9-4ded-980b-29266c98e3ff",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -4462,7 +4407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "68b5b751-f0d4-4c6a-bf9f-327ff9a31401",
+                     "jsondocId": "f2933171-f511-49fc-b9af-1f2050e81a79",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -4471,7 +4416,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3974db84-9b62-41cf-b28e-044ebbc9d46d",
+                     "jsondocId": "47a6ff1e-a09a-419a-a40e-94ae51a211d1",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -4480,7 +4425,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c89b0640-371a-41cf-a596-c001ec1be332",
+                     "jsondocId": "966d7192-842c-414e-9195-b6a42a164a29",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -4492,9 +4437,9 @@
                "verb": "POST",
                "description": "Update organism permission",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "196ba70e-891f-4a3f-88aa-76110724baa0",
+               "jsondocId": "1d0cdecc-b8ec-4eba-8595-bc4a19916dd3",
                "bodyobject": {
-                  "jsondocId": "36a68b6b-2240-4cc7-a66d-20c49190e382",
+                  "jsondocId": "ce831d2f-9d6c-4a1c-a311-a188ea794fb1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4504,7 +4449,7 @@
                "apierrors": [],
                "path": "/group/updateOrganismPermission",
                "response": {
-                  "jsondocId": "09d9af6e-de27-40ee-ac67-ac199cc9bf74",
+                  "jsondocId": "42f8997a-056e-43d9-952f-00ce3cc07fa7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4517,7 +4462,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a081dc58-2565-4e67-b783-c4579819e8cb",
+                     "jsondocId": "8388f66f-9f8b-44b1-8d4a-b427f3ddb5aa",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4526,7 +4471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "450f93b2-7ec3-4e18-ac1a-d585e7c67016",
+                     "jsondocId": "c908bd54-680a-4765-a9fc-7a3e15d2f3ad",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4535,7 +4480,62 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e200da50-fee3-4108-b17a-5e7cebb7e4bf",
+                     "jsondocId": "995ec955-31d5-434d-960f-cbdfd4e474d7",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create group",
+               "methodName": "createGroup",
+               "jsondocId": "1592e468-ce28-4c5d-ab9b-e0fa0694205b",
+               "bodyobject": {
+                  "jsondocId": "9431960d-2d9d-45d1-ba9b-59c0bbfd1f88",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/createGroup",
+               "response": {
+                  "jsondocId": "a4441a81-c933-4f89-86d4-02d75bcd58ac",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "ff1cff94-553c-4771-bc72-4d05615183ed",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3d6324d5-f5a0-45a3-8e1d-4824423b24e0",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "39f4b749-e125-4e18-81b5-2d2364d344d9",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -4544,7 +4544,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9ed1865a-26b1-48a7-8ad1-69df3cb0fc8c",
+                     "jsondocId": "bd3ce777-aff1-4348-8c58-3c22b9534f17",
                      "name": "users",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -4556,9 +4556,9 @@
                "verb": "POST",
                "description": "Update group membership",
                "methodName": "updateMembership",
-               "jsondocId": "c95f9b2e-4f16-4f3c-8aec-614d7a306e93",
+               "jsondocId": "e2666684-5eb4-421c-86b6-36049d979cd8",
                "bodyobject": {
-                  "jsondocId": "cddcb164-c6da-42fc-9d8a-02a99ce295df",
+                  "jsondocId": "21ad92f0-2001-451e-9317-1e3ba9cc7131",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4568,7 +4568,7 @@
                "apierrors": [],
                "path": "/group/updateMembership",
                "response": {
-                  "jsondocId": "e49970f0-624c-43f5-88ae-af24fae47cc1",
+                  "jsondocId": "11d9a5a2-9b7c-499b-ad81-03d6d4982be1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4581,14 +4581,14 @@
          "description": "Methods for managing groups"
       },
       {
-         "jsondocId": "03455424-84c7-4766-ae97-262deb38774b",
+         "jsondocId": "b3ab70a6-57fa-48b7-abbd-a070728c9466",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6dbe6607-89b9-4937-a997-3df17b286350",
+                     "jsondocId": "1d6a55a3-9f15-493a-b6ba-54696a7bd4dc",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4597,7 +4597,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "33bb7806-8809-450c-950a-1ab88edac111",
+                     "jsondocId": "23ed4a24-e16a-4452-a416-3f08997cbf4c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4606,7 +4606,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1942c5b0-a0d0-4d1c-817e-7b35fa530d50",
+                     "jsondocId": "4f374d24-20e9-4551-a464-0fe75c368e84",
                      "name": "type",
                      "format": "",
                      "description": "Type of annotated genomic features to export 'FASTA','GFF3','CHADO'.",
@@ -4615,7 +4615,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6263dd31-c381-4d5e-96de-dd7e43a44381",
+                     "jsondocId": "3c15fe83-6ebe-4fa0-9da2-d0855a577dcc",
                      "name": "seqType",
                      "format": "",
                      "description": "Type of output sequence 'peptide','cds','cdna','genomic'.",
@@ -4624,7 +4624,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2af648e7-de75-4c86-a0b6-753286f1e016",
+                     "jsondocId": "42480ff7-f3c4-4c2b-85d8-b82483f0df2d",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -4633,7 +4633,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14b7e6bf-017d-4274-a16d-0ced9433694f",
+                     "jsondocId": "15b25296-60fd-44a2-aa92-aa4e4f1b8234",
                      "name": "sequences",
                      "format": "",
                      "description": "Names of references sequences to add (default is all).",
@@ -4642,7 +4642,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5c45f657-df6b-49e4-9828-582973f69ee4",
+                     "jsondocId": "b4f7e656-359d-47e9-acb3-c0a82a67465e",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism that sequences belong to (will default to last organism).",
@@ -4651,7 +4651,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "377da822-fa96-416a-a38a-621b5ce24606",
+                     "jsondocId": "7e5f5267-9ce5-426d-aeb2-1512e8c92856",
                      "name": "output",
                      "format": "",
                      "description": "Output method 'file','text'",
@@ -4660,7 +4660,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0fe69f1f-c2e2-4a13-88e7-255a0b90d107",
+                     "jsondocId": "cd82056c-4ab4-4974-9e49-01b44bd31bfd",
                      "name": "exportAllSequences",
                      "format": "",
                      "description": "Export all reference sequences for an organism (over-rides 'sequences')",
@@ -4669,7 +4669,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6a3b395f-ebb4-4f51-b857-94e893a0a321",
+                     "jsondocId": "a447a865-bfd5-4f60-b016-2d1dd08aeb03",
                      "name": "exportGff3Fasta",
                      "format": "",
                      "description": "Export reference sequence when exporting GFF3 annotations.",
@@ -4678,7 +4678,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0392020a-bf71-4232-84a9-48323ca7de5f",
+                     "jsondocId": "2d6b595e-b26f-4a81-ae19-34d7821fda81",
                      "name": "region",
                      "format": "",
                      "description": "Highlighted genomic region to export in form sequence:min..max  e.g., chr3:1001..1034",
@@ -4690,9 +4690,9 @@
                "verb": "POST",
                "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "methodName": "write",
-               "jsondocId": "5ffe6d4c-415a-487c-94c8-874451534014",
+               "jsondocId": "37055487-0929-4338-ae8d-ad68d17e39ac",
                "bodyobject": {
-                  "jsondocId": "f791c301-4d68-4849-8ae8-618f379d7de7",
+                  "jsondocId": "bb839fcb-fe81-420a-a3d5-d2ad27f4a532",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4702,7 +4702,7 @@
                "apierrors": [],
                "path": "/IOService/write",
                "response": {
-                  "jsondocId": "d06ca170-c7ed-493d-a724-ed65af191524",
+                  "jsondocId": "5fd367aa-55ac-4ccc-b84a-2112d385648f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -4715,7 +4715,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3b1a86e4-b9a5-4061-b407-9438499f474f",
+                     "jsondocId": "ae84409d-da7c-4c2b-be1d-83dbd11c608e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4724,7 +4724,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2b76b14a-e5ee-4f19-8e82-22a05c5648c3",
+                     "jsondocId": "91a36d48-cfc8-4e2e-81f4-2c7a8b04d3a1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4733,7 +4733,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b405b03-faec-4e77-b6e1-f5f19b9d25a1",
+                     "jsondocId": "e82a5096-5f1b-4571-8980-e6aefc02eb8d",
                      "name": "uuid",
                      "format": "",
                      "description": "UUID that holds the key to the stored download.",
@@ -4742,7 +4742,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2d6b482b-e190-4347-a41d-bc610e217457",
+                     "jsondocId": "bb99d917-33d0-45b5-9816-4dda1d3d0922",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -4754,9 +4754,9 @@
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
                "methodName": "download",
-               "jsondocId": "2bb34f7a-3ed7-46cf-b3a3-5460e24a640b",
+               "jsondocId": "a9c1fd67-014f-4f01-abfe-9be85d48e494",
                "bodyobject": {
-                  "jsondocId": "86d95da3-860a-44c5-97b3-073fb87a2a81",
+                  "jsondocId": "863c5094-56de-40d6-b14c-a5aaf81b6240",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4766,7 +4766,7 @@
                "apierrors": [],
                "path": "/IOService/download",
                "response": {
-                  "jsondocId": "3f2557df-08f4-4d55-8efd-84d750b894b4",
+                  "jsondocId": "f0eae0a7-6adc-415c-ac44-5af144e68400",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -4779,14 +4779,14 @@
          "description": "Methods for bulk importing and exporting sequence data"
       },
       {
-         "jsondocId": "be5c3e7c-8795-4a98-a5a6-87ad9eb84682",
+         "jsondocId": "0c01855d-9c26-4951-8d40-4891ecd3d21c",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "34177166-6c2e-411d-a5af-ac016601d983",
+                     "jsondocId": "35a56104-38d8-48e7-99e0-91acdacaf81e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4795,7 +4795,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0911d808-68cf-4619-9ad7-b602ec092222",
+                     "jsondocId": "4cc8a33b-a283-4a83-93c7-0c7964241a89",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4804,11 +4804,11 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1ee6dca0-5579-4d8c-b3c3-204782d41f47",
+                     "jsondocId": "e28c22a1-d67b-4229-bea0-c35e74a3743d",
                      "name": "organism",
                      "format": "",
-                     "description": "ID or commonName that can be used to uniquely identify an organism",
-                     "type": "string",
+                     "description": "Pass an Organism JSON object with an 'id' that corresponds to the organism to be removed",
+                     "type": "json",
                      "required": "true",
                      "allowedvalues": []
                   }
@@ -4816,9 +4816,9 @@
                "verb": "POST",
                "description": "Remove an organism",
                "methodName": "deleteOrganism",
-               "jsondocId": "f21c7e20-c965-4257-878b-b0d7637f2734",
+               "jsondocId": "f60f7153-61c0-4828-acc4-a60e49aeb5b8",
                "bodyobject": {
-                  "jsondocId": "be4ad55c-feef-4050-bbfa-cc4277052715",
+                  "jsondocId": "cd66a82a-33f3-45e3-98a9-c1dbb5ac90ca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4828,7 +4828,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganism",
                "response": {
-                  "jsondocId": "a9d4dd23-0abf-4dcd-b4ad-d2ad364d5735",
+                  "jsondocId": "1b717d7f-0b89-4ea7-939a-c3c58ede43c1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4841,7 +4841,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "07b43e4c-715f-4945-b3fb-46edd88ce7da",
+                     "jsondocId": "85b6537b-ce20-4ab5-8c6a-930a8bd5db7b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4850,7 +4850,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e50c428a-b22b-4b95-98e4-315246fd17e5",
+                     "jsondocId": "ecd93283-f052-4555-980e-bb49723cf0a9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4859,7 +4859,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "24516c12-a3b2-4962-89b6-2f9ec58b6747",
+                     "jsondocId": "c519db79-b14b-4f95-924c-11b971d80b85",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -4871,9 +4871,9 @@
                "verb": "POST",
                "description": "Delete an organism along with its data directory and returns a JSON object containing properties of the deleted organism",
                "methodName": "deleteOrganismWithSequence",
-               "jsondocId": "dce99239-d00b-401a-a8b7-d1e43e9cf507",
+               "jsondocId": "31b5521c-8539-4566-96e6-66df1ff60a00",
                "bodyobject": {
-                  "jsondocId": "5a76db9c-7a72-42f3-801c-ee70fbcffe12",
+                  "jsondocId": "34e29609-bfb2-4b81-a8ba-57329869b113",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4883,7 +4883,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismWithSequence",
                "response": {
-                  "jsondocId": "8bbd2fd7-f881-4a56-afca-3cccf7bde156",
+                  "jsondocId": "4c881d0b-dcc1-4bdf-92c4-aadba3895fdb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4896,7 +4896,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d70c4264-ac5d-448d-ad36-e34960534622",
+                     "jsondocId": "308a9c0b-2338-4735-b1a9-e54eb0d9370e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4905,7 +4905,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a467719a-967f-4be6-8e75-1595e5dc15f9",
+                     "jsondocId": "9fadf95d-4cd4-40e7-ab20-5689191f149d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4914,7 +4914,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "875135bc-508b-4294-b1b1-5158c8ba974e",
+                     "jsondocId": "af3256ca-6154-4ff6-81f6-d1dffae165bd",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism.",
@@ -4926,9 +4926,9 @@
                "verb": "POST",
                "description": "Remove features from an organism",
                "methodName": "deleteOrganismFeatures",
-               "jsondocId": "d1456d06-68e4-4993-8a8b-7cbdeebfada1",
+               "jsondocId": "25ba6371-b844-47c0-aadb-6170168da034",
                "bodyobject": {
-                  "jsondocId": "d652e056-c124-4b05-94be-94f30262d7a0",
+                  "jsondocId": "c1f0a21c-6966-4f14-82d4-ad4767df1c7a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4938,7 +4938,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
                "response": {
-                  "jsondocId": "20596697-01e9-453d-b37d-9a9d9f436be4",
+                  "jsondocId": "df15707b-9abe-4e51-9aa4-d74ce440ed32",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4951,7 +4951,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c506e147-3548-479d-b7b6-fa5cad800482",
+                     "jsondocId": "b844f356-27d8-43c3-97fc-49d8127891e2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4960,7 +4960,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "146cb569-4726-4eef-852e-f9884e95721f",
+                     "jsondocId": "c82cd30f-aca7-4f6f-a9df-5c8ce504c941",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4969,7 +4969,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a516810e-6a68-4f63-817b-08f25accac7b",
+                     "jsondocId": "0b7bd1f0-fc66-410e-8b3d-6064a31efe91",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -4978,7 +4978,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "70e8c4c1-5029-48ae-94b9-50e5b90d8e2b",
+                     "jsondocId": "484046e4-0728-4d51-8c6e-2c5819eebc38",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -4987,7 +4987,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0c5f5247-984b-47bf-bd3e-623c405878bb",
+                     "jsondocId": "ec41b083-98df-4cee-b5aa-c0a7a68cb54e",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -4996,7 +4996,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f5f8ba02-c0ab-4de4-a1ba-58ff67220567",
+                     "jsondocId": "e6794083-009e-4b7a-b4d4-17a753f9bcec",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5005,7 +5005,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9ce8179e-8fde-4f08-912b-ec10683aa362",
+                     "jsondocId": "a699f6fc-eb99-466f-bedb-120059738507",
                      "name": "commonName",
                      "format": "",
                      "description": "commonName for an organism",
@@ -5014,7 +5014,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "51ea88fc-ee85-43aa-968e-197c4e386709",
+                     "jsondocId": "e3e34491-d221-4097-9a1b-7d3a9bb453d8",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -5023,7 +5023,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "474a95c5-94b4-40f0-ba3d-ee1bc7598e55",
+                     "jsondocId": "5d1586e5-4ef6-4ccc-bd43-04177fd0dc09",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5032,7 +5032,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "602d2742-69bc-4552-b593-9d08d53b50f2",
+                     "jsondocId": "62454a4c-79ff-4f0f-8df9-1060ad5a4931",
                      "name": "organismData",
                      "format": "",
                      "description": "zip or tar.gz compressed data directory",
@@ -5044,9 +5044,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganismWithSequence",
-               "jsondocId": "0094c3c0-56b4-4ccf-8fad-c4fd40c93608",
+               "jsondocId": "e73a011e-14f6-47e2-8f12-d2b95568156e",
                "bodyobject": {
-                  "jsondocId": "7459bf3c-884c-4847-b50f-9b1c214d2045",
+                  "jsondocId": "cb417ed6-280b-4b6c-81ee-dd376a617e78",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5056,7 +5056,7 @@
                "apierrors": [],
                "path": "/organism/addOrganismWithSequence",
                "response": {
-                  "jsondocId": "4028c238-0bc6-4df1-88df-95c9701ef9cc",
+                  "jsondocId": "60f3b0b7-392c-420a-a402-753210bb3c19",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5069,7 +5069,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d218ce93-86e3-42d0-83b8-a7f9692b6d30",
+                     "jsondocId": "187a9b16-b1b0-4a30-b262-299475fcfc20",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5078,7 +5078,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "81810157-ef9f-48e3-b023-09df8b75562a",
+                     "jsondocId": "97ac0cde-7ef3-4aac-b520-013c88c76c6f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5087,7 +5087,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a97ef66b-14e9-41ca-91ff-dcdb046a69ca",
+                     "jsondocId": "1b77ab8a-e10a-4a52-a1a3-e5fc58c9bc81",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5096,7 +5096,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a819312c-1eb3-4949-849a-76e19fc8e67c",
+                     "jsondocId": "b85f8013-083e-4da1-b394-113e1d7c7cc8",
                      "name": "trackData",
                      "format": "",
                      "description": "zip or tar.gz compressed track data",
@@ -5105,7 +5105,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d8b9886-81a3-4b00-a2cd-9a41456f6fc7",
+                     "jsondocId": "19366a44-a68a-478d-959f-81ba974077ce",
                      "name": "trackFile",
                      "format": "",
                      "description": "track file (*.bam, *.vcf, *.bw)",
@@ -5114,7 +5114,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "25def694-42b7-495f-8f26-533fca7cf148",
+                     "jsondocId": "74c7cd6b-7b9b-4ab5-bb7b-f6d4fef8d0f7",
                      "name": "trackFileIndex",
                      "format": "",
                      "description": "index (*.bai, *.tbi)",
@@ -5123,7 +5123,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b1de2da2-8388-47fa-bfa6-199efad1d43d",
+                     "jsondocId": "ffad5b42-4d21-46ee-aa48-78cc538be241",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -5135,9 +5135,9 @@
                "verb": "POST",
                "description": "Adds a track to an existing organism returning a JSON object containing all tracks for the current organism.",
                "methodName": "addTrackToOrganism",
-               "jsondocId": "3eb7063c-ea58-48eb-a56a-6e3d57bf639e",
+               "jsondocId": "1ddec003-dcca-45b1-b96c-abc05e78e89e",
                "bodyobject": {
-                  "jsondocId": "09179980-2ec2-448b-9e1b-c17cd0b089fd",
+                  "jsondocId": "d4c58799-1a73-4c77-8238-5eaab4b2676b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5147,7 +5147,7 @@
                "apierrors": [],
                "path": "/organism/addTrackToOrganism",
                "response": {
-                  "jsondocId": "b1b47453-3457-4b6e-8ef4-336b14596eba",
+                  "jsondocId": "ec004272-cb48-433e-9778-161e887beca2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5160,7 +5160,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d0192dfc-df1d-4496-8917-4ee3d90d67ef",
+                     "jsondocId": "8a9802f3-a30d-48b9-a6e3-8cfa9452f953",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5169,7 +5169,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2d5faed7-c949-4507-949b-8abf4def799b",
+                     "jsondocId": "c8be43f4-13e8-4e3e-9c53-7c09ef211021",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5178,7 +5178,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "977eaf06-e7ad-457f-9b3c-a961073cf9ed",
+                     "jsondocId": "ee2e3709-2c9d-42fa-b171-928114dfb9f6",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5187,7 +5187,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "af936006-b35c-4a63-a7c4-3df77eb56e91",
+                     "jsondocId": "9f87a4bf-a553-4197-abdd-d63af84adb38",
                      "name": "trackLabel",
                      "format": "",
                      "description": "Track label corresponding to the track that is to be deleted",
@@ -5199,9 +5199,9 @@
                "verb": "POST",
                "description": "Deletes a track from an existing organism and returns a JSON object of the deleted track's configuration",
                "methodName": "deleteTrackFromOrganism",
-               "jsondocId": "5017c19d-4490-4e7f-97bb-09f854030870",
+               "jsondocId": "82c9ed0e-3672-4b6a-b660-96c1eb427631",
                "bodyobject": {
-                  "jsondocId": "6482c5b7-2497-440f-bb73-7e6b452a18cf",
+                  "jsondocId": "6d562493-63cb-46c1-a322-47cb2d13f03c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5211,7 +5211,7 @@
                "apierrors": [],
                "path": "/organism/deleteTrackFromOrganism",
                "response": {
-                  "jsondocId": "44aa4ea8-98d3-49e2-9b13-1931624acf95",
+                  "jsondocId": "ee0e4989-b817-4adb-8c15-b7f25af1a758",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5224,7 +5224,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0cc93957-429a-4d65-9447-89aad637852e",
+                     "jsondocId": "7d66d0d3-3da7-4459-9553-dbd67856943c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5233,7 +5233,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "df5911b5-5637-48c7-8eac-a28542097cfa",
+                     "jsondocId": "4a877362-d3be-49de-8b8f-75f4584c246c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5242,7 +5242,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "15c9dfe3-5402-4d49-9bc3-7b154a56ee4a",
+                     "jsondocId": "90696d2c-5b56-4a96-966d-a532129a37c0",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5251,7 +5251,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3ed33678-299e-4ebc-8378-83ab14750df7",
+                     "jsondocId": "1537bdf0-df8e-463e-a6ed-1a93fbff598d",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -5263,9 +5263,9 @@
                "verb": "POST",
                "description": "Update a track in an existing organism returning a JSON object containing old and new track configurations",
                "methodName": "updateTrackForOrganism",
-               "jsondocId": "321bafc9-c3cb-41b7-8808-d23e94c38e6c",
+               "jsondocId": "820ccce0-06c1-49ed-b938-54ac0ee241f7",
                "bodyobject": {
-                  "jsondocId": "f9464983-7e85-4194-a25c-10180778f59f",
+                  "jsondocId": "cca5d62d-f8ea-422d-b7b9-9a0affdc3f0b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5275,7 +5275,7 @@
                "apierrors": [],
                "path": "/organism/updateTrackForOrganism",
                "response": {
-                  "jsondocId": "7047c04b-3fb6-4f5d-b301-43154b6647fe",
+                  "jsondocId": "f2e4060b-3b9e-47fb-b209-fa80992588f1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5288,7 +5288,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e1fa26e2-65f9-4326-a43a-a046c1c94943",
+                     "jsondocId": "720152fa-9ca7-4926-86af-2f6c1231c954",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5297,7 +5297,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7914b42e-8957-45de-806a-2ddae0092cd9",
+                     "jsondocId": "2209d6c2-4f22-45cd-a913-fcce90f4de98",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5306,7 +5306,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "673f17f4-fef9-49a8-a27a-cadbf1a21d5f",
+                     "jsondocId": "08ed9acf-bcb0-4478-ade7-e67907889ee5",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -5315,7 +5315,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a056c9db-765d-4df8-b077-4ac08b3c3a92",
+                     "jsondocId": "4ee4a53f-74f4-4101-9866-7702dffc9818",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -5324,7 +5324,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b0e175d2-0da0-4daa-829f-866ed5215f21",
+                     "jsondocId": "fbf28d33-81f2-476d-8b0c-fe429048c9c8",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -5333,7 +5333,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cd7eabee-c320-450f-8f27-de1922581cf9",
+                     "jsondocId": "e7426dc5-f9d6-43db-92fb-ae49bc986de4",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -5342,7 +5342,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "90eb6fab-a673-4778-a490-1c3f7beaff1a",
+                     "jsondocId": "c7df36cb-518d-45e4-8401-a5781824d159",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5351,7 +5351,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fb75378f-21e2-448b-9221-fac03f949f44",
+                     "jsondocId": "b13c5614-c086-48f5-812e-c4aeaffc7806",
                      "name": "commonName",
                      "format": "",
                      "description": "a name used for the organism",
@@ -5360,7 +5360,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4848ea16-31b6-492f-9039-613cb35b29e9",
+                     "jsondocId": "1d207385-58ba-48f6-a94f-d57fea922675",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5372,9 +5372,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganism",
-               "jsondocId": "e4231e11-9758-4269-9685-07f17e5b439d",
+               "jsondocId": "69fee5b5-632c-4fe0-abe9-8ad9e55fbdf2",
                "bodyobject": {
-                  "jsondocId": "0efc4830-1307-4964-8f07-6fb6eefd7d41",
+                  "jsondocId": "f68ed18a-53a4-4244-b7ed-87f3f944c53d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5384,7 +5384,7 @@
                "apierrors": [],
                "path": "/organism/addOrganism",
                "response": {
-                  "jsondocId": "2f16b603-3a8e-4423-8d9c-51ee1046e510",
+                  "jsondocId": "cfc30725-526e-4372-8bcd-cd1e12045d5f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5397,7 +5397,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0f6e6c15-9f4c-4126-baef-ed38b12ae6ff",
+                     "jsondocId": "32a6a089-028e-47b5-8c57-60aa03915e14",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5406,7 +5406,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9886f4e9-c587-498e-943d-c55846044be8",
+                     "jsondocId": "fd7da819-17b8-419d-aba6-65848c526f0a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5415,7 +5415,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "071bd9d0-38c1-4947-9905-601574c9c5f7",
+                     "jsondocId": "3ba13f95-1ef5-4a2f-98ad-5d0c967bbd36",
                      "name": "organism",
                      "format": "",
                      "description": "Common name or ID for the organism",
@@ -5427,9 +5427,9 @@
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
                "methodName": "getSequencesForOrganism",
-               "jsondocId": "4af61956-1b98-4b1d-bf42-4af932561db9",
+               "jsondocId": "c41f7ac9-dea9-4770-b710-ade6a1caed5a",
                "bodyobject": {
-                  "jsondocId": "8dde9a38-65c0-4ac1-96a4-d842e82dc04f",
+                  "jsondocId": "39b663be-86a7-45c2-b8e3-71c32670463f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5439,7 +5439,7 @@
                "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
                "response": {
-                  "jsondocId": "a475ddd0-639f-4e15-a81a-e6bde3627596",
+                  "jsondocId": "85bcdc71-3fa0-4f25-9f40-af62de82a789",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5452,7 +5452,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "148c24f1-7484-4aeb-a6d8-f7a80147b288",
+                     "jsondocId": "d4d5a793-5163-42cf-9347-202badc4380b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5461,7 +5461,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5651009c-61cd-4669-8d15-2ea533be14ca",
+                     "jsondocId": "644e0d98-ff2f-48cc-a780-9976a87e11d7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5470,7 +5470,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b5c6305f-17c8-44d1-b97c-c358c0ac24a8",
+                     "jsondocId": "c1280f58-20ce-4ffb-8bf5-169fb5d0ae68",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -5479,7 +5479,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "03f03164-0d1b-46f1-89fd-5f77c5935a65",
+                     "jsondocId": "accb1a14-7ce3-4784-85f8-c7d3d8943962",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -5488,7 +5488,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "512d0a5f-6fc3-43ca-9410-1724b591dd9d",
+                     "jsondocId": "7737bd37-0164-4549-b3f3-83c9abc36d42",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -5497,7 +5497,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "05cc1fc8-6459-483f-b18f-9764cce5375b",
+                     "jsondocId": "e869f181-9c42-4325-aa7f-9ad20e9cd2df",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -5506,7 +5506,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ed326892-88ae-44cb-b21d-910ba5594407",
+                     "jsondocId": "f040b59e-6c3c-45ea-83ba-e69ba92c5432",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -5515,7 +5515,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7d2dd44f-7e98-493e-bda4-d0bb82d9bdb1",
+                     "jsondocId": "c1ebdf67-297f-4c66-8fef-1c4b73ddef83",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5524,7 +5524,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "85ed2479-f401-46a8-9a50-84b53797991c",
+                     "jsondocId": "a637a70e-dc71-4805-8f25-b3b1e2d50fef",
                      "name": "name",
                      "format": "",
                      "description": "a common name used for the organism",
@@ -5533,7 +5533,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d5e0699c-47b9-4efd-933f-cabdb956a4e5",
+                     "jsondocId": "69edd021-109a-4568-adbf-954768983540",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -5542,7 +5542,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f9722a58-a5b6-4eeb-b689-4708e1437480",
+                     "jsondocId": "232f6bcb-3c73-4b21-88f1-5920db7f4c5f",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5554,9 +5554,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "updateOrganismInfo",
-               "jsondocId": "87ae0ac6-0f71-4ecd-8d1a-9f11d068e557",
+               "jsondocId": "8a7b9268-5bd5-45e5-8040-da71d8cf6245",
                "bodyobject": {
-                  "jsondocId": "09e0eb25-5b70-4373-8374-bc7e24c96ec9",
+                  "jsondocId": "4ff91656-68b9-47b1-9dba-9fd08cbdf009",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5566,7 +5566,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismInfo",
                "response": {
-                  "jsondocId": "01e523d4-5207-4674-af7f-c4b04a1592f0",
+                  "jsondocId": "87225b0d-5c83-440d-9345-1126a0fefa41",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5579,7 +5579,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7b73549e-ded1-4c4a-aef8-bd5332d26692",
+                     "jsondocId": "13e14d32-6b3b-4609-ab35-66b38e85a732",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5588,7 +5588,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9e48794f-44e8-4009-aac0-fc0c52be376d",
+                     "jsondocId": "8e508644-5a30-4093-b02f-e60604efc92a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5597,7 +5597,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7b62b8b-a8c3-4827-9d48-1c12fc34ee3e",
+                     "jsondocId": "0688f28a-5d7d-4e19-bac7-830519009a9c",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -5606,7 +5606,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e5e5a2e5-70a1-4d57-b968-e85dc22f17c2",
+                     "jsondocId": "24cacb20-a826-44b3-bf0f-a181da62acd0",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5618,9 +5618,9 @@
                "verb": "POST",
                "description": "Update organism metadata",
                "methodName": "updateOrganismMetadata",
-               "jsondocId": "fea85730-adf8-4dd2-bfc9-8ce62a26aca8",
+               "jsondocId": "7b0cd98f-6f3f-49b3-882a-5ff3a6c5f52e",
                "bodyobject": {
-                  "jsondocId": "80830e4d-4f4a-4175-b510-efacaf4f77d4",
+                  "jsondocId": "8d96d46f-412c-4f96-8f0f-711b4f817f2f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5630,7 +5630,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismMetadata",
                "response": {
-                  "jsondocId": "be59e5c0-67c1-4b64-bbb2-9a22be773339",
+                  "jsondocId": "3e174e06-cf4c-4b83-9d68-8f423c57150d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5643,7 +5643,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "359a8cea-cfec-47c8-931d-af1951ea63ff",
+                     "jsondocId": "4b989c03-db87-48ed-aa0d-36d4ce87bc2c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5652,7 +5652,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "238ab592-e977-444c-97ab-537f6c2d1e1b",
+                     "jsondocId": "152df879-cd12-4fb9-a824-71ea87b07d59",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5661,7 +5661,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d2d69e4-f859-4b6f-81c6-9a33f8bca88e",
+                     "jsondocId": "09890dc6-7fe7-4df9-9131-b651bdeb7409",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) ID or commonName that can be used to uniquely identify an organism",
@@ -5673,9 +5673,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "methodName": "findAllOrganisms",
-               "jsondocId": "74ff398f-0795-40db-8288-6cbb9778cea3",
+               "jsondocId": "fbab1165-b9ec-443d-afbe-483f67980f59",
                "bodyobject": {
-                  "jsondocId": "1f1a51ec-e34b-48c8-9907-335553a5de16",
+                  "jsondocId": "2cead770-bd25-4c1d-889d-1fd2c34b0617",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5685,7 +5685,7 @@
                "apierrors": [],
                "path": "/organism/findAllOrganisms",
                "response": {
-                  "jsondocId": "9da63d31-9164-40f4-98be-9f3312eb672b",
+                  "jsondocId": "888c2fed-e6e7-4154-93ba-986e22582834",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5698,14 +5698,14 @@
          "description": "Methods for managing organisms"
       },
       {
-         "jsondocId": "9e63703d-cc8f-434f-b2eb-68d0bfd09e90",
+         "jsondocId": "427cfc3b-5092-4662-bcd9-1bf80fe485d2",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "30c44592-ef1d-4c02-a386-6d9e544b2167",
+                     "jsondocId": "b31faf11-e88e-475e-abc2-8590e4beded3",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -5714,7 +5714,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5ed515d0-ab5e-4f11-af03-80b787cc90d8",
+                     "jsondocId": "71ca69dd-431b-4de1-8022-19f35f3ced98",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name (required)",
@@ -5726,12 +5726,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism and track",
                "methodName": "clearTrackCache",
-               "jsondocId": "30041e7e-49cf-44d6-904f-ac0dad59d6f8",
+               "jsondocId": "478497f9-74e3-40ba-a8bd-1f5a49e6a660",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>/<track name>",
                "response": {
-                  "jsondocId": "a30f39c5-f451-4c10-aba4-713972bea53a",
+                  "jsondocId": "54f743bc-6aa5-44ae-9b06-91430d4c36ec",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5743,7 +5743,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "d85d9db1-4bab-4543-8a28-acdd4eb4011d",
+                  "jsondocId": "5afb8575-4f08-467b-b7da-4fcb33ff0789",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required)",
@@ -5754,12 +5754,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "0d2e9d89-e227-4129-9138-62844fbfedfb",
+               "jsondocId": "b21115ce-fd1c-46fc-9076-b8a37e24f5f6",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "0de93086-bb06-4987-a65d-d670c3a78459",
+                  "jsondocId": "6a670eeb-5324-48f2-b18f-5538272b58d1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5772,7 +5772,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "07cc1e4a-7e11-4a60-8c52-1517d9e2cebf",
+                     "jsondocId": "9cb9490e-684b-43d2-b21f-08624ecd1473",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -5781,7 +5781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1fada193-d73d-412c-bc9c-fdcadf1d46e1",
+                     "jsondocId": "05005964-6d77-4586-92d9-d750dbaab7cd",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -5790,7 +5790,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "39212dae-cb0f-4120-bcdc-94c00dcabbb0",
+                     "jsondocId": "561d71ba-33cb-4f45-a26b-f2e27d8baacd",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -5799,7 +5799,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b085a167-a2d6-445e-9c98-324faec80ae9",
+                     "jsondocId": "04c53a93-fe71-48e5-af5f-d21d293cfe9c",
                      "name": "featureName",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -5808,7 +5808,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fa2eeafe-05cf-4df0-bfc2-50f04f831e77",
+                     "jsondocId": "ec59d6ca-35e9-41e6-8efc-dea0755c83d5",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -5817,7 +5817,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "affb8d84-6040-4798-9a6e-984d75473096",
+                     "jsondocId": "9d0b1032-1cd4-47cb-bb9e-04b16f11df9b",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -5829,12 +5829,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within but only for the selected name",
                "methodName": "featuresByName",
-               "jsondocId": "10ab467b-7dce-4508-9548-14e8521a7a15",
+               "jsondocId": "b4eb6c7d-ae97-44d5-a3fc-d0871ea842e7",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "5cd45908-4f44-4f34-90fc-3b299b9a6a4d",
+                  "jsondocId": "d87847e5-6e05-4e10-aac6-a90c070f76ed",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5847,7 +5847,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7fe72374-4027-4815-b28e-f922c11f390f",
+                     "jsondocId": "f72a03b5-e61d-4c81-90d9-6c0cbff04cf4",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -5856,7 +5856,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "13713d20-bde0-4b2e-8f64-f3585d07d399",
+                     "jsondocId": "2bf8b6b1-4b5e-4719-8204-0dc87592326d",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -5865,7 +5865,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f91473ee-90c9-4ff9-bd99-99be02dedb1d",
+                     "jsondocId": "579552ff-364b-4b18-9d0f-bcef79a32017",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -5874,7 +5874,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5febc4eb-34e7-42ad-9dfa-fe19c35a7724",
+                     "jsondocId": "29cee4b4-b018-4d67-9abf-8150f16b8e49",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -5883,7 +5883,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84f6f997-4d22-4ae7-bee4-9a38c12b2436",
+                     "jsondocId": "30c99c1a-97fb-4e92-9e6d-ecbd835acbd7",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -5892,7 +5892,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff5aa3c6-889a-45dc-b7cb-4e8df32819e5",
+                     "jsondocId": "03b9f5de-bbe8-4d23-aafd-cf7ce514e241",
                      "name": "name",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -5901,7 +5901,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "82a2f8fa-6d05-4679-a7af-945f69235dd1",
+                     "jsondocId": "e7889499-c9b4-48f6-898e-b334a907f38e",
                      "name": "onlySelected",
                      "format": "",
                      "description": "(default false).  If 'selected'!=1 one, then exclude.",
@@ -5910,7 +5910,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5d533309-9656-46f3-9b42-7226faa4494e",
+                     "jsondocId": "1e011603-6843-4b90-8c4b-c81290523432",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -5919,7 +5919,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2d9520e3-526c-4fca-9f97-0733eb50019b",
+                     "jsondocId": "93810dd3-a5a2-4c4f-9156-1cdbb6ed8a46",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -5931,12 +5931,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within an range",
                "methodName": "featuresByLocation",
-               "jsondocId": "d515c775-9504-4d33-9e4c-33cdc50042ad",
+               "jsondocId": "c7891b4e-48aa-4af2-9504-225e1cd27b8a",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>:<fmin>..<fmax>.<type>?name=<name>&onlySelected=<onlySelected>&ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "4f982c8b-e1f6-424e-ab96-c8e8a0c0d1d6",
+                  "jsondocId": "2994783d-a8d4-4bcf-9c45-5a7ee52ac7da",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5949,14 +5949,14 @@
          "description": "Methods for retrieving track data"
       },
       {
-         "jsondocId": "ff9291ed-4e33-4141-b934-0c6e66e094c5",
+         "jsondocId": "1a3303d3-767b-4ac7-8248-a4832e105910",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5fe63657-662d-4c51-853f-3ad21d80054c",
+                     "jsondocId": "c9308133-15e8-46b0-91c9-99630c03bf97",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5965,7 +5965,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "04a4aaa1-298a-4543-a2bf-03df05433320",
+                     "jsondocId": "c4606be8-6ae0-4860-8424-ef9aadb5afd5",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5974,7 +5974,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5eee6fc3-6460-4568-9dc8-a56b5de16e77",
+                     "jsondocId": "6ed1d725-df93-452b-91e7-9bc42cbef61d",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to fetch",
@@ -5986,9 +5986,9 @@
                "verb": "POST",
                "description": "Get organism permissions for user, returns an array of permission objects",
                "methodName": "getOrganismPermissionsForUser",
-               "jsondocId": "cdc79a99-7206-4fce-999d-46656255dd61",
+               "jsondocId": "bc7a50f2-9739-4dcb-9703-2ce11fa11877",
                "bodyobject": {
-                  "jsondocId": "051984ea-8889-4272-bf12-c16660864aba",
+                  "jsondocId": "263610d0-5c2a-452d-8b54-47b04bf58464",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5998,7 +5998,7 @@
                "apierrors": [],
                "path": "/user/getOrganismPermissionsForUser",
                "response": {
-                  "jsondocId": "62d9fa18-02a6-4cd4-bbeb-86b087656f14",
+                  "jsondocId": "12d13159-d871-4cb3-8fa7-8313ed2367cf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -6011,7 +6011,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "da940fa5-5e09-401c-8b8d-378c19af4157",
+                     "jsondocId": "2ad7e766-c045-4e2d-a5bc-cd41c365b9fd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6020,7 +6020,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "53be9e5a-27f2-4a76-b39f-0ffbf60e7c62",
+                     "jsondocId": "9b0d06f9-21d8-44c1-bd42-52f39a008f0c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6029,125 +6029,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cad8d615-dcad-4c4b-8a31-ddfd6a4ce612",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to modify permissions for",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f18e04d3-c3a6-4a45-839f-6cf6b409ab9e",
-                     "name": "user",
-                     "format": "",
-                     "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c1dbff1b-e130-491e-9929-a831d06172e0",
-                     "name": "organism",
-                     "format": "",
-                     "description": "Name of organism to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e20883b7-2055-4474-88f2-7c384a06b55d",
-                     "name": "id",
-                     "format": "",
-                     "description": "Permission ID to update (can get from userId/organism instead)",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "93876ddb-3910-40fb-8727-59b7f41f7d50",
-                     "name": "ADMINISTRATE",
-                     "format": "",
-                     "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5104a95f-562a-4af6-84c5-2d0812e54008",
-                     "name": "WRITE",
-                     "format": "",
-                     "description": "Indicate if user has write and all lesser privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "74778446-bff0-4806-8f30-3e8a1026a6c8",
-                     "name": "EXPORT",
-                     "format": "",
-                     "description": "Indicate if user has export and all lesser privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ed6ce9c4-5115-44c3-a3e1-93390253f18f",
-                     "name": "READ",
-                     "format": "",
-                     "description": "Indicate if user has read and all lesser privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update organism permissions",
-               "methodName": "updateOrganismPermission",
-               "jsondocId": "2887e986-9d73-4f86-b75c-68701a6ddbb9",
-               "bodyobject": {
-                  "jsondocId": "39e5bccd-4a68-4710-8902-52f89a6d3509",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/updateOrganismPermission",
-               "response": {
-                  "jsondocId": "8362972e-a683-422f-82ee-7c240ff8e1de",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "512dc2a7-6466-4f6a-a2ae-d674563b004e",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "56f29faa-f7a8-43e4-8393-55d96588bf64",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0537dc71-241e-44ae-b286-9ab5be2b1aae",
+                     "jsondocId": "48baa63b-bf51-4dad-8301-f08909d7ffe4",
                      "name": "userId",
                      "format": "",
                      "description": "Optionally only user a specific userId as an integer database id or a username string",
@@ -6159,9 +6041,9 @@
                "verb": "POST",
                "description": "Load all users and their permissions",
                "methodName": "loadUsers",
-               "jsondocId": "bcb6db21-c89a-4d1c-b71d-72ecb7520b0a",
+               "jsondocId": "893345d8-6a75-49dd-a068-7d926cdcb979",
                "bodyobject": {
-                  "jsondocId": "7cc2ebd4-f817-4c9e-b5fd-34a1ef466886",
+                  "jsondocId": "dfcf1b51-3b0c-4399-b994-d2c52cbde2ee",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6171,7 +6053,7 @@
                "apierrors": [],
                "path": "/user/loadUsers",
                "response": {
-                  "jsondocId": "8d5f8dd5-b54e-4d35-9280-d6b7b4f2af0a",
+                  "jsondocId": "349e9396-f6ea-4bc4-b90d-39e9e561adfb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -6184,7 +6066,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "33723d2b-8ef4-44d1-b672-1cddc762e7f6",
+                     "jsondocId": "a7ceff79-93f3-451a-89ae-3027843f80c5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6193,7 +6075,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "37fc02be-8bf3-4b66-aee6-185e223b34fa",
+                     "jsondocId": "51edc400-45d1-4772-b2c3-2b4de5e98673",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6202,7 +6084,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "95de6278-d854-4be4-b0e1-6f27b812d2b3",
+                     "jsondocId": "36b4395e-2ded-45ab-b6b8-afe3e0a49df7",
                      "name": "group",
                      "format": "",
                      "description": "Group name",
@@ -6211,7 +6093,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4efc5f9a-1586-4928-b89b-9400a6c63757",
+                     "jsondocId": "a3742568-0abd-4541-abdf-dff5622ec217",
                      "name": "userId",
                      "format": "",
                      "description": "User id",
@@ -6220,7 +6102,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2e106259-df00-47c1-90e4-7032c12cc1b0",
+                     "jsondocId": "fb47cecf-20ed-44c0-87e4-a342a542dbe3",
                      "name": "user",
                      "format": "",
                      "description": "User email/username (supplied if user id unknown)",
@@ -6232,9 +6114,9 @@
                "verb": "POST",
                "description": "Add user to group",
                "methodName": "addUserToGroup",
-               "jsondocId": "b940f1b3-8e08-4ef0-9214-b046bcb34aa6",
+               "jsondocId": "6b247787-9ce8-40a7-aa6f-1c796bc37a6a",
                "bodyobject": {
-                  "jsondocId": "000968d1-fd26-40ac-99e3-c45d0e273c51",
+                  "jsondocId": "579144a6-3188-4ac0-8d14-64477b94d464",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6244,7 +6126,7 @@
                "apierrors": [],
                "path": "/user/addUserToGroup",
                "response": {
-                  "jsondocId": "73b2c32e-2ed6-4799-a295-a55231350619",
+                  "jsondocId": "ea4499d5-e4d8-49d1-b0f2-3605b2c71821",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -6257,7 +6139,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1eb447c2-c408-416f-beca-d63abb8de24b",
+                     "jsondocId": "7d7e1d5d-f90a-4759-a802-5c8371d37dc8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6266,7 +6148,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3be111f6-eb78-4855-851d-a238db09378d",
+                     "jsondocId": "d126caba-ffb6-42d9-a81a-2a89e9a2b329",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6275,7 +6157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1b658a45-7c5d-41de-978a-f606076d3d9c",
+                     "jsondocId": "95b3e5b2-fb8a-46ca-a53e-104ab401b2ec",
                      "name": "group",
                      "format": "",
                      "description": "Group name",
@@ -6284,7 +6166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff247b49-a9e0-4278-99ac-29b5ca506ec2",
+                     "jsondocId": "55925672-cb14-4ca3-a034-3e32e0f34e77",
                      "name": "userId",
                      "format": "",
                      "description": "User id",
@@ -6293,7 +6175,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5929f1ea-1b50-488c-8b22-fd82cd7d8c37",
+                     "jsondocId": "350c2d1d-66d3-44e2-a1c5-32770a78e087",
                      "name": "user",
                      "format": "",
                      "description": "User email/username (supplied if user id unknown)",
@@ -6305,9 +6187,9 @@
                "verb": "POST",
                "description": "Remove user from group",
                "methodName": "removeUserFromGroup",
-               "jsondocId": "7852a3fe-bce2-4b5e-a06f-23c3886f7956",
+               "jsondocId": "6c786f05-ebd5-4c27-aa24-023653b568a7",
                "bodyobject": {
-                  "jsondocId": "ebfd6c5d-3e51-471a-b2ab-93fbaf672db5",
+                  "jsondocId": "02d519ef-31ba-45d7-a4cc-439db20cb878",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6317,7 +6199,7 @@
                "apierrors": [],
                "path": "/user/removeUserFromGroup",
                "response": {
-                  "jsondocId": "e67e9973-c814-4153-8a02-0aaa34a9f506",
+                  "jsondocId": "0030266e-8dc3-464c-b8c9-62b93eeb2315",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -6330,7 +6212,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "314f80b7-d5a5-46c7-88f0-2c40fd5b0fdf",
+                     "jsondocId": "aa0736e8-369c-4a3d-9bde-1691f213217f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6339,7 +6221,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "23565b6f-cb53-4b69-bda1-65758e4ba03e",
+                     "jsondocId": "ab1ef554-2768-4683-946b-4aed6faa63ca",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6348,7 +6230,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d0673c93-3fd3-45f1-94d8-5c868d82cc0b",
+                     "jsondocId": "2cb6b8d8-86ac-405e-8625-24d2a14b1004",
                      "name": "email",
                      "format": "",
                      "description": "Email of the user to add",
@@ -6357,7 +6239,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "09e82fcf-3dee-432d-a125-6d4fc5b91bdb",
+                     "jsondocId": "a79fdae9-d690-4160-8c11-7d93f92a8d8d",
                      "name": "firstName",
                      "format": "",
                      "description": "First name of user to add",
@@ -6366,7 +6248,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fdca1448-da42-4ff1-9838-b8b65d9ada9e",
+                     "jsondocId": "a6b95e50-58b3-4b26-869e-08a74705b9e1",
                      "name": "lastName",
                      "format": "",
                      "description": "Last name of user to add",
@@ -6375,7 +6257,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b6342fba-de0b-4b2b-b094-66cce43cc308",
+                     "jsondocId": "3206200c-6d73-47f4-afb9-3136faa10133",
                      "name": "metadata",
                      "format": "",
                      "description": "User metadata (optional)",
@@ -6384,7 +6266,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6397a1eb-b7c6-4f78-acf0-9fa44bcc247c",
+                     "jsondocId": "9d94de37-e965-432b-a0a9-0266e4f5b39e",
                      "name": "role",
                      "format": "",
                      "description": "User role USER / ADMIN (optional: default USER) ",
@@ -6393,7 +6275,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "957721d9-da89-4938-b62c-95ce787c3872",
+                     "jsondocId": "2332ea44-0fa4-4071-b9f8-ffa36c7bb164",
                      "name": "newPassword",
                      "format": "",
                      "description": "Password of user to add",
@@ -6405,9 +6287,9 @@
                "verb": "POST",
                "description": "Create user",
                "methodName": "createUser",
-               "jsondocId": "8b606bfc-3bc7-44e3-8b9f-794fd73684e8",
+               "jsondocId": "b19ba9a2-825b-40ea-bbfe-217ebd9d097c",
                "bodyobject": {
-                  "jsondocId": "b18f7b4a-8930-494e-b343-ce8e3fc58d71",
+                  "jsondocId": "3800708d-e6ec-4385-814d-34832013ea48",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6417,7 +6299,7 @@
                "apierrors": [],
                "path": "/user/createUser",
                "response": {
-                  "jsondocId": "5fafbbfd-c772-4236-b62a-dbb4b07a0ddd",
+                  "jsondocId": "5918cd31-e831-4919-a521-5a6b9ca3b0b9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -6430,7 +6312,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4a718a10-0280-4ebd-9a48-4e07714fe149",
+                     "jsondocId": "64bdf944-91db-4ea1-81d0-90939feeb55d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6439,7 +6321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7f379af7-33ee-461e-8083-797f593e5143",
+                     "jsondocId": "76e31e88-d6c9-4714-adbc-82b36406808a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6448,7 +6330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1089ee0d-3af4-4e0a-ada3-33c9625f988e",
+                     "jsondocId": "78b8553e-2d08-46b2-a6a1-c5c10f5f2bdc",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to delete",
@@ -6457,7 +6339,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fa793375-a0ee-4d9a-8b83-77fe563c1126",
+                     "jsondocId": "c86b0c3b-6b6f-435d-afda-62eb6ec9daf7",
                      "name": "userToDelete",
                      "format": "",
                      "description": "Username (email) to delete",
@@ -6469,9 +6351,9 @@
                "verb": "POST",
                "description": "Delete user",
                "methodName": "deleteUser",
-               "jsondocId": "dbfe0bb5-e9e5-43e5-8d4a-461c801e6113",
+               "jsondocId": "bd359bef-b41b-488d-ae14-9a1347528b37",
                "bodyobject": {
-                  "jsondocId": "5fa1d037-a367-464f-8070-0e8e7f8884d0",
+                  "jsondocId": "72ef228c-fdcd-43fe-abd0-b31a76a95a79",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6481,7 +6363,7 @@
                "apierrors": [],
                "path": "/user/deleteUser",
                "response": {
-                  "jsondocId": "429e7275-7e9d-4ebb-b691-6105f2ceef30",
+                  "jsondocId": "7bbd3cf6-c650-487f-97cd-2aa1e0a2364f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -6494,7 +6376,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c583bc13-d8cb-4a0c-9092-fabce3790b5a",
+                     "jsondocId": "be596eff-d5ca-485f-9c94-1d9e00793cea",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6503,7 +6385,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5c0006b8-9529-4565-bec7-ff0e068381b1",
+                     "jsondocId": "b8fc7de8-17a4-4a81-a567-0ed79bc7bfdb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6512,7 +6394,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "25c8c8ce-b074-4535-9f0b-d8759931d3a6",
+                     "jsondocId": "9d911efe-e721-4ddf-8fe2-f92f7efca2af",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to update",
@@ -6521,7 +6403,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3d41bbbd-7f7e-403f-9135-a1cb457e2fbf",
+                     "jsondocId": "528cb829-8ac2-421d-a073-8713b295282d",
                      "name": "email",
                      "format": "",
                      "description": "Email of the user to update",
@@ -6530,7 +6412,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6c0ef517-b6b1-4b68-aeb3-351870180820",
+                     "jsondocId": "5bb71288-a3fe-417f-8802-da1558efecd0",
                      "name": "firstName",
                      "format": "",
                      "description": "First name of user to update",
@@ -6539,7 +6421,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9c97f613-2220-42f7-96ab-1e843c5ac017",
+                     "jsondocId": "79d6fac4-07be-4904-86f6-e06add68e642",
                      "name": "lastName",
                      "format": "",
                      "description": "Last name of user to update",
@@ -6548,7 +6430,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "42fc3cc9-cc14-4232-915b-acc1a0ac6ca8",
+                     "jsondocId": "f0571329-71bd-41d9-b5f1-1abb78bbdd8d",
                      "name": "metadata",
                      "format": "",
                      "description": "User metadata (optional)",
@@ -6557,7 +6439,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b365bdb5-fc9d-4eec-807c-a1257f894042",
+                     "jsondocId": "26bbbc63-50fb-4fa8-8f71-9365e0f45972",
                      "name": "newPassword",
                      "format": "",
                      "description": "Password of user to update",
@@ -6569,9 +6451,9 @@
                "verb": "POST",
                "description": "Update user",
                "methodName": "updateUser",
-               "jsondocId": "2af4ccec-cebc-4f91-9728-db3cceea3b56",
+               "jsondocId": "46cfff19-7b91-44cf-b5f8-b3b33c7b9a67",
                "bodyobject": {
-                  "jsondocId": "8fc00144-6f91-4d2f-9c14-378a53177f03",
+                  "jsondocId": "c1c7ea30-0592-400a-854d-a7fa86d986fe",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6581,7 +6463,125 @@
                "apierrors": [],
                "path": "/user/updateUser",
                "response": {
-                  "jsondocId": "61d4585b-12c2-431c-ab2f-2e8517efbc4e",
+                  "jsondocId": "cf0a7b9c-bde2-44d2-a40c-f8193c2cc3c3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5682a9f9-c35f-4ce4-8e5f-73a6077c5e8f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0c65354c-ba3a-4b8f-9c83-bda094eb7ca4",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dfb84d07-7daf-47b6-ab5d-6ef1ebf51f19",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to modify permissions for",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a4c5abfb-7cd6-4de3-b982-f6cfe6c3feb7",
+                     "name": "user",
+                     "format": "",
+                     "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bc63bc38-b3e8-4bc5-bd97-51600505ed39",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Name of organism to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a9a51054-0e18-407e-b1ed-bc42eac2d62f",
+                     "name": "id",
+                     "format": "",
+                     "description": "Permission ID to update (can get from userId/organism instead)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8d469a59-d0a1-4749-9c53-732a246829c3",
+                     "name": "ADMINISTRATE",
+                     "format": "",
+                     "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8c4f3bb9-973e-47a7-8c10-a4ef6f968253",
+                     "name": "WRITE",
+                     "format": "",
+                     "description": "Indicate if user has write and all lesser privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a535c6e7-23b8-4c70-8ee5-bbf5c0ab4c78",
+                     "name": "EXPORT",
+                     "format": "",
+                     "description": "Indicate if user has export and all lesser privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f7134ccd-f848-4944-ac25-e72d9d699dc6",
+                     "name": "READ",
+                     "format": "",
+                     "description": "Indicate if user has read and all lesser privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update organism permissions",
+               "methodName": "updateOrganismPermission",
+               "jsondocId": "169ee322-c685-400e-bfea-833ef7021da4",
+               "bodyobject": {
+                  "jsondocId": "0fe6c3dd-50f6-4fe9-aec2-8785b47245e1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateOrganismPermission",
+               "response": {
+                  "jsondocId": "d96365b2-a8e6-4bc1-aba5-e083dcd1c45e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"


### PR DESCRIPTION
@nathandunn FYI

Cannot delete organism on 2.0.7 due to changes made to `/deleteOrganism` endpoint while working on Remote Upload feature.

This PR aims at safely fixing the issue in `/deleteOrganism` endpoint in OrganismController.