### PR TITLE
Issue 1732 - support File -> Open

### DIFF
--- a/client/apollo/js/JSONUtils.js
+++ b/client/apollo/js/JSONUtils.js
@@ -10,7 +10,7 @@ function JSONUtils() {
 }
 
 JSONUtils.verbose_conversion = false;
-
+JSONUtils.NOT_YET_SUPPORTED_MESSAGE = "Reverse complement view with local tracks not yet supported.";
 /**
 *  creates a feature in JBrowse JSON format
 *  takes as arguments:
@@ -416,6 +416,13 @@ JSONUtils.createApolloFeature = function( jfeature, specified_type, useName, spe
     }
     if (diagnose)  { console.log("result:"); console.log(afeature); }
     return afeature;
+};
+
+JSONUtils.parseSequenceList = function( refSeqName ) {
+    var refSeqNameSplit = refSeqName.split(':');
+    var sequenceListString = refSeqNameSplit.slice(0, refSeqNameSplit.length - 1).join(':');
+    var sequenceListObject = JSON.parse(sequenceListString).sequenceList;
+    return sequenceListObject;
 };
 
 // experimenting with forcing export of JSONUtils into global namespace...

--- a/client/apollo/js/Store/SeqFeature/BAMCombination.js
+++ b/client/apollo/js/Store/SeqFeature/BAMCombination.js
@@ -1,0 +1,18 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'dojo/Deferred',
+        'JBrowse/Store/SeqFeature/BAMCombination',
+        'WebApollo/Store/SeqFeature/_RemoteCombinationMixin'
+    ],
+    function(
+        declare,
+        array,
+        Deferred,
+        BAMCombinationStore,
+        RemoteCombinationMixin
+    ) {
+        return declare([ BAMCombinationStore, RemoteCombinationMixin ], {
+
+        });
+    });

--- a/client/apollo/js/Store/SeqFeature/Combination.js
+++ b/client/apollo/js/Store/SeqFeature/Combination.js
@@ -1,0 +1,18 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'dojo/Deferred',
+        'JBrowse/Store/SeqFeature/Combination',
+        'WebApollo/Store/SeqFeature/_RemoteCombinationMixin'
+    ],
+    function(
+        declare,
+        array,
+        Deferred,
+        CombinationStore,
+        RemoteCombinationMixin
+    ) {
+        return declare([ CombinationStore, RemoteCombinationMixin ], {
+
+        });
+});

--- a/client/apollo/js/Store/SeqFeature/Mask.js
+++ b/client/apollo/js/Store/SeqFeature/Mask.js
@@ -1,0 +1,66 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'dojo/Deferred',
+        'dojo/when',
+        'dojo/promise/all',
+        'JBrowse/Store/SeqFeature/Mask',
+        'WebApollo/JSONUtils'
+    ],
+    function(
+        declare,
+        array,
+        Deferred,
+        when,
+        all,
+        MaskStore,
+        JSONUtils
+    ) {
+        return declare( MaskStore, {
+
+            getFeatures: function( query, featCallback, doneCallback, errorCallback ) {
+                var thisB = this;
+
+                var sequenceList = JSONUtils.parseSequenceList(query.ref);
+                if (sequenceList[0].reverse) {
+                    errorCallback(JSONUtils.NOT_YET_SUPPORTED_MESSAGE)
+                }
+                else {
+                    query.ref = sequenceList[0].name;
+                    this.gotAllStores.then(
+                        function() {
+                            var featureArray = {};
+
+                            // Get features from one particular store
+                            var grabFeats = function( key )  {
+                                var d = new Deferred( );
+                                featureArray[key] = [];
+
+                                thisB.stores[key].getFeatures( query,
+                                    function(feature) {
+                                        featureArray[key].push( feature );
+                                    },
+                                    function() { d.resolve( true ); },
+                                    function() { d.reject( "failed to load features for " + key + " store" ); }
+                                );
+                                return d.promise;
+                            };
+
+                            when(all([grabFeats( "mask" ), grabFeats( "display" )]),
+                                function() {
+                                    // Convert mask features into simplified spans
+                                    var spans = thisB.toSpans( featureArray.mask, query );
+                                    // invert masking spans if necessary
+                                    spans = thisB.inverse ? thisB.notSpan( spans, query ) : spans;
+                                    var features = featureArray.display;
+
+                                    thisB.maskFeatures( features, spans, featCallback, doneCallback );
+                                }, errorCallback
+                            );
+                        },
+                        errorCallback
+                    );
+                }
+            }
+        });
+    });

--- a/client/apollo/js/Store/SeqFeature/QuantitativeCombination.js
+++ b/client/apollo/js/Store/SeqFeature/QuantitativeCombination.js
@@ -1,0 +1,18 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'dojo/Deferred',
+        'JBrowse/Store/SeqFeature/QuantitativeCombination',
+        'WebApollo/Store/SeqFeature/_RemoteCombinationMixin'
+    ],
+    function(
+        declare,
+        array,
+        Deferred,
+        QuantitativeCombinationStore,
+        RemoteCombinationMixin
+    ) {
+        return declare([ QuantitativeCombinationStore, RemoteCombinationMixin ], {
+
+        });
+    });

--- a/client/apollo/js/Store/SeqFeature/SNPCoverage.js
+++ b/client/apollo/js/Store/SeqFeature/SNPCoverage.js
@@ -1,0 +1,171 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'JBrowse/Util',
+        'JBrowse/Store/SeqFeature/SNPCoverage',
+        'JBrowse/Model/NestedFrequencyTable',
+        'JBrowse/Model/CoverageFeature'
+    ],
+    function(
+        declare,
+        array,
+        Util,
+        SNPCoverageStore,
+        NestedFrequencyTable,
+        CoverageFeature
+    ) {
+
+        return declare( SNPCoverageStore, {
+
+            /**
+             * Override getFeatures in JBrowse/Store/SeqFeature/SNPCoverage
+             */
+            getFeatures: function( query, featureCallback, finishCallback, errorCallback ) {
+                var thisB = this;
+                var leftBase  = query.start;
+                var rightBase = query.end;
+                var scale = query.scale || query.basesPerSpan && 1/query.basesPerSpan || 10; // px/bp
+                var widthBp = rightBase-leftBase;
+                var widthPx = widthBp * scale;
+
+                var binWidth = function() {
+                    var bpPerPixel = 1/scale;
+                    if( bpPerPixel <= 1/thisB.config.mismatchScale ) {
+                        return 1;
+                    } else {
+                        return Math.ceil( bpPerPixel );
+                    }
+                }();
+
+                function binNumber( bp ) {
+                    return Math.floor( (bp-leftBase) / binWidth );
+                };
+
+                // init coverage bins
+                var binMax = Math.ceil( (rightBase-leftBase)/binWidth );
+                var coverageBins = new Array( binMax );
+                for( var i = 0; i < binMax; i++ ) {
+                    coverageBins[i] = new NestedFrequencyTable();
+                    if( binWidth == 1 )
+                        coverageBins[i].snpsCounted = true;
+                }
+
+                function forEachBin( start, end, callback ) {
+                    var s = (start     - leftBase)/binWidth;
+                    var e = (end   - 1 - leftBase)/binWidth;
+                    var sb = Math.floor(s),
+                        eb = Math.floor(e);
+
+                    if( sb >= binMax || eb < 0 )
+                        return; // does not overlap this block
+
+                    // enforce 0 <= bin < binMax
+                    if( sb < 0 )
+                        s = sb = 0;
+                    if( eb >= binMax ) {
+                        eb = binMax-1;
+                        e  = binMax;
+                    }
+
+                    // now iterate
+                    if( sb == eb ) // if in the same bin, just one call
+                        callback( sb, e-s );
+                    else { // if in different bins, two or more calls
+                        callback( sb, sb+1-s );
+                        for( var i = sb+1; i < eb; i++ )
+                            callback( i, 1 );
+                        callback( eb, e-eb );
+                    }
+                };
+
+                thisB.store.getFeatures(
+                    query,
+                    function( feature ) {
+                        if( ! thisB.filter( feature ) )
+                            return;
+
+                        var strand = { '-1': '-', '1': '+' }[ ''+feature.get('strand') ] || 'unstranded';
+
+                        // increment start and end partial-overlap bins by proportion of overlap
+                        forEachBin( feature.get('start'), feature.get('end'), function( bin, overlap ) {
+                            coverageBins[bin].getNested('reference').increment( strand, overlap );
+                        });
+
+                        // Calculate SNP coverage
+                        if( binWidth == 1 ) {
+                            var mismatches = thisB._getMismatches( feature );
+                            // loops through mismatches and updates coverage variables accordingly.
+                            for (var i = 0; i < mismatches.length; i++) {
+                                var mismatch = mismatches[i];
+                                forEachBin( feature.get('start')+mismatch.start,
+                                    feature.get('start')+mismatch.start+mismatch.length,
+                                    function( binNumber, overlap ) {
+                                        // Note: we decrement 'reference' so that total of the score is the total coverage
+                                        var bin = coverageBins[binNumber];
+                                        bin.getNested('reference').decrement( strand, overlap );
+                                        var base = mismatch.base;
+                                        if( mismatch.type == 'insertion' )
+                                            base = 'ins '+base;
+                                        else if( mismatch.type == 'skip' )
+                                            base = 'skip';
+                                        bin.getNested( base ).increment( strand, overlap );
+                                    });
+                            }
+                        }
+                    },
+                    function ( args ) {
+                        var makeFeatures = function() {
+                            // make fake features from the coverage
+                            for( var i = 0; i < coverageBins.length; i++ ) {
+                                var bpOffset = leftBase+binWidth*i;
+                                featureCallback( new CoverageFeature({
+                                    start: bpOffset,
+                                    end:   bpOffset+binWidth,
+                                    score: coverageBins[i]
+                                }));
+                            }
+                            finishCallback( args ); // optional arguments may change callback behaviour (e.g. add masking)
+                        };
+
+                        // if we are zoomed to base level, try to fetch the
+                        // reference sequence for this region and record each
+                        // of the bases in the coverage bins
+
+                        // adjusting query to use sequenceList since are requesting data from the server
+                        query.ref = thisB.browser.refSeq.name;
+                        if( binWidth == 1 ) {
+                            var sequence;
+                            thisB.browser.getStore(
+                                'refseqs', function( refSeqStore ) {
+                                    if( refSeqStore ) {
+                                        refSeqStore.getFeatures(
+                                            query,
+                                            function(f) {
+                                                sequence = f.get('seq');
+                                            },
+                                            function() {
+                                                if( sequence ) {
+                                                    for( var base = leftBase; base <= rightBase; base++ ) {
+                                                        var bin = binNumber( base );
+                                                        coverageBins[bin].refBase = sequence[bin];
+                                                    }
+                                                }
+                                                makeFeatures();
+                                            },
+                                            makeFeatures
+                                        );
+                                    } else {
+                                        makeFeatures();
+                                    }
+                                });
+                        }
+                        else {
+                            makeFeatures();
+                        }
+                    }
+                    , errorCallback
+                );
+            }
+        });
+
+});

