### PR TITLE
Determine javac version more robustly

### DIFF
--- a/apollo
+++ b/apollo
@@ -45,7 +45,7 @@ function check_rest_api(){
 }
 
 function check_java(){
-    javac_version=`javac -version 2>&1`
+    javac_version=`javac -version 2>&1 | grep ^javac`
     echo "$javac_version found";
     if [[ $javac_version == javac*  ]]; then
         echo "javac installed";


### PR DESCRIPTION
The method for determining the javac version fails if for example JAVA_TOOLS_OPTIONS is set because javac will display that too. The change to check_java() tightens up the process so that unexpected output from javac is ignored.


