### PR TITLE
Jbrowse plugin git methods and test fixes

### DIFF
--- a/apollo
+++ b/apollo
@@ -39,8 +39,8 @@ function deploy_message(){
 }
 
 function check_rest_api(){
-	if [ ! -f web-app/js/restapidoc/restapidoc.json ]; then 
-		$grails_executable rest-api-doc 
+	if [ ! -d target ]; then
+		$grails_executable doc
 	fi
 }
 
@@ -206,9 +206,9 @@ elif [[ $1 == "debug" ]];then
 elif [[ $1 == "test" ]];then
     check_configs
     copy_configs
-    $gradle_executable handleJBrowse 
+    $gradle_executable handleJBrowse
     check_rest_api
-	$grails_executable test-app 
+	$grails_executable test-app
 elif [[ $1 == "test-unit" ]];then
     check_configs
     copy_configs
@@ -242,4 +242,3 @@ elif [[ $1 == "jbrowse" ]];then
 else
     usage
 fi
-

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ ext {
     nodeModulesDirectory = "node_modules"
     jbrowseDirectory = "jbrowse-download"
     pluginsDirectory = "jbrowse-download/plugins"
+    defaultGitMethod = "shell"
 }
 
 
@@ -60,11 +61,8 @@ dependencies {
 //    testCompile 'junit:junit:4.12'
 }
 
-
 def jbrowseConfig
 def jbrowsePlugins