--- a/client/apollo/js/Store/SeqFeature/_RemoteCombinationMixin.js
+++ b/client/apollo/js/Store/SeqFeature/_RemoteCombinationMixin.js
@@ -1,0 +1,113 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'dojo/Deferred',
+        'dojo/when',
+        'dojo/promise/all',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils'
+    ],
+    function(
+        declare,
+        array,
+        Deferred,
+        when,
+        all,
+        Util,
+        JSONUtils
+    ) {
+
+        // Helper object that wraps a feature and which store it comes from
+        var featureWrapper = Util.fastDeclare(
+            {
+                get: function( arg ) {
+                    return this.feature.get(arg);
+                },
+
+                id: function() {
+                    return this.feature.id()+this.storeName;
+                },
+
+                parent: function() {
+                    return this.feature.parent();
+                },
+
+                children: function() {
+                    return this.feature.children();
+                },
+
+                tags: function() {
+                    return this.feature.tags();
+                },
+
+                constructor: function( feat, storeName ) {
+                    this.feature = feat;
+                    this.storeName = storeName;
+                    this.source = feat ? feat.source : undefined;
+                }
+            }
+        );
+
+        return declare( null, {
+
+            _getFeatures: function( query, featCallback, doneCallback, errorCallback ) {
+                var thisB = this;
+                if(this.stores.length == 1) {
+                    this.stores[0].getFeatures( query, featCallback, doneCallback, errorCallback);
+                    return;
+                }
+
+                if(this.regionLoaded) {
+                    var spans = array.filter(this.regionLoaded.spans, function(span) {
+                        return span.start <= query.end && span.end >= query.start;
+                    });
+                    var features = this.createFeatures(spans);
+                    this.finish(features, spans, featCallback, doneCallback);
+                    return;
+                }
+
+                // featureArrays will be a map from the names of the stores to an array of each store's features
+                var featureArrays = {};
+
+                var sequenceList = JSONUtils.parseSequenceList(query.ref);
+                if (sequenceList[0].reverse) {
+                    errorCallback(JSONUtils.NOT_YET_SUPPORTED_MESSAGE);
+                }
+                else {
+                    query.ref = sequenceList[0].name;
+                    // Generate map
+                    var fetchAllFeatures = thisB.stores.map(
+                        function (store) {
+                            var d = new Deferred();
+                            if ( !featureArrays[store.name] ) {
+                                featureArrays[store.name] = [];
+                                store.getFeatures(
+                                    query,
+                                    dojo.hitch( this, function( feature ) {
+                                        var feat = new featureWrapper( feature, store.name );
+                                        featureArrays[store.name].push( feat );
+                                    }),
+                                    function(){d.resolve( featureArrays[store.name] ); },
+                                    function(){d.reject("Error fetching features for store " + store.name);}
+                                );
+                            } else {
+                                d.resolve(featureArrays[store.name], true);
+                            }
+                            d.then(function(){}, errorCallback); // Makes sure that none of the rejected deferred promises keep propagating
+                            return d.promise;
+                        }
+                    );
+
+                    // Once we have all features, combine them according to the operation tree and create new features based on them.
+                    when( all( fetchAllFeatures ), function() {
+                        // Create a set of spans based on the evaluation of the operation tree
+                        var spans = thisB.evalTree(featureArrays, thisB.opTree, query);
+                        var features = thisB.createFeatures(spans);
+                        thisB.finish(features, spans, featCallback, doneCallback);
+                    }, errorCallback);
+                }
+            }
+        });
+
+
+    });

--- a/client/apollo/js/View/Track/Combination.js
+++ b/client/apollo/js/View/Track/Combination.js
@@ -1,0 +1,36 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/lang',
+        'JBrowse/View/Track/Combination'
+    ],
+    function(
+        declare,
+        lang,
+        CombinationTrack
+    ) {
+
+        return declare( CombinationTrack, {
+
+            constructor: function() {
+                // extending supported types
+                dojo.safeMixin(this.supportedBy, {
+                    "WebApollo/View/Track/DraggableHTMLFeatures": "set",
+                    "WebApollo/View/Track/WebApolloCanvasFeatures": "set",
+                    "WebApollo/View/Track/WebApolloHTMLVariants": "set",
+                    "WebApollo/View/Track/WebApolloCanvasVariants": "set",
+                    "WebApollo/View/Track/DraggableAlignments": "BAM",
+                    "WebApollo/View/Track/RemoteDraggableHTMLFeatures": "set",
+                    "WebApollo/View/Track/RemoteWebApolloCanvasFeatures": "set",
+                    "WebApollo/View/Track/RemoteWebApolloHTMLVariants": "set",
+                    "WebApollo/View/Track/RemoteWebApolloCanvasVariants": "set",
+                    "WebApollo/View/Track/RemoteDraggableAlignments": "BAM",
+                    "WebApollo/View/Track/RemoteAlignments2": "BAM",
+                    "WebApollo/View/Track/RemoteSNPCoverage": "BAM",
+                    "WebApollo/View/Track/RemoteFeatureCoverage": "BAM",
+                    "WebApollo/View/Track/Wiggle/RemoteXYPlot": "quantitative",
+                    "WebApollo/View/Track/Wiggle/RemoteDensity": "quantitative",
+                    "WebApollo/Store/SeqFeature/Combination": "set"
+                });
+            }
+        });
+});

--- a/client/apollo/js/View/Track/Combination.js
+++ b/client/apollo/js/View/Track/Combination.js
@@ -31,6 +31,59 @@ define([
                     "WebApollo/View/Track/Wiggle/RemoteDensity": "quantitative",
                     "WebApollo/Store/SeqFeature/Combination": "set"
                 });
+
+                // overriding configuration
+                dojo.safeMixin(this.trackClasses, {
+                    "set":  {
+                        resultsTypes:   [{
+                            name: "HTMLFeatures",
+                            path: "JBrowse/View/Track/HTMLFeatures"
+                        }
+                        ],
+                        store:        "WebApollo/Store/SeqFeature/Combination",
+                        allowedOps:   ["&", "U", "X", "S"],
+                        defaultOp :   "&"
+                    },
+                    "quantitative":        {
+                        resultsTypes:   [{
+                            name: "XYPlot",
+                            path: "JBrowse/View/Track/Wiggle/XYPlot"
+                        },
+                            {
+                                name: "Density",
+                                path: "JBrowse/View/Track/Wiggle/Density"
+                            }],
+                        store:        "WebApollo/Store/SeqFeature/QuantitativeCombination",
+                        allowedOps:   ["+", "-", "*", "/"],
+                        defaultOp:    "+"
+                    },
+                    "mask": {
+                        resultsTypes: [{
+                            name: "XYPlot",
+                            path: "JBrowse/View/Track/Wiggle/XYPlot"
+                        },
+                            {
+                                name: "Density",
+                                path: "JBrowse/View/Track/Wiggle/Density"
+                            }],
+                        store:          "WebApollo/Store/SeqFeature/Mask",
+                        allowedOps: ["M", "N"],
+                        defaultOp:      "M"
+                    },
+                    "BAM": {
+                        resultsTypes: [{
+                            name: "Detail",
+                            path: "JBrowse/View/Track/Alignments2"
+                        },
+                            {
+                                name: "Summary",
+                                path: "JBrowse/View/Track/SNPCoverage"
+                            }],
+                        store:          "WebApollo/Store/SeqFeature/BAMCombination",
+                        allowedOps: ["U"],
+                        defaultOp:      "U"
+                    }
+                })
             }
         });
 });

