### PR TITLE
Add support for SNPCoverage and FeatureCoverage track types for projection

### DIFF
--- a/client/apollo/js/ProjectionUtils.js
+++ b/client/apollo/js/ProjectionUtils.js
@@ -142,6 +142,9 @@ define([ 'dojo/_base/declare',
             var start = feature.get("start");
             var end = feature.get("end");
             var projectedArray = this.projectCoordinates(refSeqName, start, end);
+            if (!feature.data) {
+                feature.data = {};
+            }
             feature.data._original_start = start;
             feature.data._original_end = end;
             feature.data.start = projectedArray[0];

--- a/client/apollo/js/Store/SeqFeature/Coverage.js
+++ b/client/apollo/js/Store/SeqFeature/Coverage.js
@@ -1,0 +1,82 @@
+define([
+        'dojo/_base/declare',
+        'JBrowse/Store/SeqFeature/Coverage',
+        'JBrowse/Model/CoverageFeature',
+        'WebApollo/ProjectionUtils'
+    ],
+    function(
+        declare,
+        Coverage,
+        CoverageFeature,
+        ProjectionUtils
+    ) {
+
+        return declare( Coverage, {
+
+            /**
+             * Override
+             */
+            getFeatures: function( query, featureCallback, finishCallback, errorCallback ) {
+                var leftBase  = query.start;
+                var rightBase = query.end;
+                var scale = query.scale || ( ('basesPerSpan' in query) ? 1/query.basesPerSpan : 10 ); // px/bp
+                var widthBp = rightBase-leftBase;
+                var widthPx = widthBp * scale;
+
+                var binWidth = Math.ceil( 1/scale ); // in bp
+
+                var coverageBins = new Array( Math.ceil( widthBp/binWidth ) );
+                var binOverlap = function( bp, isRightEnd ) {
+                    var binCoord  = (bp-leftBase-1) / binWidth;
+                    var binNumber = Math.floor( binCoord );
+                    var overlap   = isRightEnd ? 1-(binCoord-binNumber) : binCoord - binNumber;
+                    return {
+                        bin: binNumber,
+                        overlap: overlap // between 0 and 1: proportion of this bin that the feature overlaps
+                    };
+                };
+
+                this.store.getFeatures(
+                    query,
+                    function( feature ) {
+                        if (!feature.isProjected) {
+                            feature = ProjectionUtils.projectJSONFeature(feature, this.JBrowse.refSeq.name);
+                        }
+                        var startBO = binOverlap( feature.get('start'), false );
+                        var endBO   = binOverlap( feature.get('end'),   true  );
+
+                        // increment start and end partial-overlap bins by proportion of overlap
+                        if( startBO.bin == endBO.bin ) {
+                            coverageBins[startBO.bin] = (coverageBins[startBO.bin] || 0) + endBO.overlap + startBO.overlap - 1;
+                        }
+                        else {
+                            coverageBins[startBO.bin] = (coverageBins[startBO.bin] || 0) + startBO.overlap;
+                            coverageBins[endBO.bin]   = (coverageBins[endBO.bin]   || 0) + endBO.overlap;
+                        }
+
+                        // increment completely overlapped interior bins by 1
+                        for( var i = startBO.bin+1; i <= endBO.bin-1; i++ ) {
+                            coverageBins[i] = (coverageBins[i] || 0) + 1;
+                        }
+                    },
+                    function () {
+                        // make fake features from the coverage
+                        for( var i = 0; i < coverageBins.length; i++ ) {
+                            var score = (coverageBins[i] || 0);
+                            var bpOffset = leftBase+binWidth*i;
+                            featureCallback( new CoverageFeature({
+                                start: bpOffset,
+                                end:   bpOffset+binWidth,
+                                score: score
+                            }));
+                        }
+                        finishCallback();
+                    },
+                    errorCallback
+                );
+            }
+
+
+        });
+
+});

--- a/client/apollo/js/Store/SeqFeature/SNPCoverage.js
+++ b/client/apollo/js/Store/SeqFeature/SNPCoverage.js
@@ -157,7 +157,7 @@ define([
                         // if we are zoomed to base level, try to fetch the
                         // reference sequence for this region and record each
                         // of the bases in the coverage bins
-
+                        query.ref = this.JBrowse.refSeq.name;
                         if( binWidth == 1 ) {
                             var sequence;
                             thisB.browser.getStore(

--- a/client/apollo/js/Store/SeqFeature/SNPCoverage.js
+++ b/client/apollo/js/Store/SeqFeature/SNPCoverage.js
@@ -2,24 +2,43 @@ define([
         'dojo/_base/declare',
         'dojo/_base/array',
         'JBrowse/Util',
-        'JBrowse/Store/SeqFeature/SNPCoverage',
+        'WebApollo/ProjectionUtils',
+        'JBrowse/Store/SeqFeature',
         'JBrowse/Model/NestedFrequencyTable',
-        'JBrowse/Model/CoverageFeature'
+        'JBrowse/Model/CoverageFeature',
+        'WebApollo/Store/SeqFeature/_MismatchesMixin'
     ],
     function(
         declare,
         array,
         Util,
-        SNPCoverageStore,
+        ProjectionUtils,
+        SeqFeatureStore,
         NestedFrequencyTable,
-        CoverageFeature
+        CoverageFeature,
+        MismatchesMixin
     ) {
 
-        return declare( SNPCoverageStore, {
+        return declare([ SeqFeatureStore, MismatchesMixin ], {
 
-            /**
-             * Override getFeatures in JBrowse/Store/SeqFeature/SNPCoverage
-             */
+            constructor: function( args ) {
+                this.store = args.store;
+                this.filter = args.filter || function() { return true; };
+            },
+
+            getGlobalStats: function( callback, errorCallback ) {
+                callback( {} );
+            },
+
+            _defaultConfig: function() {
+                return Util.deepUpdate(
+                    dojo.clone( this.inherited(arguments) ),
+                    {
+                        mismatchScale: 1/10
+                    }
+                );
+            },
+
             getFeatures: function( query, featureCallback, finishCallback, errorCallback ) {
                 var thisB = this;
                 var leftBase  = query.start;
@@ -78,11 +97,19 @@ define([
                     }
                 };
 
+                // adding the sequenceList as query.ref since the existing query.ref is not a sequenceList
+                // and we need a sequenceList to query the underlying BAM store
+                query.ref = thisB.browser.refSeq.name;
+
                 thisB.store.getFeatures(
                     query,
                     function( feature ) {
                         if( ! thisB.filter( feature ) )
                             return;
+
+                        if (!feature.isProjected) {
+                            feature = ProjectionUtils.projectJSONFeature(feature, thisB.browser.refSeq.name);
+                        }
 
                         var strand = { '-1': '-', '1': '+' }[ ''+feature.get('strand') ] || 'unstranded';
 
@@ -131,8 +158,6 @@ define([
                         // reference sequence for this region and record each
                         // of the bases in the coverage bins
 
-                        // adjusting query to use sequenceList since are requesting data from the server
-                        query.ref = thisB.browser.refSeq.name;
                         if( binWidth == 1 ) {
                             var sequence;
                             thisB.browser.getStore(

--- a/client/apollo/js/Store/SeqFeature/_MismatchesMixin.js
+++ b/client/apollo/js/Store/SeqFeature/_MismatchesMixin.js
@@ -1,0 +1,114 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'JBrowse/Store/SeqFeature/_MismatchesMixin',
+        'WebApollo/ProjectionUtils'
+    ],
+    function(
+        declare,
+        array,
+        MismatchesMixin,
+        ProjectionUtils
+    ) {
+
+        return declare( MismatchesMixin, {
+
+            _mdToMismatches: function( feature, mdstring, cigarOps, cigarMismatches ) {
+                var sequenceList = ProjectionUtils.parseSequenceList(this.browser.refSeq.name);
+                var mismatchRecords = [];
+                var curr = { start: 0, base: '', length: 0, type: 'mismatch' };
+
+                // convert a position on the reference sequence to a position
+                // on the template sequence, taking into account hard and soft
+                // clipping of reads
+                function getTemplateCoord( refCoord, cigarOps ) {
+                    var templateOffset = 0;
+                    var refOffset = 0;
+                    for( var i = 0; i < cigarOps.length && refOffset <= refCoord ; i++ ) {
+                        var op  = cigarOps[i][0];
+                        var len = cigarOps[i][1];
+                        if( op == 'S' || op == 'I' ) {
+                            templateOffset += len;
+                        }
+                        else if( op == 'D' || op == 'P' ) {
+                            refOffset += len;
+                        }
+                        else {
+                            templateOffset += len;
+                            refOffset += len;
+                        }
+                    }
+                    return templateOffset - ( refOffset - refCoord );
+                }
+
+                function nextRecord() {
+                    // correct the start of the current mismatch if it comes after a cigar skip
+                    var skipOffset = 0;
+                    array.forEach( cigarMismatches || [], function( mismatch ) {
+                        if( mismatch.type == 'skip' && curr.start >= mismatch.start ) {
+                            curr.start += mismatch.length;
+                        }
+                    });
+
+                    // record it
+                    mismatchRecords.push( curr );
+
+                    // get a new mismatch record ready
+                    curr = { start: curr.start + curr.length, length: 0, base: '', type: 'mismatch'};
+                };
+
+                var seq = feature.get('seq');
+                if (feature.isProjected) {
+                    if (sequenceList[0].reverse) {
+                        var md_array = mdstring.match(/(\d+|\^[a-z]+|[a-z])/ig);
+                        md_array.reverse();
+                        mdstring = md_array.join('');
+
+                        seq = seq.split('').reverse().join('');
+                    }
+                }
+
+                // now actually parse the MD string
+                array.forEach( mdstring.match(/(\d+|\^[a-z]+|[a-z])/ig), function( token ) {
+                    if( token.match(/^\d/) ) { // matching bases
+                        curr.start += parseInt( token );
+                    }
+                    else if( token.match(/^\^/) ) { // insertion in the template
+                        curr.length = token.length-1;
+                        curr.base   = '*';
+                        curr.type   = 'deletion';
+                        curr.seq    = token.substring(1);
+                        nextRecord();
+                    }
+                    else if( token.match(/^[a-z]/i) ) { // mismatch
+                        for( var i = 0; i<token.length; i++ ) {
+                            curr.length = 1;
+                            curr.base = seq ? seq.substr( cigarOps ? getTemplateCoord( curr.start, cigarOps)
+                                    : curr.start,
+                                1
+                            )
+                                : 'X';
+                            curr.altbase = token;
+                            nextRecord();
+                        }
+                    }
+                });
+                return mismatchRecords;
+            },
+
+            _parseCigar: function(cigar) {
+                var sequenceListObject = ProjectionUtils.parseSequenceList(this.browser.refSeq.name);
+                if (sequenceListObject[0].reverse) {
+                    var cigar_array = cigar.match(/\d+\D/g);
+                    cigar_array.reverse();
+                    cigar = cigar_array.join('');
+                }
+                return array.map( cigar.toUpperCase().match(/\d+\D/g), function( op ) {
+                    return [ op.match(/\D/)[0], parseInt( op ) ];
+                });
+            }
+
+        });
+
+
+});

--- a/client/apollo/js/View/Track/FeatureCoverage.js
+++ b/client/apollo/js/View/Track/FeatureCoverage.js
@@ -1,0 +1,31 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'WebApollo/View/Track/Wiggle/XYPlot',
+        'JBrowse/Util',
+        'WebApollo/Store/SeqFeature/Coverage'
+    ],
+    function(
+        declare,
+        array,
+        XYPlot,
+        Util,
+        CoverageStore
+    ) {
+
+        return declare( XYPlot, {
+
+            constructor: function( args ) {
+                this.store = new CoverageStore( { store: this.store, browser: this.browser });
+            },
+
+            _defaultConfig: function() {
+                return Util.deepUpdate(
+                    dojo.clone( this.inherited(arguments) ),
+                    {
+                        autoscale: 'local'
+                    }
+                );
+            }
+        });
+});

--- a/client/apollo/js/View/Track/SNPCoverage.js
+++ b/client/apollo/js/View/Track/SNPCoverage.js
@@ -1,0 +1,366 @@
+define([
+        'dojo/_base/declare',
+        'dojo/_base/array',
+        'dojo/_base/lang',
+        'dojo/promise/all',
+        'JBrowse/View/Track/Wiggle/_Scale',
+        'WebApollo/View/Track/Wiggle/XYPlot',
+        'JBrowse/Util',
+        'WebApollo/ProjectionUtils',
+        'JBrowse/View/Track/_AlignmentsMixin',
+        'WebApollo/Store/SeqFeature/SNPCoverage'
+    ],
+    function(
+        declare,
+        array,
+        lang,
+        all,
+        Scale,
+        XYPlot,
+        Util,
+        ProjectionUtils,
+        AlignmentsMixin,
+        SNPCoverageStore
+    ) {
+
+        return declare([ XYPlot, AlignmentsMixin ], {
+
+            constructor: function() {
+                delete this.config.bicolor_pivot;
+                delete this.config.scale;
+                delete this.config.align;
+
+                var thisB = this;
+                this.store = new SNPCoverageStore(
+                    { store: this.store,
+                        config: {
+                            mismatchScale: this.config.mismatchScale
+                        },
+                        browser: this.browser,
+                        filter: function( f ) {
+                            return thisB.filterFeature( f );
+                        }
+                    });
+            },
+
+            _defaultConfig: function() {
+                return Util.deepUpdate(
+                    dojo.clone( this.inherited(arguments) ),
+                    {
+                        autoscale: 'local',
+                        min_score: 0,
+
+                        mismatchScale: 1/10,
+
+                        hideDuplicateReads: true,
+                        logScaleOption: false,
+                        hideQCFailingReads: true,
+                        hideSecondary: true,
+                        hideSupplementary: true,
+                        hideMissingMatepairs: false,
+                        hideUnmapped: true
+                    }
+                );
+            },
+
+            _drawFeatures: function( scale, leftBase, rightBase, block, canvas, features, featureRects, dataScale ) {
+                var thisB = this;
+                var context = canvas.getContext('2d');
+                var canvasHeight = canvas.height;
+
+                var ratio = Util.getResolution( context, this.browser.config.highResolutionMode );
+                var toY = dojo.hitch( this, function( val ) {
+                    return canvasHeight * ( 1-dataScale.normalize(val) ) / ratio;
+                });
+                var originY = toY( dataScale.origin );
+
+                // a canvas element below the histogram that will contain indicators of likely SNPs
+                var snpCanvasHeight = 20;
+                var snpCanvas = dojo.create('canvas',
+                    {height: snpCanvasHeight,
+                        width: canvas.width,
+                        style: {
+                            cursor: 'default',
+                            width: "100%",
+                            height: snpCanvasHeight + "px"
+                        },
+                        innerHTML: 'Your web browser cannot display this type of track.',
+                        className: 'SNP-indicator-track'
+                    }, block.domNode);
+                var snpContext = snpCanvas.getContext('2d');
+
+                // finally query the various pixel ratios
+                var ratio = Util.getResolution( snpContext, this.browser.config.highResolutionMode );
+                // upscale canvas if the two ratios don't match
+                if ( this.browser.config.highResolutionMode !='disabled' && ratio!=1 ) {
+
+                    var oldWidth = snpCanvas.width;
+                    var oldHeight = snpCanvas.height;
+
+                    snpCanvas.width = oldWidth * ratio;
+                    snpCanvas.height = oldHeight * ratio;
+
+                    //c.style.width = oldWidth + 'px';
+                    snpCanvas.style.height = oldHeight + 'px';
+
+                    // now scale the context to counter
+                    // the fact that we've manually scaled
+                    // our canvas element
+                    snpContext.scale(ratio, ratio);
+                }
+
+
+                var negColor  = this.config.style.neg_color;
+                var clipColor = this.config.style.clip_marker_color;
+                var bgColor   = this.config.style.bg_color;
+                var disableClipMarkers = this.config.disable_clip_markers;
+
+                var drawRectangle = function(ID, yPos, height, fRect) {
+                    if( yPos <= canvasHeight ) { // if the rectangle is visible at all
+                        context.fillStyle = thisB.colorForBase(ID);
+                        if( yPos <= originY ) {
+                            // bar goes upward
+                            thisB._fillRectMod( context, fRect.l, yPos, fRect.w, height);
+                            if( !disableClipMarkers && yPos < 0 ) { // draw clip marker if necessary
+                                context.fillStyle = clipColor || negColor;
+                                thisB._fillRectMod( context, fRect.l, 0, fRect.w, 2 );
+                            }
+                        }
+                        else {
+                            // bar goes downward
+                            thisB._fillRectMod( context, fRect.l, originY, fRect.w, height );
+                            if( !disableClipMarkers && yPos >= canvasHeight ) { // draw clip marker if necessary
+                                context.fillStyle = clipColor || thisB.colorForBase(ID);
+                                thisB._fillRectMod( context, fRect.l, canvasHeight-3, fRect.w, 2 );
+                            }
+                        }
+                    }
+                };
+
+                // Note: 'reference' is done first to ensure the grey part of the graph is on top
+                dojo.forEach( features, function(f,i) {
+                    var fRect = featureRects[i];
+                    var score = f.get('score');
+
+                    // draw the background color if we are configured to do so
+                    if( bgColor ) {
+                        context.fillStyle = bgColor;
+                        thisB._fillRectMod( context, fRect.l, 0, fRect.w, canvasHeight );
+                    }
+
+                    drawRectangle( 'reference', toY( score.total() ), originY-toY( score.get('reference'))+1, fRect);
+                });
+
+                dojo.forEach( features, function(f,i) {
+                    var fRect = featureRects[i];
+                    var score = f.get('score');
+                    var totalHeight = score.total();
+
+                    // draw indicators of SNPs if base coverage is greater than 50% of total coverage
+                    score.forEach( function( count, category ) {
+                        if ( !{reference:true,skip:true,deletion:true}[category] && count > 0.5*totalHeight ) {
+                            snpContext.save();
+                            if( thisB.browser.config.highResolutionMode != 'disabled' )
+                                snpContext.scale(ratio, 1);
+                            snpContext.beginPath();
+                            snpContext.arc( (fRect.l + 0.5*fRect.w),
+                                0.40*snpCanvas.height/ratio,
+                                0.20*snpCanvas.height/ratio,
+                                1.75 * Math.PI,
+                                1.25 * Math.PI,
+                                false);
+                            snpContext.lineTo(fRect.l + 0.5*fRect.w, 0);
+                            snpContext.closePath();
+                            snpContext.fillStyle = thisB.colorForBase(category);
+                            snpContext.fill();
+                            snpContext.lineWidth = 1;
+                            snpContext.strokeStyle = 'black';
+                            snpContext.stroke();
+                            if( thisB.browser.config.highResolutionMode != 'disabled' )
+                                snpContext.restore();
+                        }
+                    });
+
+                    totalHeight -= score.get('reference');
+
+                    score.forEach( function( count, category ) {
+                        if ( category != 'reference' ) {
+                            drawRectangle( category, toY(totalHeight), originY-toY( count )+1, fRect);
+                            totalHeight -= count;
+                        }
+                    });
+                }, this );
+            },
+
+            _getBlockFeatures: function (args) {
+                var thisB = this;
+                var blockIndex = args.blockIndex;
+                var block = args.block;
+
+                var leftBase = args.leftBase;
+                var rightBase = args.rightBase;
+
+                var scale = args.scale;
+                var finishCallback = args.finishCallback || function () {
+                    };
+
+                var canvasWidth = this._canvasWidth(args.block);
+
+                var errorCallback = dojo.hitch(this, function(e) {
+                    this._handleError(e, args);
+                    finishCallback(e);
+                });
+
+                var features = [];
+
+                this.getFeatures(
+                    {
+                        ref: this.refSeq.name,
+                        basesPerSpan: 1 / scale,
+                        scale: scale,
+                        start: leftBase,
+                        end: rightBase + 1
+                    },
+
+                    function (f) {
+                        if (thisB.filterFeature(f))
+                            features.push(f);
+                    },
+                    dojo.hitch(this, function (args) {
+
+                        // if the block has been freed in the meantime,
+                        // don't try to render
+                        if (!(block.domNode && block.domNode.parentNode ))
+                            return;
+
+                        var featureRects = array.map(features, function (f) {
+                            f = ProjectionUtils.projectJSONFeature(f, this.refSeq.name);
+                            return this._featureRect(scale, leftBase, canvasWidth, f);
+                        }, this);
+
+                        block.features = features;
+                        block.featureRects = featureRects;
+                        block.pixelScores = this._calculatePixelScores(this._canvasWidth(block), features, featureRects);
+
+                        if (args && args.maskingSpans)
+                            block.maskingSpans = args.maskingSpans; // used for masking
+
+                        finishCallback();
+                    }),
+                    errorCallback
+                );
+            },
+
+            _getScalingStats: function( viewArgs, callback, errorCallback ) {
+                if( ! Scale.prototype.needStats( this.config ) ) {
+                    callback( null );
+                    return null;
+                }
+                else if( this.config.autoscale == 'local' ) {
+                    var region = lang.mixin( { scale: viewArgs.scale }, this.browser.view.visibleRegion() );
+                    region.ref = ProjectionUtils.parseSequenceList(region.ref)[0].name;
+                    region.start = Math.ceil( region.start );
+                    region.end = Math.floor( region.end );
+                    return this.getRegionStats.call( this, region, callback, errorCallback );
+                }
+                else {
+                    return this.getGlobalStats.call( this, callback, errorCallback );
+                }
+            },
+
+            _draw: function( scale, leftBase, rightBase, block, canvas, features, featureRects, dataScale, pixels, spans ) {
+                // Note: pixels currently has no meaning, as the function that generates it is not yet defined for this track
+                this._preDraw(      scale, leftBase, rightBase, block, canvas, features, featureRects, dataScale );
+                this._drawFeatures( scale, leftBase, rightBase, block, canvas, features, featureRects, dataScale );
+                if ( spans ) {
+                    this._maskBySpans( scale, leftBase, canvas, spans );
+                }
+                this._postDraw(     scale, leftBase, rightBase, block, canvas, features, featureRects, dataScale );
+            },
+
+            _maskBySpans: function( scale, leftBase, canvas, spans ) {
+                var context = canvas.getContext('2d');
+                var canvasHeight = canvas.height;
+                var booleanAlpha = this.config.style.masked_transparancy || 0.17;
+                this.config.style.masked_transparancy = booleanAlpha;
+
+                // make a temporary canvas to store image data
+                var tempCan = dojo.create( 'canvas', {height: canvasHeight, width: canvas.width} );
+                var ctx2 = tempCan.getContext('2d');
+
+                for ( var index in spans ) {
+                    if (spans.hasOwnProperty(index)) {
+                        var w = Math.round(( spans[index].end   - spans[index].start ) * scale );
+                        var l = Math.round(( spans[index].start - leftBase ) * scale );
+                        if (l+w >= canvas.width)
+                            w = canvas.width-l; // correct possible rounding errors
+                        if (w==0)
+                            continue; // skip if there's no width.
+                        ctx2.drawImage(canvas, l, 0, w, canvasHeight, l, 0, w, canvasHeight);
+                        context.globalAlpha = booleanAlpha;
+                        // clear masked region and redraw at lower opacity.
+                        context.clearRect(l, 0, w, canvasHeight);
+                        context.drawImage(tempCan, l, 0, w, canvasHeight, l, 0, w, canvasHeight);
+                        context.globalAlpha = 1;
+                    }
+                }
+            },
+
+            _showPixelValue: function( scoreDisplay, score ) {
+                if( ! score || ! score.score )
+                    return false;
+                score = score.score;
+
+                function fmtNum( num ) {
+                    return parseFloat( num ).toPrecision(6).replace(/0+$/,'').replace(/\.$/,'');
+                }
+                function pctString( count ) {
+                    count = Math.round(count/total*100);
+                    if( typeof count == 'number' && ! isNaN(count) )
+                        return count+'%';
+                    return '';
+                }
+                if( score.snpsCounted ) {
+                    var total = score.total();
+                    var scoreSummary = '<table>';
+
+
+                    score.forEach( function( count, category ) {
+                        // if this count has more nested categories, do counts of those
+                        var subdistribution = '';
+                        if( count.forEach ) {
+                            subdistribution = [];
+                            count.forEach( function( count, category ) {
+                                subdistribution.push( fmtNum(count) + ' '+category );
+                            });
+                            subdistribution = subdistribution.join(', ');
+                            if( subdistribution )
+                                subdistribution = '('+subdistribution+')';
+                        }
+
+                        category = { '*': 'del', reference: 'Ref', skip: 'Skip/intron' }[category] || category;
+                        scoreSummary += '<tr><td>'+category + '</td><td class="count">' + fmtNum(count) + '</td><td class="pct">'
+                            +pctString(count)+'</td><td class="subdist">'+subdistribution + '</td></tr>';
+                    });
+                    scoreSummary += '<tr class="total"><td>Total</td><td class="count">'+fmtNum(total)+'</td><td class="pct">&nbsp;</td><td class="subdist">&nbsp;</td></tr>';
+                    scoreDisplay.innerHTML = scoreSummary+'</table>';
+                    return true;
+                } else {
+                    scoreDisplay.innerHTML = '<table><tr><td>Total</td><td class="count">'+fmtNum(score)+'</td></tr></table>';
+                    return true;
+                }
+            },
+
+            _trackMenuOptions: function() {
+                return all([ this.inherited(arguments), this._alignmentsFilterTrackMenuOptions() ])
+                    .then( function( options ) {
+                        var o = options.shift();
+                        options.unshift({ type: 'dijit/MenuSeparator' } );
+                        return o.concat.apply( o, options );
+                    });
+            }
+
+
+        });
+
+    });


### PR DESCRIPTION
@nathandunn This is ready for test and review.

To test, make sure the BAM track's store is `WebApollo/Store/SeqFeature/BAM` and the track type is `WebApollo/Track/SeqFeature/SNPCoverage` and `WebApollo/Track/SeqFeature/FeatureCoverage`.

For SNPCoverage, it would be best to try with a BAM which has reads with MD tag (not all BAMs have them).

Fixes #1826 