### PR TITLE
remove permission if empty

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/GroupController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/GroupController.groovy
@@ -312,6 +312,12 @@ class GroupController {
             permissionsArray.add(PermissionEnum.READ.name())
         }
 
+        if(permissionsArray.size()==0){
+            groupOrganismPermission.delete(flush: true)
+            render groupOrganismPermission as JSON
+            return
+        }
+
 
         groupOrganismPermission.permissions = permissionsArray.toString()
         groupOrganismPermission.save(flush: true)


### PR DESCRIPTION
"empty" permissions for organism are handled funny (client shows them, but user has no permission).  They should be removed, instead, similar to the user permissions.