--- a/client/apollo/js/View/Track/RemoteAlignments2.js
+++ b/client/apollo/js/View/Track/RemoteAlignments2.js
@@ -1,0 +1,186 @@
+define( [
+        'dojo/_base/declare',
+        'dojo/dom-construct',
+        'dojo/_base/array',
+        'dojo/Deferred',
+        'dojo/promise/all',
+        'JBrowse/Util',
+        'JBrowse/View/Track/Alignments2'
+    ],
+    function(
+        declare,
+        domConstruct,
+        array,
+        Deferred,
+        all,
+        Util,
+        Alignments2
+    ) {
+
+        return declare( Alignments2, {
+
+            /**
+             * Override fillFeatures
+             */
+            fillFeatures: function (args) {
+                var thisB = this;
+
+                var blockIndex = args.blockIndex;
+                var block = args.block;
+                var blockWidthPx = block.domNode.offsetWidth;
+                var scale = args.scale;
+                var leftBase = args.leftBase;
+                var rightBase = args.rightBase;
+                var finishCallback = args.finishCallback;
+
+                var fRects = [];
+
+                // count of how many features are queued up to be laid out
+                var featuresInProgress = 0;
+                // promise that resolved when all the features have gotten laid out by their glyphs
+                var featuresLaidOut = new Deferred();
+                // flag that tells when all features have been read from the
+                // store (not necessarily laid out yet)
+                var allFeaturesRead = false;
+
+                var errorCallback = dojo.hitch(thisB, function (e) {
+                    this._handleError(e, args);
+                    finishCallback(e);
+                });
+
+                var layout = this._getLayout(scale);
+
+                // query for a slightly larger region than the block, so that
+                // we can draw any pieces of glyphs that overlap this block,
+                // but the feature of which does not actually lie in the block
+                // (long labels that extend outside the feature's bounds, for
+                // example)
+                var bpExpansion = Math.round(this.config.maxFeatureGlyphExpansion / scale);
+
+                var region = {
+                    ref: this.refSeq.name,
+                    start: Math.max(0, leftBase - bpExpansion),
+                    end: rightBase + bpExpansion
+                };
+
+                var sequenceList = JSONUtils.parseSequenceList(this.refSeq.name);
+                if (sequenceList[0].reverse) {
+                    errorCallback(JSONUtils.NOT_YET_SUPPORTED_MESSAGE);
+                }
+                else {
+                    region.ref = sequenceList[0].name;
+                    this.store.getFeatures(region,
+                        function (feature) {
+                            if (thisB.destroyed || !thisB.filterFeature(feature))
+                                return;
+                            fRects.push(null); // put a placeholder in the fRects array
+                            featuresInProgress++;
+                            var rectNumber = fRects.length - 1;
+
+                            // get the appropriate glyph object to render this feature
+                            thisB.getGlyph(
+                                args,
+                                feature,
+                                function (glyph) {
+                                    // have the glyph attempt
+                                    // to add a rendering of
+                                    // this feature to the
+                                    // layout
+                                    var fRect = glyph.layoutFeature(
+                                        args,
+                                        layout,
+                                        feature
+                                    );
+                                    if (fRect === null) {
+                                        // could not lay out, would exceed our configured maxHeight
+                                        // mark the block as exceeding the max height
+                                        block.maxHeightExceeded = true;
+                                    }
+                                    else {
+                                        // laid out successfully
+                                        if (!( fRect.l >= blockWidthPx || fRect.l + fRect.w < 0 ))
+                                            fRects[rectNumber] = fRect;
+                                    }
+
+                                    // this might happen after all the features have been sent from the store
+                                    if (!--featuresInProgress && allFeaturesRead) {
+                                        featuresLaidOut.resolve();
+                                    }
+                                },
+                                errorCallback
+                            );
+                        },
+
+                        // callback when all features sent
+                        function () {
+                            if (thisB.destroyed)
+                                return;
+
+                            allFeaturesRead = true;
+                            if (!featuresInProgress && !featuresLaidOut.isFulfilled()) {
+                                featuresLaidOut.resolve();
+                            }
+
+                            featuresLaidOut.then(function () {
+
+                                var totalHeight = layout.getTotalHeight();
+                                var c = block.featureCanvas =
+                                    domConstruct.create(
+                                        'canvas',
+                                        {
+                                            height: totalHeight,
+                                            width: block.domNode.offsetWidth + 1,
+                                            style: {
+                                                cursor: 'default',
+                                                height: totalHeight + 'px',
+                                                position: 'absolute'
+                                            },
+                                            innerHTML: 'Your web browser cannot display this type of track.',
+                                            className: 'canvas-track'
+                                        },
+                                        block.domNode
+                                    );
+                                var ctx = c.getContext('2d');
+
+                                // finally query the various pixel ratios
+                                var ratio = Util.getResolution(ctx, thisB.browser.config.highResolutionMode);
+                                // upscale canvas if the two ratios don't match
+                                if (thisB.browser.config.highResolutionMode != 'disabled' && ratio >= 1) {
+
+                                    var oldWidth = c.width;
+                                    var oldHeight = c.height;
+
+                                    c.width = oldWidth * ratio;
+                                    c.height = oldHeight * ratio;
+
+                                    c.style.width = oldWidth + 'px';
+                                    c.style.height = oldHeight + 'px';
+
+                                    // now scale the context to counter
+                                    // the fact that we've manually scaled
+                                    // our canvas element
+                                    ctx.scale(ratio, ratio);
+                                }
+
+
+                                if (block.maxHeightExceeded)
+                                    thisB.markBlockHeightOverflow(block);
+
+                                thisB.heightUpdate(totalHeight,
+                                    blockIndex);
+
+
+                                thisB.renderFeatures(args, fRects);
+
+                                thisB.renderClickMap(args, fRects);
+
+                                finishCallback();
+                            });
+                        },
+                        errorCallback
+                    );
+                }
+            }
+
+        });
+});

