### PR TITLE
Update the travis badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apollo
 [![DOI](https://zenodo.org/badge/13471446.svg)](https://zenodo.org/badge/latestdoi/13471446)
-![Build](https://travis-ci.org/GMOD/Apollo.svg?branch=master)
+[![Build](https://travis-ci.org/GMOD/Apollo.svg?branch=master)](https://travis-ci.org/GMOD/Apollo?branch=master)
 [![Coverage](https://coveralls.io/repos/github/GMOD/Apollo/badge.svg?branch=master)](https://coveralls.io/github/GMOD/Apollo?branch=master)
 [![Documentation](https://readthedocs.org/projects/genomearchitect/badge/?version=latest)](https://genomearchitect.readthedocs.org/en/latest/)
 [![Chat at Gitter](https://badges.gitter.im/GMOD/Apollo.svg)](https://gitter.im/GMOD/Apollo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)


### PR DESCRIPTION
Just a quick fix in README.md that make hyperlink on Travis Badge better.
Originally, the link points to the svg image itself.
Now, it links to the current build page of master branch on Travis.