-
-
 
 task evaluateJBrowseConfigs {
     // gradle read in Config.groovy
@@ -93,7 +91,6 @@ task evaluateJBrowseConfigs {
     println "final JBrowse settings ${jbrowseConfig}"
     println "final plugins ${jbrowsePlugins}"
 }
-
 
 task installJBrowse(dependsOn: evaluateJBrowseConfigs) << {
     println "installing jbrowse ${jbrowseConfig}"
@@ -198,7 +195,9 @@ task installJBrowsePlugins(dependsOn: copyApolloPlugin) << {
                 }
             } else {
                 println "Cloning '${plugin.value.git}' into '${path}'"
-                cloneRepo(plugin.value.git, path, plugin.value.branch)
+                // checking if gitMethod exists, otherwise setting the default to 'shell'
+                def gitMethod = plugin.value.gitMethod ? plugin.value.gitMethod : defaultGitMethod
+                cloneRepo(plugin.value.git, path, plugin.value.branch, 0, gitMethod)
                 println "CLONED from ${plugin.value.git} into ${path}"
             }
         } else if (plugin.value.url == true) {
@@ -216,7 +215,6 @@ task installJBrowsePlugins(dependsOn: copyApolloPlugin) << {
 
 // wrapper for ant script
 task buildJBrowse(dependsOn: 'build.jbrowse'){}
-
 
 // TODO: should inherent handleJBrowse
 task handleJBrowseRelease(dependsOn: [copyApolloPlugin]) {
@@ -249,50 +247,37 @@ def confirmPlugin(String path) {
     return file.exists() && file.isDirectory() && file.canRead()
 }
 
-def cloneRepo(String url, String directory, String branch) {
-    cloneRepo(url, directory, branch, null)
-}
-
-//def cloneRepoNoBower(String url, String directory, String branch, Integer depth) {
-//    String depthString = depth != null && depth > 0 ? " --recursive --depth ${depth} " : ""
-//    def commandToExecute = "git clone ${depthString} ${url} ${directory} "
-//    println "command to execute [${commandToExecute}]"
-//    def proc = commandToExecute.execute()
-//    def outputStream = new StringBuffer();
-//    def errorStream = new StringBuffer();
-//    proc.waitForProcessOutput(outputStream, errorStream);
-//    println outputStream
-//    println errorStream
-//
-//    if (branch.startsWith("tags")) {
-//        fetchTags(new File(directory))
-//    }
-//    checkoutBranch(new File(directory), branch)
-//}
-
-task removeJBrowseDownload(type:Delete){
-    delete(jbrowseDirectory)
-}
-
-task moveNodeModulesJBrowse(dependsOn:removeJBrowseDownload) {
-    doLast {
-        file("jbrowse-download").deleteDir() // dependency handles this
-        file("node_modules/jbrowse").renameTo(file("jbrowse-download"))
-        file("node_modules/*").renameTo(file("jbrowse-download/src"))
-        file("node_modules").deleteDir()
-//        file("jbrowse-download/node_modules").deleteDir()
+def cloneRepo(String url, String directory, String branch, Integer depth=0, String method=defaultGitMethod){
+    println "Cloning ${url} via ${method}"
+    switch (method){
+        case "npm":
+            cloneRepoNpm(url, directory, branch)
+            break
+        case "shell":
+            cloneRepoShell(url, directory, branch, depth)
+            break
+        default:
+            throw new GradleException("Error in cloneRepo: invalid method ${method}")
+	    break
     }
 }
 
-task installJBrowseNpm(type:Exec) {
-    workingDir jbrowseDirectory
-    commandLine './setup.sh'
-}
+def cloneRepoShell(String url, String directory, String branch, Integer depth) {
+    String depthString = depth != null && depth > 0 ? " --recursive --depth ${depth} " : ""
+    def commandToExecute = "git clone ${depthString} ${url} ${directory} "
+    println "command to execute [${commandToExecute}]"
+    def proc = commandToExecute.execute()
+    def outputStream = new StringBuffer();
+    def errorStream = new StringBuffer();
+    proc.waitForProcessOutput(outputStream, errorStream);
+    println outputStream
+    println errorStream
 
-task refreshNpmRepo(type: Exec){
-//    println "using npm to update: ${directory}"
-    workingDir jbrowseDirectory
-    commandLine "npm","update"
+    if (branch.startsWith("tags")) {
+        fetchTags(new File(directory))
+    }
+    checkoutBranch(new File(directory), branch)
+    tasks.installJBrowseScript.execute()
 }
 
 def cloneRepoNpm(String url, String directory, String branch){
@@ -315,7 +300,7 @@ def cloneRepoNpm(String url, String directory, String branch){
     if(finalUrl.contains("#") && (finalUrl.endsWith("jbrowse") || finalUrl.split("#")[0].endsWith("jbrowse"))) {
         println "Moving JBrowse into position ${finalUrl}"
         tasks.moveNodeModulesJBrowse.execute()
-        tasks.installJBrowseNpm.execute()
+        tasks.installJBrowseScript.execute()
     }
     else{
         npmDirectory.eachDir {
@@ -331,6 +316,31 @@ def cloneRepoNpm(String url, String directory, String branch){
     }
 }
 
+task removeJBrowseDownload(type:Delete){
+    delete(jbrowseDirectory)
+}
+
+task moveNodeModulesJBrowse(dependsOn:removeJBrowseDownload) {
+    doLast {
+        file("jbrowse-download").deleteDir() // dependency handles this
+        file("node_modules/jbrowse").renameTo(file("jbrowse-download"))
+        file("node_modules/*").renameTo(file("jbrowse-download/src"))
+        file("node_modules").deleteDir()
+//        file("jbrowse-download/node_modules").deleteDir()
+    }
+}
+
+task installJBrowseScript(type:Exec) {
+    println "setting up jbrowse ... "
+    workingDir jbrowseDirectory
+    commandLine './setup.sh'
+}
+
+task refreshNpmRepo(type: Exec){
+//    println "using npm to update: ${directory}"
+    workingDir jbrowseDirectory
+    commandLine "npm","update"
+}
 
 // Get the path for the locally installed binaries
 task npmBin << {
@@ -344,7 +354,6 @@ task npmBin << {
     }
 }
 
-
 // Install packages from package.json
 task npm(type: Exec) {
     description = "Grab NodeJS dependencies (from package.json)"
@@ -356,11 +365,6 @@ task npm(type: Exec) {
 
 task cleanAll(type:Delete){
     delete 'web-app/WEB-INF/deploy', 'web-app/annotator','target'
-}
-
-
-def cloneRepo(String url, String directory, String branch, Integer depth) {
-      cloneRepoNpm(url,directory,branch)
 }
 
 def fetchTags(File file) {

--- a/tools/data/add_features_from_gff3_to_annotations.pl
+++ b/tools/data/add_features_from_gff3_to_annotations.pl
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use FindBin qw($RealBin);
-use lib "$RealBin/../../src/perl5";
+use lib "$RealBin/../../jbrowse-download/src/perl5";
 use JBlibs;
 
 use File::Basename;

--- a/tools/data/add_transcripts_from_gff3_to_annotations.pl
+++ b/tools/data/add_transcripts_from_gff3_to_annotations.pl
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use FindBin qw($RealBin);
-use lib "$RealBin/../../src/perl5";
+use lib "$RealBin/../../jbrowse-download/src/perl5";
 use JBlibs;
 
 use File::Basename;


### PR DESCRIPTION
This PR is an effort at fixing the issues with bowerless git plugin acquisition; notable changes:

apollo:
the function `check_rest_api` has been slightly modified to address a testing issue; the prior conditional checked for the existence of a json file that is already included in the repo; however, the rest-api-docs do not get generated on the first run of `apollo test`. changing the check to the `target` directory ensures this runs initially -- though it might be prudent to remove the check altogether and just compile the rest-api-docs to avoid the whole issue. 
also, the command `$grails_executable rest-api-doc` raised an error that asks the user to select the package they want to install, which in actuality is 'doc' -- hence the change to `$grails_executable doc`

build.gradle:
an extra variable, defaultGitMethod, has been added and set to "shell." this variable controls whether git is run via NPM (requiring any git packages acquired to have a package.json file in the base directory) or via command. an extra nicety of the command approach is that it uses https in lieu of ssh, so no key configuration is required. should the user wish to use npm, they can set the defaultGitMethod variable by including it in their apollo-config 'plugins' section.
to accomplish the command git method, an existing (presumably in progress) commented out function was uncommented-out, and modified slightly (to run ` tasks.installJBrowseScript.execute()` which resolved some errors).

add_features_from_gff3_to_annotations.pl & add_transcripts_from_gff3_to_annotations.pl:
changed the path these scripts look for dependencies in 

relevant issue: #1752 