--- a/client/apollo/js/View/Track/RemoteAlignments2.js
+++ b/client/apollo/js/View/Track/RemoteAlignments2.js
@@ -5,6 +5,7 @@ define( [
         'dojo/Deferred',
         'dojo/promise/all',
         'JBrowse/Util',
+        'WebApollo/JSONUtils',
         'JBrowse/View/Track/Alignments2'
     ],
     function(
@@ -14,6 +15,7 @@ define( [
         Deferred,
         all,
         Util,
+        JSONUtils,
         Alignments2
     ) {
 

--- a/client/apollo/js/View/Track/RemoteDraggableAlignments.js
+++ b/client/apollo/js/View/Track/RemoteDraggableAlignments.js
@@ -1,0 +1,112 @@
+define([
+        'dojo/_base/declare',
+        'dojo/dom-construct',
+        'dojo/_base/array',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils',
+        'WebApollo/View/Track/DraggableAlignments'
+    ],
+    function(
+        declare,
+        domConstruct,
+        array,
+        Util,
+        JSONUtils,
+        DraggableAlignmentsTrack
+    ) {
+
+    return declare( DraggableAlignmentsTrack, {
+
+        /**
+         * Override fillFeatures
+         */
+        fillFeatures: function(args) {
+            var blockIndex = args.blockIndex;
+            var block = args.block;
+            var leftBase = args.leftBase;
+            var rightBase = args.rightBase;
+            var scale = args.scale;
+            var stats = args.stats;
+            var containerStart = args.containerStart;
+            var containerEnd = args.containerEnd;
+            var finishCallback = args.finishCallback;
+            var browser = this.browser;
+
+            this.scale = scale;
+
+            block.featureNodes = {};
+
+            //determine the glyph height, arrowhead width, label text dimensions, etc.
+            if( !this.haveMeasurements ) {
+                this.measureStyles();
+                this.haveMeasurements = true;
+            }
+
+            var labelScale       = this.config.style.labelScale       || stats.featureDensity * this.config.style._defaultLabelScale;
+            var descriptionScale = this.config.style.descriptionScale || stats.featureDensity * this.config.style._defaultDescriptionScale;
+
+            var curTrack = this;
+
+            var featCallback = dojo.hitch(this,function( feature ) {
+                var uniqueId = feature.id();
+                if( ! this._featureIsRendered( uniqueId ) ) {
+                    if( this.filterFeature( feature ) )  {
+                        // hook point
+                        var render = 1;
+                        if (typeof this.renderFilter === 'function')
+                            render = this.renderFilter(feature);
+
+                        if (render === 1) {
+                            this.addFeatureToBlock( feature, uniqueId, block, scale, labelScale, descriptionScale, containerStart, containerEnd );
+                        }
+                    }
+                }
+            });
+
+            var errorCallback = dojo.hitch(this, function(e) {
+                this._handleError(e, args);
+                finishCallback(e);
+            });
+
+            var sequenceList = JSONUtils.parseSequenceList(this.refSeq.name);
+            if (sequenceList[0].reverse) {
+                errorCallback(JSONUtils.NOT_YET_SUPPORTED_MESSAGE)
+            }
+            else {
+                var refSeqName = sequenceList[0].name;
+                this.store.getFeatures( { ref: refSeqName,
+                        start: leftBase,
+                        end: rightBase
+                    },
+                    featCallback,
+                    function ( args ) {
+                        curTrack.heightUpdate(curTrack._getLayout(scale).getTotalHeight(), blockIndex);
+                        if ( args && args.maskingSpans ) {
+                            //note: spans have to be inverted
+                            var invSpan = [];
+                            invSpan[0] = { start: leftBase };
+                            var i = 0;
+                            for ( var span in args.maskingSpans) {
+                                if (args.maskingSpans.hasOwnProperty(span)) {
+                                    span = args.maskingSpans[span];
+                                    invSpan[i].end = span.start;
+                                    i++;
+                                    invSpan[i] = { start: span.end };
+                                }
+                            }
+                            invSpan[i].end = rightBase;
+                            if (invSpan[i].end <= invSpan[i].start) {
+                                invSpan.splice(i,1); }
+                            if (invSpan[0].end <= invSpan[0].start) {
+                                invSpan.splice(0,1); }
+                            curTrack.maskBySpans( invSpan, args.maskingSpans );
+                        }
+                        finishCallback();
+                    },
+                    errorCallback
+                );
+            }
+        }
+    });
+
+});

--- a/client/apollo/js/View/Track/RemoteDraggableHTMLFeatures.js
+++ b/client/apollo/js/View/Track/RemoteDraggableHTMLFeatures.js
@@ -1,0 +1,24 @@
+define([
+        'dojo/_base/declare',
+        'dojo/dom-construct',
+        'dojo/_base/array',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils',
+        'WebApollo/View/Track/DraggableHTMLFeatures',
+        'WebApollo/View/Track/_RemoteHTMLMixin'
+    ],
+    function(
+        declare,
+        domConstruct,
+        array,
+        Util,
+        JSONUtils,
+        DraggableHTMLFeatureTrack,
+        RemoteHTMLMixin
+    ) {
+
+        return declare( [ DraggableHTMLFeatureTrack, RemoteHTMLMixin ], {
+
+        });
+
+});

--- a/client/apollo/js/View/Track/RemoteFeatureCoverage.js
+++ b/client/apollo/js/View/Track/RemoteFeatureCoverage.js
@@ -1,0 +1,31 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'WebApollo/View/Track/Wiggle/RemoteXYPlot',
+        'JBrowse/Util',
+        'JBrowse/Store/SeqFeature/Coverage'
+    ],
+    function(
+        declare,
+        array,
+        RemoteWiggleXYPlotTrack,
+        Util,
+        CoverageStore
+    ) {
+
+        return declare( RemoteWiggleXYPlotTrack, {
+
+            constructor: function( args ) {
+                this.store = new CoverageStore( { store: this.store, browser: this.browser });
+            },
+
+            _defaultConfig: function() {
+                return Util.deepUpdate(
+                    dojo.clone( this.inherited(arguments) ),
+                    {
+                        autoscale: 'local'
+                    }
+                );
+            }
+        });
+});

--- a/client/apollo/js/View/Track/RemoteSNPCoverage.js
+++ b/client/apollo/js/View/Track/RemoteSNPCoverage.js
@@ -1,0 +1,387 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'dojo/_base/lang',
+        'dojo/promise/all',
+        'JBrowse/View/Track/Wiggle/_Scale',
+        'WebApollo/View/Track/Wiggle/RemoteXYPlot',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils',
+        'JBrowse/View/Track/_AlignmentsMixin',
+        'WebApollo/Store/SeqFeature/SNPCoverage'
+    ],
+    function(
+        declare,
+        array,
+        lang,
+        all,
+        Scale,
+        RemoteXYPlotTrack,
+        Util,
+        JSONUtils,
+        AlignmentsMixin,
+        SNPCoverageStore
+    ) {
+
+        return declare( [ RemoteXYPlotTrack, AlignmentsMixin ], {
+
+            constructor: function() {
+                delete this.config.bicolor_pivot;
+                delete this.config.scale;
+                delete this.config.align;
+
+                var thisB = this;
+                this.store = new SNPCoverageStore(
+                    { store: this.store,
+                        config: {
+                            mismatchScale: this.config.mismatchScale
+                        },
+                        browser: this.browser,
+                        filter: function( f ) {
+                            return thisB.filterFeature( f );
+                        }
+                    });
+            },
+
+            _defaultConfig: function() {
+                return Util.deepUpdate(
+                    dojo.clone( this.inherited(arguments) ),
+                    {
+                        autoscale: 'local',
+                        min_score: 0,
+
+                        mismatchScale: 1/10,
+
+                        hideDuplicateReads: true,
+                        logScaleOption: false,
+                        hideQCFailingReads: true,
+                        hideSecondary: true,
+                        hideSupplementary: true,
+                        hideMissingMatepairs: false,
+                        hideUnmapped: true
+                    }
+                );
+            },
+
+            /*
+             * Draw a set of features on the canvas.
+             * @private
+             */
+            _drawFeatures: function( scale, leftBase, rightBase, block, canvas, features, featureRects, dataScale ) {
+                var thisB = this;
+                var context = canvas.getContext('2d');
+                var canvasHeight = canvas.height;
+
+                var ratio = Util.getResolution( context, this.browser.config.highResolutionMode );
+                var toY = dojo.hitch( this, function( val ) {
+                    return canvasHeight * ( 1-dataScale.normalize(val) ) / ratio;
+                });
+                var originY = toY( dataScale.origin );
+
+                // a canvas element below the histogram that will contain indicators of likely SNPs
+                var snpCanvasHeight = 20;
+                var snpCanvas = dojo.create('canvas',
+                    {height: snpCanvasHeight,
+                        width: canvas.width,
+                        style: {
+                            cursor: 'default',
+                            width: "100%",
+                            height: snpCanvasHeight + "px"
+                        },
+                        innerHTML: 'Your web browser cannot display this type of track.',
+                        className: 'SNP-indicator-track'
+                    }, block.domNode);
+                var snpContext = snpCanvas.getContext('2d');
+
+                // finally query the various pixel ratios
+                var ratio = Util.getResolution( snpContext, this.browser.config.highResolutionMode );
+                // upscale canvas if the two ratios don't match
+                if ( this.browser.config.highResolutionMode !='disabled' && ratio!=1 ) {
+
+                    var oldWidth = snpCanvas.width;
+                    var oldHeight = snpCanvas.height;
+
+                    snpCanvas.width = oldWidth * ratio;
+                    snpCanvas.height = oldHeight * ratio;
+
+                    //c.style.width = oldWidth + 'px';
+                    snpCanvas.style.height = oldHeight + 'px';
+
+                    // now scale the context to counter
+                    // the fact that we've manually scaled
+                    // our canvas element
+                    snpContext.scale(ratio, ratio);
+                }
+
+
+                var negColor  = this.config.style.neg_color;
+                var clipColor = this.config.style.clip_marker_color;
+                var bgColor   = this.config.style.bg_color;
+                var disableClipMarkers = this.config.disable_clip_markers;
+
+                var drawRectangle = function(ID, yPos, height, fRect) {
+                    if( yPos <= canvasHeight ) { // if the rectangle is visible at all
+                        context.fillStyle = thisB.colorForBase(ID);
+                        if( yPos <= originY ) {
+                            // bar goes upward
+                            thisB._fillRectMod( context, fRect.l, yPos, fRect.w, height);
+                            if( !disableClipMarkers && yPos < 0 ) { // draw clip marker if necessary
+                                context.fillStyle = clipColor || negColor;
+                                thisB._fillRectMod( context, fRect.l, 0, fRect.w, 2 );
+                            }
+                        }
+                        else {
+                            // bar goes downward
+                            thisB._fillRectMod( context, fRect.l, originY, fRect.w, height );
+                            if( !disableClipMarkers && yPos >= canvasHeight ) { // draw clip marker if necessary
+                                context.fillStyle = clipColor || thisB.colorForBase(ID);
+                                thisB._fillRectMod( context, fRect.l, canvasHeight-3, fRect.w, 2 );
+                            }
+                        }
+                    }
+                };
+
+                // Note: 'reference' is done first to ensure the grey part of the graph is on top
+                dojo.forEach( features, function(f,i) {
+                    var fRect = featureRects[i];
+                    var score = f.get('score');
+
+                    // draw the background color if we are configured to do so
+                    if( bgColor ) {
+                        context.fillStyle = bgColor;
+                        thisB._fillRectMod( context, fRect.l, 0, fRect.w, canvasHeight );
+                    }
+
+                    drawRectangle( 'reference', toY( score.total() ), originY-toY( score.get('reference'))+1, fRect);
+                });
+
+                dojo.forEach( features, function(f,i) {
+                    var fRect = featureRects[i];
+                    var score = f.get('score');
+                    var totalHeight = score.total();
+
+                    // draw indicators of SNPs if base coverage is greater than 50% of total coverage
+                    score.forEach( function( count, category ) {
+                        if ( !{reference:true,skip:true,deletion:true}[category] && count > 0.5*totalHeight ) {
+                            snpContext.save();
+                            if( thisB.browser.config.highResolutionMode != 'disabled' )
+                                snpContext.scale(ratio, 1);
+                            snpContext.beginPath();
+                            snpContext.arc( (fRect.l + 0.5*fRect.w),
+                                0.40*snpCanvas.height/ratio,
+                                0.20*snpCanvas.height/ratio,
+                                1.75 * Math.PI,
+                                1.25 * Math.PI,
+                                false);
+                            snpContext.lineTo(fRect.l + 0.5*fRect.w, 0);
+                            snpContext.closePath();
+                            snpContext.fillStyle = thisB.colorForBase(category);
+                            snpContext.fill();
+                            snpContext.lineWidth = 1;
+                            snpContext.strokeStyle = 'black';
+                            snpContext.stroke();
+                            if( thisB.browser.config.highResolutionMode != 'disabled' )
+                                snpContext.restore();
+                        }
+                    });
+
+                    totalHeight -= score.get('reference');
+
+                    score.forEach( function( count, category ) {
+                        if ( category != 'reference' ) {
+                            drawRectangle( category, toY(totalHeight), originY-toY( count )+1, fRect);
+                            totalHeight -= count;
+                        }
+                    });
+                }, this );
+            },
+
+            /**
+             * Override _getBlockFeatures
+             */
+            _getBlockFeatures: function (args) {
+                var thisB = this;
+                var blockIndex = args.blockIndex;
+                var block = args.block;
+
+                var leftBase = args.leftBase;
+                var rightBase = args.rightBase;
+
+                var scale = args.scale;
+                var finishCallback = args.finishCallback || function () {
+                    };
+
+                var canvasWidth = this._canvasWidth(args.block);
+
+                var errorCallback = dojo.hitch(this, function(e) {
+                    this._handleError(e, args);
+                    finishCallback(e);
+                });
+
+                var features = [];
+                var sequenceList = JSONUtils.parseSequenceList(this.refSeq.name);
+                if (sequenceList[0].reverse) {
+                    errorCallback(JSONUtils.NOT_YET_SUPPORTED_MESSAGE)
+                }
+                else {
+                    var refSeqName = sequenceList[0].name;
+                    this.getFeatures(
+                        {
+                            ref: refSeqName,
+                            basesPerSpan: 1 / scale,
+                            scale: scale,
+                            start: leftBase,
+                            end: rightBase + 1
+                        },
+
+                        function (f) {
+                            if (thisB.filterFeature(f))
+                                features.push(f);
+                        },
+                        dojo.hitch(this, function (args) {
+
+                            // if the block has been freed in the meantime,
+                            // don't try to render
+                            if (!(block.domNode && block.domNode.parentNode ))
+                                return;
+
+                            var featureRects = array.map(features, function (f) {
+                                return this._featureRect(scale, leftBase, canvasWidth, f);
+                            }, this);
+
+                            block.features = features;
+                            block.featureRects = featureRects;
+                            block.pixelScores = this._calculatePixelScores(this._canvasWidth(block), features, featureRects);
+
+                            if (args && args.maskingSpans)
+                                block.maskingSpans = args.maskingSpans; // used for masking
+
+                            finishCallback();
+                        }),
+                        errorCallback
+                    );
+                }
+            },
+
+            /**
+             * Override _getScalingStats
+             */
+            _getScalingStats: function( viewArgs, callback, errorCallback ) {
+                if( ! Scale.prototype.needStats( this.config ) ) {
+                    callback( null );
+                    return null;
+                }
+                else if( this.config.autoscale == 'local' ) {
+                    var region = lang.mixin( { scale: viewArgs.scale }, this.browser.view.visibleRegion() );
+                    region.ref = JSONUtils.parseSequenceList(region.ref)[0].name;
+                    region.start = Math.ceil( region.start );
+                    region.end = Math.floor( region.end );
+                    return this.getRegionStats.call( this, region, callback, errorCallback );
+                }
+                else {
+                    return this.getGlobalStats.call( this, callback, errorCallback );
+                }
+            },
+
+            // Overwrites the method from WiggleBase
+            _draw: function( scale, leftBase, rightBase, block, canvas, features, featureRects, dataScale, pixels, spans ) {
+                // Note: pixels currently has no meaning, as the function that generates it is not yet defined for this track
+                this._preDraw(      scale, leftBase, rightBase, block, canvas, features, featureRects, dataScale );
+                this._drawFeatures( scale, leftBase, rightBase, block, canvas, features, featureRects, dataScale );
+                if ( spans ) {
+                    this._maskBySpans( scale, leftBase, canvas, spans );
+                }
+                this._postDraw(     scale, leftBase, rightBase, block, canvas, features, featureRects, dataScale );
+            },
+
+            /* If it's a boolean track, mask accordingly */
+            _maskBySpans: function( scale, leftBase, canvas, spans ) {
+                var context = canvas.getContext('2d');
+                var canvasHeight = canvas.height;
+                var booleanAlpha = this.config.style.masked_transparancy || 0.17;
+                this.config.style.masked_transparancy = booleanAlpha;
+
+                // make a temporary canvas to store image data
+                var tempCan = dojo.create( 'canvas', {height: canvasHeight, width: canvas.width} );
+                var ctx2 = tempCan.getContext('2d');
+
+                for ( var index in spans ) {
+                    if (spans.hasOwnProperty(index)) {
+                        var w = Math.round(( spans[index].end   - spans[index].start ) * scale );
+                        var l = Math.round(( spans[index].start - leftBase ) * scale );
+                        if (l+w >= canvas.width)
+                            w = canvas.width-l; // correct possible rounding errors
+                        if (w==0)
+                            continue; // skip if there's no width.
+                        ctx2.drawImage(canvas, l, 0, w, canvasHeight, l, 0, w, canvasHeight);
+                        context.globalAlpha = booleanAlpha;
+                        // clear masked region and redraw at lower opacity.
+                        context.clearRect(l, 0, w, canvasHeight);
+                        context.drawImage(tempCan, l, 0, w, canvasHeight, l, 0, w, canvasHeight);
+                        context.globalAlpha = 1;
+                    }
+                }
+            },
+
+            /*
+             * The following method is required to override the equivalent method in "WiggleBase.js"
+             * It displays more complete data.
+             */
+            _showPixelValue: function( scoreDisplay, score ) {
+                if( ! score || ! score.score )
+                    return false;
+                score = score.score;
+
+                function fmtNum( num ) {
+                    return parseFloat( num ).toPrecision(6).replace(/0+$/,'').replace(/\.$/,'');
+                }
+                function pctString( count ) {
+                    count = Math.round(count/total*100);
+                    if( typeof count == 'number' && ! isNaN(count) )
+                        return count+'%';
+                    return '';
+                }
+                if( score.snpsCounted ) {
+                    var total = score.total();
+                    var scoreSummary = '<table>';
+
+
+                    score.forEach( function( count, category ) {
+                        // if this count has more nested categories, do counts of those
+                        var subdistribution = '';
+                        if( count.forEach ) {
+                            subdistribution = [];
+                            count.forEach( function( count, category ) {
+                                subdistribution.push( fmtNum(count) + ' '+category );
+                            });
+                            subdistribution = subdistribution.join(', ');
+                            if( subdistribution )
+                                subdistribution = '('+subdistribution+')';
+                        }
+
+                        category = { '*': 'del', reference: 'Ref', skip: 'Skip/intron' }[category] || category;
+                        scoreSummary += '<tr><td>'+category + '</td><td class="count">' + fmtNum(count) + '</td><td class="pct">'
+                            +pctString(count)+'</td><td class="subdist">'+subdistribution + '</td></tr>';
+                    });
+                    scoreSummary += '<tr class="total"><td>Total</td><td class="count">'+fmtNum(total)+'</td><td class="pct">&nbsp;</td><td class="subdist">&nbsp;</td></tr>';
+                    scoreDisplay.innerHTML = scoreSummary+'</table>';
+                    return true;
+                } else {
+                    scoreDisplay.innerHTML = '<table><tr><td>Total</td><td class="count">'+fmtNum(score)+'</td></tr></table>';
+                    return true;
+                }
+            },
+
+            _trackMenuOptions: function() {
+                return all([ this.inherited(arguments), this._alignmentsFilterTrackMenuOptions() ])
+                    .then( function( options ) {
+                        var o = options.shift();
+                        options.unshift({ type: 'dijit/MenuSeparator' } );
+                        return o.concat.apply( o, options );
+                    });
+            }
+
+
+        });
+
+});

