### PR TITLE
Fix warnings by moving removeIncludedPlugins to TrackService

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -27,6 +27,7 @@ class JbrowseController {
     def jbrowseService
     def servletContext
     def configWrapperService
+    def trackService
 
     def chooseOrganismForJbrowse() {
         [organisms: Organism.findAllByPublicMode(true, [sort: 'commonName', order: 'asc']), flash: [message: params.error]]
@@ -459,7 +460,7 @@ class JbrowseController {
             }
         }
 
-        removeIncludedPlugins(jsonObject.plugins)
+        trackService.removeIncludedPlugins(jsonObject.plugins)
 
         // add extendedTrackList.json, if available
         if (!currentOrganism.dataAddedViaWebServices) {
@@ -474,29 +475,6 @@ class JbrowseController {
 
         response.outputStream << jsonObject.toString()
         response.outputStream.close()
-    }
-
-    /**
-     * Removes plugins included in annot.json (which is just WebApollo)
-     * @param pluginsArray
-     */
-    def removeIncludedPlugins(JSONArray pluginsArray) {
-        def iterator = pluginsArray.iterator()
-        while(iterator.hasNext()){
-            def plugin = iterator.next()
-            if(plugin instanceof JSONObject){
-                if(plugin.name == "WebApollo"){
-                    iterator.remove()
-                }
-            }
-            else
-            if(plugin instanceof String){
-                if(plugin=="WebApollo"){
-                    iterator.remove()
-                }
-            }
-
-        }
     }
 
     private static boolean isCacheableFile(String fileName) {

--- a/grails-app/services/org/bbop/apollo/TrackService.groovy
+++ b/grails-app/services/org/bbop/apollo/TrackService.groovy
@@ -467,4 +467,25 @@ class TrackService {
 
         return null
     }
+
+    /**
+     * Removes plugins included in annot.json (which is just WebApollo)
+     * @param pluginsArray
+     */
+    def removeIncludedPlugins(JSONArray pluginsArray) {
+        def iterator = pluginsArray.iterator()
+        while(iterator.hasNext()) {
+            def plugin = iterator.next()
+            if(plugin instanceof JSONObject) {
+                if(plugin.name == "WebApollo") {
+                    iterator.remove()
+                }
+            }
+            else if(plugin instanceof String) {
+                if(plugin == "WebApollo") {
+                    iterator.remove()
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This is just to fix the warning we see everytime we do `run-local` or `deploy`.

```
| Compiling 339 source files

| Warning The [removeIncludedPlugins] action accepts a parameter of type [org.codehaus.groovy.grails.web.json.JSONArray] which has not been marked with @Validateable.  Data binding will still be applied to this command object but the instance will not be validateable.

       def removeIncludedPlugins(JSONArray pluginsArray) {
       ^
| Compiling 339 source files.....
***

```

Since `removeIncludedPlugins` is not an action within JBrowseController, I moved it to TrackService.