### PR TITLE
Add a WebApollo version of Alignments2 track type

### DIFF
--- a/client/apollo/js/TrackConfigTransformer.js
+++ b/client/apollo/js/TrackConfigTransformer.js
@@ -36,7 +36,9 @@ constructor: function( args )  {
         }
     };
 
-    this.transformers["JBrowse/View/Track/Alignments2"] = this.transformers["JBrowse/View/Track/Alignments"];
+    this.transformers["JBrowse/View/Track/Alignments2"] = function(trackConfig) {
+        trackConfig.type = "WebApollo/View/Track/WebApolloAlignments2";
+    };
 
 },
 

--- a/client/apollo/js/View/Track/WebApolloAlignments2.js
+++ b/client/apollo/js/View/Track/WebApolloAlignments2.js
@@ -1,0 +1,123 @@
+define( [
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'dojo/promise/all',
+        'dijit/Menu',
+        'dijit/MenuItem',
+        'dijit/CheckedMenuItem',
+        'dijit/MenuSeparator',
+        'dijit/PopupMenuItem',
+        'dijit/Dialog',
+        'JBrowse/Util',
+        'JBrowse/View/Track/Alignments2'
+    ],
+    function(
+        declare,
+        array,
+        all,
+        dijitMenu,
+        dijitMenuItem,
+        dijitCheckedMenuItem,
+        dijitMenuSeparator,
+        dijitPopupMenuItem,
+        dijitDialog,
+        Util,
+        Alignments2
+    ) {
+        return declare(Alignments2, {
+
+            /**
+             * An extension to JBrowse/View/Track/Alignments2 to allow for creating annotations
+             * from read alignments.
+             */
+
+            constructor: function() {
+                this.browser.getPlugin('WebApollo', dojo.hitch(this, function(plugin) {
+                    this.webapollo = plugin;
+                }));
+            },
+
+            _defaultConfig: function() {
+                var thisB = this;
+                var config = this.inherited(arguments);
+
+                config.menuTemplate.push({
+                    "label": "Create new annotation",
+                    "children": [
+                        {
+                            "label": "gene",
+                            "action":  function() {
+                                var atrack = thisB.webapollo.getAnnotTrack();
+                                atrack.createAnnotations({selection: {feature: this.feature}});
+                            }
+                        },
+                        {
+                            "label": "pseudogene",
+                            "action": function() {
+                                var atrack = thisB.webapollo.getAnnotTrack();
+                                atrack.createGenericAnnotations([this.feature], "transcript", null, "pseudogene");
+                            }
+                        },
+                        {
+                            "label": "tRNA",
+                            "action": function() {
+                                var atrack = thisB.webapollo.getAnnotTrack();
+                                atrack.createGenericAnnotations([this.feature], "tRNA", null, "gene");
+                            }
+                        },
+                        {
+                            "label": "snRNA",
+                            "action": function() {
+                                var atrack = thisB.webapollo.getAnnotTrack();
+                                atrack.createGenericAnnotations([this.feature], "snRNA", null, "gene");
+                            }
+                        },
+                        {
+                            "label": "snoRNA",
+                            "action": function() {
+                                var atrack = thisB.webapollo.getAnnotTrack();
+                                atrack.createGenericAnnotations([this.feature], "snoRNA", null, "gene");
+                            }
+                        },
+                        {
+                            "label": "ncRNA",
+                            "action": function() {
+                                var atrack = thisB.webapollo.getAnnotTrack();
+                                atrack.createGenericAnnotations([this.feature], "ncRNA", null, "gene");
+                            }
+                        },
+                        {
+                            "label": "rRNA",
+                            "action": function() {
+                                var atrack = thisB.webapollo.getAnnotTrack();
+                                atrack.createGenericAnnotations([this.feature], "rRNA", null, "gene");
+                            }
+                        },
+                        {
+                            "label": "miRNA",
+                            "action": function() {
+                                var atrack = thisB.webapollo.getAnnotTrack();
+                                atrack.createGenericAnnotations([this.feature], "miRNA", null, "gene");
+                            }
+                        },
+                        {
+                            "label": "repeat_region",
+                            "action": function() {
+                                var atrack = thisB.webapollo.getAnnotTrack();
+                                atrack.createGenericOneLevelAnnotations([this.feature], "repeat_region", true);
+                            }
+                        },
+                        {
+                            "label": "transposable_element",
+                            "action": function() {
+                                var atrack = thisB.webapollo.getAnnotTrack();
+                                atrack.createGenericOneLevelAnnotations([this.feature], "transposable_element", true);
+                            }
+                        }
+                    ]
+                });
+                return config;
+            }
+        });
+    }
+);


### PR DESCRIPTION
Extend `JBrowse/View/Track/Alignments2` to support the ability to create an annotation from reads. The annotation can be created via Right-Click -> Create New Annotation -> Select the feature type.

The logic is similar to `WebApollo/View/Track/WebApolloCanvasFeatures`.