--- a/client/apollo/js/View/Track/RemoteWebApolloCanvasFeatures.js
+++ b/client/apollo/js/View/Track/RemoteWebApolloCanvasFeatures.js
@@ -1,0 +1,25 @@
+define([
+        'dojo/_base/declare',
+        'dojo/dom-construct',
+        'dojo/_base/array',
+        'dojo/Deferred',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils',
+        'WebApollo/View/Track/WebApolloCanvasFeatures',
+        'WebApollo/View/Track/_RemoteCanvasMixin'
+    ],
+    function(
+        declare,
+        domConstruct,
+        array,
+        Deferred,
+        Util,
+        JSONUtils,
+        WebApolloCanvasFeaturesTrack,
+        RemoteCanvasMixin
+    ) {
+
+        return declare( [ WebApolloCanvasFeaturesTrack, RemoteCanvasMixin ], {
+
+        });
+});

--- a/client/apollo/js/View/Track/RemoteWebApolloCanvasVariants.js
+++ b/client/apollo/js/View/Track/RemoteWebApolloCanvasVariants.js
@@ -1,0 +1,26 @@
+define([
+        'dojo/_base/declare',
+        'dojo/dom-construct',
+        'dojo/_base/array',
+        'dojo/Deferred',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils',
+        'WebApollo/View/Track/WebApolloCanvasVariants',
+        'WebApollo/View/Track/_RemoteCanvasMixin'
+    ],
+
+    function(
+        declare,
+        domConstruct,
+        array,
+        Deferred,
+        Util,
+        JSONUtils,
+        WebApolloCanvasVariants,
+        RemoteCanvasMixin
+    ) {
+
+        return declare( [ WebApolloCanvasVariants, RemoteCanvasMixin ], {
+
+        });
+});

--- a/client/apollo/js/View/Track/RemoteWebApolloHTMLVariants.js
+++ b/client/apollo/js/View/Track/RemoteWebApolloHTMLVariants.js
@@ -1,0 +1,24 @@
+define([
+        'dojo/_base/declare',
+        'dojo/dom-construct',
+        'dojo/_base/array',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils',
+        'WebApollo/View/Track/WebApolloHTMLVariants',
+        'WebApollo/View/Track/_RemoteHTMLMixin'
+    ],
+
+    function(
+        declare,
+        domConstruct,
+        array,
+        Util,
+        JSONUtils,
+        WebApolloHTMLVariants,
+        RemoteHTMLMixin
+    ) {
+
+        return declare( [ WebApolloHTMLVariants, RemoteHTMLMixin ], {
+
+        });
+});

