### PR TITLE
prevents bad setting of translation start and end

### DIFF
--- a/grails-app/services/org/bbop/apollo/CdsService.groovy
+++ b/grails-app/services/org/bbop/apollo/CdsService.groovy
@@ -19,12 +19,12 @@ class CdsService {
     def sequenceService
     def overlapperService
     
-    public void setManuallySetTranslationStart(CDS cds, boolean manuallySetTranslationStart) {
+    void setManuallySetTranslationStart(CDS cds, boolean manuallySetTranslationStart) {
         if (manuallySetTranslationStart && isManuallySetTranslationStart(cds)) {
-            return;
+            return
         }
         if (!manuallySetTranslationStart && !isManuallySetTranslationStart(cds)) {
-            return;
+            return
         }
         if (manuallySetTranslationStart) {
             featurePropertyService.addComment(cds, MANUALLY_SET_TRANSLATION_START)
@@ -34,32 +34,32 @@ class CdsService {
         }
     }
 
-    public boolean isManuallySetTranslationStart(CDS cds) {
+    boolean isManuallySetTranslationStart(CDS cds) {
         for (Comment comment : featurePropertyService.getComments(cds)) {
             if (comment.value.equals(MANUALLY_SET_TRANSLATION_START)) {
-                return true;
+                return true
             }
         }
-        return false;
+        return false
     }
 
 
-    public boolean isManuallySetTranslationEnd(CDS cds) {
+    boolean isManuallySetTranslationEnd(CDS cds) {
 
         for (Comment comment : featurePropertyService.getComments(cds)) {
             if (comment.value.equals(MANUALLY_SET_TRANSLATION_END)) {
-                return true;
+                return true
             }
         }
-        return false;
+        return false
     }
 
-    public void setManuallySetTranslationEnd(CDS cds, boolean manuallySetTranslationEnd) {
+    void setManuallySetTranslationEnd(CDS cds, boolean manuallySetTranslationEnd) {
         if (manuallySetTranslationEnd && isManuallySetTranslationEnd(cds)) {
-            return;
+            return
         }
         if (!manuallySetTranslationEnd && !isManuallySetTranslationEnd(cds)) {
-            return;
+            return
         }
         if (manuallySetTranslationEnd) {
             featurePropertyService.addComment(cds, MANUALLY_SET_TRANSLATION_END)
@@ -95,7 +95,7 @@ class CdsService {
         return featureRelationshipService.getChildrenForFeatureAndTypes(cds,StopCodonReadThrough.ontologyId)
     }
 
-    public StopCodonReadThrough createStopCodonReadThrough(CDS cds) {
+    StopCodonReadThrough createStopCodonReadThrough(CDS cds) {
         String uniqueName = cds.getUniqueName() + FeatureStringEnum.STOP_CODON_READHTHROUGH_SUFFIX.value;
         StopCodonReadThrough stopCodonReadThrough = new StopCodonReadThrough(
                 uniqueName: uniqueName

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -620,7 +620,7 @@ class FeatureService {
  * @param setTranslationEnd - if set to true, will search for the nearest in frame stop codon
  */
     @Transactional
-    void setTranslationStart(Transcript transcript, int translationStart, boolean setTranslationEnd) {
+    void setTranslationStart(Transcript transcript, int translationStart, boolean setTranslationEnd) throws AnnotationException{
         log.debug "setTranslationStart(transcript,translationStart,translationEnd)"
         setTranslationStart(transcript, translationStart, setTranslationEnd, false);
     }
@@ -635,7 +635,7 @@ class FeatureService {
  * @param readThroughStopCodon - if set to true, will read through the first stop codon to the next
  */
     @Transactional
-    void setTranslationStart(Transcript transcript, int translationStart, boolean setTranslationEnd, boolean readThroughStopCodon) {
+    void setTranslationStart(Transcript transcript, int translationStart, boolean setTranslationEnd, boolean readThroughStopCodon) throws AnnotationException{
         log.debug "setTranslationStart(transcript,translationStart,translationEnd,readThroughStopCodon)"
         setTranslationStart(transcript, translationStart, setTranslationEnd, setTranslationEnd ? organismService.getTranslationTable(transcript.featureLocation.sequence.organism) : null, readThroughStopCodon);
     }
@@ -859,7 +859,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
  * @param translationEnd - Coordinate of the end of translation
  */
     @Transactional
-    void setTranslationEnd(Transcript transcript, int translationEnd) {
+    void setTranslationEnd(Transcript transcript, int translationEnd) throws AnnotationException{
         setTranslationEnd(transcript, translationEnd, false);
     }
 
@@ -872,7 +872,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
  * @param setTranslationStart - if set to true, will search for the nearest in frame start
  */
     @Transactional
-    void setTranslationEnd(Transcript transcript, int translationEnd, boolean setTranslationStart) {
+    void setTranslationEnd(Transcript transcript, int translationEnd, boolean setTranslationStart) throws AnnotationException{
         setTranslationEnd(transcript, translationEnd, setTranslationStart,
                 setTranslationStart ? organismService.getTranslationTable(transcript.featureLocation.sequence.organism) : null
         );
@@ -896,13 +896,14 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         }
         // if the start is set, then we make sure we are going to set a legal coordinate
         if (cdsService.isManuallySetTranslationStart(cds)) {
+            println "${transcript.strand} min ${cds.featureLocation.fmin} vs transl end ${translationEnd}"
             if (transcript.strand == Strand.NEGATIVE.value) {
                 if (cds.featureLocation.fmin <= translationEnd) {
-                    throw new AnnotationException("Translation start ${cds.featureLocation.fmin} must be upstream of the end ${translationEnd}")
+                    throw new AnnotationException("Translation end ${cds.featureLocation.fmin} must be upstream of the end ${translationEnd}")
                 }
             } else {
                 if (cds.featureLocation.fmin >= translationEnd) {
-                    throw new AnnotationException("Translation start ${cds.featureLocation.fmax} must be upstream of the end ${translationEnd}")
+                    throw new AnnotationException("Translation end ${cds.featureLocation.fmax} must be upstream of the end ${translationEnd}")
                 }
             }
         }

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -747,8 +747,8 @@ class FeatureService {
         // if the end is set, then we make sure we are going to set a legal coordinate
         if (cdsService.isManuallySetTranslationEnd(cds)) {
             if (transcript.strand == Strand.NEGATIVE.value) {
-                if (translationStart <= cds.featureLocation.fmax) {
-                    throw new AnnotationException("Translation start ${translationStart} must be upstream of the end ${cds.featureLocation.fmax} (larger)")
+                if (translationStart <= cds.featureLocation.fmin) {
+                    throw new AnnotationException("Translation start ${translationStart} must be upstream of the end ${cds.featureLocation.fmin} (larger)")
                 }
             } else {
                 if (translationStart >= cds.featureLocation.fmax) {
@@ -758,17 +758,17 @@ class FeatureService {
         }
         FeatureLocation transcriptFeatureLocation = FeatureLocation.findByFeature(transcript)
         if (transcriptFeatureLocation.strand == Strand.NEGATIVE.value) {
-            setFmax(cds, translationStart + 1);
+            setFmax(cds, translationStart + 1)
         } else {
-            setFmin(cds, translationStart);
+            setFmin(cds, translationStart)
         }
         cdsService.setManuallySetTranslationStart(cds, true);
 //        cds.deleteStopCodonReadThrough();
-        cdsService.deleteStopCodonReadThrough(cds);
+        cdsService.deleteStopCodonReadThrough(cds)
 //        featureRelationshipService.deleteRelationships()
 
         if (setTranslationEnd && translationTable != null) {
-            String mrna = getResiduesWithAlterationsAndFrameshifts(transcript);
+            String mrna = getResiduesWithAlterationsAndFrameshifts(transcript)
             if (mrna == null || mrna.equals("null")) {
                 return;
             }
@@ -898,13 +898,11 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         if (cdsService.isManuallySetTranslationStart(cds)) {
             println "${transcript.strand} min ${cds.featureLocation.fmin} vs transl end ${translationEnd}"
             if (transcript.strand == Strand.NEGATIVE.value) {
-                if (translationEnd  >= cds.featureLocation.fmin ) {
-//                    throw new AnnotationException("Translation end ${cds.featureLocation.fmin} must be upstream of the end ${translationEnd}")
-                    throw new AnnotationException("Translation end ${translationEnd} must be downstream of the start ${cds.featureLocation.fmin} (smaller)")
+                if (translationEnd  >= cds.featureLocation.fmax ) {
+                    throw new AnnotationException("Translation end ${translationEnd} must be downstream of the start ${cds.featureLocation.fmax} (smaller)")
                 }
             } else {
                 if (translationEnd <= cds.featureLocation.fmin ) {
-//                    throw new AnnotationException("Translation end ${cds.featureLocation.fmax} must be upstream of the end ${translationEnd}")
                     throw new AnnotationException("Translation end ${translationEnd} must be downstream of the start ${cds.featureLocation.fmin} (larger)")
                 }
             }

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -744,15 +744,15 @@ class FeatureService {
             featureRelationshipService.addChildFeature(transcript, cds)
 //            transcript.setCDS(cds);
         }
-        // if the start is set, then we make sure we are going to set a legal coordinate
-        if (cdsService.isManuallySetTranslationStart(cds)) {
+        // if the end is set, then we make sure we are going to set a legal coordinate
+        if (cdsService.isManuallySetTranslationEnd(cds)) {
             if (transcript.strand == Strand.NEGATIVE.value) {
-                if (cds.featureLocation.fmax <= translationStart) {
-                    throw new AnnotationException("Translation end ${cds.featureLocation.fmax } must be downstream of the start ${translationStart}")
+                if (translationStart <= cds.featureLocation.fmax) {
+                    throw new AnnotationException("Translation start ${translationStart} must be upstream of the end ${cds.featureLocation.fmax} (larger)")
                 }
             } else {
-                if (cds.featureLocation.fmax >= translationStart) {
-                    throw new AnnotationException("Translation end ${cds.featureLocation.fmax } must be downstream of the start ${translationStart}")
+                if (translationStart >= cds.featureLocation.fmax) {
+                    throw new AnnotationException("Translation start ${translationStart} must be upstream of the end ${cds.featureLocation.fmax} (smaller) ")
                 }
             }
         }
@@ -898,12 +898,14 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         if (cdsService.isManuallySetTranslationStart(cds)) {
             println "${transcript.strand} min ${cds.featureLocation.fmin} vs transl end ${translationEnd}"
             if (transcript.strand == Strand.NEGATIVE.value) {
-                if (cds.featureLocation.fmin <= translationEnd) {
-                    throw new AnnotationException("Translation end ${cds.featureLocation.fmin} must be upstream of the end ${translationEnd}")
+                if (translationEnd  >= cds.featureLocation.fmin ) {
+//                    throw new AnnotationException("Translation end ${cds.featureLocation.fmin} must be upstream of the end ${translationEnd}")
+                    throw new AnnotationException("Translation end ${translationEnd} must be downstream of the start ${cds.featureLocation.fmin} (smaller)")
                 }
             } else {
-                if (cds.featureLocation.fmin >= translationEnd) {
-                    throw new AnnotationException("Translation end ${cds.featureLocation.fmax} must be upstream of the end ${translationEnd}")
+                if (translationEnd <= cds.featureLocation.fmin ) {
+//                    throw new AnnotationException("Translation end ${cds.featureLocation.fmax} must be upstream of the end ${translationEnd}")
+                    throw new AnnotationException("Translation end ${translationEnd} must be downstream of the start ${cds.featureLocation.fmin} (larger)")
                 }
             }
         }

--- a/grails-app/services/org/bbop/apollo/FeatureService.groovy
+++ b/grails-app/services/org/bbop/apollo/FeatureService.groovy
@@ -34,8 +34,10 @@ class FeatureService {
 
     public static final String MANUALLY_ASSOCIATE_TRANSCRIPT_TO_GENE = "Manually associate transcript to gene"
     public static final String MANUALLY_DISSOCIATE_TRANSCRIPT_FROM_GENE = "Manually dissociate transcript from gene"
-    public static final def rnaFeatureTypes = [MRNA.alternateCvTerm,MiRNA.alternateCvTerm,NcRNA.alternateCvTerm, RRNA.alternateCvTerm, SnRNA.alternateCvTerm, SnoRNA.alternateCvTerm, TRNA.alternateCvTerm, Transcript.alternateCvTerm]
+    public static final
+    def rnaFeatureTypes = [MRNA.alternateCvTerm, MiRNA.alternateCvTerm, NcRNA.alternateCvTerm, RRNA.alternateCvTerm, SnRNA.alternateCvTerm, SnoRNA.alternateCvTerm, TRNA.alternateCvTerm, Transcript.alternateCvTerm]
     public static final def singletonFeatureTypes = [RepeatRegion.alternateCvTerm, TransposableElement.alternateCvTerm]
+
     @Timed
     @Transactional
     FeatureLocation convertJSONToFeatureLocation(JSONObject jsonLocation, Sequence sequence, int defaultStrand = Strand.POSITIVE.value) throws JSONException {
@@ -47,8 +49,7 @@ class FeatureService {
         gsolLocation.setFmax(jsonLocation.getInt(FeatureStringEnum.FMAX.value));
         if (jsonLocation.getInt(FeatureStringEnum.STRAND.value) == Strand.POSITIVE.value || jsonLocation.getInt(FeatureStringEnum.STRAND.value) == Strand.NEGATIVE.value) {
             gsolLocation.setStrand(jsonLocation.getInt(FeatureStringEnum.STRAND.value));
-        }
-        else {
+        } else {
             gsolLocation.setStrand(defaultStrand)
         }
         gsolLocation.setSequence(sequence)
@@ -157,8 +158,7 @@ class FeatureService {
 
             if (!useCDS || cds == null) {
                 calculateCDS(transcript, readThroughStopCodon)
-            }
-            else {
+            } else {
                 // if there are any sequence alterations that overlaps this transcript then
                 // recalculate the CDS to account for these changes
                 def sequenceAlterations = getSequenceAlterationsForFeature(transcript)
@@ -223,8 +223,7 @@ class FeatureService {
                             tmpTranscript = (Transcript) convertJSONToFeature(jsonTranscript, sequence);
                             jsonTranscript.put(FeatureStringEnum.NAME.value, originalName)
                             updateNewGsolFeatureAttributes(tmpTranscript)
-                        }
-                        else {
+                        } else {
                             tmpTranscript = (Transcript) convertJSONToFeature(jsonTranscript, sequence);
                             updateNewGsolFeatureAttributes(tmpTranscript)
                         }
@@ -243,8 +242,7 @@ class FeatureService {
 
                         if (!useCDS || cds == null) {
                             calculateCDS(tmpTranscript, readThroughStopCodon)
-                        }
-                        else {
+                        } else {
                             // if there are any sequence alterations that overlaps this transcript then
                             // recalculate the CDS to account for these changes
                             def sequenceAlterations = getSequenceAlterationsForFeature(tmpTranscript)
@@ -304,8 +302,7 @@ class FeatureService {
                                         tmpGene.featureProperties.each {
                                             if (it instanceof Comment) {
                                                 exists = true
-                                            }
-                                            else if (it.tag == tagString && it.value == valueString) {
+                                            } else if (it.tag == tagString && it.value == valueString) {
                                                 exists = true
                                             }
                                         }
@@ -313,8 +310,7 @@ class FeatureService {
                                             if (tagString == FeatureStringEnum.COMMENT.value) {
                                                 // if FeatureProperty is a comment
                                                 featurePropertyService.addComment(tmpGene, valueString)
-                                            }
-                                            else {
+                                            } else {
                                                 addNonReservedProperties(tmpGene, tagString, valueString)
                                             }
                                         }
@@ -342,8 +338,7 @@ class FeatureService {
                 // Scenario IIIa - use the 'parent' attribute, if provided, from transcript JSON
                 jsonGene = JSON.parse(jsonTranscript.getString(FeatureStringEnum.PARENT.value)) as JSONObject
                 jsonGene.put(FeatureStringEnum.CHILDREN.value, new JSONArray().put(jsonTranscript))
-            }
-            else {
+            } else {
                 // Scenario IIIb - use the current mRNA's featurelocation for gene
                 jsonGene.put(FeatureStringEnum.CHILDREN.value, new JSONArray().put(jsonTranscript));
                 jsonGene.put(FeatureStringEnum.LOCATION.value, jsonTranscript.getJSONObject(FeatureStringEnum.LOCATION.value));
@@ -354,11 +349,9 @@ class FeatureService {
             String geneName = null
             if (jsonGene.has(FeatureStringEnum.NAME.value)) {
                 geneName = jsonGene.get(FeatureStringEnum.NAME.value)
-            }
-            else if (jsonTranscript.has(FeatureStringEnum.NAME.value)) {
+            } else if (jsonTranscript.has(FeatureStringEnum.NAME.value)) {
                 geneName = jsonTranscript.getString(FeatureStringEnum.NAME.value)
-            }
-            else {
+            } else {
 //                geneName = nameService.makeUniqueFeatureName(sequence.organism, sequence.name, new LetterPaddingStrategy(), false)
                 geneName = nameService.makeUniqueGeneName(sequence.organism, sequence.name, false)
             }
@@ -386,8 +379,7 @@ class FeatureService {
 
             if (!useCDS || cds == null) {
                 calculateCDS(transcript, readThroughStopCodon)
-            }
-            else {
+            } else {
                 // if there are any sequence alterations that overlaps this transcript then
                 // recalculate the CDS to account for these changes
                 def sequenceAlterations = getSequenceAlterationsForFeature(transcript)
@@ -502,7 +494,7 @@ class FeatureService {
      */
     @Transactional
     def removeExonOverlapsAndAdjacencies(Transcript transcript) throws AnnotationException {
-        List<Exon> sortedExons = transcriptService.getSortedExons(transcript,false)
+        List<Exon> sortedExons = transcriptService.getSortedExons(transcript, false)
         if (!sortedExons || sortedExons?.size() <= 1) {
             return;
         }
@@ -516,7 +508,7 @@ class FeatureService {
                 if (overlapperService.overlaps(leftExon, rightExon) || isAdjacentTo(leftExon.getFeatureLocation(), rightExon.getFeatureLocation())) {
                     try {
                         exonService.mergeExons(leftExon, rightExon);
-                        sortedExons = transcriptService.getSortedExons(transcript,false)
+                        sortedExons = transcriptService.getSortedExons(transcript, false)
                         // we have to reload the sortedExons again and start over
                         ++inc;
                     } catch (AnnotationException e) {
@@ -668,7 +660,7 @@ class FeatureService {
 
     int convertLocalCoordinateToSourceCoordinateForTranscript(Transcript transcript, int localCoordinate) {
         // Method converts localCoordinate to sourceCoordinate in reference to the Transcript
-        List<Exon> exons = transcriptService.getSortedExons(transcript,true)
+        List<Exon> exons = transcriptService.getSortedExons(transcript, true)
         int sourceCoordinate = -1;
         if (exons.size() == 0) {
             return convertLocalCoordinateToSourceCoordinate(transcript, localCoordinate);
@@ -698,7 +690,7 @@ class FeatureService {
             return convertLocalCoordinateToSourceCoordinate(cds, localCoordinate);
         }
         int offset = 0;
-        List<Exon> exons = transcriptService.getSortedExons(transcript,true)
+        List<Exon> exons = transcriptService.getSortedExons(transcript, true)
         if (exons.size() == 0) {
             log.debug "FS::convertLocalCoordinateToSourceCoordinateForCDS() - No exons for given transcript"
             return convertLocalCoordinateToSourceCoordinate(cds, localCoordinate)
@@ -745,12 +737,24 @@ class FeatureService {
  * @param readThroughStopCodon - if set to true, will read through the first stop codon to the next
  */
     @Transactional
-    void setTranslationStart(Transcript transcript, int translationStart, boolean setTranslationEnd, TranslationTable translationTable, boolean readThroughStopCodon) {
+    void setTranslationStart(Transcript transcript, int translationStart, boolean setTranslationEnd, TranslationTable translationTable, boolean readThroughStopCodon) throws AnnotationException{
         CDS cds = transcriptService.getCDS(transcript);
         if (cds == null) {
             cds = transcriptService.createCDS(transcript);
             featureRelationshipService.addChildFeature(transcript, cds)
 //            transcript.setCDS(cds);
+        }
+        // if the start is set, then we make sure we are going to set a legal coordinate
+        if (cdsService.isManuallySetTranslationStart(cds)) {
+            if (transcript.strand == Strand.NEGATIVE.value) {
+                if (cds.featureLocation.fmax <= translationStart) {
+                    throw new AnnotationException("Translation end ${cds.featureLocation.fmax } must be downstream of the start ${translationStart}")
+                }
+            } else {
+                if (cds.featureLocation.fmax >= translationStart) {
+                    throw new AnnotationException("Translation end ${cds.featureLocation.fmax } must be downstream of the start ${translationStart}")
+                }
+            }
         }
         FeatureLocation transcriptFeatureLocation = FeatureLocation.findByFeature(transcript)
         if (transcriptFeatureLocation.strand == Strand.NEGATIVE.value) {
@@ -884,12 +888,25 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
  * @param translationTable - Translation table that defines the codon translation
  */
     @Transactional
-    void setTranslationEnd(Transcript transcript, int translationEnd, boolean setTranslationStart, TranslationTable translationTable) {
+    void setTranslationEnd(Transcript transcript, int translationEnd, boolean setTranslationStart, TranslationTable translationTable) throws AnnotationException{
         CDS cds = transcriptService.getCDS(transcript);
         if (cds == null) {
             cds = transcriptService.createCDS(transcript);
             transcriptService.setCDS(transcript, cds);
         }
+        // if the start is set, then we make sure we are going to set a legal coordinate
+        if (cdsService.isManuallySetTranslationStart(cds)) {
+            if (transcript.strand == Strand.NEGATIVE.value) {
+                if (cds.featureLocation.fmin <= translationEnd) {
+                    throw new AnnotationException("Translation start ${cds.featureLocation.fmin} must be upstream of the end ${translationEnd}")
+                }
+            } else {
+                if (cds.featureLocation.fmin >= translationEnd) {
+                    throw new AnnotationException("Translation start ${cds.featureLocation.fmax} must be upstream of the end ${translationEnd}")
+                }
+            }
+        }
+
         if (transcript.strand == Strand.NEGATIVE.value) {
             cds.featureLocation.setFmin(translationEnd);
         } else {
@@ -985,7 +1002,6 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
 //        fireAnnotationChangeEvent(transcript, transcript.getGene(), AnnotationChangeEvent.Operation.UPDATE);
 
     }
-
 
     /** Get the residues for a feature with any alterations and frameshifts.
      *
@@ -1105,6 +1121,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
  * @param allowPartialExtension - Where partial ORFs should be used for possible extension
  *
  */
+
     @Timed
     @Transactional
     void setLongestORF(Transcript transcript, boolean readThroughStopCodon) {
@@ -1126,7 +1143,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
             for (String startCodon : translationTable.getStartCodons()) {
                 // find the first start codon
                 startIndex = mrna.indexOf(startCodon)
-                while(startIndex >= 0) {
+                while (startIndex >= 0) {
                     String mrnaSubstring = mrna.substring(startIndex)
                     String aa = SequenceTranslationHandler.translateSequence(mrnaSubstring, translationTable, true, readThroughStopCodon)
                     if (aa.length() > longestPeptide.length()) {
@@ -1140,7 +1157,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
             // Just in case the 5' end is missing, check to see if a longer
             // translation can be obatained without looking for a start codon
             startIndex = 0
-            while(startIndex < 3) {
+            while (startIndex < 3) {
                 String mrnaSubstring = mrna.substring(startIndex)
                 String aa = SequenceTranslationHandler.translateSequence(mrnaSubstring, translationTable, true, readThroughStopCodon)
                 if (aa.length() > longestPeptide.length()) {
@@ -1156,8 +1173,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         if (!longestPeptide.substring(longestPeptide.length() - 1).equals(TranslationTable.STOP)) {
             partialStop = true
             bestStopIndex = -1
-        }
-        else {
+        } else {
             stopIndex = bestStartIndex + (longestPeptide.length() * 3)
             partialStop = false
             bestStopIndex = stopIndex
@@ -1184,8 +1200,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
                 }
                 setFmin(cds, fmin)
                 setFmax(cds, fmax)
-            }
-            else {
+            } else {
                 log.debug "bestStopIndex < 0"
                 int fmax = transcript.strand == Strand.NEGATIVE.value ? transcript.fmin : transcript.fmax
                 if (cds.strand == Strand.NEGATIVE.value) {
@@ -1200,8 +1215,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
             if (cds.featureLocation.strand == Strand.NEGATIVE.value) {
                 cds.featureLocation.setIsFminPartial(partialStop)
                 cds.featureLocation.setIsFmaxPartial(partialStart)
-            }
-            else {
+            } else {
                 cds.featureLocation.setIsFminPartial(partialStart)
                 cds.featureLocation.setIsFmaxPartial(partialStop)
             }
@@ -1252,8 +1266,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
             }
             if (jsonFeature.has(FeatureStringEnum.NAME.value)) {
                 gsolFeature.setName(jsonFeature.getString(FeatureStringEnum.NAME.value));
-            }
-            else {
+            } else {
                 // since name attribute cannot be null, using the feature's own uniqueName
                 gsolFeature.name = gsolFeature.uniqueName
             }
@@ -1329,8 +1342,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
                     String propertyName = ""
                     if (property.has(FeatureStringEnum.NAME.value)) {
                         propertyName = property.get(FeatureStringEnum.NAME.value)
-                    }
-                    else {
+                    } else {
                         propertyName = propertyType.get(FeatureStringEnum.NAME.value)
                     }
                     String propertyValue = property.get(FeatureStringEnum.VALUE.value)
@@ -1346,12 +1358,10 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
                             ).save(failOnError: true)
                             gsolFeature.status = status
                             gsolFeature.save()
-                        }
-                        else {
+                        } else {
                             log.warn "Ignoring status ${propertyValue} as its not defined."
                         }
-                    }
-                    else {
+                    } else {
                         if (propertyName == FeatureStringEnum.COMMENT.value) {
                             // property of type 'Comment'
                             gsolProperty = new Comment();
@@ -1550,7 +1560,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
     }
 
     int convertSourceCoordinateToLocalCoordinateForTranscript(Transcript transcript, int sourceCoordinate) {
-        List<Exon> exons = transcriptService.getSortedExons(transcript,true)
+        List<Exon> exons = transcriptService.getSortedExons(transcript, true)
         int localCoordinate = -1
         int currentCoordinate = 0
         for (Exon exon : exons) {
@@ -1574,8 +1584,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         if (feature instanceof Transcript) {
             exons = transcriptService.getSortedExons(feature, true)
             cds = transcriptService.getCDS(feature)
-        }
-        else if (feature instanceof CDS) {
+        } else if (feature instanceof CDS) {
             Transcript transcript = transcriptService.getTranscript(feature)
             exons = transcriptService.getSortedExons(transcript, true)
             cds = feature
@@ -1721,9 +1730,9 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         return jsonFeature;
     }
 
-    String generateOwnerString(Feature feature){
-        if(feature.owner){
-          return feature.owner.username
+    String generateOwnerString(Feature feature) {
+        if (feature.owner) {
+            return feature.owner.username
         }
         if (feature.owners) {
             String ownerString = ""
@@ -2264,8 +2273,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
                     uniqueName: nameService.generateUniqueName(),
                     name: nameService.generateUniqueName(gene)
             ).save()
-        }
-        else {
+        } else {
             newGene = new Gene(
                     uniqueName: nameService.generateUniqueName(),
                     name: nameService.generateUniqueName(gene)
@@ -2361,8 +2369,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
         def exonList = []
         if (feature instanceof Transcript) {
             exonList = transcriptService.getSortedExons(feature, true)
-        }
-        else if (feature instanceof CDS) {
+        } else if (feature instanceof CDS) {
             Transcript transcript = transcriptService.getTranscript(feature)
             exonList = transcriptService.getSortedExons(transcript, true)
         }
@@ -2538,7 +2545,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
                 }
             }
         } else {
-            List<Exon> exonList = feature instanceof CDS ? transcriptService.getSortedExons(transcriptService.getTranscript(feature),true) : transcriptService.getSortedExons( (Transcript) feature, true)
+            List<Exon> exonList = feature instanceof CDS ? transcriptService.getSortedExons(transcriptService.getTranscript(feature), true) : transcriptService.getSortedExons((Transcript) feature, true)
             for (Exon exon : exonList) {
                 int exonFmin = exon.fmin
                 int exonFmax = exon.fmax
@@ -2663,7 +2670,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
                 coordinateInContext = convertSourceCoordinateToLocalCoordinateForCDS(feature, alteration.fmin)
             } else if (feature instanceof Transcript) {
                 // if feature is Transcript then calling convertSourceCoordinateToLocalCoordinateForTranscript
-                coordinateInContext = convertSourceCoordinateToLocalCoordinateForTranscript( (Transcript) feature, alteration.fmin)
+                coordinateInContext = convertSourceCoordinateToLocalCoordinateForTranscript((Transcript) feature, alteration.fmin)
             } else {
                 // calling convertSourceCoordinateToLocalCoordinate
                 coordinateInContext = convertSourceCoordinateToLocalCoordinate(feature, alteration.fmin)
@@ -2952,8 +2959,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
                     // Scenario IIIa - use the 'parent' attribute, if provided, from feature JSON
                     jsonGene = JSON.parse(jsonFeature.getString(FeatureStringEnum.PARENT.value)) as JSONObject
                     jsonGene.put(FeatureStringEnum.CHILDREN.value, new JSONArray().put(jsonFeature))
-                }
-                else {
+                } else {
                     // Scenario IIIb - use the current mRNA's featurelocation for gene
                     jsonGene.put(FeatureStringEnum.CHILDREN.value, new JSONArray().put(jsonFeature))
                     jsonGene.put(FeatureStringEnum.LOCATION.value, jsonFeature.getJSONObject(FeatureStringEnum.LOCATION.value))
@@ -2965,18 +2971,14 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
                 if (jsonGene.has(FeatureStringEnum.NAME.value)) {
                     geneName = jsonGene.getString(FeatureStringEnum.NAME.value)
                     log.debug "jsonGene already has 'name': ${geneName}"
-                }
-                else if (jsonFeature.has(FeatureStringEnum.PARENT_NAME.value)) {
+                } else if (jsonFeature.has(FeatureStringEnum.PARENT_NAME.value)) {
                     String principalName = jsonFeature.getString(FeatureStringEnum.PARENT_NAME.value)
                     geneName = nameService.makeUniqueGeneName(sequence.organism, principalName, false)
                     log.debug "jsonFeature has 'parent_name' attribute; using ${principalName} to generate ${geneName}"
-                }
-                else
-                if (jsonFeature.has(FeatureStringEnum.NAME.value)) {
+                } else if (jsonFeature.has(FeatureStringEnum.NAME.value)) {
                     geneName = jsonFeature.getString(FeatureStringEnum.NAME.value)
                     log.debug "jsonGene already has 'name': ${geneName}"
-                }
-                else {
+                } else {
                     geneName = nameService.makeUniqueGeneName(sequence.organism, sequence.name, false)
                     log.debug "Making a new unique gene name: ${geneName}"
                 }
@@ -3092,7 +3094,7 @@ public void setTranslationEnd(Transcript transcript, int translationEnd) {
 
     def checkForComment(Feature feature, String value) {
         def comments = featurePropertyService.getComments(feature)
-        for(FeatureProperty comment : comments) {
+        for (FeatureProperty comment : comments) {
             if (comment.value == value) {
                 return true
             }

--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -685,7 +685,7 @@ class RequestHandlingService {
      * @param inputObject
      */
     @Timed
-    JSONObject setTranslationStart(JSONObject inputObject) {
+    JSONObject setTranslationStart(JSONObject inputObject) throws AnnotationException{
         JSONArray features = inputObject.getJSONArray(FeatureStringEnum.FEATURES.value)
         JSONObject transcriptJSONObject = features.getJSONObject(0);
 

--- a/test/integration/org/bbop/apollo/RequestHandlingServiceIntegrationSpec.groovy
+++ b/test/integration/org/bbop/apollo/RequestHandlingServiceIntegrationSpec.groovy
@@ -2433,6 +2433,38 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec {
 
         then: "the previous gene of transcript2 doesn't exist as it is deleted when it has no connected child features"
         Gene.count == 1
+
+
+        when: "we set the proper translation end"
+//        requestHandlingService.setTranslationEnd(JSON.parse(setTranslationEndForTranscript1) as JSONObject)
+
+
+        then: "it should use the translation end on the CDS"
+
+
+
+
+        when: "we attempt to add a bad start location on transcript 1"
+//        requestHandlingService.setTranslationStart(JSON.parse(setTranslationStartForTranscript1) as JSONObject)
+
+
+        then: "we expect a failure and the CDS to remain in the same spot"
+        thrown AnnotationException
+        AnnotationException ex = thrown()
+        ex.message.contains("upstream")
+
+
+
+        when: "we attempt to add a bad end location on transcript 1"
+//        requestHandlingService.setTranslationEnd(JSON.parse(setTranslationEndForTranscript1) as JSONObject)
+
+
+
+        then: "we expect a failure and the CDS to remain in the same spot"
+        ex = thrown(AnnotationException)
+//        ex = thrown()
+        ex.message.contains("upstream")
+
     }
 
     void "when a setTranslationEnd action is performed on a transcript, there should be a check for overlapping isoforms"() {
@@ -2495,6 +2527,32 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec {
 
         then: "the previous gene of transcript2 doesn't exist as it is deleted when it has no connected child features"
         Gene.count == 1
+
+
+        when: "we attempt to add a bad start location on transcript 1"
+//        requestHandlingService.setTranslationStart(JSON.parse(setTranslationStartForTranscript1) as JSONObject)
+
+
+        then: "we expect a failure and the CDS to remain in the same spot"
+        thrown AnnotationException
+        AnnotationException ex = thrown()
+        ex.message.contains("downstream")
+
+
+
+
+        when: "we attempt to add a bad end location on transcript 1"
+//        requestHandlingService.setTranslationEnd(JSON.parse(setTranslationEndForTranscript1) as JSONObject)
+
+
+
+        then: "we expect a failure and the CDS to remain in the same spot"
+        thrown AnnotationException
+        ex = thrown()
+        ex.message.contains("downstream")
+
+
+
     }
 
     void "when a setExonBoundaries action is performed on a transcript, there should be a check for overlapping isoforms"() {

--- a/test/integration/org/bbop/apollo/RequestHandlingServiceIntegrationSpec.groovy
+++ b/test/integration/org/bbop/apollo/RequestHandlingServiceIntegrationSpec.groovy
@@ -2375,15 +2375,11 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec {
         assert Insertion.count == 2
     }
 
-    @IgnoreRest
     void "when a setTranslationStart action is performed on a transcript, there should be a check of overlapping isoforms"() {
 
         given: "Two transcripts having separate parent gene"
         String transcript1 = "{ ${testCredentials} \"features\":[{\"children\":[{\"location\":{\"strand\":-1,\"fmin\":958639,\"fmax\":959315},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":953072,\"fmax\":953075},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":949590,\"fmax\":950737},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":949590,\"fmax\":950830},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":951050,\"fmax\":951116},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":951349,\"fmax\":951703},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":952162,\"fmax\":952606},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":952865,\"fmax\":953075},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":958639,\"fmax\":959315},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":950737,\"fmax\":953072},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"CDS\"}}],\"name\":\"GB40735-RA\",\"location\":{\"strand\":-1,\"fmin\":949590,\"fmax\":959315},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"mRNA\"}}],\"track\":\"Group1.10\",\"operation\":\"add_transcript\"}"
         String setTranslationStartForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmin\":959297}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
-        String setTranslationEndForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmax\":959305}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
-        String setTranslationBadEndForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmax\":959240}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
-        String setTranslationBadStartForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmin\":959230}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
         String transcript2 = "{${testCredentials} \"features\":[{\"children\":[{\"location\":{\"strand\":-1,\"fmin\":956828,\"fmax\":956837},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":958023,\"fmax\":958067},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":958639,\"fmax\":959315},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":958639,\"fmax\":958819},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":958023,\"fmax\":958067},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":956828,\"fmax\":956837},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":958897,\"fmax\":959315},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":958819,\"fmax\":958897},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"CDS\"}}],\"name\":\"fgeneshpp_with_rnaseq_Group1.10_208_mRNA\",\"location\":{\"strand\":-1,\"fmin\":956828,\"fmax\":959315},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"mRNA\"}}],\"track\":\"Group1.10\",\"operation\":\"add_transcript\"}"
         String setTranslationStartForTranscript2 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmin\":959297}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
 
@@ -2435,6 +2431,38 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec {
         then: "Name for transcript2 should have changed, in light of the new CDS overlap"
         assert transcript2Name != transcript2ModifiedName
 
+    }
+
+//    @IgnoreRest
+    void "test translation start and end validation for negative strand"(){
+
+        given: "Two transcripts having separate parent gene"
+        String transcript1 = "{ ${testCredentials} \"features\":[{\"children\":[{\"location\":{\"strand\":-1,\"fmin\":958639,\"fmax\":959315},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":953072,\"fmax\":953075},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":949590,\"fmax\":950737},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":949590,\"fmax\":950830},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":951050,\"fmax\":951116},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":951349,\"fmax\":951703},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":952162,\"fmax\":952606},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":952865,\"fmax\":953075},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":958639,\"fmax\":959315},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":-1,\"fmin\":950737,\"fmax\":953072},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"CDS\"}}],\"name\":\"GB40735-RA\",\"location\":{\"strand\":-1,\"fmin\":949590,\"fmax\":959315},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"mRNA\"}}],\"track\":\"Group1.10\",\"operation\":\"add_transcript\"}"
+        String setTranslationStartForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmin\":959297}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
+        String setTranslationEndForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmax\":959281}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
+        String setTranslationBadEndForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmax\":959240}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
+        String setTranslationBadStartForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmin\":959230}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
+
+        when: "we add transcript1"
+        JSONObject addTranscript1ReturnObject = requestHandlingService.addTranscript(JSON.parse(transcript1) as JSONObject).get("features")
+
+        then: "we should have 1 Gene and 1 MRNA"
+        assert Gene.count == 1
+        assert MRNA.count == 1
+        String transcript1UniqueName = addTranscript1ReturnObject.uniquename
+        CDS initialCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
+        int initialCDSLength = initialCDS.featureLocation.fmax - initialCDS.featureLocation.fmin
+
+        when: "we set translation start for transcript1"
+        setTranslationStartForTranscript1 = setTranslationStartForTranscript1.replace("@UNIQUENAME@", transcript1UniqueName)
+        JSONObject setTranslationStartTranscript1ReturnObject = requestHandlingService.setTranslationStart(JSON.parse(setTranslationStartForTranscript1) as JSONObject).get("features")
+
+        then: "we should see a difference in CDS length for transcript1"
+        CDS alteredCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
+        int alteredCDSLength = alteredCDS.featureLocation.fmax - alteredCDS.featureLocation.fmin
+        assert initialCDSLength != alteredCDSLength
+
+
         then: "the previous gene of transcript2 doesn't exist as it is deleted when it has no connected child features"
         Gene.count == 1
 
@@ -2481,7 +2509,66 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec {
 
     }
 
-    @IgnoreRest
+//    @IgnoreRest
+    void "set translation start and end for positive strand"() {
+
+        given: "two transcripts having separate parent gene"
+        String transcript1 = "{${testCredentials} \"features\":[{\"children\":[{\"location\":{\"strand\":1,\"fmin\":592678,\"fmax\":592731},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":1,\"fmin\":593507,\"fmax\":594164},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":1,\"fmin\":588729,\"fmax\":588910},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":1,\"fmin\":592526,\"fmax\":592731},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":1,\"fmin\":593507,\"fmax\":594164},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"exon\"}},{\"location\":{\"strand\":1,\"fmin\":588729,\"fmax\":592678},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"CDS\"}}],\"name\":\"GB40820-RA\",\"location\":{\"strand\":1,\"fmin\":588729,\"fmax\":594164},\"type\":{\"cv\":{\"name\":\"sequence\"},\"name\":\"mRNA\"}}],\"track\":\"Group1.10\",\"operation\":\"add_transcript\"}"
+        String setTranslationStartForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmin\":593550}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
+        String setTranslationEndForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmax\":593579}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_end\"}"
+        String setTranslationBadEndForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmax\":959280}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
+        String setTranslationBadStartForTranscript1 = "{${testCredentials} \"features\":[{\"uniquename\":\"@UNIQUENAME@\",\"location\":{\"fmin\":959230}}],\"track\":\"Group1.10\",\"operation\":\"set_translation_start\"}"
+
+        when: "we add transcript1"
+        JSONObject addTranscript1ReturnObject = requestHandlingService.addTranscript(JSON.parse(transcript1) as JSONObject).get("features")
+
+        then: "we should have 1 Gene and 1 MRNA"
+        assert Gene.count == 1
+        assert MRNA.count == 1
+        String transcript1UniqueName = addTranscript1ReturnObject.uniquename
+        CDS initialCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
+        int initialCDSLength = initialCDS.featureLocation.fmax - initialCDS.featureLocation.fmin
+
+        when: "we set translation start and end for transcript1"
+        setTranslationStartForTranscript1 = setTranslationStartForTranscript1.replace("@UNIQUENAME@", transcript1UniqueName)
+        setTranslationEndForTranscript1 = setTranslationEndForTranscript1.replace("@UNIQUENAME@", transcript1UniqueName)
+        requestHandlingService.setTranslationStart(JSON.parse(setTranslationStartForTranscript1) as JSONObject)
+        requestHandlingService.setTranslationEnd(JSON.parse(setTranslationEndForTranscript1) as JSONObject)
+
+        then: "we should see a difference in CDS length for transcript 1"
+        CDS alteredCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
+        int alteredCDSLength = alteredCDS.featureLocation.fmax - alteredCDS.featureLocation.fmin
+        assert initialCDSLength != alteredCDSLength
+
+        when: "we attempt to add a bad start location on transcript 1"
+//        requestHandlingService.setTranslationStart(JSON.parse(setTranslationStartForTranscript1) as JSONObject)
+        setTranslationBadStartForTranscript1 = setTranslationBadStartForTranscript1.replace("@UNIQUENAME@", transcript1UniqueName)
+        requestHandlingService.setTranslationStart(JSON.parse(setTranslationBadStartForTranscript1) as JSONObject)
+        alteredCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
+
+
+        then: "we expect a failure and the CDS to remain in the same spot"
+        AnnotationException ex = thrown(AnnotationException)
+        ex.message.contains("downstream")
+
+
+
+
+        when: "we attempt to add a bad end location on transcript 1"
+//        requestHandlingService.setTranslationEnd(JSON.parse(setTranslationEndForTranscript1) as JSONObject)
+        setTranslationBadEndForTranscript1 = setTranslationBadEndForTranscript1.replace("@UNIQUENAME@", transcript1UniqueName)
+        requestHandlingService.setTranslationEnd(JSON.parse(setTranslationBadEndForTranscript1) as JSONObject)
+        alteredCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
+
+
+
+        then: "we expect a failure and the CDS to remain in the same spot"
+        ex = thrown(AnnotationException)
+        ex.message.contains("downstream")
+
+
+    }
+
     void "when a setTranslationEnd action is performed on a transcript, there should be a check for overlapping isoforms"() {
 
         given: "two transcripts having separate parent gene"
@@ -2544,33 +2631,6 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec {
 
         then: "the previous gene of transcript2 doesn't exist as it is deleted when it has no connected child features"
         Gene.count == 1
-
-
-        when: "we attempt to add a bad start location on transcript 1"
-//        requestHandlingService.setTranslationStart(JSON.parse(setTranslationStartForTranscript1) as JSONObject)
-        setTranslationBadStartForTranscript1 = setTranslationBadStartForTranscript1.replace("@UNIQUENAME@", transcript1UniqueName)
-        requestHandlingService.setTranslationEnd(JSON.parse(setTranslationBadStartForTranscript1) as JSONObject)
-        alteredCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
-
-
-        then: "we expect a failure and the CDS to remain in the same spot"
-        AnnotationException ex = thrown(AnnotationException)
-        ex.message.contains("downstream")
-
-
-
-
-        when: "we attempt to add a bad end location on transcript 1"
-//        requestHandlingService.setTranslationEnd(JSON.parse(setTranslationEndForTranscript1) as JSONObject)
-        setTranslationBadEndForTranscript1 = setTranslationBadEndForTranscript1.replace("@UNIQUENAME@", transcript1UniqueName)
-        requestHandlingService.setTranslationEnd(JSON.parse(setTranslationBadEndForTranscript1) as JSONObject)
-        alteredCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
-
-
-
-        then: "we expect a failure and the CDS to remain in the same spot"
-        ex = thrown(AnnotationException)
-        ex.message.contains("downstream")
 
 
     }

--- a/test/integration/org/bbop/apollo/RequestHandlingServiceIntegrationSpec.groovy
+++ b/test/integration/org/bbop/apollo/RequestHandlingServiceIntegrationSpec.groovy
@@ -2482,6 +2482,7 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec {
         requestHandlingService.setTranslationStart(JSON.parse(setTranslationBadStartForTranscript1) as JSONObject)
         alteredCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
 //        requestHandlingService.setTranslationStart(JSON.parse(setTranslationStartForTranscript1) as JSONObject)
+//        throw new AnnotationException("upstream")
 
 
         then: "we expect a failure and the CDS to remain in the same spot"
@@ -2496,6 +2497,7 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec {
         setTranslationBadEndForTranscript1 = setTranslationBadEndForTranscript1.replace("@UNIQUENAME@", transcript1UniqueName)
         requestHandlingService.setTranslationEnd(JSON.parse(setTranslationBadEndForTranscript1) as JSONObject)
         alteredCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
+//        throw new AnnotationException("upstream")
 //        requestHandlingService.setTranslationEnd(JSON.parse(setTranslationEndForTranscript1) as JSONObject)
 
 
@@ -2545,6 +2547,7 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec {
         setTranslationBadStartForTranscript1 = setTranslationBadStartForTranscript1.replace("@UNIQUENAME@", transcript1UniqueName)
         requestHandlingService.setTranslationStart(JSON.parse(setTranslationBadStartForTranscript1) as JSONObject)
         alteredCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
+//        throw new AnnotationException("downstream")
 
 
         then: "we expect a failure and the CDS to remain in the same spot"
@@ -2559,6 +2562,7 @@ class RequestHandlingServiceIntegrationSpec extends AbstractIntegrationSpec {
         setTranslationBadEndForTranscript1 = setTranslationBadEndForTranscript1.replace("@UNIQUENAME@", transcript1UniqueName)
         requestHandlingService.setTranslationEnd(JSON.parse(setTranslationBadEndForTranscript1) as JSONObject)
         alteredCDS = transcriptService.getCDS(MRNA.findByUniqueName(transcript1UniqueName))
+//        throw new AnnotationException("downstream")
 
 
 


### PR DESCRIPTION
fixes #1838 
- [x] initial implementation
- [x] add integration tests for forward normal case, start (if not exist)
- [x] add integration tests for forward normal case, end (if not exist)
- [x] add integration tests for reverse normal case, start (if not exist)
- [x] add integration tests for reverse normal case, end (if not exist)

- [x] add failing integration test for forward strand case:
  - [x] move start beyond end
  - [x] move end beyond start
- [x] add failing integration test for reverse strand case:
  - [x] move start beyond end
  - [x] move end beyond start