--- a/client/apollo/js/View/Track/WebApolloCanvasVariants.js
+++ b/client/apollo/js/View/Track/WebApolloCanvasVariants.js
@@ -1,19 +1,15 @@
-define( [
-            'dojo/_base/declare',
-            'dojo/promise/all',
-            'JBrowse/Util',
-            'JBrowse/View/Track/CanvasVariants',
-            'WebApollo/View/Track/_WebApolloVariantDetailMixin'
-        ],
-        function(
-            declare,
-            all,
-            Util,
-            CanvasVariants,
-            WebApolloVariantDetailMixin
-        ) {
+define([
+        'dojo/_base/declare',
+        'JBrowse/View/Track/CanvasVariants',
+        'WebApollo/View/Track/_WebApolloVariantDetailMixin'
+    ],
+    function(
+        declare,
+        CanvasVariants,
+        WebApolloVariantDetailMixin
+    ) {
 
-return declare( [ CanvasVariants, WebApolloVariantDetailMixin ], {
+        return declare( [ CanvasVariants, WebApolloVariantDetailMixin ], {
 
-});
+        });
 });

--- a/client/apollo/js/View/Track/WebApolloHTMLVariants.js
+++ b/client/apollo/js/View/Track/WebApolloHTMLVariants.js
@@ -1,24 +1,15 @@
-define( [
-            'dojo/_base/declare',
-            'dojo/_base/lang',
-            'dojo/dom-construct',
-            'dojo/promise/all',
-            'JBrowse/Util',
-            'JBrowse/View/Track/HTMLVariants',
-            'WebApollo/View/Track/_WebApolloVariantDetailMixin'
+define([
+        'dojo/_base/declare',
+        'JBrowse/View/Track/HTMLVariants',
+        'WebApollo/View/Track/_WebApolloVariantDetailMixin'
     ],
-
     function(
         declare,
-        lang,
-        domConstruct,
-        all,
-        Util,
         HTMLVariants,
         WebApolloVariantDetailMixin
     ) {
 
-return declare( [ HTMLVariants, WebApolloVariantDetailMixin ], {
+        return declare( [ HTMLVariants, WebApolloVariantDetailMixin ], {
 
-});
+        });
 });

--- a/client/apollo/js/View/Track/Wiggle/RemoteDensity.js
+++ b/client/apollo/js/View/Track/Wiggle/RemoteDensity.js
@@ -1,0 +1,126 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'dojo/_base/lang',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils',
+        'JBrowse/View/Track/Wiggle/Density',
+        'JBrowse/View/Track/Wiggle/_Scale'
+    ],
+    function(
+        declare,
+        array,
+        lang,
+        Util,
+        JSONUtils,
+        DensityTrack,
+        Scale
+    ) {
+
+        return declare( DensityTrack, {
+
+            _defaultConfig: function() {
+                return Util.deepUpdate(
+                    dojo.clone( this.inherited(arguments) ),
+                    {
+                        maxExportSpan: 500000,
+                        style: {
+                            height: 31,
+                            pos_color: '#00f',
+                            neg_color: '#f00',
+                            bg_color: 'rgba(230,230,230,0.6)',
+                            clip_marker_color: 'black'
+                        }
+                    }
+                );
+            },
+
+            /**
+             * Override _getBlockFeatures
+             */
+            _getBlockFeatures: function (args) {
+                var thisB = this;
+                var blockIndex = args.blockIndex;
+                var block = args.block;
+
+                var leftBase = args.leftBase;
+                var rightBase = args.rightBase;
+
+                var scale = args.scale;
+                var finishCallback = args.finishCallback || function () {
+                    };
+
+                var canvasWidth = this._canvasWidth(args.block);
+
+                var features = [];
+
+                var errorCallback = dojo.hitch(this, function(e) {
+                    this._handleError(e, args);
+                    finishCallback(e);
+                });
+
+                var sequenceList = JSONUtils.parseSequenceList(this.refSeq.name);
+                if (sequenceList[0].reverse) {
+                    errorCallback(JSONUtils.NOT_YET_SUPPORTED_MESSAGE)
+                }
+                else {
+                    var refSeqName = sequenceList[0].name;
+                    this.getFeatures(
+                        {
+                            ref: refSeqName,
+                            basesPerSpan: 1 / scale,
+                            scale: scale,
+                            start: leftBase,
+                            end: rightBase + 1
+                        },
+
+                        function (f) {
+                            if (thisB.filterFeature(f))
+                                features.push(f);
+                        },
+                        dojo.hitch(this, function (args) {
+
+                            // if the block has been freed in the meantime,
+                            // don't try to render
+                            if (!(block.domNode && block.domNode.parentNode ))
+                                return;
+
+                            var featureRects = array.map(features, function (f) {
+                                return this._featureRect(scale, leftBase, canvasWidth, f);
+                            }, this);
+
+                            block.features = features;
+                            block.featureRects = featureRects;
+                            block.pixelScores = this._calculatePixelScores(this._canvasWidth(block), features, featureRects);
+
+                            if (args && args.maskingSpans)
+                                block.maskingSpans = args.maskingSpans; // used for masking
+
+                            finishCallback();
+                        }),
+                        errorCallback
+                    );
+                }
+            },
+
+            /**
+             * Override _getScalingStats
+             */
+            _getScalingStats: function( viewArgs, callback, errorCallback ) {
+                if( ! Scale.prototype.needStats( this.config ) ) {
+                    callback( null );
+                    return null;
+                }
+                else if( this.config.autoscale == 'local' ) {
+                    var region = lang.mixin( { scale: viewArgs.scale }, this.browser.view.visibleRegion() );
+                    region.ref = JSONUtils.parseSequenceList(region.ref)[0].name;
+                    region.start = Math.ceil( region.start );
+                    region.end = Math.floor( region.end );
+                    return this.getRegionStats.call( this, region, callback, errorCallback );
+                }
+                else {
+                    return this.getGlobalStats.call( this, callback, errorCallback );
+                }
+            }
+        });
+    });

--- a/client/apollo/js/View/Track/Wiggle/RemoteXYPlot.js
+++ b/client/apollo/js/View/Track/Wiggle/RemoteXYPlot.js
@@ -1,0 +1,127 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'dojo/_base/lang',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils',
+        'JBrowse/View/Track/Wiggle/XYPlot',
+        'JBrowse/View/Track/Wiggle/_Scale'
+    ],
+
+    function(
+        declare,
+        array,
+        lang,
+        Util,
+        JSONUtils,
+        XYPlotTrack,
+        Scale
+    ) {
+
+    return declare( XYPlotTrack, {
+
+        _defaultConfig: function() {
+            return Util.deepUpdate(
+                dojo.clone( this.inherited(arguments) ),
+                {
+                    style: {
+                        pos_color: 'blue',
+                        neg_color: 'red',
+                        origin_color: '#888',
+                        variance_band_color: 'rgba(0,0,0,0.3)'
+                    },
+                    autoscale: 'global',
+                    variance_band: 1,
+                    logScaleOption: true
+                }
+            );
+        },
+
+        /**
+         * Override _getBlockFeatures
+         */
+        _getBlockFeatures: function (args) {
+            var thisB = this;
+            var blockIndex = args.blockIndex;
+            var block = args.block;
+
+            var leftBase = args.leftBase;
+            var rightBase = args.rightBase;
+
+            var scale = args.scale;
+            var finishCallback = args.finishCallback || function () {};
+
+            var canvasWidth = this._canvasWidth(args.block);
+
+            var features = [];
+
+            var errorCallback = dojo.hitch(this, function (e) {
+                this._handleError(e, args);
+                finishCallback(e);
+            });
+
+            var sequenceList = JSONUtils.parseSequenceList(this.refSeq.name);
+            if (sequenceList[0].reverse) {
+                errorCallback(JSONUtils.NOT_YET_SUPPORTED_MESSAGE)
+            }
+            else {
+                var refSeqName = sequenceList[0].name;
+                this.getFeatures(
+                    {
+                        ref: refSeqName,
+                        basesPerSpan: 1 / scale,
+                        scale: scale,
+                        start: leftBase,
+                        end: rightBase + 1
+                    },
+
+                    function (f) {
+                        if (thisB.filterFeature(f))
+                            features.push(f);
+                    },
+                    dojo.hitch(this, function (args) {
+
+                        // if the block has been freed in the meantime,
+                        // don't try to render
+                        if (!(block.domNode && block.domNode.parentNode ))
+                            return;
+
+                        var featureRects = array.map(features, function (f) {
+                            return this._featureRect(scale, leftBase, canvasWidth, f);
+                        }, this);
+
+                        block.features = features;
+                        block.featureRects = featureRects;
+                        block.pixelScores = this._calculatePixelScores(this._canvasWidth(block), features, featureRects);
+
+                        if (args && args.maskingSpans)
+                            block.maskingSpans = args.maskingSpans; // used for masking
+
+                        finishCallback();
+                    }),
+                    errorCallback
+                );
+            }
+        },
+
+        /**
+         * Override _getScalingStats
+         */
+        _getScalingStats: function( viewArgs, callback, errorCallback ) {
+            if( ! Scale.prototype.needStats( this.config ) ) {
+                callback( null );
+                return null;
+            }
+            else if( this.config.autoscale == 'local' ) {
+                var region = lang.mixin( { scale: viewArgs.scale }, this.browser.view.visibleRegion() );
+                region.ref = JSONUtils.parseSequenceList(region.ref)[0].name;
+                region.start = Math.ceil( region.start );
+                region.end = Math.floor( region.end );
+                return this.getRegionStats.call( this, region, callback, errorCallback );
+            }
+            else {
+                return this.getGlobalStats.call( this, callback, errorCallback );
+            }
+        }
+    });
+});

--- a/client/apollo/js/View/Track/_RemoteCanvasMixin.js
+++ b/client/apollo/js/View/Track/_RemoteCanvasMixin.js
@@ -1,0 +1,181 @@
+define([
+        'dojo/_base/declare',
+        'dojo/dom-construct',
+        'dojo/_base/array',
+        'dojo/Deferred',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils'
+    ],
+    function(
+        declare,
+        domConstruct,
+        array,
+        Deferred,
+        Util,
+        JSONUtils
+    ) {
+
+        return declare( null, {
+
+            fillFeatures: function(args) {
+                var thisB = this;
+
+                var blockIndex = args.blockIndex;
+                var block = args.block;
+                var blockWidthPx = block.domNode.offsetWidth;
+                var scale = args.scale;
+                var leftBase = args.leftBase;
+                var rightBase = args.rightBase;
+                var finishCallback = args.finishCallback;
+
+                var fRects = [];
+
+                // count of how many features are queued up to be laid out
+                var featuresInProgress = 0;
+                // promise that resolved when all the features have gotten laid out by their glyphs
+                var featuresLaidOut = new Deferred();
+                // flag that tells when all features have been read from the
+                // store (not necessarily laid out yet)
+                var allFeaturesRead = false;
+
+                var errorCallback = dojo.hitch(thisB, function(e) {
+                    this._handleError(e, args);
+                    finishCallback(e);
+                });
+
+                var layout = this._getLayout( scale );
+
+                // query for a slightly larger region than the block, so that
+                // we can draw any pieces of glyphs that overlap this block,
+                // but the feature of which does not actually lie in the block
+                // (long labels that extend outside the feature's bounds, for
+                // example)
+                var bpExpansion = Math.round( this.config.maxFeatureGlyphExpansion / scale );
+
+                var region = {
+                    ref: this.refSeq.name,
+                    start: Math.max( 0, leftBase - bpExpansion ),
+                    end: rightBase + bpExpansion
+                };
+
+                // get just the sequence name from the sequenceList
+                var sequenceList = JSONUtils.parseSequenceList(this.refSeq.name);
+                if (sequenceList[0].reverse) {
+                    errorCallback(JSONUtils.NOT_YET_SUPPORTED_MESSAGE)
+                }
+                else {
+                    region.ref = sequenceList[0].name;
+                    this.store.getFeatures( region,
+                        function( feature ) {
+                            if( thisB.destroyed || ! thisB.filterFeature( feature ) )
+                                return;
+                            fRects.push( null ); // put a placeholder in the fRects array
+                            featuresInProgress++;
+                            var rectNumber = fRects.length-1;
+
+                            // get the appropriate glyph object to render this feature
+                            thisB.getGlyph(
+                                args,
+                                feature,
+                                function( glyph ) {
+                                    // have the glyph attempt
+                                    // to add a rendering of
+                                    // this feature to the
+                                    // layout
+                                    var fRect = glyph.layoutFeature(
+                                        args,
+                                        layout,
+                                        feature
+                                    );
+                                    if( fRect === null ) {
+                                        // could not lay out, would exceed our configured maxHeight
+                                        // mark the block as exceeding the max height
+                                        block.maxHeightExceeded = true;
+                                    }
+                                    else {
+                                        // laid out successfully
+                                        if( !( fRect.l >= blockWidthPx || fRect.l+fRect.w < 0 ) )
+                                            fRects[rectNumber] = fRect;
+                                    }
+
+                                    // this might happen after all the features have been sent from the store
+                                    if( ! --featuresInProgress && allFeaturesRead ) {
+                                        featuresLaidOut.resolve();
+                                    }
+                                },
+                                errorCallback
+                            );
+                        },
+
+                        // callback when all features sent
+                        function () {
+                            if( thisB.destroyed )
+                                return;
+
+                            allFeaturesRead = true;
+                            if( ! featuresInProgress && ! featuresLaidOut.isFulfilled() ) {
+                                featuresLaidOut.resolve();
+                            }
+
+                            featuresLaidOut.then( function() {
+
+                                var totalHeight = layout.getTotalHeight();
+                                var c = block.featureCanvas =
+                                    domConstruct.create(
+                                        'canvas',
+                                        { height: totalHeight,
+                                            width:  block.domNode.offsetWidth+1,
+                                            style: {
+                                                cursor: 'default',
+                                                height: totalHeight+'px',
+                                                position: 'absolute'
+                                            },
+                                            innerHTML: 'Your web browser cannot display this type of track.',
+                                            className: 'canvas-track'
+                                        },
+                                        block.domNode
+                                    );
+                                var ctx = c.getContext('2d');
+
+                                // finally query the various pixel ratios
+                                var ratio = Util.getResolution( ctx, thisB.browser.config.highResolutionMode );
+                                // upscale canvas if the two ratios don't match
+                                if ( thisB.browser.config.highResolutionMode != 'disabled' && ratio >= 1 ) {
+
+                                    var oldWidth = c.width;
+                                    var oldHeight = c.height;
+
+                                    c.width = oldWidth * ratio;
+                                    c.height = oldHeight * ratio;
+
+                                    c.style.width = oldWidth + 'px';
+                                    c.style.height = oldHeight + 'px';
+
+                                    // now scale the context to counter
+                                    // the fact that we've manually scaled
+                                    // our canvas element
+                                    ctx.scale(ratio, ratio);
+                                }
+
+
+
+                                if( block.maxHeightExceeded )
+                                    thisB.markBlockHeightOverflow( block );
+
+                                thisB.heightUpdate( totalHeight,
+                                    blockIndex );
+
+
+                                thisB.renderFeatures( args, fRects );
+
+                                thisB.renderClickMap( args, fRects );
+
+                                finishCallback();
+                            });
+                        },
+                        errorCallback
+                    );
+                }
+            }
+        })
+});

--- a/client/apollo/js/View/Track/_RemoteHTMLMixin.js
+++ b/client/apollo/js/View/Track/_RemoteHTMLMixin.js
@@ -1,0 +1,107 @@
+define([
+        'dojo/_base/declare',
+        'dojo/dom-construct',
+        'dojo/_base/array',
+        'JBrowse/Util',
+        'WebApollo/JSONUtils'
+    ],
+    function(
+        declare,
+        domConstruct,
+        array,
+        Util,
+        JSONUtils
+    ) {
+
+        return declare( null, {
+
+            fillFeatures: function(args) {
+                var blockIndex = args.blockIndex;
+                var block = args.block;
+                var leftBase = args.leftBase;
+                var rightBase = args.rightBase;
+                var scale = args.scale;
+                var stats = args.stats;
+                var containerStart = args.containerStart;
+                var containerEnd = args.containerEnd;
+                var finishCallback = args.finishCallback;
+                var browser = this.browser;
+
+                this.scale = scale;
+
+                block.featureNodes = {};
+
+                //determine the glyph height, arrowhead width, label text dimensions, etc.
+                if( !this.haveMeasurements ) {
+                    this.measureStyles();
+                    this.haveMeasurements = true;
+                }
+
+                var labelScale       = this.config.style.labelScale       || stats.featureDensity * this.config.style._defaultLabelScale;
+                var descriptionScale = this.config.style.descriptionScale || stats.featureDensity * this.config.style._defaultDescriptionScale;
+
+                var curTrack = this;
+
+                var featCallback = dojo.hitch(this,function( feature ) {
+                    var uniqueId = feature.id();
+                    if( ! this._featureIsRendered( uniqueId ) ) {
+                        if( this.filterFeature( feature ) )  {
+                            // hook point
+                            var render = 1;
+                            if (typeof this.renderFilter === 'function')
+                                render = this.renderFilter(feature);
+
+                            if (render === 1) {
+                                this.addFeatureToBlock( feature, uniqueId, block, scale, labelScale, descriptionScale, containerStart, containerEnd );
+                            }
+                        }
+                    }
+                });
+
+                var errorCallback = dojo.hitch(this, function(e) {
+                    this._handleError(e, args);
+                    finishCallback(e);
+                });
+
+                var sequenceList = JSONUtils.parseSequenceList(this.refSeq.name);
+                if (sequenceList[0].reverse) {
+                    errorCallback(JSONUtils.NOT_YET_SUPPORTED_MESSAGE)
+                }
+                else {
+                    var refSeqName = sequenceList[0].name;
+                    this.store.getFeatures( {
+                            ref: refSeqName,
+                            start: leftBase,
+                            end: rightBase
+                        },
+                        featCallback,
+                        function ( args ) {
+                            curTrack.heightUpdate(curTrack._getLayout(scale).getTotalHeight(), blockIndex);
+                            if ( args && args.maskingSpans ) {
+                                //note: spans have to be inverted
+                                var invSpan = [];
+                                invSpan[0] = { start: leftBase };
+                                var i = 0;
+                                for ( var span in args.maskingSpans) {
+                                    if (args.maskingSpans.hasOwnProperty(span)) {
+                                        span = args.maskingSpans[span];
+                                        invSpan[i].end = span.start;
+                                        i++;
+                                        invSpan[i] = { start: span.end };
+                                    }
+                                }
+                                invSpan[i].end = rightBase;
+                                if (invSpan[i].end <= invSpan[i].start) {
+                                    invSpan.splice(i,1); }
+                                if (invSpan[0].end <= invSpan[0].start) {
+                                    invSpan.splice(0,1); }
+                                curTrack.maskBySpans( invSpan, args.maskingSpans );
+                            }
+                            finishCallback();
+                        },
+                        errorCallback
+                    );
+                }
+            }
+        });
+});

--- a/client/apollo/js/View/Track/_WebApolloVariantDetailMixin.js
+++ b/client/apollo/js/View/Track/_WebApolloVariantDetailMixin.js
@@ -4,7 +4,7 @@ define([
         'dojo/dom-construct',
         'dojo/promise/all',
         'JBrowse/Util',
-        'JBrowse/View/Track/_VariantDetailMixin',
+        'JBrowse/View/Track/_VariantDetailMixin'
     ],
     function(
         declare,
@@ -15,18 +15,25 @@ define([
         VariantDetailMixin
     ) {
 
-return declare( [ VariantDetailMixin ], {
+return declare( VariantDetailMixin, {
 
     _renderGenotypes: function( parentElement, track, f, featDiv  ) {
         var thisB = this;
         var genotypes;
         var hasGenotypes = f.get('genotypes');
+        var isRestStore = track.config.storeClass === "WebApollo/Store/SeqFeature/VCFTabixREST";
+
         if (hasGenotypes) {
-            this.store.requestGenotypes(f).then(function(data) {
-                genotypes = data;
-                if (!genotypes) return;
-                thisB._renderVariantGenotypes(parentElement, track, f, genotypes, featDiv);
-            });
+            if (isRestStore) {
+                this.store.requestGenotypes(f).then(function(data) {
+                    genotypes = data;
+                    if (!genotypes) return;
+                    thisB._renderVariantGenotypes(parentElement, track, f, genotypes, featDiv);
+                });
+            }
+            else {
+                thisB._renderVariantGenotypes(parentElement, track, f, f.get('genotypes'), featDiv);
+            }
         }
     },
 

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -376,7 +376,7 @@ return declare( [JBPlugin, HelpMixin,Evented],
             var storeConf = {
                 browser: this,
                 refSeq: this.refSeq,
-                type: 'JBrowse/Store/SeqFeature/Combination'
+                type: 'WebApollo/Store/SeqFeature/Combination'
             };
             var storeName = this.addStoreConfig(undefined, storeConf);
             storeConf.name = storeName;

--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -11,6 +11,7 @@ define.amd.jQuery = true;
 
 define([
            'dojo/_base/declare',
+           'dojo/Deferred',
            'dojo/_base/lang',
            'dojo/dom-construct',
            'dojo/dom-class',
@@ -32,6 +33,7 @@ define([
            'dijit/form/ComboBox',
            'JBrowse/Plugin',
            'JBrowse/View/InfoDialog',
+           'JBrowse/View/ConfirmDialog',
            'WebApollo/FeatureEdgeMatchManager',
            'WebApollo/FeatureSelectionManager',
            'WebApollo/TrackConfigTransformer',
@@ -50,7 +52,9 @@ define([
            'lazyload/lazyload',
             'JBrowse/Util'
        ],
-    function( declare,
+    function(
+            declare,
+            Deferred,
             lang,
             domConstruct,
             domClass,
@@ -72,6 +76,7 @@ define([
             dijitComboBox,
             JBPlugin,
             InfoDialog,
+            ConfirmDialog,
             FeatureEdgeMatchManager,
             FeatureSelectionManager,
             TrackConfigTransformer,
@@ -171,19 +176,80 @@ return declare( [JBPlugin, HelpMixin,Evented],
         // that the open-file dialog and other things will have them
         // as options
         browser.registerTrackType({
-            type:                 'WebApollo/View/Track/DraggableHTMLFeatures',
-            defaultForStoreTypes: [ 'JBrowse/Store/SeqFeature/NCList',
+            type:                 'WebApollo/View/Track/RemoteWebApolloCanvasFeatures',
+            defaultForStoreTypes: [
+                                    'JBrowse/Store/SeqFeature/NCList',
                                     'JBrowse/Store/SeqFeature/GFF3',
+                                    'JBrowse/Store/SeqFeature/BED',
                                     'WebApollo/Store/SeqFeature/ApolloGFF3'
-                                  ],
-            label: 'WebApollo Features'
+            ],
+            label: 'WebApollo Canvas Features'
         });
         browser.registerTrackType({
-            type:                 'WebApollo/View/Track/DraggableAlignments',
+            type:                 'WebApollo/View/Track/RemoteDraggableHTMLFeatures',
+            defaultForStoreTypes: [
+                                    'JBrowse/Store/SeqFeature/NCList',
+                                    'JBrowse/Store/SeqFeature/GFF3',
+                                    'JBrowse/Store/SeqFeature/BED',
+                                    'WebApollo/Store/SeqFeature/ApolloGFF3'
+                                  ],
+            label: 'WebApollo HTML Features'
+        });
+        browser.registerTrackType({
+            type:                 'WebApollo/View/Track/RemoteSNPCoverage',
             defaultForStoreTypes: [
                                     'JBrowse/Store/SeqFeature/BAM'
-                                  ],
+            ],
+            label: 'WebApollo SNPCoverage'
+        });
+        browser.registerTrackType({
+            type:                 'WebApollo/View/Track/RemoteFeatureCoverage',
+            defaultForStoreTypes: [
+                'JBrowse/Store/SeqFeature/BAM'
+            ],
+            label: 'WebApollo FeatureCoverage'
+        });
+        browser.registerTrackType({
+            type:                 'WebApollo/View/Track/RemoteAlignments2',
+            defaultForStoreTypes: [
+                'JBrowse/Store/SeqFeature/BAM'
+            ],
+            label: 'WebApollo Alignments2'
+        });
+        browser.registerTrackType({
+            type:                 'WebApollo/View/Track/RemoteDraggableAlignments',
+            defaultForStoreTypes: [
+                'JBrowse/Store/SeqFeature/BAM'
+            ],
             label: 'WebApollo Alignments'
+        });
+        browser.registerTrackType({
+            type:                 'WebApollo/View/Track/RemoteWebApolloCanvasVariants',
+            defaultForStoreTypes: [
+                                    'JBrowse/Store/SeqFeature/VCFTabix'
+            ],
+            label: 'WebApollo Canvas Variants'
+        });
+        browser.registerTrackType({
+            type:                 'WebApollo/View/Track/RemoteWebApolloHTMLVariants',
+            defaultForStoreTypes: [
+                                    'JBrowse/Store/SeqFeature/VCFTabix'
+            ],
+            label: 'WebApollo HTML Variants'
+        });
+        browser.registerTrackType({
+            type:                 'WebApollo/View/Track/Wiggle/RemoteDensity',
+            defaultForStoreTypes: [
+                'JBrowse/Store/SeqFeature/BigWig'
+            ],
+            label: 'WebApollo Density Plot'
+        });
+        browser.registerTrackType({
+            type:                 'WebApollo/View/Track/Wiggle/RemoteXYPlot',
+            defaultForStoreTypes: [
+                                    'JBrowse/Store/SeqFeature/BigWig'
+            ],
+            label: 'WebApollo XY Plot'
         });
         browser.registerTrackType({
             type:                 'WebApollo/View/Track/SequenceTrack',
@@ -286,15 +352,62 @@ return declare( [JBPlugin, HelpMixin,Evented],
 
             browser.view.pxPerBp = ratio ;
             browser.view.onResize();
+
+            // unregister JBrowse track types from the open-file dialog
+            // since Apollo provides its alternative
+            browser.unregisterTrackType('JBrowse/View/Track/HTMLFeatures');
+            browser.unregisterTrackType('JBrowse/View/Track/CanvasFeatures');
+            browser.unregisterTrackType('JBrowse/View/Track/HTMLVariants');
+            browser.unregisterTrackType('JBrowse/View/Track/CanvasVariants');
+            browser.unregisterTrackType('JBrowse/View/Track/SNPCoverage');
+            browser.unregisterTrackType('JBrowse/View/Track/FeatureCoverage');
+            browser.unregisterTrackType('JBrowse/View/Track/Wiggle/XYPlot');
+            browser.unregisterTrackType('JBrowse/View/Track/Wiggle/Density');
+            browser.unregisterTrackType('JBrowse/View/Track/Alignments');
+            browser.unregisterTrackType('JBrowse/View/Track/Alignments2');
+
         });
 
         this.monkeyPatchRegexPlugin();
 
+        browser.createCombinationTrack = function() {
+            if(this._combinationTrackCount === undefined) this._combinationTrackCount = 0;
+            var d = new Deferred();
+            var storeConf = {
+                browser: this,
+                refSeq: this.refSeq,
+                type: 'JBrowse/Store/SeqFeature/Combination'
+            };
+            var storeName = this.addStoreConfig(undefined, storeConf);
+            storeConf.name = storeName;
+            this.getStore(storeName, function(store) {
+                d.resolve(true);
+            });
+            var thisB = this;
+            d.promise.then(function(){
+                var combTrackConfig = {
+                    type: 'WebApollo/View/Track/Combination',
+                    label: "combination_track" + (thisB._combinationTrackCount++),
+                    key: "Combination Track " + (thisB._combinationTrackCount),
+                    metadata: {Description: "Drag-and-drop interface that creates a track out of combinations of other tracks."},
+                    store: storeName
+                };
+                // send out a message about how the user wants to create the new tracks
+                thisB.publish( '/jbrowse/v1/v/tracks/new', [combTrackConfig] );
 
+                // Open the track immediately
+                thisB.publish( '/jbrowse/v1/v/tracks/show', [combTrackConfig] );
+            });
+        };
+
+        browser.unregisterTrackType = function(typeName) {
+            var types = browser.getTrackTypes();
+            var idx = types.knownTrackTypes.indexOf(typeName);
+            if (idx !== -1) {
+                types.knownTrackTypes.splice(idx, 1);
+            }
+        };
     },
-
-
-
 
     runningApollo: function () {
         return (this.getApollo() && typeof this.getApollo().getEmbeddedVersion == 'function' && this.getApollo().getEmbeddedVersion() == 'ApolloGwt-2.0');
@@ -504,7 +617,8 @@ return declare( [JBPlugin, HelpMixin,Evented],
         }
         this.addSearchBox();
         this.addNavBox();
-        this.removeFileMenu();
+        // re-enabling fileMenu
+        //this.removeFileMenu();
 
         // get all toplinks and hide the one that says 'Full-screen view'
         $('.topLink').each(function(index){
@@ -654,6 +768,7 @@ return declare( [JBPlugin, HelpMixin,Evented],
                     return translated;
                 }
             });
+
         });
     },
     // createMenus adds new menu items and is run before the initView milestone


### PR DESCRIPTION
@nathandunn This is ready for testing and review (but not ready to merge).

This PR introduces new track types (and stores) which are automatically registered and applied when a file is opened via the File -> 'Open track file or URL'.

When a local file is opened in the original forward orientation, the features will show up as usual:

![screen shot 2017-09-21 at 10 32 04 am](https://user-images.githubusercontent.com/4530272/30704362-25ff3c2c-9eb8-11e7-8dfc-d3f4d6b0a952.png)


When a local file is opened in a reverse complement orientation you will see the following:

![screen shot 2017-09-21 at 10 29 41 am](https://user-images.githubusercontent.com/4530272/30704263-d06bf0f2-9eb7-11e7-98ff-d22f5f8e3fd2.png)


This PR also adds combination track support for native Apollo tracks (such as DraggableHTMLFeatures) which were not supported before.