### PR TITLE
Add ability to fetch variant data from track via web services

### DIFF
--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -972,14 +972,12 @@ define([
                         if (target_track.verbose_drop) {
                             console.log("droppable entered AnnotTrack")
                         }
-                        ;
                     },
                     out: function (event, ui) {
                         target_track.track_under_mouse_drag = false;
                         if (target_track.verbose_drop) {
                             console.log("droppable exited AnnotTrack")
                         }
-                        ;
                     },
                     deactivate: function (event, ui) {
                         // console.log("trackdiv droppable detected: draggable
@@ -1021,8 +1019,8 @@ define([
 
             createAnnotations: function (selection_records,force_type) {
                 var target_track = this;
-                var featuresToAdd = new Array();
-                var parentFeatures = new Object();
+                var featuresToAdd = [];
+                var parentFeatures = {};
                 var subfeatures = [];
                 var strand;
                 var parentFeature;
@@ -1039,10 +1037,10 @@ define([
                     var parentId = parent.id();
                     parentFeatures[parentId] = parent;
 
-                    if (strand == undefined) {
+                    if (strand === undefined) {
                         strand = dragfeat.get("strand");
                     }
-                    else if (strand != dragfeat.get("strand")) {
+                    else if (strand !== dragfeat.get("strand")) {
                         strand = -2;
                     }
 
@@ -1071,7 +1069,7 @@ define([
 
                 function process() {
                     var keys = Object.keys(parentFeatures);
-                    var singleParent = keys.length == 1;
+                    var singleParent = keys.length === 1;
                     var featureToAdd;
                     if (singleParent) {
                         featureToAdd = JSONUtils.makeSimpleFeature(parentFeatures[keys[0]]);
@@ -1085,7 +1083,7 @@ define([
                     featureToAdd.set("strand", strand);
                     var fmin;
                     var fmax;
-                    featureToAdd.set('subfeatures', new Array());
+                    featureToAdd.set('subfeatures', []);
                     array.forEach(subfeatures, function (subfeature) {
                         if (!singleParent && SequenceOntologyUtils.cdsTerms[subfeature.get("type")]) {
                             return;
@@ -1118,8 +1116,18 @@ define([
 
 
                     var biotype ;
+
+                    // TODO: pull from the server at some point
+                    var recognizedBioType = [
+                        'transcript' ,'tRNA','snRNA','snoRNA','ncRNA','rRNA','mRNA','miRNA','repeat_region','transposable_element'
+                    ];
+
                     if(force_type) {
                         biotype = featureToAdd.get('type');
+                        if(!recognizedBioType[biotype]){
+                            console.log('biotype not found ['+biotype + '] converting to mRNA');
+                            biotype = 'mRNA';
+                        }
                     }
                     else{
                         var default_biotype = selection_records[0].track.config.default_biotype;
@@ -1149,7 +1157,6 @@ define([
                     target_track.executeUpdateOperation(JSON.stringify(postData));
                 }
 
-                console.log('process: ' + strand);
                 if (strand == -2) {
                     var content = dojo.create("div");
                     var message = dojo.create("div", {
@@ -1197,8 +1204,8 @@ define([
 
             createGenericAnnotations: function (feats, type, subfeatType, topLevelType) {
                 var target_track = this;
-                var featuresToAdd = new Array();
-                var parentFeatures = new Object();
+                var featuresToAdd = [];
+                var parentFeatures = {};
                 for (var i in feats) {
                     var dragfeat = feats[i];
 

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -73,7 +73,7 @@ grails.project.dependency.resolution = {
         compile 'commons-collections:commons-collections:3.2.1'
 
         // HTSJDK
-        compile group: 'com.github.samtools', name: 'htsjdk', version: '2.10.0'
+        compile group: 'com.github.samtools', name: 'htsjdk', version: '2.14.3'
 
         // svg generation
         compile group: 'org.apache.xmlgraphics', name: 'batik-svg-dom', version: '1.9'

--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -33,6 +33,8 @@ class UrlMappings {
         "/track/cache/clear/${organismName}/${trackName}"(controller: "track", action: "clearTrackCache")
         "/track/cache/clear/${organismName}"(controller: "track", action: "clearOrganismCache")
 
+        "/vcf/${organismString}/${trackName}/${sequence}:${fmin}..${fmax}.${type}"(controller: "vcf", action: "featuresByLocation",[params:params])
+
         "/sequence/${organismString}/?loc=${sequenceName}:${fmin}..${fmax}"(controller: "sequence", action: "sequenceByLocation",[params:params])
         "/sequence/${organismString}/${sequenceName}:${fmin}..${fmax}"(controller: "sequence", action: "sequenceByLocation",[params:params])
         "/sequence/${organismString}/${sequenceName}/${featureName}.${type}"(controller: "sequence", action: "sequenceByName",[params:params])

--- a/grails-app/controllers/org/bbop/apollo/VcfController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/VcfController.groovy
@@ -1,0 +1,73 @@
+package org.bbop.apollo
+
+import grails.converters.JSON
+import htsjdk.variant.vcf.VCFFileReader
+import org.bbop.apollo.gwt.shared.FeatureStringEnum
+import org.bbop.apollo.gwt.shared.PermissionEnum
+import org.codehaus.groovy.grails.web.json.JSONArray
+import org.codehaus.groovy.grails.web.json.JSONObject
+import org.restapidoc.annotation.RestApi
+import org.restapidoc.annotation.RestApiMethod
+import org.restapidoc.annotation.RestApiParam
+import org.restapidoc.annotation.RestApiParams
+import org.restapidoc.pojo.RestApiParamType
+import org.restapidoc.pojo.RestApiVerb
+
+import javax.servlet.http.HttpServletResponse
+
+@RestApi(name = "VCF Services", description = "Methods for retrieving VCF track data as JSON")
+class VcfController {
+
+    def preferenceService
+    def permissionService
+    def vcfService
+    def trackService
+
+    @RestApiMethod(description = "Get VCF track data for a given range as JSON", path = "/vcf/<organism_name>/<track_name>/<sequence_name>:<fmin>..<fmax>.<type>?includeGenotypes=<includeGenotypes>&ignoreCache=<ignoreCache>", verb = RestApiVerb.GET)
+    @RestApiParams(params = [
+            @RestApiParam(name = "organismString", type = "string", paramType = RestApiParamType.QUERY, description = "Organism common name or ID (required)"),
+            @RestApiParam(name = "trackName", type = "string", paramType = RestApiParamType.QUERY, description = "Track name by label in trackList.json (required)"),
+            @RestApiParam(name = "sequence", type = "string", paramType = RestApiParamType.QUERY, description = "Sequence name (required)"),
+            @RestApiParam(name = "fmin", type = "integer", paramType = RestApiParamType.QUERY, description = "Minimum range (required)"),
+            @RestApiParam(name = "fmax", type = "integer", paramType = RestApiParamType.QUERY, description = "Maximum range (required)"),
+            @RestApiParam(name = "type", type = "string", paramType = RestApiParamType.QUERY, description = ".json (required)"),
+            @RestApiParam(name = "includeGenotypes", type = "boolean", paramType = RestApiParamType.QUERY, description = "(default: false).  If true, will include genotypes associated with variants from VCF."),
+            @RestApiParam(name = "ignoreCache", type = "boolean", paramType = RestApiParamType.QUERY, description = "(default: false).  Use cache for request, if available."),
+    ])
+    def featuresByLocation(String organismString, String trackName, String sequence, Long fmin, Long fmax, String type, boolean includeGenotypes) {
+        if(!trackService.checkPermission(request, response, organismString)) return
+
+        JSONArray featuresArray = new JSONArray()
+        Organism organism = preferenceService.getOrganismForToken(organismString)
+        JSONObject trackListObject = trackService.getTrackList(organism.directory)
+        String trackUrlTemplate
+        for(JSONObject track : trackListObject.getJSONArray(FeatureStringEnum.TRACKS.value)) {
+            if(track.getString(FeatureStringEnum.LABEL.value) == trackName) {
+                trackUrlTemplate = track.urlTemplate
+                break
+            }
+        }
+
+        Boolean ignoreCache = params.ignoreCache != null ? Boolean.valueOf(params.ignoreCache) : false
+        if (!ignoreCache) {
+            String responseString = trackService.checkCache(organismString, trackName, sequence, fmin, fmax, type, null)
+            if (responseString) {
+                render JSON.parse(responseString) as JSON
+                return
+            }
+        }
+
+        File file = new File(organism.directory + File.separator + trackUrlTemplate)
+        try {
+            VCFFileReader vcfFileReader = new VCFFileReader(file)
+            featuresArray = vcfService.processVcfRecords(organism, vcfFileReader, sequence, fmin, fmax, includeGenotypes)
+        }
+        catch (IOException e) {
+            log.error(e.stackTrace)
+        }
+
+        trackService.cacheRequest(featuresArray.toString(), organismString, trackName, sequence, fmin, fmax, type, null)
+        render featuresArray as JSON
+    }
+
+}

--- a/grails-app/services/org/bbop/apollo/TrackService.groovy
+++ b/grails-app/services/org/bbop/apollo/TrackService.groovy
@@ -3,12 +3,14 @@ package org.bbop.apollo
 import grails.converters.JSON
 import grails.transaction.NotTransactional
 import grails.transaction.Transactional
+import org.bbop.apollo.gwt.shared.PermissionEnum
 import org.bbop.apollo.gwt.shared.track.TrackIndex
 import org.bbop.apollo.sequence.SequenceDTO
 import org.codehaus.groovy.grails.web.json.JSONArray
 import org.codehaus.groovy.grails.web.json.JSONElement
 import org.codehaus.groovy.grails.web.json.JSONObject
 
+import javax.servlet.http.HttpServletResponse
 import java.util.zip.GZIPInputStream
 
 @Transactional
@@ -16,6 +18,7 @@ class TrackService {
 
     def preferenceService
     def trackMapperService
+    def permissionService
 
     public static String TRACK_NAME_SPLITTER = "::"
 
@@ -555,4 +558,14 @@ class TrackService {
         return geneChildren
     }
 
+    def checkPermission(def request, def response, String organismString) {
+        Organism organism = preferenceService.getOrganismForToken(organismString)
+        if (organism && (organism.publicMode || permissionService.checkPermissions(PermissionEnum.READ))) {
+            return true
+        } else {
+            // not accessible to the public
+            response.status = HttpServletResponse.SC_FORBIDDEN
+            return false
+        }
+    }
 }

--- a/grails-app/services/org/bbop/apollo/TrackService.groovy
+++ b/grails-app/services/org/bbop/apollo/TrackService.groovy
@@ -431,15 +431,30 @@ class TrackService {
 
     @Transactional
     def cacheRequest(String responseString, String organismString, String trackName, String sequenceName, Long fmin, Long fmax, String type, Map paramMap) {
-        TrackCache trackCache = new TrackCache(
-                response: responseString
-                , organismName: organismString
-                , trackName: trackName
-                , sequenceName: sequenceName
-                , fmin: fmin
-                , fmax: fmax
-                , type: type
+
+        TrackCache trackCache = TrackCache.findByOrganismNameAndTrackNameAndSequenceNameAndFminAndFmaxAndType(
+                organismString,
+                trackName,
+                sequenceName,
+                fmin,
+                fmax,
+                type
         )
+
+        if(trackCache){
+            trackCache.response = responseString
+        }
+        else{
+            trackCache =  new TrackCache(
+                    response: responseString
+                    , organismName: organismString
+                    , trackName: trackName
+                    , sequenceName: sequenceName
+                    , fmin: fmin
+                    , fmax: fmax
+                    , type: type
+            )
+        }
         if (paramMap) {
             trackCache.paramMap = (paramMap as JSON).toString()
         }

--- a/grails-app/services/org/bbop/apollo/VcfService.groovy
+++ b/grails-app/services/org/bbop/apollo/VcfService.groovy
@@ -1,0 +1,349 @@
+package org.bbop.apollo
+
+import grails.transaction.Transactional
+import htsjdk.variant.variantcontext.Genotype
+import htsjdk.variant.variantcontext.VariantContext
+import htsjdk.variant.variantcontext.VariantContextUtils
+import htsjdk.variant.vcf.VCFCompoundHeaderLine
+import htsjdk.variant.vcf.VCFConstants
+import htsjdk.variant.vcf.VCFFileReader
+import htsjdk.variant.vcf.VCFHeader
+import org.bbop.apollo.gwt.shared.FeatureStringEnum
+import org.codehaus.groovy.grails.web.json.JSONArray
+import org.codehaus.groovy.grails.web.json.JSONObject
+
+import java.text.DecimalFormat
+
+@Transactional
+class VcfService {
+
+    public static final String ALTERNATIVE_ALLELE_METADATA = "VCF ALT field, list of alternate non-reference alleles called on at least one of the samples"
+    public static final String ALTERNATIVE_ALLELE_MISSING = "ALT_MISSING"
+    public static final String SNV = "SNV"
+    public static final String INVERSION = "inversion"
+    public static final String SUBSTITUTION = "substitution"
+    public static final String INSERTION = "insertion"
+    public static final String DELETION = "deletion"
+
+    /**
+     * Given a VCF and a location, extract variants and process them into a JSON array
+     * @param organism
+     * @param vcfFileReader
+     * @param sequenceName
+     * @param start
+     * @param end
+     * @param includeGenotypes
+     * @return
+     */
+    def processVcfRecords(Organism organism, VCFFileReader vcfFileReader, String sequenceName, Long start, Long end, boolean includeGenotypes = false) {
+        // Note: incoming coordinates are zero-based
+        JSONArray processedFeaturesArray = new JSONArray()
+        log.info "incoming start: ${start} end: ${end}"
+        (start, end) = processCoordinates(organism, sequenceName, start, end)
+
+        if(start < 0 && end < 0) {
+            return processedFeaturesArray
+        }
+
+        def vcfEntries = []
+        VCFHeader vcfHeader = vcfFileReader.getFileHeader()
+
+        // changing zero-based start to one-based start while querying VCF
+        log.info "querying with ${sequenceName} ${start + 1} ${end}"
+        // casting start and end to int since query() method doesn't support long data type for coordinates
+        def queryResults = vcfFileReader.query(sequenceName, (int) start + 1, (int) end)
+        vcfEntries.addAll(queryResults.toList())
+        log.info "result size: ${vcfEntries.size()}"
+        processedFeaturesArray = processVcfRecords(vcfHeader, vcfEntries, sequenceName, includeGenotypes)
+
+        return processedFeaturesArray
+    }
+
+    /**
+     * Process a set of variants and its genotypes into a JSON array
+     * @param vcfHeader
+     * @param vcfEntries
+     * @param sequenceName
+     * @param includeGenotypes
+     * @return
+     */
+    def processVcfRecords(VCFHeader vcfHeader, def vcfEntries, String sequenceName, boolean includeGenotypes = false) {
+        JSONArray featuresArray = new JSONArray()
+        for(VariantContext vc : vcfEntries) {
+            JSONObject jsonFeature = new JSONObject()
+            jsonFeature = processVcfRecord(vcfHeader, vc, sequenceName, includeGenotypes)
+            featuresArray.add(jsonFeature)
+        }
+
+        return featuresArray
+    }
+
+    /**
+     * Process a given variant and its genotypes into JSON
+     * @param vcfHeader
+     * @param variantContext
+     * @param sequenceName
+     * @param includeGenotypes
+     * @return
+     */
+    def processVcfRecord(VCFHeader vcfHeader, VariantContext variantContext, String sequenceName, boolean includeGenotypes = false) {
+        JSONObject jsonFeature = new JSONObject()
+        String type = classifyType(variantContext)
+        String referenceAlleleString = variantContext.getReference().baseString
+        String alternativeAllelesString = variantContext.getAlternateAlleles().baseString.join(',')
+        if(alternativeAllelesString.isEmpty()) alternativeAllelesString = ALTERNATIVE_ALLELE_MISSING
+
+        def availableFormatFields = []
+        vcfHeader.getFormatHeaderLines().each {
+            availableFormatFields.add(it.properties.get("ID"))
+        }
+
+        // alternative alleles
+        JSONObject alternativeAllelesMetaObject = new JSONObject()
+        alternativeAllelesMetaObject.put(FeatureStringEnum.DESCRIPTION.value, ALTERNATIVE_ALLELE_METADATA)
+        JSONObject alternativeAllelesObject = new JSONObject()
+        alternativeAllelesObject.put(FeatureStringEnum.VALUES.value, alternativeAllelesString)
+        alternativeAllelesObject.put(FeatureStringEnum.META.value, alternativeAllelesMetaObject)
+        jsonFeature.put(FeatureStringEnum.ALTERNATIVE_ALLELES.value, alternativeAllelesObject)
+        String descriptionString = "${type} ${referenceAlleleString} > ${alternativeAllelesString}"
+
+        // changing one-based start to zero-based start
+        int start = variantContext.getStart()
+        int end = variantContext.getEnd()
+        // Note: the use of 'seqId' doesn't match Apollo's default JSON format; might need revisions in the future
+        jsonFeature.put("seqId", sequenceName)
+        jsonFeature.put(FeatureStringEnum.FMIN.value, start - 1)
+        jsonFeature.put(FeatureStringEnum.FMAX.value, end)
+        jsonFeature.put(FeatureStringEnum.TYPE.value, type)
+
+        if(variantContext.getID() != ".") {
+            jsonFeature.put("uniqueID", variantContext.getID())
+            jsonFeature.put(FeatureStringEnum.NAME.value, variantContext.getID())
+        }
+        else {
+            jsonFeature.put("uniqueID", "${descriptionString} at position ${start}")
+        }
+
+        // reference allele
+        jsonFeature.put(FeatureStringEnum.REFERENCE_ALLELE.value, referenceAlleleString)
+
+        // description
+        jsonFeature.put(FeatureStringEnum.DESCRIPTION.value, descriptionString)
+
+        // score
+        if(variantContext.getPhredScaledQual() > 0) {
+            jsonFeature.put(FeatureStringEnum.SCORE.value, new DecimalFormat("##.###").format(variantContext.getPhredScaledQual()))
+        }
+
+        // attributes
+        def variantAttributes = variantContext.getCommonInfo().getAttributes()
+        for(String attributeKey : variantAttributes.keySet()) {
+            JSONObject attributeObject = new JSONObject()
+            JSONArray valuesArray = new JSONArray()
+            valuesArray.add(variantAttributes.get(attributeKey))
+            attributeObject.put(FeatureStringEnum.VALUES.value, valuesArray)
+
+            // metadata for attributes
+            VCFCompoundHeaderLine metaData = VariantContextUtils.getMetaDataForField(vcfHeader, attributeKey)
+            if(metaData) {
+                JSONObject attributeMetaDataObject = generateMetaDataObjectForProperty(metaData, variantContext)
+                attributeObject.put(FeatureStringEnum.META.value, attributeMetaDataObject)
+            }
+            jsonFeature.put(attributeKey, attributeObject)
+        }
+
+        // genotypes
+        def genotypes = variantContext.getGenotypes()
+        if(genotypes.size() > 0) {
+            if(includeGenotypes) {
+                JSONObject genotypeJSONObject = parseGenotypes(variantContext, genotypes, vcfHeader, availableFormatFields)
+                jsonFeature.put(FeatureStringEnum.GENOTYPES.value, genotypeJSONObject)
+            }
+            else {
+                jsonFeature.put(FeatureStringEnum.GENOTYPES.value, true)
+            }
+        }
+
+        // filter
+        if(variantContext.filtered) {
+            JSONObject filterObject = new JSONObject()
+            JSONArray valuesArray = new JSONArray()
+            variantContext.getFilters().each {
+                valuesArray.add(it)
+            }
+            filterObject.put(FeatureStringEnum.VALUES.value, valuesArray)
+            jsonFeature.put(FeatureStringEnum.FILTER.value, filterObject)
+        }
+        else {
+            if(variantContext.getFiltersMaybeNull() != null) {
+                // PASS
+                JSONObject filterObject = new JSONObject()
+                JSONArray valuesArray = new JSONArray()
+                valuesArray.add("PASS")
+                filterObject.put(FeatureStringEnum.VALUES.value, valuesArray)
+                jsonFeature.put(FeatureStringEnum.FILTER.value, filterObject)
+            }
+        }
+
+        return jsonFeature
+    }
+
+    /**
+     * Parse genotypes for a given variant
+     * @param variantContext
+     * @param genotypes
+     * @param vcfHeader
+     * @param availableFormatFields
+     */
+    def parseGenotypes(VariantContext variantContext, def genotypes, VCFHeader vcfHeader, def availableFormatFields) {
+        JSONObject genotypeObject = new JSONObject()
+        for(int i = 0; i < genotypes.size(); i++) {
+            Genotype genotype = genotypes.get(i)
+            JSONObject formatJsonObject = new JSONObject()
+            for(String key : availableFormatFields) {
+                log.debug "processing format field: ${key}"
+                if(genotype.hasAnyAttribute(key)) {
+                    JSONObject formatPropertiesJsonObject = new JSONObject()
+                    if(key == VCFConstants.GENOTYPE_KEY) {
+                        def alleles = genotype.getAlleles()
+                        def alleleAsIndices = variantContext.getAlleleIndices(alleles)
+                        String delimiter = genotype.isPhased() ? VCFConstants.PHASED : VCFConstants.UNPHASED
+                        String genotypeAsIndices = alleleAsIndices.join(delimiter)
+
+                        JSONArray valuesArray = new JSONArray()
+                        valuesArray.add(genotypeAsIndices)
+                        formatPropertiesJsonObject.put(FeatureStringEnum.VALUES.value, valuesArray)
+                        VCFCompoundHeaderLine metaData = VariantContextUtils.getMetaDataForField(vcfHeader, key)
+                        if(metaData) {
+                            JSONObject attributeMetaDataObject = generateMetaDataObjectForProperty(metaData, variantContext)
+                            formatPropertiesJsonObject.put(FeatureStringEnum.META.value, attributeMetaDataObject)
+                        }
+                    }
+                    else {
+                        JSONArray valuesArray = new JSONArray()
+                        def keyValues = genotype.getAnyAttribute(key)
+                        keyValues instanceof String ? valuesArray.add(keyValues.split(",")) : valuesArray.add(keyValues)
+                        formatPropertiesJsonObject.put(FeatureStringEnum.VALUES.value, valuesArray)
+                        VCFCompoundHeaderLine metaData = VariantContextUtils.getMetaDataForField(vcfHeader, key)
+                        if(metaData) {
+                            JSONObject attributeMetaDataObject = generateMetaDataObjectForProperty(metaData, variantContext)
+                            formatPropertiesJsonObject.put(FeatureStringEnum.META.value, attributeMetaDataObject)
+                        }
+                    }
+                    formatJsonObject.put(key, formatPropertiesJsonObject)
+                }
+                genotypeObject.put(genotype.sampleName, formatJsonObject)
+            }
+        }
+
+        return genotypeObject
+    }
+
+    /**
+     *
+     * @param metaData
+     * @param variantContext
+     * @return
+     */
+    def generateMetaDataObjectForProperty(VCFCompoundHeaderLine metaData, VariantContext variantContext) {
+        JSONObject metaDataObject = new JSONObject()
+        metaDataObject.put(FeatureStringEnum.ID.value, new JSONArray())
+        metaDataObject.put(FeatureStringEnum.TYPE.value, new JSONArray())
+        metaDataObject.put(FeatureStringEnum.NUMBER.value, new JSONArray())
+        metaDataObject.put(FeatureStringEnum.DESCRIPTION.value, new JSONArray())
+        metaDataObject.getJSONArray(FeatureStringEnum.ID.value).add(metaData.getID())
+        metaDataObject.getJSONArray(FeatureStringEnum.TYPE.value).add(metaData.getCountType())
+        metaDataObject.getJSONArray(FeatureStringEnum.NUMBER.value).add(metaData.getCount(variantContext))
+        metaDataObject.getJSONArray(FeatureStringEnum.DESCRIPTION.value).add(metaData.getDescription())
+        return metaDataObject
+    }
+
+    /**
+     * Classify variant type for compatibility with JBrowse
+     * @param variantContext
+     * @return
+     */
+    def classifyType(VariantContext variantContext) {
+        String type = variantContext.getType().name()
+        String referenceAlleleString = variantContext.getReference().baseString
+        def alternateAlleles = variantContext.getAlternateAlleles()
+        int minAlternateAlleleLength = 0
+        int maxAlternateAlleleLength = 0
+
+        alternateAlleles.baseString.each {
+            if(minAlternateAlleleLength == 0 && maxAlternateAlleleLength == 0) {
+                minAlternateAlleleLength = it.length()
+                maxAlternateAlleleLength = it.length()
+            }
+            else {
+                if(minAlternateAlleleLength > it.length()) {
+                    minAlternateAlleleLength = it.length()
+                }
+                if(maxAlternateAlleleLength < it.length()) {
+                    maxAlternateAlleleLength = it.length()
+                }
+            }
+
+        }
+
+        if(referenceAlleleString.length() == minAlternateAlleleLength && referenceAlleleString.length() == maxAlternateAlleleLength) {
+            type = SNV
+        }
+        else if(referenceAlleleString.length() == minAlternateAlleleLength && referenceAlleleString.length() == maxAlternateAlleleLength) {
+            if(alternateAlleles.size() == 1 && referenceAlleleString.split('').reverse(true).join('') == alternateAlleles[0].baseString) {
+                type = INVERSION
+            }
+            else {
+                type = SUBSTITUTION
+            }
+        }
+        if(referenceAlleleString.length() <= minAlternateAlleleLength && referenceAlleleString.length() < maxAlternateAlleleLength) {
+            type = INSERTION
+        }
+        if(referenceAlleleString.length() > minAlternateAlleleLength && referenceAlleleString.length() >= maxAlternateAlleleLength) {
+            type = DELETION
+        }
+
+        return type
+    }
+
+    /**
+     *
+     * @param organism
+     * @param sequenceName
+     * @param start
+     * @param end
+     * @return
+     */
+    def processCoordinates(Organism organism, String sequenceName, Long start, Long end) {
+        Sequence sequence = Sequence.findByNameAndOrganism(sequenceName, organism)
+
+        if(start > 0) {
+            if(end < 0) {
+                // that means the request is to fetch something near the end of the sequence
+                // and the requested end is outside the sequence boundary.
+                // Thus, adjust end to max length of current sequence
+                end = sequence.length
+            }
+            else {
+                // that means the request is to fetch something near the end of the sequence
+                // and the requested end is outside the sequence boundary.
+                // Thus, adjust end to max length of current sequence
+                if(start < sequence.length && end > sequence.length) end = sequence.length
+            }
+        }
+        else if(start < 0) {
+            if(end < 0) {
+                // do nothing
+            }
+            else {
+                // that means the request is to fetch something at the start of the sequence
+                // and the requested start is outside the sequence boundary.
+                // Thus, adjust start to 0
+                start = 0
+            }
+        }
+
+        return [start, end]
+    }
+}

--- a/grails-app/services/org/bbop/apollo/VcfService.groovy
+++ b/grails-app/services/org/bbop/apollo/VcfService.groovy
@@ -52,6 +52,12 @@ class VcfService {
         log.info "querying with ${sequenceName} ${start + 1} ${end}"
         // casting start and end to int since query() method doesn't support long data type for coordinates
         def queryResults = vcfFileReader.query(sequenceName, (int) start + 1, (int) end)
+
+        // we want to be generous with the sequence name lookup
+        if(!queryResults && sequenceName.toLowerCase().startsWith("chr")){
+            String filteredName = sequenceName.substring("chr".length())
+            queryResults = vcfFileReader.query(filteredName, (int) start + 1, (int) end)
+        }
         vcfEntries.addAll(queryResults.toList())
         log.info "result size: ${vcfEntries.size()}"
         processedFeaturesArray = processVcfRecords(vcfHeader, vcfEntries, sequenceName, includeGenotypes)
@@ -70,8 +76,7 @@ class VcfService {
     def processVcfRecords(VCFHeader vcfHeader, def vcfEntries, String sequenceName, boolean includeGenotypes = false) {
         JSONArray featuresArray = new JSONArray()
         for(VariantContext vc : vcfEntries) {
-            JSONObject jsonFeature = new JSONObject()
-            jsonFeature = processVcfRecord(vcfHeader, vc, sequenceName, includeGenotypes)
+            JSONObject jsonFeature = processVcfRecord(vcfHeader, vc, sequenceName, includeGenotypes)
             featuresArray.add(jsonFeature)
         }
 

--- a/src/gwt/org/bbop/apollo/gwt/shared/FeatureStringEnum.java
+++ b/src/gwt/org/bbop/apollo/gwt/shared/FeatureStringEnum.java
@@ -140,7 +140,17 @@ public enum FeatureStringEnum {
         URL_TEMPLATE("urlTemplate"),
         TRACK_DATA("trackData"),
         TRACK_CONFIG("trackConfig"),
-        TRACK_LABEL("trackLabel")
+        TRACK_LABEL("trackLabel"),
+        START,
+        END,
+        SCORE,
+        NUMBER,
+        FILTER,
+        VALUES,
+        META,
+        REFERENCE_ALLELE,
+        ALTERNATIVE_ALLELES,
+        GENOTYPES
         ;
 
 

--- a/web-app/js/restapidoc/restapidoc.json
+++ b/web-app/js/restapidoc/restapidoc.json
@@ -2,14 +2,14 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
-         "jsondocId": "cae80c7a-347a-4383-9638-58295b541fd9",
+         "jsondocId": "b54ceb70-35fd-4aeb-9754-270d889535d1",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3eaeb406-1801-493d-8044-60204e1e534f",
+                     "jsondocId": "d885dd62-2121-4e17-90eb-8294395e9170",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -18,7 +18,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3d4abd03-fbd0-4692-bcf2-8c504173e738",
+                     "jsondocId": "10402d44-226c-4669-8012-2af7ca7800a1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -27,7 +27,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7e541af5-49c6-4656-b18e-5c85d6c8cdb6",
+                     "jsondocId": "8c7036ba-56d4-4e6e-9717-92f75e11fcdc",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -36,7 +36,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4f0df9df-78bd-4c7b-a7c5-abcd76755d3c",
+                     "jsondocId": "8cace074-d587-4f99-b8de-2ac3399ebcc7",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -45,7 +45,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cae4a76e-e148-4270-8974-955239f5211a",
+                     "jsondocId": "74bf336d-dff6-4494-a5fa-c09fdb69660b",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
@@ -57,9 +57,9 @@
                "verb": "POST",
                "description": "Set name of a feature",
                "methodName": "setName",
-               "jsondocId": "80d60c4c-6dd8-4584-b21a-a77cf1d62707",
+               "jsondocId": "7d12bd63-8bbb-4989-8fec-ac529cb9fff1",
                "bodyobject": {
-                  "jsondocId": "2abf6a4f-f77e-48b3-93cb-5e55036c4c99",
+                  "jsondocId": "7ef1ec70-9aec-4714-abc9-1bae907f544b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -69,7 +69,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setName",
                "response": {
-                  "jsondocId": "cee8223c-cb03-4bc0-8bd2-d72012f21016",
+                  "jsondocId": "0407a3c4-b90f-4aa0-9716-e66bfdb512bf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -82,7 +82,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "cb0b8386-ea2f-480c-ab03-ac2f069504c3",
+                     "jsondocId": "2b2d1b5e-cd5f-4af8-8ac4-4332ccf26567",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -91,7 +91,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "402838a5-9823-41aa-9f6c-578b5a1b2c80",
+                     "jsondocId": "ee6963f1-4d48-407b-867e-0d5068aee3ae",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -100,7 +100,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2503fa35-d0de-4344-b1cb-ac653e9330c7",
+                     "jsondocId": "41221281-10a2-4bd2-9629-98c7ddc411c0",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -109,7 +109,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b68bdd3a-16bc-4682-a4c2-7e4c54250e6d",
+                     "jsondocId": "4cae408f-02ad-4ed2-b265-060a36de5c29",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -118,226 +118,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45d73c31-4146-4b9f-8d45-b7ac47eec5e2",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set symbol of a feature",
-               "methodName": "setSymbol",
-               "jsondocId": "d3cdce21-d0f9-4fec-bf3c-adb747466fa2",
-               "bodyobject": {
-                  "jsondocId": "09f6bc3b-a18f-4eae-97cc-bcb376778a09",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setSymbol",
-               "response": {
-                  "jsondocId": "941f61ab-c43c-4df5-87af-112b6a5cf7ed",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "4cbe8e5c-2f7c-4bb1-acc9-1283b8c02e3e",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ae2285e2-97af-47c5-b918-620720efe6a4",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "26dc9302-0fb6-4306-a4a8-2e60baf12721",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b7f0f5d8-427d-4403-883a-a70b5456e658",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c7b0a90a-4cc4-4628-90ea-2f05ad54f08a",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set status of a feature",
-               "methodName": "setStatus",
-               "jsondocId": "a6623b67-f9b1-4698-ab1d-1c7fc23f0311",
-               "bodyobject": {
-                  "jsondocId": "508e0d74-9969-4c4a-85a7-0f12c6a75819",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setStatus",
-               "response": {
-                  "jsondocId": "aef2b833-4afe-49f6-9095-19d6443c91f5",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "05559509-3795-4d31-ba5d-ccbad4b803dc",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "50ce56ed-adc8-4f1d-8a9b-bc56e406ca0b",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3e4d4445-02e3-4504-9319-87a91718af5d",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "74696740-e4d8-49c3-bf09-3f8b857c5790",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9f9488c7-9722-4c48-b697-74fbc02adbc7",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set description for a feature",
-               "methodName": "setDescription",
-               "jsondocId": "428eec1a-53db-4eb9-98c4-fb8aeac51e93",
-               "bodyobject": {
-                  "jsondocId": "636d6165-c05c-4f74-950a-acf436519541",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setDescription",
-               "response": {
-                  "jsondocId": "8f1e0966-3a7c-487d-ae71-04a5350a111d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "9b650032-95b5-4c76-a68a-455129c209bf",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "60c80c0d-0338-4d8a-9298-10cbb3d90999",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ce2c1a3b-2e85-42b9-8e44-4cabdaace435",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "15b74b37-25db-4807-9d44-59679fc6b08b",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "752d8d18-dda1-497b-a19f-23331727d1d3",
+                     "jsondocId": "737a3bcd-14bc-49f7-9ebb-73e2d84d10a8",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -349,9 +130,9 @@
                "verb": "POST",
                "description": "Get comments",
                "methodName": "getComments",
-               "jsondocId": "7bab8226-22a5-4c84-907e-e5cf8f20fee7",
+               "jsondocId": "de64aaaa-648a-4d64-866b-080e879737b5",
                "bodyobject": {
-                  "jsondocId": "ee26c507-5726-4ce4-92b7-d0fc9b5306bd",
+                  "jsondocId": "52f966ba-dbe7-438a-8248-724c86a0ffda",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -361,7 +142,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getComments",
                "response": {
-                  "jsondocId": "f9b6c469-6457-4150-ad51-3838c06af010",
+                  "jsondocId": "f871721a-bf05-43e4-a174-41d2e3aee47b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -374,7 +155,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e5e5f8b8-c5ed-4e98-ac30-88bdc8cafb7c",
+                     "jsondocId": "99028cca-1e5f-4e8c-97e7-8cebae110906",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -383,7 +164,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1facd11b-670f-4355-960e-cb5a08f412d0",
+                     "jsondocId": "ff5ef210-c268-44e2-b7b4-f6d7be600c09",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -392,16 +173,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dd55f419-b8c7-4e85-a19d-2e942dd9a202",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "81b5ce9f-b178-48ad-88ed-1afff5e0e71e",
+                     "jsondocId": "72847ce0-5845-4508-a8b2-a1c9fa69efff",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -410,7 +182,235 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1a41e560-5a84-4096-aeb4-b70cabb3c50f",
+                     "jsondocId": "ebd77972-afe2-439e-96bc-e41a8963bd80",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "269b25fe-5e76-41c6-a517-55182db50167",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set description for a feature",
+               "methodName": "setDescription",
+               "jsondocId": "0a26de8b-71e1-4044-a87c-41221afc493e",
+               "bodyobject": {
+                  "jsondocId": "9ae6839e-6c3e-40c2-b0ef-b9d6e80b663a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setDescription",
+               "response": {
+                  "jsondocId": "9cd64789-88fd-410a-aeb7-ff9f97af5865",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c6b51a40-594c-4d2a-85ba-844a4179d128",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "19c37c76-ab87-4f03-b567-7c7104c826b6",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "86ab8533-2e8f-4c78-b62e-4f030c82281f",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "59748fde-4ba9-47b9-a142-bba7eb714649",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "87965ea8-5785-440a-893b-bd1a1f8baf4b",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add attribute (key,value pair) to feature",
+               "methodName": "addAttribute",
+               "jsondocId": "27158f8f-4a36-4682-8ff3-af2498bc3f01",
+               "bodyobject": {
+                  "jsondocId": "b8e34fdc-268d-4947-89b4-1a0ee295010f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addAttribute",
+               "response": {
+                  "jsondocId": "b2eacd72-85b7-4c66-b031-78a2f8532946",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "3677d0c2-f343-49d8-a194-894aa06f4061",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2560ff3a-110f-48d9-9356-1919ded7b1c4",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ec554ec1-2728-4fb1-a5fa-eb4fbd85549c",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5e6c6f11-26eb-4f95-a96b-54e145c1bd51",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "493027b0-423b-48d6-8ffe-03c2d8bd1ff5",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set status of a feature",
+               "methodName": "setStatus",
+               "jsondocId": "4da0135f-220c-48ab-a49a-2c6df149f1ed",
+               "bodyobject": {
+                  "jsondocId": "2bea6742-f250-4245-b621-a73762a435e5",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setStatus",
+               "response": {
+                  "jsondocId": "3b4d7e07-b6d8-42a3-a287-6be3b490b211",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "b13a9fb0-4ce5-45cd-bfb8-a2b557840024",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7660585d-e0c2-4756-a8b9-dc4598404028",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c7ce0d9d-7d29-4354-a341-d616d8f64399",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c3f4620f-529f-48db-9ff7-6d556e5bcda1",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "502e3e73-82ec-428c-acaf-318c8fedde51",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -419,7 +419,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3f523e5f-29ec-4968-be64-a21b343403aa",
+                     "jsondocId": "16e41d67-7581-43db-8e4d-5d19d772b4d0",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -428,7 +428,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d8454b2a-a76f-450f-a0a0-6c176f65c145",
+                     "jsondocId": "3a7410bf-b90b-439e-b60d-96d961c69a05",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -440,9 +440,9 @@
                "verb": "POST",
                "description": "Set exon feature boundaries",
                "methodName": "setExonBoundaries",
-               "jsondocId": "22f74ded-4dcc-4d61-9b06-1ba8e25ac5d3",
+               "jsondocId": "0f1b8f3a-7a8e-4119-af97-a9bbcdf559f3",
                "bodyobject": {
-                  "jsondocId": "07981b54-03ae-4598-a083-bb4a5a61fb29",
+                  "jsondocId": "c8f5ee10-f0a6-4569-8d47-7695dd752d7f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -452,7 +452,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setExonBoundaries",
                "response": {
-                  "jsondocId": "7e5fa624-dec9-4bc1-b2d0-f5012356bbee",
+                  "jsondocId": "32953f09-f088-4bfb-9a09-cfdbd4fbd560",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -467,9 +467,9 @@
                "verb": "POST",
                "description": "Returns a translation table as JSON",
                "methodName": "getTranslationTable",
-               "jsondocId": "a9ff9f38-1f14-48f4-9ffc-91f6539b7d32",
+               "jsondocId": "ee755e42-170f-4eed-8f3f-c568a3fd27e0",
                "bodyobject": {
-                  "jsondocId": "c1207a88-3291-4f8c-a567-6fce5a068b80",
+                  "jsondocId": "f23f4a73-903f-4f7b-a87a-e6650d5524bf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -479,7 +479,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getTranslationTable",
                "response": {
-                  "jsondocId": "b1cffefa-3961-4105-b720-ea21d9eb48dc",
+                  "jsondocId": "6ccde643-080f-4ce0-bf22-9d7bf01576da",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -492,7 +492,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d2eec637-7336-4571-836a-bcfc934246e9",
+                     "jsondocId": "39fd3423-f6cb-48c5-b3a7-e4c662d6a2e2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -501,7 +501,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f0cefc5b-6f14-4604-b824-6c0028dbe99b",
+                     "jsondocId": "13548b3b-6c70-4052-9ec8-738c2d9fb469",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -510,7 +510,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4f60a9d0-53d5-4371-b7fe-04c1441fbbf4",
+                     "jsondocId": "639b74de-e244-49ad-8c70-add5f38c9ef6",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -519,7 +519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7c1cb0ee-1e1c-43d4-a3e7-90a55cbc33f9",
+                     "jsondocId": "8a24e747-bc64-4bd1-ae51-1f56091f8ee5",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -528,7 +528,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d3d8d45b-a0c5-41ee-b961-a7052a6b881d",
+                     "jsondocId": "708a635b-b3b7-48ab-8e10-029c1fcd1f8a",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -537,7 +537,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eff48d2b-a5b7-445c-bcb0-eabc852d5da0",
+                     "jsondocId": "9e8c2d24-6d49-4e27-8685-a5545e47c043",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -546,7 +546,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4352fc9d-a84f-40d7-9589-8c7e463f33a8",
+                     "jsondocId": "5675ee8a-cd7d-4f20-8438-0bc52a18dc85",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -558,9 +558,9 @@
                "verb": "POST",
                "description": "Add non-coding genomic feature",
                "methodName": "addFeature",
-               "jsondocId": "fd06dc8e-a552-4886-9010-6806f4a67306",
+               "jsondocId": "cdc59c9d-622b-4b3c-8451-4d5d7c892c92",
                "bodyobject": {
-                  "jsondocId": "0bfc35f8-e89a-464d-8098-f8d441982660",
+                  "jsondocId": "83152058-037d-4e92-864f-489524745aa9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -570,7 +570,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addFeature",
                "response": {
-                  "jsondocId": "b8885eb0-2dc1-41ea-ad22-462340eff154",
+                  "jsondocId": "857f0341-69d0-42dd-9691-934a27b3d031",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -583,7 +583,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8ab9bb7c-6b44-4be7-aecf-0b1a449007fb",
+                     "jsondocId": "6fe4ca38-40b5-45a8-9d66-6917197c301d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -592,7 +592,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "786b1341-19df-49e9-a96f-f2d8e3be11ed",
+                     "jsondocId": "3be79187-3bff-41cb-94e7-4d202a393d86",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -601,7 +601,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "93a4d37b-74b5-4c32-8e95-70daff97b999",
+                     "jsondocId": "27a03490-a2a6-4356-a3ca-41f5757ed75d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -610,7 +610,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dc2c6ade-17d5-4b9d-ba45-e8aa1ab2dfdf",
+                     "jsondocId": "aeba77f7-4c8c-4f09-83c5-62c0a241649a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -619,7 +619,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "940a7d6a-718c-448a-99e6-6c9b5cf39a31",
+                     "jsondocId": "3d73197a-fe7c-476d-abae-f5551ba350ae",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -628,7 +628,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "25c5546e-a4de-405a-9786-edb0076d12e1",
+                     "jsondocId": "b008d718-d429-48e5-8945-a1922c345141",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -637,7 +637,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8ae8c415-0d5a-4c6d-b6d9-4e133ed65713",
+                     "jsondocId": "ed695519-ec5b-424d-a5c5-ac0acef65c11",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -649,9 +649,9 @@
                "verb": "POST",
                "description": "Add an exon",
                "methodName": "addExon",
-               "jsondocId": "8a8a9558-f55f-4f31-803f-14cc594e137e",
+               "jsondocId": "1a5ea253-b4f2-4c46-a192-fbf67e016bc6",
                "bodyobject": {
-                  "jsondocId": "fa2e4826-5d01-4968-ac8c-c19b845fe518",
+                  "jsondocId": "ccd655d3-1efa-4db9-9f10-9acfc98acb3d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -661,7 +661,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addExon",
                "response": {
-                  "jsondocId": "ffbd5d67-4441-4452-8a80-7dd65ec9198b",
+                  "jsondocId": "97e8c6d6-90c7-4d37-a70b-0fdf521b2763",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -674,7 +674,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "dbab200a-f054-4e50-a608-7fbf28daf463",
+                     "jsondocId": "03d98775-3eef-4b78-a1fc-ed434ba0f6f5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -683,7 +683,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1a8fdfc-5143-48d9-bc50-db56f6d499c3",
+                     "jsondocId": "b0976c07-f48d-4bd5-babf-fcd15a65ac4a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -692,7 +692,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5c4251d5-6cb0-4c17-ba5c-b91f9bcfe38b",
+                     "jsondocId": "5b5af7bf-f5f8-4224-a82d-326e8377b8ce",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -701,7 +701,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "05e74714-36a2-4e4b-92aa-d0c2c5dc6ae0",
+                     "jsondocId": "ee4b3038-3b07-41ad-a6d2-0f0f55393752",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -710,7 +710,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1f06d543-6fa6-4144-9907-ad3a9c07a028",
+                     "jsondocId": "53600af6-b7bc-4d3b-869c-549b4db756a1",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -722,9 +722,9 @@
                "verb": "POST",
                "description": "Add comments",
                "methodName": "addComments",
-               "jsondocId": "e5e679e4-22c9-417d-ab7d-d3d819cb3c93",
+               "jsondocId": "4c806ed1-ca21-48e1-831c-e85082980cf6",
                "bodyobject": {
-                  "jsondocId": "e8b60b40-91d6-4123-ae53-ed8f08105cb9",
+                  "jsondocId": "b54c53e9-1e13-4f99-ad6f-e6b91e6fc722",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -734,7 +734,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addComments",
                "response": {
-                  "jsondocId": "7a7b6f65-f051-40eb-97c0-e0b495c724f4",
+                  "jsondocId": "f9586ba8-0263-40fd-8041-381b0ce16300",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -747,7 +747,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e9163935-0447-428d-b537-3cc5e12ef422",
+                     "jsondocId": "7a2c4359-78a1-4143-a37b-a1e3cc18d968",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -756,7 +756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7649042e-24f8-4cfb-ade2-3b763ffa8a82",
+                     "jsondocId": "a6c5ccd3-0764-4a37-8926-c8afffee3ba0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -765,7 +765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e9f72f7-f8b4-4b31-9ed0-749b56a6356c",
+                     "jsondocId": "35768e71-36f0-4178-9ccb-513aad58d983",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -774,7 +774,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "702d4a31-9b15-4d5b-be1a-635cc87810e0",
+                     "jsondocId": "4d22fb9b-a386-4cc1-966b-b8eb70364567",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -783,7 +783,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "42aee094-450c-41b6-9574-68c4b3dc1d94",
+                     "jsondocId": "21071e32-d74b-43a6-853d-ea0fc8d2a5d7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -795,9 +795,9 @@
                "verb": "POST",
                "description": "Delete comments",
                "methodName": "deleteComments",
-               "jsondocId": "705b0655-23ab-498a-b09f-307fd0857b1e",
+               "jsondocId": "23858b01-969c-4fdb-98b9-47fa1f229931",
                "bodyobject": {
-                  "jsondocId": "f3995b15-3feb-46d9-9717-257b7b983245",
+                  "jsondocId": "007ce835-a558-4276-bd16-4057492e49c4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -807,7 +807,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteComments",
                "response": {
-                  "jsondocId": "08f118ca-fc9e-4422-9ffd-2bbb869c4dd0",
+                  "jsondocId": "fb691a50-fb85-4ff4-99eb-3b21daeacb12",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -820,7 +820,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5b408e85-a7a5-4225-9a8e-7f082b3182ea",
+                     "jsondocId": "b4b34e8c-639e-4a65-9474-79f354907b3f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -829,7 +829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e66e16e7-1eb0-4ab7-99df-263c572bf83e",
+                     "jsondocId": "2f2881f8-fe56-4dbe-8535-2a28e987a6ca",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -838,7 +838,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d94aea49-4faf-46f8-903b-9193fc35ae4d",
+                     "jsondocId": "bf7ee786-2ff6-4224-91ec-c3441e56ef05",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -847,7 +847,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "10d1966c-b348-4040-88e6-494c7c0c3497",
+                     "jsondocId": "7eed5172-42b9-46a2-9b4e-f8190d5ab4a1",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -856,7 +856,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1b3a984b-3604-4635-b667-1a159cff4419",
+                     "jsondocId": "be8b79ca-302c-4c27-84fa-999212fe79d0",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -868,9 +868,9 @@
                "verb": "POST",
                "description": "Update comments",
                "methodName": "updateComments",
-               "jsondocId": "86015cdb-6301-464c-9889-d6ece88b8ab5",
+               "jsondocId": "adc4dece-4416-4448-99d7-df7774295bea",
                "bodyobject": {
-                  "jsondocId": "c9fab33c-f067-4dda-afa1-bcee33b53062",
+                  "jsondocId": "fdf24ccd-8800-45e8-8c48-695fce172685",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -880,7 +880,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateComments",
                "response": {
-                  "jsondocId": "a1bc4a53-8fc9-4633-8bb0-e0f4acb05ec6",
+                  "jsondocId": "66f31332-89ca-45b4-b50b-a35ab4e9709e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -893,7 +893,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "50b92e58-992e-4e96-8974-d76e1f33e290",
+                     "jsondocId": "dc8ee525-4fed-4d5e-9505-a07baaff28af",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -902,7 +902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1d4a7e37-0bad-40e7-bc55-13b7418133e3",
+                     "jsondocId": "0ad35f1c-7d52-48df-98e5-5ce062eada00",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -911,7 +911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5d21c9ed-6a9a-4420-b624-373b79b5a3e1",
+                     "jsondocId": "1e2aaf19-4dd5-49c2-ac17-f96c528f8219",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -920,7 +920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7df56231-60c2-468c-8f5a-b93e41df8b89",
+                     "jsondocId": "36f24ed4-9014-4bcd-b7d4-120295202dd7",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -929,7 +929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e1d81f3-d394-4da9-b8fa-9fcf8a46f157",
+                     "jsondocId": "f584d389-411f-4e47-97f1-824f52161cc0",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -938,7 +938,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65206c87-b17d-4e60-bbb9-c982ae41d33e",
+                     "jsondocId": "2c4e632b-edaf-428e-8286-734bcbbc7a16",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -947,7 +947,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dfce6d8b-5764-45e9-8d1e-0a49fa625569",
+                     "jsondocId": "f3e7dcf0-65ac-4b04-922d-6647b8b45e36",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -959,9 +959,9 @@
                "verb": "POST",
                "description": "Add transcript",
                "methodName": "addTranscript",
-               "jsondocId": "7aa4b267-4e58-457a-99da-e24680791799",
+               "jsondocId": "ce66d94d-9b54-4fe9-b69d-32fa2cc684f7",
                "bodyobject": {
-                  "jsondocId": "2b62e48c-68ca-412b-b5b8-c607106eb828",
+                  "jsondocId": "06120831-8adc-4634-9adc-aecef742169b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -971,7 +971,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addTranscript",
                "response": {
-                  "jsondocId": "f9b57faf-bdf8-4d41-a5c1-a526efb1fc83",
+                  "jsondocId": "9149f81b-80c5-43e3-8e70-093d75ae813f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -984,7 +984,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "feeca2d4-96a1-4536-811e-8d5108d8f8cd",
+                     "jsondocId": "b34547d5-5ef7-4b76-af3a-c2e1f9bd69d7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -993,7 +993,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c8d83f5-af5e-4361-9827-d54d5cc40b28",
+                     "jsondocId": "1569d850-b797-4fc3-a81d-caac400d1cdb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1002,7 +1002,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "69a95a7c-31a0-4a7f-8e37-13dbbc0119b2",
+                     "jsondocId": "125d8a4a-d38b-4391-99a9-74ea274442f0",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1011,7 +1011,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e80c07dc-2c1f-4706-b343-19f6e2cec1cd",
+                     "jsondocId": "b3e0af1d-0c91-4d3c-a6f9-3b37647d97f8",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1020,7 +1020,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8c338b88-acc5-458d-b959-9a467562f626",
+                     "jsondocId": "502397b3-16ca-4044-969d-4a568977d44e",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1029,7 +1029,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7bdf38dd-179f-42ee-a786-c8e533cea132",
+                     "jsondocId": "be4d6479-9ef8-4bf3-bdf2-663cb454c803",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1038,7 +1038,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e95ceb5a-c050-4744-9e4e-bf30efc3bc99",
+                     "jsondocId": "a217b6e5-4f44-45ec-88bb-e2fe61bbd37d",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
@@ -1050,9 +1050,9 @@
                "verb": "POST",
                "description": "Duplicate transcript",
                "methodName": "duplicateTranscript",
-               "jsondocId": "1cb6ffec-2fa7-4f97-b2ca-60ae9e9a9d0d",
+               "jsondocId": "6b9114ea-6e55-486c-b809-44121b12296e",
                "bodyobject": {
-                  "jsondocId": "9c32c752-22dc-4845-ae0a-d83b4c302636",
+                  "jsondocId": "6a3c50a3-bf19-4fab-91e3-24062de847f3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1062,7 +1062,7 @@
                "apierrors": [],
                "path": "/annotationEditor/duplicateTranscript",
                "response": {
-                  "jsondocId": "ee17c911-05ed-476c-98dd-00c0919623b7",
+                  "jsondocId": "7adfa259-19ba-4dd1-a2df-f981c809d326",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1075,7 +1075,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1c02884a-64ff-470d-b624-6bdc48176bdf",
+                     "jsondocId": "ca7ed9d8-37ee-408e-8f9a-ba03eb4bde15",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1084,7 +1084,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5127d0e5-a9a7-4e9b-ab5e-93f6b71525ac",
+                     "jsondocId": "9ae19de9-141c-4e27-99f9-eaf3ebbfc47f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1093,7 +1093,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4b9aa73-8121-4b22-9885-46d573f4fa36",
+                     "jsondocId": "e4cb25c9-bc14-4e63-bfee-c6173e9d0d41",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1102,7 +1102,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f6588dbb-3faf-4a32-a457-6fce0877f571",
+                     "jsondocId": "99b90171-ce9b-4ef0-b47f-bcb9a2252415",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1111,7 +1111,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fc9c4093-aa2c-4e67-afe6-86c1991a24c7",
+                     "jsondocId": "88cdd8ae-1722-444f-bc34-db9119769804",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -1123,9 +1123,9 @@
                "verb": "POST",
                "description": "Set translation start",
                "methodName": "setTranslationStart",
-               "jsondocId": "5ade75a5-844d-4e6c-9fea-a248a56482e8",
+               "jsondocId": "47d18b73-5908-441b-a59e-6f35c255c75b",
                "bodyobject": {
-                  "jsondocId": "68c901ad-e51a-4644-96d4-f7efe7f6f555",
+                  "jsondocId": "3954f575-10b8-499d-aa4f-2fc436491366",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1135,7 +1135,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationStart",
                "response": {
-                  "jsondocId": "f08bb173-b527-47c8-a5d0-d1fb878003b2",
+                  "jsondocId": "8a1dad63-e9f2-4517-ab1e-8f35373329b1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1148,7 +1148,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "179f993a-d2d8-4c71-9899-32f9ec36cce9",
+                     "jsondocId": "e967ecca-e0f4-434e-bfd1-bf9169392ab1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1157,7 +1157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c8022e87-00ea-4d5a-a616-8e1d98eb96d8",
+                     "jsondocId": "d9f087f3-9105-4f17-a98a-f837e98c29ee",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1166,7 +1166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f7af54bd-d76f-4fdd-b7c5-407cca8f3ca1",
+                     "jsondocId": "b90e8016-d2af-4925-8cf4-f0f792d1f67d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1175,7 +1175,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bfcf8460-949e-42b0-b404-0008bf83aaab",
+                     "jsondocId": "b4999119-457e-47fd-92c4-eb173180a8d8",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1184,7 +1184,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "735c0640-ce99-464b-a317-7495f3453ed6",
+                     "jsondocId": "6f28f11f-baaa-46a9-a4b0-b6d0a2c4d63c",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
@@ -1196,9 +1196,9 @@
                "verb": "POST",
                "description": "Set translation end",
                "methodName": "setTranslationEnd",
-               "jsondocId": "3821b95a-cd3a-4365-a32a-a9c984b1e18e",
+               "jsondocId": "da3cd550-e8e2-43bf-94a5-40f4d5943b32",
                "bodyobject": {
-                  "jsondocId": "e356301d-6404-45b0-964a-8391a258d42b",
+                  "jsondocId": "9b2fd37f-00d3-443a-a17b-628597226242",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1208,7 +1208,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationEnd",
                "response": {
-                  "jsondocId": "8013dfdb-8a5d-49f8-a9e8-db0d67bb60d8",
+                  "jsondocId": "ea625047-9437-44dc-a34a-16a78c280a47",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1221,7 +1221,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ec2aff49-c9be-4cfd-9df3-17629581f964",
+                     "jsondocId": "c1adbda7-c2c5-4157-9fbb-e648f3e293a3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1230,7 +1230,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7c1493fe-bcb3-4660-84ef-36d685370c8a",
+                     "jsondocId": "77fc1b75-b55f-4aa6-a893-dc38b3c2507a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1239,7 +1239,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b211ac5a-69a4-4ba5-bbe4-1fd4d79c2de4",
+                     "jsondocId": "28a2defd-04d0-4d08-a376-b9b229f8fe51",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1248,7 +1248,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8f755702-aefb-4d10-9eb6-d45215445f92",
+                     "jsondocId": "a4029454-f3c6-4ba4-8435-b4810c44b797",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1257,7 +1257,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9debeb9-abfe-4992-b94c-086f02184ce5",
+                     "jsondocId": "4513d3d9-cef9-4a9a-ae6e-3ba2033e3983",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
@@ -1269,9 +1269,9 @@
                "verb": "POST",
                "description": "Set longest ORF",
                "methodName": "setLongestOrf",
-               "jsondocId": "ed427d5b-e1c0-47e6-ac8c-267b2444955e",
+               "jsondocId": "1991a302-0352-4844-b69e-98f4de6168dc",
                "bodyobject": {
-                  "jsondocId": "2319996f-76fc-4cf7-b9da-c2cb46d7a2aa",
+                  "jsondocId": "dd35724d-5735-4406-bc88-c9bde21e373b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1281,7 +1281,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setLongestOrf",
                "response": {
-                  "jsondocId": "a815b34e-ca5e-4ab6-a78e-141059679716",
+                  "jsondocId": "bfc44d3c-f042-478d-8dde-1fabda4d5aa7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1294,7 +1294,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "243ed2c0-441c-473b-b70f-4111cc5283ca",
+                     "jsondocId": "641a5e87-0e93-48e3-8698-d39ee87b3d76",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1303,7 +1303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bc9fcffc-a652-4bfd-87b0-6c8c7a09d592",
+                     "jsondocId": "89e79285-b29c-4f32-99e5-fd30861b1e6e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1312,7 +1312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "41cc4027-c0d8-4dc6-bb4c-df8fff4717d1",
+                     "jsondocId": "503cdcae-5e3d-41e3-8b24-536263014823",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1321,7 +1321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "848fc324-aee2-4399-983c-437a2a47997d",
+                     "jsondocId": "a4ae2134-0442-4c36-95bc-c92f824386ef",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1330,7 +1330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ecc4cc79-1d6d-49ca-b449-9e3acdf121dc",
+                     "jsondocId": "71996bc4-792f-43c3-b9e5-926dead64591",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -1342,9 +1342,9 @@
                "verb": "POST",
                "description": "Set boundaries of genomic feature",
                "methodName": "setBoundaries",
-               "jsondocId": "ec6555e2-f25f-42ef-b8df-fac0f673556e",
+               "jsondocId": "352f4b79-90e3-492f-861e-30f905f316fd",
                "bodyobject": {
-                  "jsondocId": "f3647ece-7182-48a6-9361-8237c2f60d7f",
+                  "jsondocId": "963a7d6c-5888-4eb4-98b2-7fe14348386f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1354,7 +1354,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setBoundaries",
                "response": {
-                  "jsondocId": "01fea87a-b21a-4c14-8da1-0147c42a9016",
+                  "jsondocId": "f5108172-a48e-4f30-971f-39e3deb26774",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1367,7 +1367,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6f4e8051-7d61-4d81-9c0c-a7acce55aa4a",
+                     "jsondocId": "14cec99f-f1fd-46d8-9e3d-34fdce9990f3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1376,7 +1376,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5bdf335d-f9f7-4516-95a7-4cb1cc0827df",
+                     "jsondocId": "f070c82c-ef68-46f7-9fcc-6534a800b109",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1385,7 +1385,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ea78351e-27c3-47be-83bd-88e3e4b2c8a8",
+                     "jsondocId": "9f4f18f1-ded3-4143-b6d1-a18d358ea14f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1394,7 +1394,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "36ef1a96-3b8e-46a9-9a6e-e00f8d9c8b24",
+                     "jsondocId": "2d10966d-5c30-48ef-811d-8de824073640",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1406,9 +1406,9 @@
                "verb": "POST",
                "description": "Get all annotated features for a sequence",
                "methodName": "getFeatures",
-               "jsondocId": "270e25e0-a3c2-4c97-9b2c-d52d4c276f0c",
+               "jsondocId": "b8574dce-1519-4a8d-b211-aa7199a9062b",
                "bodyobject": {
-                  "jsondocId": "9902e408-9500-4855-98ed-21230770f94d",
+                  "jsondocId": "f02e29ac-f3b4-4353-be79-f886a72eb529",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1418,7 +1418,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getFeatures",
                "response": {
-                  "jsondocId": "ad8eba09-c63f-4dce-8c01-10a029a6ebee",
+                  "jsondocId": "6e4fef52-b383-4faf-ac1d-6f6469e8538e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1431,7 +1431,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "eba3907f-0e7a-4032-917c-df497eee7ccc",
+                     "jsondocId": "83c71b84-4d9c-4b8e-b33c-6def90842672",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1440,7 +1440,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45703707-0a19-4e04-aee0-97cdcae59a9d",
+                     "jsondocId": "e04fc8d1-4062-4f49-b7c1-e26d22c2e65d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1449,7 +1449,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "517c0275-ca21-4024-96bf-a0dd853ce3eb",
+                     "jsondocId": "14b40bac-769a-410a-a040-ac510cf3741b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1458,7 +1458,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8cf96184-c8fd-4da1-9511-4cfe1ee63a71",
+                     "jsondocId": "5c1f57e5-d884-4541-93df-31d2e88af30d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1470,9 +1470,9 @@
                "verb": "POST",
                "description": "Get sequence alterations for a given sequence",
                "methodName": "getSequenceAlterations",
-               "jsondocId": "36bed71f-cf7c-4216-88bf-c0c926a882d4",
+               "jsondocId": "15f99923-0a61-4966-a307-96720c92c749",
                "bodyobject": {
-                  "jsondocId": "2577a58d-9cd7-4ede-b95f-3b1ee7289f72",
+                  "jsondocId": "95418f4e-fd32-46eb-9932-fe2f0ea3dbc1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1482,7 +1482,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequenceAlterations",
                "response": {
-                  "jsondocId": "52a89f8b-e20f-4518-83ab-3f67c8979d56",
+                  "jsondocId": "e980f29a-7a01-40d4-9f33-664dbeb489ca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1495,7 +1495,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ee205e9b-5a3d-4a3a-b662-47d73fc359db",
+                     "jsondocId": "e3ed6ce8-888f-4515-a9aa-b06f3b3ac6fe",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1504,7 +1504,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "17e508f4-4cbc-438c-9d32-dea1fd1698c0",
+                     "jsondocId": "3c7c052d-50ec-4cf4-8a2e-a699e80026b7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1513,7 +1513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cad68e5a-811f-476b-b779-6539287f4708",
+                     "jsondocId": "e0038709-cb44-4179-893e-82a6a75834e7",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1522,7 +1522,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "11af80da-468f-479b-898f-21d224c61193",
+                     "jsondocId": "34a7c81f-d0b7-49b8-a391-e524371715aa",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1531,7 +1531,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ad8bc531-5df5-4e20-9464-f462ff27c3ef",
+                     "jsondocId": "1b7f9c5e-d07d-4824-9b24-712896eea1f4",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -1543,9 +1543,9 @@
                "verb": "POST",
                "description": "Delete attribute (key,value pair) for feature",
                "methodName": "deleteAttribute",
-               "jsondocId": "9a58d879-a75c-43e1-b67e-838a9c016c6d",
+               "jsondocId": "1de34d39-7f12-4ff9-9c15-e834b74e331e",
                "bodyobject": {
-                  "jsondocId": "5e11069a-8078-42f1-b3a2-cd46b8d363d2",
+                  "jsondocId": "b87c55fe-e86e-4c44-937a-f0802c239411",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1555,7 +1555,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteAttribute",
                "response": {
-                  "jsondocId": "9f93b36a-5072-4941-9d5c-4e3ccd4a6a11",
+                  "jsondocId": "bcae54f7-5301-4ceb-af58-80d5e77ee37e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1568,7 +1568,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ca99d645-ba90-45f3-9955-eba16fe8f944",
+                     "jsondocId": "e1b77e20-2b5c-44b8-8210-154f2529d8c8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1577,7 +1577,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "992008cf-ec09-498e-8c51-8de83b151983",
+                     "jsondocId": "e4c75ffc-5930-4142-86fb-f7dad98ac22f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1586,7 +1586,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8165ca19-a42f-4cbd-bbec-36e0e43184aa",
+                     "jsondocId": "356d893a-f302-48df-99c2-9692b11b4f94",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1595,7 +1595,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "68aa4423-2b19-42bd-87e8-cc461d5c51c0",
+                     "jsondocId": "0e7b334d-f4ad-404d-9dda-2552419db06f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1604,7 +1604,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8a765b70-5b37-4236-8c74-f507d69ccdde",
+                     "jsondocId": "7d84ffb9-834b-4ba9-911f-440fbbdd735c",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.",
@@ -1616,9 +1616,9 @@
                "verb": "POST",
                "description": "Update attribute (key,value pair) for feature",
                "methodName": "updateAttribute",
-               "jsondocId": "52070980-efbf-4e6e-9887-b328e5eb4a09",
+               "jsondocId": "1985a84f-129d-4e77-aa79-2bb01f0b64bf",
                "bodyobject": {
-                  "jsondocId": "69ac59e8-6155-4df9-b28d-350903757fb4",
+                  "jsondocId": "61f77fe6-7fe0-43b4-8a02-83ca3881b763",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1628,7 +1628,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateAttribute",
                "response": {
-                  "jsondocId": "6633c9dc-bb78-4b76-9458-dc94d53866ed",
+                  "jsondocId": "e376bd54-9f7d-4dea-ad7c-2e1f065b6e7b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1641,7 +1641,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fbc8f928-0a7e-4e3a-9b51-5de689c60508",
+                     "jsondocId": "9f2db684-ae52-44d2-897b-bbb067414583",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1650,7 +1650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8d04ce49-d094-4238-ad59-ce03de303bb0",
+                     "jsondocId": "2bf893c3-2241-49e9-bb65-99b4a023fcbc",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1659,7 +1659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a86275ef-6bdf-4161-b3a3-bd05a1442ca4",
+                     "jsondocId": "34ef4362-ef8c-4428-8bdb-a1fe3a3578a8",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1668,7 +1668,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "13463d37-0c27-4065-8aba-179fd6a62cc5",
+                     "jsondocId": "5c806452-957e-49bb-a26c-9bddba912873",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1677,7 +1677,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a4da99e4-0db0-433a-a67f-8616d2594e92",
+                     "jsondocId": "c1a0f708-4f1d-4df6-9afe-2e7263ad3832",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1689,9 +1689,9 @@
                "verb": "POST",
                "description": "Add dbxref (db,id pair) to feature",
                "methodName": "addDbxref",
-               "jsondocId": "97b3e779-47a1-40b6-bd78-96990e7c01c3",
+               "jsondocId": "06882035-749d-486a-8ea5-04ed81059c7a",
                "bodyobject": {
-                  "jsondocId": "8598a8e8-dba7-4e17-ab07-ffdd702de688",
+                  "jsondocId": "c6f8dff4-aab2-413d-ba6e-7cb153440144",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1701,7 +1701,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addDbxref",
                "response": {
-                  "jsondocId": "39536b10-676a-480b-927f-dc6de5a174ec",
+                  "jsondocId": "315f30fc-5d25-48f9-aca0-3ec650681766",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1714,7 +1714,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c8103b23-c409-4ad8-8a70-54529bdd2b82",
+                     "jsondocId": "f3988152-f2f9-440d-a203-80d94dd88fb2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1723,7 +1723,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bda774d5-851a-42fe-9bc0-642115fb0ecb",
+                     "jsondocId": "e9e536ef-e20b-4a50-9627-3bc1b51e9737",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1732,7 +1732,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6abbbb11-a7a0-4ff7-896d-8f69ea68fd5c",
+                     "jsondocId": "ba4d0855-a58c-4110-82e7-f38985f58796",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1741,7 +1741,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f6f56a0f-e586-4783-8d6a-8282e001ef2c",
+                     "jsondocId": "b8785495-4792-4d83-bc81-abf2f5228848",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1750,7 +1750,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3256f733-c2fa-402f-9666-603dbf862472",
+                     "jsondocId": "89cde668-e47c-4802-bfb1-44870b24d434",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.",
@@ -1762,9 +1762,9 @@
                "verb": "POST",
                "description": "Update dbxrefs (db,id pairs) for a feature",
                "methodName": "updateDbxref",
-               "jsondocId": "6b03cfd8-3d35-423d-a05f-3f935d25fd82",
+               "jsondocId": "08b4d792-5f19-4675-ab33-c4a88e12db19",
                "bodyobject": {
-                  "jsondocId": "c30b786b-785d-48f3-852f-48d8540e016b",
+                  "jsondocId": "a0870373-f7a1-4220-9d20-7761b002cffc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1774,7 +1774,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateDbxref",
                "response": {
-                  "jsondocId": "d811b9e4-2570-4bb4-8caa-56d687abc0d8",
+                  "jsondocId": "9049c74f-a56f-414d-9605-e2b23238008f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1787,7 +1787,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "aeaec2de-cb09-42b8-bfce-3aee03858c63",
+                     "jsondocId": "0ef5882c-30ba-4181-9b26-ad8cd276c439",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1796,7 +1796,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26343a43-208f-44e3-934d-c69aed676931",
+                     "jsondocId": "26d7713c-79e8-4637-b04e-c51a804d960f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1805,7 +1805,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "412520c6-0fc6-4bd5-8adc-fdce79ddf048",
+                     "jsondocId": "3d2b1f53-4841-444b-93e6-3c825ffce91a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1814,7 +1814,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e9cf864b-9c7a-488b-9f97-af0bc6ec0cae",
+                     "jsondocId": "3a37dce5-ea4c-437a-a14b-34617f676d61",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1823,7 +1823,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "de7f95a2-6cc8-4334-890a-bafd3a132e26",
+                     "jsondocId": "1c32e256-4277-4500-9afa-cb51a7ac5dd4",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1835,9 +1835,9 @@
                "verb": "POST",
                "description": "Delete dbxrefs (db,id pairs) for a feature",
                "methodName": "deleteDbxref",
-               "jsondocId": "c8c0ab95-0ded-4d22-a240-3f85c0da33fe",
+               "jsondocId": "18fa1057-14a0-4c5b-a233-f2fcbebb14fd",
                "bodyobject": {
-                  "jsondocId": "7f5215d5-ee36-4900-90f0-a14edf683a3e",
+                  "jsondocId": "f03a6547-4590-401a-9e09-35acc3fb5410",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1847,7 +1847,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteDbxref",
                "response": {
-                  "jsondocId": "b980600f-1577-4d78-bbde-a393b5089497",
+                  "jsondocId": "47585c2e-4ffa-41d1-9fd7-179e27378953",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1860,7 +1860,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c3566b91-5b42-472e-a825-7741ada942a5",
+                     "jsondocId": "27365161-9f70-486a-9bac-7e6292377e50",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1869,7 +1869,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c3aa1625-4258-40ac-a6f7-feed55853218",
+                     "jsondocId": "0760dd3e-410e-49de-8727-024fdfae0c89",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1878,7 +1878,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14b90304-cc8e-46e1-a70d-670b6ac45f4f",
+                     "jsondocId": "d0ec6e09-91fe-409a-b3bc-49638f623bc1",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1887,7 +1887,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b8335078-c81f-4f61-8197-d4e9edbdeb9d",
+                     "jsondocId": "66d3ea28-43e9-4187-82b5-4c42094edb74",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1896,7 +1896,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "785d0059-076b-470f-a4e0-d6ab16f3bae6",
+                     "jsondocId": "534ac307-2170-485b-99e9-704058098487",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
@@ -1908,9 +1908,9 @@
                "verb": "POST",
                "description": "Set readthrough stop codon",
                "methodName": "setReadthroughStopCodon",
-               "jsondocId": "9505dca0-e4a6-43bd-a96e-570fb67e5b4b",
+               "jsondocId": "d1a5f230-5a74-4c8f-86ba-f96b994b7333",
                "bodyobject": {
-                  "jsondocId": "0417835a-fb09-4d4e-a762-f03fb43cf126",
+                  "jsondocId": "f18798c3-7312-4e64-9e5e-4021739dceef",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1920,7 +1920,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setReadthroughStopCodon",
                "response": {
-                  "jsondocId": "78f1e2f5-e737-4937-bf81-5dbfbcd10338",
+                  "jsondocId": "46004438-2b84-4d28-b613-3eb3408b9f36",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1933,7 +1933,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "59da607b-ffb7-4d6f-ac32-291236dff1e6",
+                     "jsondocId": "fbff532b-b183-4075-a295-72b87f7af24d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1942,7 +1942,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4b0589b3-b469-47ae-92f3-509825cb5f86",
+                     "jsondocId": "cf19f471-12e8-4bda-b88c-62249d33715d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1951,7 +1951,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7ef9181e-123c-4550-a1f2-20b07df2bd5f",
+                     "jsondocId": "26a748ad-a164-4f63-b421-61f7975191ac",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1960,7 +1960,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "228b035e-3e99-4479-9da2-0bf3de366936",
+                     "jsondocId": "368e922c-c2e9-4daa-9448-61625c628bcf",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1969,7 +1969,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8f38759c-a714-4eb3-86d5-775ce1be9ec8",
+                     "jsondocId": "82075c91-43aa-4650-83a9-679d3af5b88b",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
@@ -1981,9 +1981,9 @@
                "verb": "POST",
                "description": "Add sequence alteration",
                "methodName": "addSequenceAlteration",
-               "jsondocId": "b1ad61ce-7393-4e3a-b01e-0441bc091cf0",
+               "jsondocId": "3e00cd3a-f314-40d5-8210-ef9367ca4658",
                "bodyobject": {
-                  "jsondocId": "9276f8f0-852a-440a-a2f3-22588d8104ae",
+                  "jsondocId": "df3e3b85-e33b-4b94-8595-9531133e0361",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1993,7 +1993,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addSequenceAlteration",
                "response": {
-                  "jsondocId": "acc31ad7-55d7-488c-88f9-dc937d84f3e2",
+                  "jsondocId": "7fdbcfe5-d4b9-4c7f-997a-eda77fdf7c06",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2006,7 +2006,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ae228d8b-00d5-478e-8dbd-e770e18c0385",
+                     "jsondocId": "c82feea6-d087-4fef-9acb-3636a43fca7c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2015,7 +2015,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "498599b9-1541-47c8-ac23-75ad262fe9a1",
+                     "jsondocId": "bb6d444e-db96-4d66-8077-be78efe8c965",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2024,7 +2024,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8ed7c0bf-2877-45d2-a080-454c1e1739d2",
+                     "jsondocId": "d25ed03c-2254-4bcc-9e1b-704b8d0e2f3a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2033,7 +2033,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3279485a-3f80-4506-9732-d7117f6086cb",
+                     "jsondocId": "88a15cc6-0792-4efb-a699-1dd6e9d2fb65",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2042,7 +2042,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "20ea0174-5c33-4070-ab2c-08d78394b969",
+                     "jsondocId": "221fd806-56e3-4e42-8fa7-807e54d43ec7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
@@ -2054,9 +2054,9 @@
                "verb": "POST",
                "description": "Delete sequence alteration",
                "methodName": "deleteSequenceAlteration",
-               "jsondocId": "0d00e0a4-f3b1-4781-b099-381c8ac8e439",
+               "jsondocId": "47844703-befc-4617-b43f-934a1e1d1036",
                "bodyobject": {
-                  "jsondocId": "bce12853-62f2-4638-a274-dc7e91434acd",
+                  "jsondocId": "cd2ba93f-53c4-40cb-8340-46592cda99bb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2066,7 +2066,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteSequenceAlteration",
                "response": {
-                  "jsondocId": "1bc698bd-8b02-4a7a-b7e2-ab4b713c3869",
+                  "jsondocId": "60c37101-916a-49a6-aca3-cd35ec6dd45a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2079,7 +2079,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "93c1aff3-107e-4ed2-8bb5-7ca7ccac5497",
+                     "jsondocId": "7fa07cee-ffb7-47bf-991a-7533cce4842d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2088,7 +2088,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6735cc81-d9ce-41ef-9e64-ec69bbeda824",
+                     "jsondocId": "f6c638b2-53c2-4244-9e45-161a78423dae",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2097,7 +2097,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "464ef2af-1bdb-4a00-91bb-ebf99073e949",
+                     "jsondocId": "10cf2581-0709-441f-b0ca-27705b1f866e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2106,7 +2106,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2b8c7851-9d92-4611-abed-e43b16bcac45",
+                     "jsondocId": "c906a669-cbcf-482e-bd81-ade46bfc46b6",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2115,7 +2115,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "28225bcc-1c36-408b-8162-0e0712378736",
+                     "jsondocId": "2a3276f5-b75a-43fa-94e5-df27ec99ee35",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
@@ -2127,9 +2127,9 @@
                "verb": "POST",
                "description": "Flip strand",
                "methodName": "flipStrand",
-               "jsondocId": "e7bbf45f-7892-4c00-8daf-5d1d63d8f2e7",
+               "jsondocId": "6f386c5b-2215-4c99-b6cf-9f78bb2c7e6a",
                "bodyobject": {
-                  "jsondocId": "688aec24-cf76-4af4-8664-a69b27a3b6bc",
+                  "jsondocId": "fa08cbf1-3501-468b-ae63-e76729871e9e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2139,7 +2139,7 @@
                "apierrors": [],
                "path": "/annotationEditor/flipStrand",
                "response": {
-                  "jsondocId": "c88d3c13-9150-4cd4-ad21-465e5fe99f59",
+                  "jsondocId": "21b9ad1a-4562-460c-89c7-18209dcdf136",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2152,7 +2152,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a22d5310-0d6a-46fa-a55c-45d8c420db48",
+                     "jsondocId": "7a1e7592-b57b-4145-8e0f-5547eb2e13fe",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2161,7 +2161,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9366c90f-b714-4ffd-a5ae-d63000d7d934",
+                     "jsondocId": "db448b0e-3731-4708-924d-37476e3f8c2c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2170,7 +2170,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63d5ff7a-1e11-4e62-ad3a-f25a28e5038f",
+                     "jsondocId": "3b662017-0c5e-4540-adc3-05bf65494899",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2179,7 +2179,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3de87bd7-a131-4cec-bbc9-9b4b668fa0ba",
+                     "jsondocId": "11978c11-1b83-49f6-8590-9e721150cf1b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2188,7 +2188,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "30426172-2363-4304-a844-acb00dc5620a",
+                     "jsondocId": "63f47590-4b0a-4d92-a65a-1698a2f85829",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
@@ -2200,9 +2200,9 @@
                "verb": "POST",
                "description": "Merge exons",
                "methodName": "mergeExons",
-               "jsondocId": "efc9f74a-b6d0-4be8-b26a-65db40bd364c",
+               "jsondocId": "9cdec64c-cc6f-4b77-ac56-782b03a69e97",
                "bodyobject": {
-                  "jsondocId": "b2236936-1386-4840-99ab-5c9cc36dd95a",
+                  "jsondocId": "53eaad57-e682-48f9-b8af-64de80844920",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2212,7 +2212,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeExons",
                "response": {
-                  "jsondocId": "1a2c3bf4-32a9-4cb1-8db5-6aac488b4093",
+                  "jsondocId": "88a84e53-7c5c-423c-842e-a58964bf56eb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2225,7 +2225,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "18921b0e-7728-470b-abbc-6d31e2aa7c3d",
+                     "jsondocId": "4c04d9ad-3ff9-409a-ad93-5654bcbcb36f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2234,7 +2234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ee3d34c1-a4bc-4a74-b80d-622f55e1dc8c",
+                     "jsondocId": "078d68fb-5fbe-44a5-b865-05c2fd49af1c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2243,7 +2243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "35314d81-4081-4d0d-8f0f-ce8121022981",
+                     "jsondocId": "93424ab0-dc65-4a7e-a517-6713d18803d6",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2252,7 +2252,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a497bf66-6f54-4d29-9d0e-86502198752c",
+                     "jsondocId": "a033c91d-d08a-4317-a597-7e8bc71138ae",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2261,7 +2261,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b1ff9c45-f6c3-47b0-a410-7467e8676e06",
+                     "jsondocId": "92b3fc58-efe1-4c86-91e7-2218efce5f8f",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -2273,9 +2273,9 @@
                "verb": "POST",
                "description": "Split exons",
                "methodName": "splitExon",
-               "jsondocId": "4498953e-2dc7-4095-861b-fa32ba636d1e",
+               "jsondocId": "614781ce-4543-4119-9cf2-a2f1972fb7a8",
                "bodyobject": {
-                  "jsondocId": "62dd1288-f100-4e4a-b73a-07fd5b47eb2a",
+                  "jsondocId": "7266c548-e8ab-407b-9622-f7cec2100479",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2285,7 +2285,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitExon",
                "response": {
-                  "jsondocId": "2adae8cb-c464-4896-bf56-ab1fba3616a0",
+                  "jsondocId": "fe07af68-64e1-4658-a273-dc0dcebee542",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2298,7 +2298,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b178f6b2-db1b-40c4-9108-0170725011cc",
+                     "jsondocId": "d20ab437-2569-4624-8c09-3207479b5c7c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2307,7 +2307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cdc00541-f120-4143-9fab-f9ff68d91859",
+                     "jsondocId": "a27c3427-46e6-4814-8ed9-de24996120bf",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2316,7 +2316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ea69c8a6-be0d-4075-bb20-3ee0efbbf8d8",
+                     "jsondocId": "362526d5-7124-4e83-8f7d-3cd715454dcf",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2325,7 +2325,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1ab16bed-d2d3-48cf-9121-9258267546d3",
+                     "jsondocId": "58e7416f-9e24-4641-8a7b-e866ad5a1107",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2334,7 +2334,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d4fd1cd-36a5-46cc-bd15-3e4c967976ca",
+                     "jsondocId": "d62d8447-9613-4e2b-a1ea-b2ddb84fe654",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
@@ -2346,9 +2346,9 @@
                "verb": "POST",
                "description": "Delete feature",
                "methodName": "deleteFeature",
-               "jsondocId": "9b90983e-e2b8-4444-8156-cc426e686412",
+               "jsondocId": "e0cfbcbe-33e3-40e7-bf74-64c861eabaca",
                "bodyobject": {
-                  "jsondocId": "28401994-cb97-4f0e-966a-8b8cb2fd7e25",
+                  "jsondocId": "4fd55fc8-f1c1-449e-97d5-cd4f83d8ead7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2358,7 +2358,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeature",
                "response": {
-                  "jsondocId": "4328d1d3-84ac-462b-a9b6-f97d34ba446e",
+                  "jsondocId": "f8a3f5a4-f2c2-49dd-b0d5-3ad0b129aa54",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2371,7 +2371,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "90186024-2f43-4a60-ae0e-f3870f339955",
+                     "jsondocId": "5ab91889-f1e8-42f2-9761-8495d794eeb0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2380,7 +2380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ca72c351-3cff-4f28-9577-233290397077",
+                     "jsondocId": "b0e30c44-46d5-49ea-8abd-e02143e25d68",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2389,7 +2389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e0320df9-ca44-4cc1-90ba-6769f6a64b66",
+                     "jsondocId": "e73ac833-385c-428a-9a48-13014854766d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2398,7 +2398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0f9f87a6-1929-4750-8440-829f147c9760",
+                     "jsondocId": "7cdeb1ce-2211-40c0-862f-ca3ad72107e0",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2407,7 +2407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "35b16c54-1c45-4981-a8e8-9e50304e20b7",
+                     "jsondocId": "48c0d82e-dd6f-492d-a08b-cf0dd4e10656",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
@@ -2419,9 +2419,9 @@
                "verb": "POST",
                "description": "Delete exons",
                "methodName": "deleteExon",
-               "jsondocId": "65984384-1999-4426-b425-70308174c1fd",
+               "jsondocId": "fcb20f67-3b2c-46fd-a059-04922ec6b3f8",
                "bodyobject": {
-                  "jsondocId": "9a8d819c-f929-4f5d-9ae9-7c3880eff3ab",
+                  "jsondocId": "f90b67cd-e3da-473a-a7ac-663fc0a2720c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2431,7 +2431,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteExon",
                "response": {
-                  "jsondocId": "3be6416f-b159-4426-9ee6-2d3f1bda9634",
+                  "jsondocId": "11548aa3-14d1-4824-96f8-eb0c15454185",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2444,7 +2444,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "cbed124a-9d3f-4f20-8352-c209ac889841",
+                     "jsondocId": "fe71400a-2d0b-47b6-80d9-5333769dcfa1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2453,7 +2453,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "022b534f-98a1-4a22-b081-afad679d1859",
+                     "jsondocId": "9e65e7bf-a6fe-4e0b-9d0a-68ea5e7ec424",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2462,7 +2462,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "168b4d08-ec48-4c7f-9fc3-0c9022d6b57a",
+                     "jsondocId": "a30405eb-f71a-4ba9-ad74-a244c88f6710",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2471,7 +2471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "274e19aa-caf4-4102-8f52-158c6a038ae7",
+                     "jsondocId": "fea27ccb-41b4-4dfc-96ac-b359a4923c3c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2480,7 +2480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65d67aaa-7832-4532-8b70-1c401b820bd0",
+                     "jsondocId": "45076965-a72e-44d0-b867-380aa56d0b67",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -2492,9 +2492,9 @@
                "verb": "POST",
                "description": "Make intron",
                "methodName": "makeIntron",
-               "jsondocId": "e3967289-b961-4221-895f-8a5ed948c2df",
+               "jsondocId": "c5b30ce9-c610-4ac8-8c3f-57df170a4dc4",
                "bodyobject": {
-                  "jsondocId": "c1a24bf0-0686-4733-ac51-4df9acab8035",
+                  "jsondocId": "e0f40464-dfd5-46b5-8ac2-fc5325e69541",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2504,7 +2504,7 @@
                "apierrors": [],
                "path": "/annotationEditor/makeIntron",
                "response": {
-                  "jsondocId": "0dbb3a3b-02f5-4b27-98f6-e6b8aecceea0",
+                  "jsondocId": "4c8fb6c2-94f8-4ddd-82b6-d48cb0ed743d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2517,7 +2517,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d0a7bb48-0fe0-4638-9853-2b6afff38849",
+                     "jsondocId": "a4f2059c-2a24-41cd-abc2-ef11e1046ba3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2526,7 +2526,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "600d3bb5-543c-44a3-9179-c91809484f04",
+                     "jsondocId": "8f4dca06-4a82-4652-9a49-d48497548e31",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2535,7 +2535,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3a5246a4-7b00-4201-b350-0db8b76cf26d",
+                     "jsondocId": "3f671166-1560-4ed4-bcba-3f54b75209a4",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2544,7 +2544,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f96186ae-bd2c-4fbd-aed7-81d3d3298c1c",
+                     "jsondocId": "6d36a558-de0f-4d04-9eb1-8db2ac79736c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2553,7 +2553,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e030532c-b1f3-4c8c-b6f5-aa2913dedc68",
+                     "jsondocId": "61f7ff3e-5fcd-479f-b31a-7ad6098b1401",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2565,9 +2565,9 @@
                "verb": "POST",
                "description": "Split transcript",
                "methodName": "splitTranscript",
-               "jsondocId": "d76535e8-9cc7-40aa-9ba4-eef8fbfa47c5",
+               "jsondocId": "f43e7aae-41fc-4fb7-bc46-5ef18aae7557",
                "bodyobject": {
-                  "jsondocId": "af204475-4405-466b-a105-4554b33ff233",
+                  "jsondocId": "91db9643-1639-4504-887e-8ddb93c8182a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2577,7 +2577,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitTranscript",
                "response": {
-                  "jsondocId": "076b1510-112f-4fe8-bda2-7b4fd30683e2",
+                  "jsondocId": "2d6fea9c-6def-4541-a8e7-0cca01d0c1f0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2590,7 +2590,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e6ac8b32-7e44-4c47-af69-32eae2c37232",
+                     "jsondocId": "ea26152c-2f27-47f8-aa89-65469a6db7c7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2599,7 +2599,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "47f13f4e-4872-41ad-a1ad-eb08ac868cfc",
+                     "jsondocId": "975657ae-105d-4f66-9b8d-e251bd211dd4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2608,7 +2608,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7e06b1c1-5265-47bc-9933-d2d2dbeda649",
+                     "jsondocId": "0243764b-8765-441e-9052-97b0b2bb2452",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2617,7 +2617,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7676e507-8fea-40e3-b917-f861d93c2139",
+                     "jsondocId": "b3f9e248-5c94-4b1c-b4d6-c7fd3d9d0f76",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2626,7 +2626,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "937917ce-6c96-4c79-a1c0-3989e0085989",
+                     "jsondocId": "55fda462-0281-4a76-a2dc-2992bfacbc9b",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2638,9 +2638,9 @@
                "verb": "POST",
                "description": "Merge transcripts",
                "methodName": "mergeTranscripts",
-               "jsondocId": "aad9eb33-5cab-4b8d-909d-ec4a3f79b646",
+               "jsondocId": "755421bc-5e1b-4076-bb3a-dba1e09869ba",
                "bodyobject": {
-                  "jsondocId": "3ca25893-74a6-4bfb-b948-48fede2ba58a",
+                  "jsondocId": "c8319277-43bd-45fb-9d81-4fedac2f11f9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2650,7 +2650,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeTranscripts",
                "response": {
-                  "jsondocId": "deb1cc0b-2af1-49b2-8d0d-f81342804229",
+                  "jsondocId": "d7ddbf4f-9e12-4621-9cd1-2f7b8bc084d2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2663,7 +2663,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f2473fe2-1019-4cb5-ac33-fb7a83802902",
+                     "jsondocId": "dbd39a4d-a51a-4bd1-a567-bb07e57e47d7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2672,7 +2672,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b524e823-5e49-4d6a-99cf-8c38516633fe",
+                     "jsondocId": "8859af21-5fe1-42b8-885b-c7768cbe95c0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2681,7 +2681,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f314ecf9-2495-4d3e-aa54-7438eadac0d5",
+                     "jsondocId": "0299f4fd-7140-4f26-a898-a58245991462",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2690,7 +2690,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "301c7f1c-c170-40f0-b4b1-fd373721eecd",
+                     "jsondocId": "0f88dc95-94bb-428a-8f2f-ef99de9cf881",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2699,7 +2699,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "58f20323-21ac-4d2a-b813-19fec92172c7",
+                     "jsondocId": "64c4383d-e13e-4f55-a36f-7ada510b0397",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2711,9 +2711,9 @@
                "verb": "POST",
                "description": "Get sequences for features",
                "methodName": "getSequence",
-               "jsondocId": "9110c467-7619-42e0-8e03-fc83d07a22ea",
+               "jsondocId": "c98c2cae-7faf-4017-b2c7-509ce6771391",
                "bodyobject": {
-                  "jsondocId": "51c5ae61-f358-4e51-b194-007dc2fd5067",
+                  "jsondocId": "910b1bb7-8ce8-4491-8cb4-66bab4588743",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2723,7 +2723,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequences",
                "response": {
-                  "jsondocId": "cfe1b37f-dc62-44ff-9482-f8f97e0d25e8",
+                  "jsondocId": "a3b4bf1d-af94-464f-aab6-fd2e5655dd5e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2732,7 +2732,7 @@
                "consumes": ["application/json"]
             },
             {
-               "jsondocId": "c86f7e32-4b71-4dcd-8780-f602f8adb98e",
+               "jsondocId": "6e52f7c9-52f8-43db-b7ec-4956dddeca27",
                "bodyobject": null,
                "apierrors": [],
                "path": "/annotationEditor/getSequenceSearchTools",
@@ -2740,7 +2740,7 @@
                "pathparameters": [],
                "queryparameters": [],
                "response": {
-                  "jsondocId": "c3532f46-33e2-420b-9560-0e6b365f19d8",
+                  "jsondocId": "0ecd2c75-5c02-4a46-969b-f054daf5ea9a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2755,7 +2755,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "213468ca-0d5d-4569-971a-a92d39a54e01",
+                     "jsondocId": "0baed5d1-01a3-42df-80ac-49bc6d18a439",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2764,7 +2764,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e36be472-562f-478c-a719-b95c153194fb",
+                     "jsondocId": "5146261b-76cb-4078-9f82-3105af573116",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2776,9 +2776,9 @@
                "verb": "POST",
                "description": "Get canned comments",
                "methodName": "getCannedComments",
-               "jsondocId": "7e30dec0-2093-45f4-ad4c-7ab2ce0bd93d",
+               "jsondocId": "9659c4b8-454a-4ad4-b1f8-7c4ed89ade6f",
                "bodyobject": {
-                  "jsondocId": "31771f95-146b-4fca-9bd6-9722f366e3e0",
+                  "jsondocId": "d35e4f57-4a97-41a9-8d74-71e6944c238d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2788,7 +2788,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getCannedComments",
                "response": {
-                  "jsondocId": "e9cc9ec8-b00c-4925-92fa-b80e1e4ff93f",
+                  "jsondocId": "6c2d9024-75f2-41fa-984c-3a30350fa479",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2801,7 +2801,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6cf76d3f-af63-462c-ab40-1d7cc9263158",
+                     "jsondocId": "4c4e15f4-31b2-49e2-962a-49772d197965",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2810,7 +2810,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cb19fa9a-cd31-4896-83a3-2671b2b09eb6",
+                     "jsondocId": "01889d83-866e-4b94-ae53-7446cc24ece2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2819,7 +2819,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02cea335-8b54-4603-be47-9fb60278fe60",
+                     "jsondocId": "1aaf4907-6797-4a38-9cd2-fda7d6ff7a74",
                      "name": "client_token",
                      "format": "",
                      "description": "Organism ID/Name or Client-generated ",
@@ -2828,7 +2828,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "30ba1060-f14b-49a8-871b-ea836163814e",
+                     "jsondocId": "497acea3-4142-4a3b-a924-4b56a9be2102",
                      "name": "search",
                      "format": "",
                      "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
@@ -2840,9 +2840,9 @@
                "verb": "POST",
                "description": "Search sequences",
                "methodName": "searchSequence",
-               "jsondocId": "57db1ff8-12a5-4b8b-9921-7ecce10e38fe",
+               "jsondocId": "574ed700-39c7-4911-ab00-5fc9d2bd0551",
                "bodyobject": {
-                  "jsondocId": "760198e8-b2c9-4623-a981-7554ef347eb1",
+                  "jsondocId": "22188907-4aa8-4650-b488-40afa46f8313",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2852,7 +2852,7 @@
                "apierrors": [],
                "path": "/annotationEditor/searchSequences",
                "response": {
-                  "jsondocId": "628ff8c3-8b22-4bd1-9b45-80c5ce058173",
+                  "jsondocId": "c50e10c2-b741-45e5-b006-269c4c64b228",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2865,7 +2865,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c6a0093a-ad23-4b24-a4e2-1ada0b5a6635",
+                     "jsondocId": "5cac9ff0-0cf6-44ec-b21a-06802e762949",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2874,7 +2874,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cb4df74c-16cd-4838-869f-fa50eaacb2a5",
+                     "jsondocId": "c0737996-fdca-42f4-a141-6e10add7411e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2883,7 +2883,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0b6fd6e5-c9fb-4381-b7d7-76a687ec28cd",
+                     "jsondocId": "6727edad-9855-4aae-af6d-74e03c10fe68",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2895,9 +2895,9 @@
                "verb": "POST",
                "description": "Get gff3",
                "methodName": "getGff3",
-               "jsondocId": "15f1fe45-bfdd-4809-9794-3b95c91adcab",
+               "jsondocId": "cb0c2a45-5fc4-4e24-95ca-4ebdd50f859e",
                "bodyobject": {
-                  "jsondocId": "379cf94a-ec35-4b79-82ee-293ebfd613ff",
+                  "jsondocId": "b4d66913-af61-46cc-98ca-b7b83299ec0c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2907,7 +2907,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getGff3",
                "response": {
-                  "jsondocId": "c5d817a2-7a06-44d6-87ef-4a99aab60a1c",
+                  "jsondocId": "0d1262e4-83cf-4709-a91c-1c68f715114e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2920,7 +2920,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "84da0b05-844d-4944-bcf2-c4d413d1ba52",
+                     "jsondocId": "c2246cf0-91cf-4413-9ba4-0f8a043e65da",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2929,7 +2929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3f1d190f-7c95-4165-bdae-4f0c0373c38f",
+                     "jsondocId": "c344bd13-0bfe-464b-848e-9245f64ccc5c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2938,7 +2938,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b5336c75-83e7-406c-835c-89f4bfef9a01",
+                     "jsondocId": "8c8da553-f14c-4316-8016-32901089a35f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2947,7 +2947,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9abc64d6-8ffd-45fb-90fd-7b41036a6e7c",
+                     "jsondocId": "1f979138-3fdc-49d6-897e-7f3b2c72014d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2956,21 +2956,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9091a4cd-a3a5-4a38-aa1b-8b5311ff9721",
+                     "jsondocId": "48a98dbc-c32e-451c-8b45-29707da217c4",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Add attribute (key,value pair) to feature",
-               "methodName": "addAttribute",
-               "jsondocId": "47827a9d-ebcf-4341-a49f-e39761c0d2fa",
+               "description": "Set symbol of a feature",
+               "methodName": "setSymbol",
+               "jsondocId": "9389a324-52c1-4367-adb8-1db4b80d56e1",
                "bodyobject": {
-                  "jsondocId": "9e049f77-a5c1-456a-b08e-e6fd68686717",
+                  "jsondocId": "e96a396a-98e8-490f-88b7-f98521ba0344",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2978,9 +2978,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/addAttribute",
+               "path": "/annotationEditor/setSymbol",
                "response": {
-                  "jsondocId": "4fabfcde-4b89-40af-86c8-1be7d9bf7ba4",
+                  "jsondocId": "dd8af966-fc52-444d-87dd-e1f5bda5ce1f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2993,14 +2993,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "85cdf2e4-1bc1-4200-bdb0-3311e86f30bb",
+         "jsondocId": "0e845cbb-2f7b-4365-9b01-dfd174be87a9",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "12c22e44-b01c-44f0-9ec3-2eafb53bff48",
+                     "jsondocId": "f3f01711-fbda-4b4d-b2fe-ca51d232a27a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3009,7 +3009,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "57137a0a-66b8-47cb-9d00-823bc0283901",
+                     "jsondocId": "7eec396b-742e-44e0-abeb-3ac2c2ad6427",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3018,7 +3018,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "47d14692-9afd-43c5-b996-dfe558911b91",
+                     "jsondocId": "7bfbe655-296c-4438-84ea-957c852abb50",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to update (or specify the old_value)",
@@ -3027,7 +3027,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c95b61ac-83d7-4002-8d58-7e615ae91004",
+                     "jsondocId": "7145d25c-1beb-4b10-abc0-c3f1795502fb",
                      "name": "old_value",
                      "format": "",
                      "description": "Status name to update",
@@ -3036,7 +3036,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a01b1755-b211-4473-8e7c-42d34204a356",
+                     "jsondocId": "1cf1de4a-f8e6-4403-8911-62c47646f33a",
                      "name": "new_value",
                      "format": "",
                      "description": "Status name to change to (the only editable option)",
@@ -3048,9 +3048,9 @@
                "verb": "POST",
                "description": "Update status",
                "methodName": "updateStatus",
-               "jsondocId": "1553c8b1-0f66-4c36-80d3-f7968d992897",
+               "jsondocId": "269cbfdd-dc4c-4e1a-afcb-2c64635d7817",
                "bodyobject": {
-                  "jsondocId": "63e777cd-d9dd-4753-a62e-25e3ecd1aa73",
+                  "jsondocId": "a72db65b-fe73-41dd-96ea-4044d9bbab7f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3060,7 +3060,7 @@
                "apierrors": [],
                "path": "/availableStatus/updateStatus",
                "response": {
-                  "jsondocId": "a49946bc-303b-49dc-98b2-0d636d4b9abf",
+                  "jsondocId": "babb1602-2bb3-4f2c-9415-0f0fbb413f6f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3073,7 +3073,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c415afea-867a-4d66-8183-a9c5ae7f2cd8",
+                     "jsondocId": "fcc0df17-4034-4e2f-958f-3f5491248879",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3082,7 +3082,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "67f56b7e-1f9c-4324-934b-d58981e113cf",
+                     "jsondocId": "efefdefa-4a4b-421c-ba53-04b0f5af2f1a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3091,7 +3091,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "37d84f99-952a-4103-8e5d-8a61480bdff3",
+                     "jsondocId": "1fc4b7fb-ec91-483f-b9b3-f037b9e1c6cf",
                      "name": "value",
                      "format": "",
                      "description": "Status name to add",
@@ -3103,9 +3103,9 @@
                "verb": "POST",
                "description": "Create status",
                "methodName": "createStatus",
-               "jsondocId": "aa6a4077-8a90-4161-9414-85ac2c863e2c",
+               "jsondocId": "65cf2b78-f8ea-4138-a804-ad3a2eb20e81",
                "bodyobject": {
-                  "jsondocId": "1cf91a61-ad55-4537-8910-484e50588015",
+                  "jsondocId": "8387a6e0-1b4c-4391-9c1f-117edd59182d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3115,7 +3115,7 @@
                "apierrors": [],
                "path": "/availableStatus/createStatus",
                "response": {
-                  "jsondocId": "2b315834-5971-4573-a002-17a2df3817af",
+                  "jsondocId": "07388266-2dbb-46a6-8540-277e38723b14",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3128,7 +3128,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0aad4b11-3cc6-48d2-a68d-ff5987858b6a",
+                     "jsondocId": "29e750aa-28a4-4c99-8476-22c4d59ee29b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3137,7 +3137,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5af8c2f1-b033-45d0-8ced-3b245c55f411",
+                     "jsondocId": "1993b4e3-7147-499b-954b-d5122ea0e0d6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3146,7 +3146,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8cb10bf5-1ad9-46bf-ad92-190006e670f6",
+                     "jsondocId": "4fee3cb7-e38f-48f0-9917-1a5461dd7028",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to remove (or specify the name)",
@@ -3155,7 +3155,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "01016b40-62dc-406d-826b-328617d58851",
+                     "jsondocId": "0e68c2f0-9040-4f2f-a41f-8d38eaec1a2a",
                      "name": "value",
                      "format": "",
                      "description": "Status name to delete",
@@ -3167,9 +3167,9 @@
                "verb": "POST",
                "description": "Remove a status",
                "methodName": "deleteStatus",
-               "jsondocId": "0a0a9d48-2199-42b7-8f92-f84d974806d5",
+               "jsondocId": "d3287af1-df6d-40d3-9b5a-fcaa9de37ed3",
                "bodyobject": {
-                  "jsondocId": "dfc2d3bb-c065-4bce-95c3-10311f8b7cbe",
+                  "jsondocId": "4e1bba42-7766-4d57-9c12-cfc1b4cd6ccf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3179,7 +3179,7 @@
                "apierrors": [],
                "path": "/availableStatus/deleteStatus",
                "response": {
-                  "jsondocId": "d675d356-8911-43bd-8dd0-832b9e8c7e3f",
+                  "jsondocId": "9947cf1f-6563-42bd-a752-dfd858e19b89",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3192,7 +3192,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e5b458d5-3886-45aa-9938-9253c38cb50f",
+                     "jsondocId": "79cc4986-c45e-40c2-9cac-4ee74f5d30b9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3201,7 +3201,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1f40ac4-1b88-447e-89cf-a80be4406dee",
+                     "jsondocId": "f78d62a3-9c62-4700-ae6a-3950936872e5",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3210,7 +3210,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6ff80c5b-a120-427e-aded-adf4ce42dbb8",
+                     "jsondocId": "ad04d5d1-848f-4e7d-ad07-03e7b913e793",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to show (or specify a name)",
@@ -3219,7 +3219,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d3a8d8c2-003a-4690-9d8e-4c16c4f1dcdf",
+                     "jsondocId": "38064c65-87d0-46a3-9456-631f3579fb3b",
                      "name": "name",
                      "format": "",
                      "description": "Status name to show",
@@ -3231,9 +3231,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all statuses, or optionally, gets information about a specific status",
                "methodName": "showStatus",
-               "jsondocId": "f21791ca-2c73-42e4-bcb6-e72acaed1e6d",
+               "jsondocId": "09c0acc3-f584-457e-96ec-82a4b70d8b88",
                "bodyobject": {
-                  "jsondocId": "ec3ec3b2-faef-4bdd-ac71-e557c1cd36bf",
+                  "jsondocId": "775dca39-c85f-4a35-91f3-e2add358e339",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3243,7 +3243,7 @@
                "apierrors": [],
                "path": "/availableStatus/showStatus",
                "response": {
-                  "jsondocId": "1fd837ab-8359-4408-92f4-00208462412e",
+                  "jsondocId": "e2a7f06c-f4dd-497d-9800-c78bf6f610a9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3256,14 +3256,14 @@
          "description": "Methods for managing available statuses"
       },
       {
-         "jsondocId": "0c7c6d5a-2a9a-4eb7-87dc-fbd4517d11dd",
+         "jsondocId": "b6cb8d48-4ff6-4c3c-b187-77812e2e2595",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "691e0246-7949-4268-851a-e0cb05d161d4",
+                     "jsondocId": "4592fade-8888-4afe-9549-9cedfb710e38",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3272,7 +3272,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f6bd6cf1-fca8-416f-bc7b-f50ec44141a3",
+                     "jsondocId": "5061bf97-652d-4d0e-8ca8-ce85c161ad10",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3281,7 +3281,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1e3a4c6c-31f8-420f-86cd-5bc8f5614af5",
+                     "jsondocId": "898a2c52-7048-43ee-aeba-21502c60cef0",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to add",
@@ -3290,7 +3290,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a8ee37ac-d5a4-4375-a99b-055d727d732d",
+                     "jsondocId": "3adee53d-42e8-4309-8865-d3ce6266fc8e",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3302,9 +3302,9 @@
                "verb": "POST",
                "description": "Create canned comment",
                "methodName": "createComment",
-               "jsondocId": "a9f3f398-ac48-48f8-b2c3-26a7ca720b90",
+               "jsondocId": "f9427c4f-ec28-437a-8309-04a1548a8a38",
                "bodyobject": {
-                  "jsondocId": "757be3c9-1566-4023-954b-f45be9ab1b83",
+                  "jsondocId": "4d79741b-5253-4346-bab2-98c78715fe11",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3314,7 +3314,7 @@
                "apierrors": [],
                "path": "/cannedComment/createComment",
                "response": {
-                  "jsondocId": "c12d718e-7d79-438f-9585-716686fee683",
+                  "jsondocId": "4f10470c-cd32-4667-a2aa-bc90ffed1b5f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3327,7 +3327,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a17ba5bf-2a9b-4c2b-b951-2ba282e72894",
+                     "jsondocId": "2f20cb9e-f0c3-4ad9-bb48-0c4867f4e7d7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3336,7 +3336,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "20788ff8-8b51-40c3-abc6-ecb66a179a1c",
+                     "jsondocId": "057fa6af-ecce-40d8-85ce-fe356dc5fa62",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3345,7 +3345,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "436fb4af-e787-4228-b367-37ddb33aec2a",
+                     "jsondocId": "f9e3fabf-540d-483c-a766-56cf252d917a",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to update (or specify the old_comment)",
@@ -3354,7 +3354,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dd70de73-73c3-4403-8605-00e1afa7de89",
+                     "jsondocId": "5d181de5-7504-4a26-a06e-d61d019a2ab7",
                      "name": "old_comment",
                      "format": "",
                      "description": "Canned comment to update",
@@ -3363,7 +3363,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c848c8d4-0859-47e0-aa4f-717bdb346976",
+                     "jsondocId": "eb30bb54-f2d1-4ea3-90a4-cc4eadbced22",
                      "name": "new_comment",
                      "format": "",
                      "description": "Canned comment to change to (the only editable option)",
@@ -3372,7 +3372,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "33a4b9d7-f125-4c52-a04d-cfc4739cdc11",
+                     "jsondocId": "adffccae-d699-4580-a16c-8409be32ea05",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3384,9 +3384,9 @@
                "verb": "POST",
                "description": "Update canned comment",
                "methodName": "updateComment",
-               "jsondocId": "1de7f4a0-a4bd-49a6-9ca8-846a4cc818e3",
+               "jsondocId": "9befe1c6-c9ff-495c-a304-fae2453a6da8",
                "bodyobject": {
-                  "jsondocId": "09be3404-ba75-4c04-99a6-9bb90b138e23",
+                  "jsondocId": "9714b206-eafe-4ee8-80d6-93c2b0d7ed5e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3396,7 +3396,7 @@
                "apierrors": [],
                "path": "/cannedComment/updateComment",
                "response": {
-                  "jsondocId": "3831cc31-fd82-4147-a23f-3f2413cd715b",
+                  "jsondocId": "2d72d353-478a-48f5-a665-93c02226c41a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3409,7 +3409,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c6758ab1-a950-49fa-85e5-73843c293efa",
+                     "jsondocId": "dc1efc58-18b5-4fd4-a85c-c556d289460a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3418,7 +3418,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "34065dd1-0c2b-4f53-bd95-a8a36585c9d8",
+                     "jsondocId": "dd5c9889-45bd-408a-945c-6e7d248bbab6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3427,7 +3427,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f707bc2c-85a7-43db-9c50-8f81ff5fbb8a",
+                     "jsondocId": "1d25fefd-5955-4832-bbac-18eb86563c83",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to remove (or specify the name)",
@@ -3436,7 +3436,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cc54c3fc-a4d7-4e42-a80a-9c5bd65ca2e5",
+                     "jsondocId": "02325765-842a-427d-9a76-7f29e4eedc5c",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to delete",
@@ -3448,9 +3448,9 @@
                "verb": "POST",
                "description": "Remove a canned comment",
                "methodName": "deleteComment",
-               "jsondocId": "6ada4c1c-4bbb-4abc-add7-f94ce6f89de6",
+               "jsondocId": "956870cc-6df4-466c-94a5-3746976ac0ae",
                "bodyobject": {
-                  "jsondocId": "67071592-fc8f-449b-9310-b6034505edf5",
+                  "jsondocId": "60f9767a-217e-41e0-a065-098a846114b6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3460,7 +3460,7 @@
                "apierrors": [],
                "path": "/cannedComment/deleteComment",
                "response": {
-                  "jsondocId": "ffa34c63-bbd2-4ee2-8407-e88ac9a7570f",
+                  "jsondocId": "313b312d-d8c9-4707-8f76-efafb185abdf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3473,7 +3473,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f0be6003-533a-46af-be7d-85875d553def",
+                     "jsondocId": "e5c333cc-fb5e-49f8-abdd-05a751e57213",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3482,7 +3482,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "def7905f-5183-4b63-b598-f44a4470562e",
+                     "jsondocId": "ea4e99b1-2400-40c3-a182-78b30ecaa3db",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3491,7 +3491,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "105391a4-9dfe-4461-8099-717fa63486d0",
+                     "jsondocId": "c86cbe88-08b8-4824-ad18-de52864b86ad",
                      "name": "id",
                      "format": "",
                      "description": "Comment ID to show (or specify a comment)",
@@ -3500,7 +3500,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "39ad31c8-b29b-42db-9496-7c3f46bd38d9",
+                     "jsondocId": "73070621-8cc9-4e90-9bed-362447fc7dbb",
                      "name": "comment",
                      "format": "",
                      "description": "Comment to show",
@@ -3512,9 +3512,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned comments, or optionally, gets information about a specific canned comment",
                "methodName": "showComment",
-               "jsondocId": "d45b13a2-672a-4c10-8ee7-36befc4dc4ea",
+               "jsondocId": "0caaccab-ba27-4680-bf3c-b6315545a6c1",
                "bodyobject": {
-                  "jsondocId": "cf31e2fc-405e-4110-9d21-bcc8a523163e",
+                  "jsondocId": "dd3d0472-875b-4cbe-bdc8-ff794d3c409f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3524,7 +3524,7 @@
                "apierrors": [],
                "path": "/cannedComment/showComment",
                "response": {
-                  "jsondocId": "941ee5f0-a395-4755-8a8a-8ef24cebf583",
+                  "jsondocId": "b1abb364-e43b-4ea8-ba39-dfead710c8de",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3537,14 +3537,14 @@
          "description": "Methods for managing canned comments"
       },
       {
-         "jsondocId": "e89e730c-834b-4961-b862-9451690221f3",
+         "jsondocId": "23ebc190-e46e-4c05-b37e-0027e9c4fb1a",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "45ed713f-eb7b-4fba-ac44-76f3f03667f7",
+                     "jsondocId": "882910f0-fb71-4924-9956-0919e9e82788",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3553,7 +3553,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a2c4a28b-d13d-4a5b-9e33-86ce3ac3470b",
+                     "jsondocId": "6149afe5-4c39-4d88-80f3-dca0b64a2d0a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3562,7 +3562,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a51a9970-6141-4c19-8958-a113696d408e",
+                     "jsondocId": "57a2aedb-6ea1-4195-afe5-4ed44cab91e9",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to update (or specify the old_key)",
@@ -3571,7 +3571,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ab302661-3277-47b5-85df-aefe27ccf9cf",
+                     "jsondocId": "9e3ddfdc-7f45-4965-9ee2-9ce39416d4b4",
                      "name": "old_key",
                      "format": "",
                      "description": "Canned key to update",
@@ -3580,7 +3580,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "819534b2-a7a8-4266-9c32-678c582daff2",
+                     "jsondocId": "17d4e6cf-aa49-4088-8151-fb072db368b9",
                      "name": "new_key",
                      "format": "",
                      "description": "Canned key to change to (the only editable option)",
@@ -3589,7 +3589,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8e500b39-0c91-4e10-9f28-e47a6c5d820d",
+                     "jsondocId": "82b44003-86c2-49eb-ac79-5ce71c538c14",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3601,9 +3601,9 @@
                "verb": "POST",
                "description": "Update canned key",
                "methodName": "updateKey",
-               "jsondocId": "7d5c6730-0fe8-47c5-90a8-ca7e840288f9",
+               "jsondocId": "ecc87ab8-1306-4762-9e17-97fef61a8184",
                "bodyobject": {
-                  "jsondocId": "86995a8a-2226-4f45-a3d8-b8b3f9cff243",
+                  "jsondocId": "d830a34e-99ae-43bf-89e0-c4921b110429",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3613,7 +3613,7 @@
                "apierrors": [],
                "path": "/cannedKey/updateKey",
                "response": {
-                  "jsondocId": "cea38a48-cf4c-43c0-9ab8-d8580f3eced7",
+                  "jsondocId": "3c48df0b-82d4-4523-9993-8bd38ac35656",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3626,7 +3626,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "87578b57-de30-45ad-a416-95a56a65e394",
+                     "jsondocId": "5edcb6b8-0e7b-4ac7-a8c8-97d757bc3465",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3635,7 +3635,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fd806323-5069-486f-9d59-866d7a982823",
+                     "jsondocId": "6875d7d1-612e-44f7-a8e4-e30788201a94",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3644,7 +3644,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c6b9377d-d9da-4440-9786-780efcc9d710",
+                     "jsondocId": "5aef84a4-eb1b-4053-bcb5-e9141c48eedb",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to add",
@@ -3653,7 +3653,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff8f84e6-f492-40de-a557-1541c11bf4c6",
+                     "jsondocId": "a42254b4-0ccd-48db-a218-a194a0df58d7",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3665,9 +3665,9 @@
                "verb": "POST",
                "description": "Create canned key",
                "methodName": "createKey",
-               "jsondocId": "fdea057e-ff74-4e6a-a892-b3e65b6522e3",
+               "jsondocId": "c0df3b97-eef1-416d-b5b2-b9b81f341768",
                "bodyobject": {
-                  "jsondocId": "9a085982-c9ef-47e7-a431-322f9fb2b52a",
+                  "jsondocId": "bd59aff3-1b8b-4c0a-9439-c4c96c782213",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3677,7 +3677,7 @@
                "apierrors": [],
                "path": "/cannedKey/createKey",
                "response": {
-                  "jsondocId": "0ac746ff-8fc7-49b9-a93f-f14606496d5c",
+                  "jsondocId": "163cc6ed-e4f6-425b-84ef-c8dd4cebef59",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3690,7 +3690,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c788403c-3c10-4d7f-abfb-36fb3088750d",
+                     "jsondocId": "3551e076-a7cb-436d-bdab-e4d6b47b272c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3699,7 +3699,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d6523e62-470a-4f43-bcd6-cb3938341882",
+                     "jsondocId": "b3d261cc-5dc5-45b3-930d-ea3e27acb738",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3708,7 +3708,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "93572b4b-6386-4c3a-a878-b7588b99ea6e",
+                     "jsondocId": "585a6c0b-918b-45ac-b562-132fd1dd779c",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to remove (or specify the name)",
@@ -3717,7 +3717,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6c791cb4-36cf-4bb3-bfd0-da391c9f58b4",
+                     "jsondocId": "b735d931-7992-4a11-80fb-d774282cfd36",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to delete",
@@ -3729,9 +3729,9 @@
                "verb": "POST",
                "description": "Remove a canned key",
                "methodName": "deleteKey",
-               "jsondocId": "19082cee-8678-4688-8b3c-dc1c3fadf3d3",
+               "jsondocId": "96a9b70c-c63f-4e19-bb15-7158ca869d8a",
                "bodyobject": {
-                  "jsondocId": "71c7355d-a3e5-4a01-a90e-8642d4723d4a",
+                  "jsondocId": "df297e88-8f66-47a0-b6b6-90a92c5782c7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3741,7 +3741,7 @@
                "apierrors": [],
                "path": "/cannedKey/deleteKey",
                "response": {
-                  "jsondocId": "52d0d7ea-b2f8-4540-bf34-88926f43d65c",
+                  "jsondocId": "782036f5-6091-4ab4-9446-a957719209c1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3754,7 +3754,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e77e271c-8794-41b2-801b-39b4a079d6a6",
+                     "jsondocId": "08130575-0213-4a18-a1c1-9095c2356e5d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3763,7 +3763,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3737cb5f-038f-4f04-bb51-4c2ebfb1e1f6",
+                     "jsondocId": "0e23e284-ddbc-4d50-9f6f-084a09625601",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3772,7 +3772,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e3863724-39d4-4b38-99f8-3b99dcd13bdc",
+                     "jsondocId": "e69b3dab-9d39-4429-8112-fc43cbe7f054",
                      "name": "id",
                      "format": "",
                      "description": "Key ID to show (or specify a key)",
@@ -3781,7 +3781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f07ca15c-e1c5-4253-bdb9-82a15042367c",
+                     "jsondocId": "f589863e-c2a0-477e-8795-9deefbd4e389",
                      "name": "key",
                      "format": "",
                      "description": "Key to show",
@@ -3793,9 +3793,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned keys, or optionally, gets information about a specific canned key",
                "methodName": "showKey",
-               "jsondocId": "37e152af-43c0-4ec9-9b3e-87965814e924",
+               "jsondocId": "87dd0873-cf31-47a5-9e4c-51de589a93b3",
                "bodyobject": {
-                  "jsondocId": "bbb4013d-16d9-4410-adde-13a63c985dde",
+                  "jsondocId": "60146c31-ba59-4cab-8784-c9cbd68c5304",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3805,7 +3805,7 @@
                "apierrors": [],
                "path": "/cannedKey/showKey",
                "response": {
-                  "jsondocId": "931b01ba-cc5e-4942-a3cb-30cb8f0e15a6",
+                  "jsondocId": "15c39cf8-4bb6-4db1-9e37-bf9271573b5d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -3818,14 +3818,14 @@
          "description": "Methods for managing canned keys"
       },
       {
-         "jsondocId": "3dcb3f07-c401-4a04-950a-1dab15675f75",
+         "jsondocId": "957d2590-db8f-4373-a14b-091fe6eb011e",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b1b9dfeb-391e-43cc-b24d-541e8acf44b9",
+                     "jsondocId": "ca64beb2-aafb-47f2-b05d-7d31c6e9d0d1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3834,7 +3834,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "deded65c-13a1-4ae3-ab98-0f93220e85ef",
+                     "jsondocId": "e146b0e5-1f3a-47e6-9123-20cbe52a84ae",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3843,7 +3843,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2131d5b7-178a-4274-af37-0517cd8dd35a",
+                     "jsondocId": "248b4c5a-afd0-4b42-969f-7f9e0873f6ba",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to add",
@@ -3852,7 +3852,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2982908b-ca03-4aae-aa87-346b84cff54d",
+                     "jsondocId": "c4ff3df5-c41a-410a-af5a-c5c7c0f0276a",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3864,9 +3864,9 @@
                "verb": "POST",
                "description": "Create canned value",
                "methodName": "createValue",
-               "jsondocId": "e227f875-bfef-4990-92bc-ff517e0e4a05",
+               "jsondocId": "0e7ac240-b47a-412d-bbc4-f2749a1ca88f",
                "bodyobject": {
-                  "jsondocId": "f28b9380-5dda-4073-8d53-16a45f3e36d2",
+                  "jsondocId": "f6ec8e67-8ce7-4f64-82ca-9051b80712ca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3876,7 +3876,7 @@
                "apierrors": [],
                "path": "/cannedValue/createValue",
                "response": {
-                  "jsondocId": "df5cdf6e-0152-4ded-85d0-701f49dfa2c4",
+                  "jsondocId": "65303f37-e1b7-40a1-a616-c16fcef09030",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -3889,7 +3889,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8d629f57-4b8b-4a04-99f9-f8ef65a9b04e",
+                     "jsondocId": "2e4d7909-593e-4a1e-a0c1-915d258a29ee",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3898,7 +3898,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9788355c-9782-4bb4-80cd-cb9d9cf83122",
+                     "jsondocId": "fd164884-c0e6-4ec8-9fb3-7dc74e5c6b1c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3907,7 +3907,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e26374f6-8702-4ba5-a8ae-e1546e13c0ee",
+                     "jsondocId": "83371f0e-71a2-4895-a769-107583f4f5bc",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to update (or specify the old_value)",
@@ -3916,7 +3916,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2ae43563-3793-4188-beec-2edc78af350b",
+                     "jsondocId": "4ec51988-80c9-49f2-a5a5-14977b7935af",
                      "name": "old_value",
                      "format": "",
                      "description": "Canned value to update",
@@ -3925,7 +3925,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "35c0175b-6ee9-49d4-ae2c-095caf7d5f46",
+                     "jsondocId": "20928a76-7ca7-47b9-97c7-13328ed65e73",
                      "name": "new_value",
                      "format": "",
                      "description": "Canned value to change to (the only editable option)",
@@ -3934,7 +3934,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "94466b10-6735-4276-9194-61c43f17c123",
+                     "jsondocId": "8abc8f35-8f6e-459f-afd7-c617fa4c61f4",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3946,9 +3946,9 @@
                "verb": "POST",
                "description": "Update canned value",
                "methodName": "updateValue",
-               "jsondocId": "d3692aed-6448-49b1-a71c-124fc8f620fe",
+               "jsondocId": "7dc13aef-8a0d-422b-857b-545a1d7872c1",
                "bodyobject": {
-                  "jsondocId": "011edf61-a1d1-40ba-b07e-43a8dcc8226e",
+                  "jsondocId": "997d8b5a-6a9c-497c-898c-bc42d98a6dff",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3958,7 +3958,7 @@
                "apierrors": [],
                "path": "/cannedValue/updateValue",
                "response": {
-                  "jsondocId": "cd4ef9b1-bb35-4601-baa2-219102c9fecc",
+                  "jsondocId": "04b87243-a1e8-4142-b33a-5dc56a540324",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -3971,7 +3971,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5d26b78f-bb63-47cc-92e8-b6ffa441bd7b",
+                     "jsondocId": "065e94a7-380b-4283-ae22-4e49f543bc94",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3980,7 +3980,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f995434f-1467-4e11-aaec-c2edef25bf6d",
+                     "jsondocId": "172a3d23-5bea-47d6-90b7-6cf9ffeca42c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3989,7 +3989,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c718eb2d-98b7-4aa6-821a-f92104856faa",
+                     "jsondocId": "1131c16a-2d98-4b97-92b6-befbf84cdc43",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to remove (or specify the name)",
@@ -3998,7 +3998,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d4cfabd-5dfb-4f01-8110-af805e27a696",
+                     "jsondocId": "30631634-f4c3-4949-8c8a-73bf5ee78514",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to delete",
@@ -4010,9 +4010,9 @@
                "verb": "POST",
                "description": "Remove a canned value",
                "methodName": "deleteValue",
-               "jsondocId": "28d92100-e1b5-422d-bafd-3452f75dd661",
+               "jsondocId": "38b99d07-dd53-4add-9646-1d87fc8886ee",
                "bodyobject": {
-                  "jsondocId": "fb0b225f-b469-4c68-8393-85048b6d4393",
+                  "jsondocId": "c48728af-12af-4ac5-b3da-017f0c6721e9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4022,7 +4022,7 @@
                "apierrors": [],
                "path": "/cannedValue/deleteValue",
                "response": {
-                  "jsondocId": "145881d3-2510-48b7-a5d9-4290b823fe57",
+                  "jsondocId": "4368ac85-b4f1-4392-8df9-4be6d0bde2cd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4035,7 +4035,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6dc9dea4-caaf-4f51-a415-11303de9b88c",
+                     "jsondocId": "d0cb6fcc-b791-4cba-bd26-82eaa5e87c74",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4044,7 +4044,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2e3bfdd9-27d1-4b13-bb7b-205535249a2c",
+                     "jsondocId": "2aee6fd2-19e2-4c9d-b517-a9482f8fb2ae",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4053,7 +4053,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "87dd8a72-3d7f-4c14-9311-82bbf8fa2d12",
+                     "jsondocId": "01340cdd-3c11-45ab-86cd-6e26970ec5d8",
                      "name": "id",
                      "format": "",
                      "description": "Value ID to show (or specify a value)",
@@ -4062,7 +4062,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eef77796-8135-4084-b7f5-ab4157614330",
+                     "jsondocId": "4f0f41a7-ed8f-46fd-a3d6-87b1621b3523",
                      "name": "value",
                      "format": "",
                      "description": "Value to show",
@@ -4074,9 +4074,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned values, or optionally, gets information about a specific canned value",
                "methodName": "showValue",
-               "jsondocId": "d24ab784-8f02-42c3-b52e-af6c42a0e1fd",
+               "jsondocId": "c81671af-1932-41bf-885a-3726a20f8476",
                "bodyobject": {
-                  "jsondocId": "19dbab51-1934-4087-9853-9cb02cefbf23",
+                  "jsondocId": "bcb68169-13d1-47e7-9cc9-d69d73ee534f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4086,7 +4086,7 @@
                "apierrors": [],
                "path": "/cannedValue/showValue",
                "response": {
-                  "jsondocId": "ca6d4458-fa11-42cf-8ab5-ce37aa2718bd",
+                  "jsondocId": "f17e4c2d-2453-4874-9e37-13af225d0e6f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4099,14 +4099,14 @@
          "description": "Methods for managing canned values"
       },
       {
-         "jsondocId": "3108bec5-0879-4a29-84bc-c0fbf33cf7e3",
+         "jsondocId": "8134eaeb-6d79-49db-b700-bd279d648a7d",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "76329db8-d855-4cbe-9149-f4f1f8f8ebf7",
+                     "jsondocId": "4c877cf2-c487-471e-99a8-0f12f28faa7e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4115,7 +4115,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "119cb6b3-574b-464e-a4a5-529d9cbef89d",
+                     "jsondocId": "c02d48f2-caa9-4918-9bb4-7f274f745ed0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4124,62 +4124,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1f2007e-638c-44d4-b7d0-e91bfade8d9b",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create group",
-               "methodName": "createGroup",
-               "jsondocId": "619121e4-cd2d-4238-a32b-48398f32ee79",
-               "bodyobject": {
-                  "jsondocId": "71583a3c-e6a2-4c92-ad24-56b560ceabdb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/createGroup",
-               "response": {
-                  "jsondocId": "989ea557-b9ed-4370-8330-a94bf654e850",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "4e6f2cb3-f118-4f24-be29-42b8f607c3ec",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f32693bf-9b26-45eb-b0f3-985bae475301",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d3e20e64-30fb-441d-9978-509e3b8fb6e9",
+                     "jsondocId": "f400d0c2-860a-4070-a38d-8a3eb6f8a057",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -4188,7 +4133,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "25bee69d-f73b-49b0-a9d4-8ef3d1227e76",
+                     "jsondocId": "aae1ba00-3e87-4b79-84b2-5f8d6e53cbef",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -4200,9 +4145,9 @@
                "verb": "POST",
                "description": "Get organism permissions for group",
                "methodName": "getOrganismPermissionsForGroup",
-               "jsondocId": "7c565a91-a885-49c0-a289-7318fcec8530",
+               "jsondocId": "9d793aeb-75f6-4a33-aee2-00577a2e5a7a",
                "bodyobject": {
-                  "jsondocId": "b096038a-a057-4544-8107-d77cf6c72868",
+                  "jsondocId": "051fadeb-bb1f-4be3-9016-d9844fa850fc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4212,7 +4157,7 @@
                "apierrors": [],
                "path": "/group/getOrganismPermissionsForGroup",
                "response": {
-                  "jsondocId": "d8682d80-c66b-4dc6-a081-1186934a3191",
+                  "jsondocId": "a47b45c1-2c40-4641-bd42-2d0a7cc67494",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4225,7 +4170,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e0c53e4a-809e-4f7f-80d9-7144a07c8fb7",
+                     "jsondocId": "0f8e20d1-f69e-44ad-91a7-e5ab0539fffe",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4234,7 +4179,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a0f9087b-ce7b-493a-945a-c0a5764a8142",
+                     "jsondocId": "712b058f-f804-44c2-9cf5-b0495ba9fd28",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4243,7 +4188,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8cbb6e1f-6772-4eed-9a99-d3d85a5160ec",
+                     "jsondocId": "49a376cd-4cff-4786-8673-32aae5cb46a7",
                      "name": "groupId",
                      "format": "",
                      "description": "Optional only load a specific groupId",
@@ -4255,9 +4200,9 @@
                "verb": "POST",
                "description": "Load all groups",
                "methodName": "loadGroups",
-               "jsondocId": "f9192522-f06e-4477-bd58-9d2708421462",
+               "jsondocId": "6aea0e77-a73d-4fe6-9987-71120fa5fa52",
                "bodyobject": {
-                  "jsondocId": "cf179122-82e5-4f8c-b899-aa1bd82127c1",
+                  "jsondocId": "e00668d5-d034-4c40-a36a-754e00c79ac5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4267,7 +4212,7 @@
                "apierrors": [],
                "path": "/group/loadGroups",
                "response": {
-                  "jsondocId": "473ad97b-e942-4c0f-9c53-a78d90513643",
+                  "jsondocId": "16ce29f8-2b92-4dd7-b911-ec6232dbd6ba",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4280,7 +4225,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d9f267ce-800b-4999-9040-117bc7055c2b",
+                     "jsondocId": "7cc3c0f7-9c71-4e90-bc18-5175f624a4ef",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4289,7 +4234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b2300b5a-5ec2-4db5-be86-a9a76d760e25",
+                     "jsondocId": "256bb384-de68-4c60-bb1e-46acfbd361b4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4298,7 +4243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a247e0d1-1d27-4341-80a0-5e99c592852b",
+                     "jsondocId": "6288fa64-3d35-456e-b4ba-baf15a7823ec",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to remove (or specify the name)",
@@ -4307,7 +4252,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "72425372-d266-4b82-9f55-30bc22e3dc8f",
+                     "jsondocId": "61b40926-8ce4-44a0-a79d-6a20b3d72f36",
                      "name": "name",
                      "format": "",
                      "description": "Group name to remove",
@@ -4319,9 +4264,9 @@
                "verb": "POST",
                "description": "Delete a group",
                "methodName": "deleteGroup",
-               "jsondocId": "b26f2651-d480-4d88-81bb-d1958dac96b0",
+               "jsondocId": "fa7f821d-a2d2-4c62-8db8-77634b899abc",
                "bodyobject": {
-                  "jsondocId": "c5a4487b-ac1d-460a-9a54-0e733f33e082",
+                  "jsondocId": "f7e12358-86a4-4206-ba98-cf1dd41f7524",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4331,7 +4276,7 @@
                "apierrors": [],
                "path": "/group/deleteGroup",
                "response": {
-                  "jsondocId": "fc553b47-8be1-4a9d-b75c-39b04f11c28b",
+                  "jsondocId": "c4299155-268a-4600-99eb-d38c6257ba05",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4344,7 +4289,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "19ed7ed8-32a8-4a7e-b732-180e82194e4f",
+                     "jsondocId": "ca9cfb5b-8de6-4b5f-a432-def9b888123d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4353,7 +4298,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "852f72ea-02f7-4d45-9934-15c50dd157f3",
+                     "jsondocId": "c8c7cf0e-be84-4b18-937e-c99c12096fa5",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4362,7 +4307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7097bb2c-ff14-4cd1-bb56-e3a9edcf4fa9",
+                     "jsondocId": "cdcf9273-2fb3-44ee-8be5-5ee479d43120",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to update",
@@ -4371,7 +4316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b3089ac3-09c2-4194-b340-6cba06562edb",
+                     "jsondocId": "60080e22-e20c-43f4-8431-ecca044990f4",
                      "name": "name",
                      "format": "",
                      "description": "Group name to change to (the only editable optoin)",
@@ -4383,9 +4328,9 @@
                "verb": "POST",
                "description": "Update group",
                "methodName": "updateGroup",
-               "jsondocId": "4919a684-cfcf-4aeb-8bba-a328162a9220",
+               "jsondocId": "a01a7755-082f-43dd-a89c-a887545b6627",
                "bodyobject": {
-                  "jsondocId": "753b268d-ab86-4fe9-8b98-d356f5d36025",
+                  "jsondocId": "6ea977bb-87e1-45b0-ad4c-070c48e7f6bf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4395,7 +4340,7 @@
                "apierrors": [],
                "path": "/group/updateGroup",
                "response": {
-                  "jsondocId": "8fc6cf31-4666-42fd-83ea-42fe53ee42ca",
+                  "jsondocId": "66b22869-957a-4960-93d0-f70fb5ba848e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4408,7 +4353,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f5000d79-76b4-4cda-b7f7-c8dc51edd27a",
+                     "jsondocId": "d7f2c0c9-a1a1-464a-8299-f272df5a7a3e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4417,7 +4362,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "05a55d28-9b28-42b9-8800-6dc02a8af56a",
+                     "jsondocId": "3d215b4c-78d2-4587-9c05-fd9c327cd043",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4426,7 +4371,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2cd89299-47f9-4c94-a103-7eef700cbf5a",
+                     "jsondocId": "2bc818f2-8634-44a8-b539-97f23f64f573",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to modify permissions for (must provide this or 'name')",
@@ -4435,7 +4380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4af675bb-a778-4486-8739-90cba8620a82",
+                     "jsondocId": "37d7eb30-ec61-4fe4-a4b4-9dfa80ce8e17",
                      "name": "name",
                      "format": "",
                      "description": "Group name to modify permissions for (must provide this or 'groupId')",
@@ -4444,7 +4389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "93f35f07-6fd3-4947-8491-2f996f6f4f0b",
+                     "jsondocId": "b2480e6f-ff08-44d5-b9c6-10e94f537f98",
                      "name": "organism",
                      "format": "",
                      "description": "Organism common name",
@@ -4453,7 +4398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8b535f02-a107-40ef-bf3e-d5ca6f666ab9",
+                     "jsondocId": "21809980-c73e-4c7f-9791-a272b100831f",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -4462,7 +4407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a0b21041-fbad-489b-b474-a4a68f78d882",
+                     "jsondocId": "d6aebf71-b6de-4823-8731-8f199e33d986",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -4471,7 +4416,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "489f0a1e-1da0-4653-b1cf-cc021928c038",
+                     "jsondocId": "a5c99750-a4b4-4a27-b258-cb8d41b28630",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -4480,7 +4425,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "546829dc-5a69-4bc6-9111-6fa26a912341",
+                     "jsondocId": "9c459540-cafc-40cf-ab37-ebb253b13a64",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -4492,9 +4437,9 @@
                "verb": "POST",
                "description": "Update organism permission",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "575b29af-ea49-40b4-8389-0ae01b5d5eb7",
+               "jsondocId": "1551eb75-ecdd-413a-a221-d01f89753835",
                "bodyobject": {
-                  "jsondocId": "4deff59d-92c2-42d2-89c2-711b4815d119",
+                  "jsondocId": "56132a56-e227-4cc3-b45a-3a8f84879f29",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4504,7 +4449,7 @@
                "apierrors": [],
                "path": "/group/updateOrganismPermission",
                "response": {
-                  "jsondocId": "89b98142-1029-4562-9ec0-e56d3835320c",
+                  "jsondocId": "8fe52c64-0246-4a95-ab1b-625838199ce7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4517,7 +4462,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "bff13471-8704-4c16-b1b9-5dffc6ea1c4f",
+                     "jsondocId": "5285fc7d-d7ef-44d7-916d-aad0500cc7ff",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4526,7 +4471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a6c38388-98d8-45f6-96fd-27e0085e04e6",
+                     "jsondocId": "a6fd638e-7784-492f-8316-dfea3f057fa2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4535,7 +4480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "81943d93-99db-46de-93bb-ca510fdfb032",
+                     "jsondocId": "5cca3b4b-01a8-4d38-bfdf-83692e2f024b",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -4544,7 +4489,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "91fd12c8-412b-4a43-a92c-d74927e677d5",
+                     "jsondocId": "58eb253c-40c5-43d6-9132-075a88e7cf06",
                      "name": "users",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -4556,9 +4501,9 @@
                "verb": "POST",
                "description": "Update group membership",
                "methodName": "updateMembership",
-               "jsondocId": "0dfcd9c6-348f-4c54-aae4-527b52d735d6",
+               "jsondocId": "b472a005-9873-46f8-8c2c-90de30e722fb",
                "bodyobject": {
-                  "jsondocId": "7afeed11-a19e-44dd-ab4f-0fb2a5df2586",
+                  "jsondocId": "202db0b2-c0d9-4994-8119-cbf7858a9fef",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4568,7 +4513,126 @@
                "apierrors": [],
                "path": "/group/updateMembership",
                "response": {
-                  "jsondocId": "ba3fb233-910f-4ef1-af57-2397cda85eac",
+                  "jsondocId": "862a77e1-f636-4aa3-8d99-cfc58a62a16c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c690d441-c106-44bd-9756-d2bd9d8b0352",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f1f76e8e-d89e-42a4-bae3-7878c57a1a15",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "eff42e7b-b736-4703-bb87-60928c22a515",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Group ID to alter membership of",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "173522e7-0d88-4a63-881c-5f07bee0b98f",
+                     "name": "users",
+                     "format": "",
+                     "description": "A JSON array of strings of emails of users the now belong to the group",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update group admin",
+               "methodName": "updateGroupAdmin",
+               "jsondocId": "d99d2869-8bf2-46ba-986e-469afc7e3bf4",
+               "bodyobject": {
+                  "jsondocId": "a2870f7a-19b9-415d-bfea-1d6515c41eb0",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/updateGroupAdmin",
+               "response": {
+                  "jsondocId": "e5ac4722-22e6-48f4-8a41-1e4dea1bf7d3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "039ad399-e374-4cb7-a713-fcd42b9dc5e1",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "29fbf944-ab7d-41f5-86f9-f84ece4efe1c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "035fb29e-a0f2-4b49-be16-37c2363d0fce",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create group",
+               "methodName": "createGroup",
+               "jsondocId": "15a5abf0-8b55-4f04-9aa9-9f5c920f66aa",
+               "bodyobject": {
+                  "jsondocId": "8c73c661-0fc9-4230-917e-3b5821483ac8",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/createGroup",
+               "response": {
+                  "jsondocId": "27b70cc4-df30-43bc-876b-ef4c1c3fee86",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4581,14 +4645,14 @@
          "description": "Methods for managing groups"
       },
       {
-         "jsondocId": "b8fe0cda-eefb-428e-bf02-05850ebbf081",
+         "jsondocId": "2758d69e-19e2-4330-8473-e5f034d80318",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fda92bc3-b89a-4207-87fa-2b951d811d8d",
+                     "jsondocId": "468573eb-3d15-47fc-943c-a62a80042286",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4597,7 +4661,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1cdb6248-9b53-4b69-be7b-a0308f14131e",
+                     "jsondocId": "f9e834e8-cbbb-4865-880a-076d6a124154",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4606,7 +4670,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e93f111f-d7af-4fff-ba89-e9c90eb47eee",
+                     "jsondocId": "f350ed27-2cd9-4d97-811a-4bc7e4149a53",
                      "name": "type",
                      "format": "",
                      "description": "Type of annotated genomic features to export 'FASTA','GFF3','CHADO'.",
@@ -4615,7 +4679,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0bb82c1f-902a-4418-8ed7-32b2959aaff2",
+                     "jsondocId": "108f0614-3386-4cfe-bfa5-a9ad1fcbffe7",
                      "name": "seqType",
                      "format": "",
                      "description": "Type of output sequence 'peptide','cds','cdna','genomic'.",
@@ -4624,7 +4688,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "46463e2c-b9e5-4b95-9cd8-5f510e5fd213",
+                     "jsondocId": "5c956303-ec4e-4719-8dc4-3de1ab40df47",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -4633,7 +4697,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "36c56f92-4c9f-416b-87b2-c6b88030198f",
+                     "jsondocId": "1a8d8b90-c5e6-424a-b9f7-f988938a9e4d",
                      "name": "sequences",
                      "format": "",
                      "description": "Names of references sequences to add (default is all).",
@@ -4642,7 +4706,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8504ba66-f4d8-4769-9404-e78ac0d38722",
+                     "jsondocId": "0a48a803-c061-4e7a-bb82-03ee4de4ed29",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism that sequences belong to (will default to last organism).",
@@ -4651,7 +4715,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "36bf54a0-5e4e-4012-a227-8551f26e2491",
+                     "jsondocId": "85922c05-02fb-4087-abf8-66ff141b922f",
                      "name": "output",
                      "format": "",
                      "description": "Output method 'file','text'",
@@ -4660,7 +4724,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "57d6db8e-461d-4465-ad5a-643ea1d494c3",
+                     "jsondocId": "3ca7f215-3e07-4bc2-8739-fe65d5f8200f",
                      "name": "exportAllSequences",
                      "format": "",
                      "description": "Export all reference sequences for an organism (over-rides 'sequences')",
@@ -4669,7 +4733,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c8d9d9bf-0e76-4178-8360-a54180f235f8",
+                     "jsondocId": "0255aac9-c743-4c67-982e-05d479926834",
                      "name": "exportGff3Fasta",
                      "format": "",
                      "description": "Export reference sequence when exporting GFF3 annotations.",
@@ -4678,7 +4742,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "03c2d45e-7739-46c5-a171-dcc7c87a3ede",
+                     "jsondocId": "7efa2fcc-1315-4224-abf1-f1c3ec5982db",
                      "name": "region",
                      "format": "",
                      "description": "Highlighted genomic region to export in form sequence:min..max  e.g., chr3:1001..1034",
@@ -4690,9 +4754,9 @@
                "verb": "POST",
                "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "methodName": "write",
-               "jsondocId": "2d4cf62b-8765-4eb5-bd54-2d6d051665ec",
+               "jsondocId": "8e56cc6c-25d3-488e-9453-d4a1069efcf9",
                "bodyobject": {
-                  "jsondocId": "4e01b3a9-1f23-46f1-af99-e821cdc6d849",
+                  "jsondocId": "a46202e7-57a2-48b6-80be-2e2b3e3b2964",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4702,7 +4766,7 @@
                "apierrors": [],
                "path": "/IOService/write",
                "response": {
-                  "jsondocId": "19d95922-d748-4223-9d9f-8cbd35ba584d",
+                  "jsondocId": "e1697b45-ad79-4e71-930d-b7450fbb9819",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -4715,7 +4779,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7354eb40-91ae-4668-8eca-3d8697863411",
+                     "jsondocId": "c686ddc3-8f43-4729-96ed-76dbf5184804",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4724,7 +4788,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6dd0bae4-03c2-42c6-994b-7c6b80f58c17",
+                     "jsondocId": "305edd81-81c3-4cd2-83cd-811a313cb2e5",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4733,7 +4797,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "802fd5e2-5c02-43c7-af25-731d33dde11c",
+                     "jsondocId": "ac718d03-6ab2-4883-9cc0-1ffd26a166d0",
                      "name": "uuid",
                      "format": "",
                      "description": "UUID that holds the key to the stored download.",
@@ -4742,7 +4806,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "768d1575-673a-4769-84e7-91a5b3f48be4",
+                     "jsondocId": "87e5c956-9ac8-4047-b3c3-791b75bc1a4f",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -4754,9 +4818,9 @@
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
                "methodName": "download",
-               "jsondocId": "d29e8a4b-944d-42fd-a39a-8e5c4452031a",
+               "jsondocId": "73dae055-2e00-44bd-b7da-61e0d440188e",
                "bodyobject": {
-                  "jsondocId": "ada6ab20-0d8e-4aeb-ab3a-027097a4accc",
+                  "jsondocId": "fe7bc4b7-375b-4409-afa3-9897bae60ff6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4766,7 +4830,7 @@
                "apierrors": [],
                "path": "/IOService/download",
                "response": {
-                  "jsondocId": "3e25e6be-d41e-40ea-bee5-59503529a7a1",
+                  "jsondocId": "85948dce-101d-4cca-8a16-76750575906c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -4779,14 +4843,14 @@
          "description": "Methods for bulk importing and exporting sequence data"
       },
       {
-         "jsondocId": "5497abac-8161-4446-8abe-6e09296bd245",
+         "jsondocId": "54594f72-d103-4cd4-b241-195cbe24a707",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "363b8ca7-1521-4f0b-95d5-153b9096665b",
+                     "jsondocId": "1c602ed9-aef7-436e-91de-3eadc56f6437",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4795,7 +4859,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "40f5f942-a2d9-45e6-af6d-f4d0cdc492ca",
+                     "jsondocId": "32def7b6-92f6-4fd9-a882-c43884a13565",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4804,7 +4868,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b2c6b187-a195-4b2b-b6cf-079202099670",
+                     "jsondocId": "70a78628-ecce-44c2-8bbe-f654b93faa46",
                      "name": "organism",
                      "format": "",
                      "description": "Pass an Organism JSON object with an 'id' that corresponds to the organism to be removed",
@@ -4816,9 +4880,9 @@
                "verb": "POST",
                "description": "Remove an organism",
                "methodName": "deleteOrganism",
-               "jsondocId": "b8af2891-2219-4cf0-950c-136dcc1e9182",
+               "jsondocId": "1005cf2f-84c3-4a16-8764-de383eed6c5c",
                "bodyobject": {
-                  "jsondocId": "3e555e58-ea02-40e4-80f3-0e7c51d92bb2",
+                  "jsondocId": "c7443c49-f5ca-4af3-ad60-9129040d3060",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4828,7 +4892,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganism",
                "response": {
-                  "jsondocId": "6e9469eb-a8b9-40d4-af29-d7b35e20adde",
+                  "jsondocId": "f90660fb-26be-4526-ba58-6b717ab51135",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4841,7 +4905,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "eed951ea-0886-42a9-a08c-398145e07e3c",
+                     "jsondocId": "80222303-df34-4240-9db7-58c0a99c82f9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4850,7 +4914,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a089a7e0-d39b-46c1-ac80-f19d97c19c44",
+                     "jsondocId": "29ed92f4-1501-4d4e-94d1-036bc87f0029",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4859,7 +4923,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e415acfc-0ce5-44d3-a1f8-f59c3febb989",
+                     "jsondocId": "88b034d6-f245-43b8-b26a-c11ab4cf7708",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -4871,9 +4935,9 @@
                "verb": "POST",
                "description": "Delete an organism along with its data directory and returns a JSON object containing properties of the deleted organism",
                "methodName": "deleteOrganismWithSequence",
-               "jsondocId": "d7803e3f-4a67-4791-8dce-ade7873cce2c",
+               "jsondocId": "b95517c1-4605-40bf-be58-89f25f884e0d",
                "bodyobject": {
-                  "jsondocId": "5da73be4-d019-4dfa-8200-acbd525287fc",
+                  "jsondocId": "f1bc8d9c-a4d3-4dbc-90a8-90bf4bbdde64",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4883,7 +4947,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismWithSequence",
                "response": {
-                  "jsondocId": "0fd9ab25-2774-439a-850a-1625687e7cbb",
+                  "jsondocId": "7b9ebbb9-a696-48e6-9726-bcab85b4bcda",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4896,7 +4960,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a48f943a-b805-4a21-af94-93282d201b30",
+                     "jsondocId": "2ceb2e0a-9512-47b9-9706-545bf5e2a96c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4905,7 +4969,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e0a57acb-979c-488c-9840-175763debb11",
+                     "jsondocId": "bb7c46d6-d262-49b7-b9df-60d901bf024c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4914,7 +4978,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "80e0b388-a6ca-4081-bb62-e056400a9b10",
+                     "jsondocId": "3e5b2e49-d9c6-4883-b4be-043913a78b31",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism.",
@@ -4926,9 +4990,9 @@
                "verb": "POST",
                "description": "Remove features from an organism",
                "methodName": "deleteOrganismFeatures",
-               "jsondocId": "132dc8f3-4926-4da6-af96-6dc0fb507953",
+               "jsondocId": "c3c7155b-2f24-435b-980b-1fafb0274af8",
                "bodyobject": {
-                  "jsondocId": "fcb6d228-bfc7-4f39-8634-81790ef09d40",
+                  "jsondocId": "ed1a138e-1328-43d7-b7c4-612b4cb33bf9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4938,7 +5002,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
                "response": {
-                  "jsondocId": "905f7456-2de8-4fa7-9125-e7963fad114c",
+                  "jsondocId": "43ed0886-9902-42d9-9bd6-bfe4ffdd7455",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -4951,7 +5015,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "17234212-648c-4ba0-8c30-15f000efa75d",
+                     "jsondocId": "e3fd8ac5-4396-4c5e-9ef5-3a56b7e96aaf",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4960,7 +5024,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0f2263d7-6cd9-438d-8275-fe08a8653f1b",
+                     "jsondocId": "5a050a58-1028-4637-b7e3-4b8be87a35c9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4969,7 +5033,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8b525eb5-ec8a-4f0d-8b0b-b91efee3daf6",
+                     "jsondocId": "5aaaee3f-19ee-43c3-a483-40e5681c718d",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -4978,7 +5042,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "adecdabb-a134-4f9b-8c1d-3a9af3ed3ef1",
+                     "jsondocId": "22363057-b606-4295-b0e3-33b239f496f4",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -4987,7 +5051,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "142300f9-8367-4305-9729-f01e050f5b19",
+                     "jsondocId": "328c0bc3-8e77-47a6-80c7-6d8e3c4a9efd",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -4996,7 +5060,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d3f8915-f255-4a1e-96d2-65ebe33b9c6c",
+                     "jsondocId": "3b956690-c59d-42bb-a514-379ea9cfd478",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5005,7 +5069,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "88c830e1-a998-4453-ade7-647b659ea9d5",
+                     "jsondocId": "4d5d5d2a-788f-4eee-adb3-7b3a35c37dda",
                      "name": "commonName",
                      "format": "",
                      "description": "commonName for an organism",
@@ -5014,7 +5078,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "552b3477-22bc-4071-b17c-8bf2b73d7bc8",
+                     "jsondocId": "69f411f9-e64e-4dda-811d-6a080b18b691",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -5023,7 +5087,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e6bc2a03-f20b-4649-aee5-8f8f55c78ac5",
+                     "jsondocId": "236ed3f2-f3b5-4a25-9b1b-e42ecb6b9b94",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5032,7 +5096,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3e78c775-19ce-4d9c-904d-4dce1d7a5ae4",
+                     "jsondocId": "8f4c3d58-9c14-47db-9a67-11a23b2c41f1",
                      "name": "organismData",
                      "format": "",
                      "description": "zip or tar.gz compressed data directory",
@@ -5044,9 +5108,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganismWithSequence",
-               "jsondocId": "3872b383-3d40-4629-af2e-c6d331950396",
+               "jsondocId": "ccd5a493-fd46-43b8-8b50-313d9704dade",
                "bodyobject": {
-                  "jsondocId": "ef7f0a78-7d0b-4897-b0fa-4b5959827cda",
+                  "jsondocId": "f9541d45-5da9-4d95-8e1e-923478bc18de",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5056,7 +5120,7 @@
                "apierrors": [],
                "path": "/organism/addOrganismWithSequence",
                "response": {
-                  "jsondocId": "443cbaa1-2688-44cf-82c6-9f4344e62d7d",
+                  "jsondocId": "6fccce30-485c-40a7-8b99-979a4d26eaa7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5069,7 +5133,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "13a61b6a-f5e9-412e-9024-c8837a4ed589",
+                     "jsondocId": "3f42b9b5-be1c-4693-9300-cfb41c40285a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5078,7 +5142,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c380db6-56fa-40a2-be7a-59e69e87b3b9",
+                     "jsondocId": "b7898439-8cb7-47b7-8809-2df535ab0955",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5087,7 +5151,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "565e3907-c244-4f48-bd70-86f6f9e4722a",
+                     "jsondocId": "e387b63c-f9fe-4486-95cb-e9b5b7209edb",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5096,7 +5160,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1f0d7744-c06a-4280-a604-5f9cf80bb9a1",
+                     "jsondocId": "c7ae4d1c-e6b2-4f0b-b82a-4c445fea7a7a",
                      "name": "trackData",
                      "format": "",
                      "description": "zip or tar.gz compressed track data",
@@ -5105,7 +5169,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9ad709b3-ba36-4040-bf8f-ccc99595cb50",
+                     "jsondocId": "8437a65b-6552-4198-8ff6-d79e8d2872de",
                      "name": "trackFile",
                      "format": "",
                      "description": "track file (*.bam, *.vcf, *.bw)",
@@ -5114,7 +5178,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e54e2899-3913-4fb9-b195-ae9a0e536f23",
+                     "jsondocId": "e459677f-20a0-4ff5-9c4f-b492cf0c9b29",
                      "name": "trackFileIndex",
                      "format": "",
                      "description": "index (*.bai, *.tbi)",
@@ -5123,7 +5187,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4fb69aa8-6599-43ed-90a8-e8a6608dd2a3",
+                     "jsondocId": "b70bcaad-c544-4b22-9bc8-ddfeae0bcb8a",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -5135,9 +5199,9 @@
                "verb": "POST",
                "description": "Adds a track to an existing organism returning a JSON object containing all tracks for the current organism.",
                "methodName": "addTrackToOrganism",
-               "jsondocId": "5462fe6d-5971-4c76-b6f7-459eb7a93972",
+               "jsondocId": "61e3313e-417c-443b-b581-8e08a3a7cdcb",
                "bodyobject": {
-                  "jsondocId": "081c2257-1768-4842-95f0-484ca636398d",
+                  "jsondocId": "0f182f44-42fe-4e15-9222-1a62640ab79f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5147,7 +5211,7 @@
                "apierrors": [],
                "path": "/organism/addTrackToOrganism",
                "response": {
-                  "jsondocId": "81381bf9-95da-4d68-bce5-683a70128739",
+                  "jsondocId": "90bb6c7d-637d-448c-8444-42449dce2493",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5160,7 +5224,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "610a25f0-c86e-4bab-b1d9-6910e24db598",
+                     "jsondocId": "43b95f95-8a85-471b-9f76-306a2305643c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5169,7 +5233,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "787c3a45-f9ca-4a01-a99b-944522c2f97b",
+                     "jsondocId": "bd29c02f-7c64-4189-a20e-1607cb899af1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5178,7 +5242,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b08c545b-b7df-4295-8f8c-060840d6c470",
+                     "jsondocId": "dff761af-2210-4b2a-9ddd-ebbd266f0f3d",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5187,7 +5251,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "750f57a1-fe3b-4598-891a-37b7665a45a1",
+                     "jsondocId": "4d4f0f1e-676b-4309-a99d-dea9dd49e87c",
                      "name": "trackLabel",
                      "format": "",
                      "description": "Track label corresponding to the track that is to be deleted",
@@ -5199,9 +5263,9 @@
                "verb": "POST",
                "description": "Deletes a track from an existing organism and returns a JSON object of the deleted track's configuration",
                "methodName": "deleteTrackFromOrganism",
-               "jsondocId": "73b582c9-0e36-4019-855e-102d058c6a70",
+               "jsondocId": "5b9dcb6e-b8c8-4983-9cf2-932c1fefe72a",
                "bodyobject": {
-                  "jsondocId": "3fc9f4f6-f470-4eb6-abda-a34c335869c4",
+                  "jsondocId": "be89c43e-5778-4a7e-9c6f-c06f18bbc4ad",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5211,7 +5275,7 @@
                "apierrors": [],
                "path": "/organism/deleteTrackFromOrganism",
                "response": {
-                  "jsondocId": "50796a76-88c8-457d-8d84-f7bb9cac0b7d",
+                  "jsondocId": "43c813f1-6979-499b-aa7c-a341d5a3a6b3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5224,7 +5288,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "903e4ac8-92d3-4f49-9612-0bf4a600ee4f",
+                     "jsondocId": "c387a723-b8e1-4ee1-87f5-3415df0749ac",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5233,7 +5297,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2808e288-7b99-4ab1-a85c-92b0659a5320",
+                     "jsondocId": "efcf2f5b-959e-4e70-8930-bc0dffaf3818",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5242,7 +5306,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d292581-7731-4264-89cd-d16daf4ac94a",
+                     "jsondocId": "a0fa1490-1af4-4499-bb12-cb77c832466d",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5251,7 +5315,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "904e1405-1617-4d15-9f26-9a87666c9a58",
+                     "jsondocId": "b976dc93-6adb-4627-ace0-fa648570324a",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -5263,9 +5327,9 @@
                "verb": "POST",
                "description": "Update a track in an existing organism returning a JSON object containing old and new track configurations",
                "methodName": "updateTrackForOrganism",
-               "jsondocId": "1b015408-647f-4d29-ac49-15a028b4b15c",
+               "jsondocId": "0f428b33-2751-42ed-a033-cb87671dd368",
                "bodyobject": {
-                  "jsondocId": "30049161-b89a-41f0-96d3-5f4194879d70",
+                  "jsondocId": "b873d837-a835-4bdc-a26a-019c38d7a3f7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5275,7 +5339,7 @@
                "apierrors": [],
                "path": "/organism/updateTrackForOrganism",
                "response": {
-                  "jsondocId": "9843d00e-ae2a-4570-ad09-36a719781fae",
+                  "jsondocId": "dba3b1ac-3710-4fe5-a19e-e7982f32a7ce",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5288,7 +5352,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ee210d44-76a6-41f7-955a-1bf3e951a513",
+                     "jsondocId": "82184778-c1a4-440f-8c38-dd381db79c13",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5297,7 +5361,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "416bd7bc-a488-4dfb-9265-1f1f078b5328",
+                     "jsondocId": "5fe2ce83-1b12-46a6-8fd5-1a5354c94435",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5306,7 +5370,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4f97865a-cbec-4f1b-be87-18b730d01663",
+                     "jsondocId": "e619eb79-4980-4bda-adad-08f2774c0746",
                      "name": "directory",
                      "format": "",
                      "description": "Filesystem path for the organisms data directory (required)",
@@ -5315,7 +5379,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3bf099a6-15bf-49bd-a3ef-0b155163e84e",
+                     "jsondocId": "9b79a18e-09a1-4964-a944-fcf1c2544a10",
                      "name": "commonName",
                      "format": "",
                      "description": "A name used for the organism",
@@ -5324,7 +5388,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fbd34057-90cd-4086-8eae-28394e557a5d",
+                     "jsondocId": "00007d49-9841-41e5-a155-08aec15b8ffd",
                      "name": "species",
                      "format": "",
                      "description": "(optional) Species name",
@@ -5333,7 +5397,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8f4d3e4a-d19b-47b7-87d8-9c7980780996",
+                     "jsondocId": "0bcffa74-ff27-44f3-91a9-52f68e59eefb",
                      "name": "genus",
                      "format": "",
                      "description": "(optional) Species genus",
@@ -5342,7 +5406,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "326f73f3-6456-4a71-9e86-7185347f12d6",
+                     "jsondocId": "4ee2c333-4558-483a-b559-85c2421d1782",
                      "name": "blatdb",
                      "format": "",
                      "description": "(optional) Filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -5351,7 +5415,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dd2db88a-2b9f-4196-8625-2decb1170194",
+                     "jsondocId": "fbe35e4b-6169-425e-8708-f9cf7112a703",
                      "name": "publicMode",
                      "format": "",
                      "description": "(optional) A flag for whether the organism appears as in the public genomes list (default false)",
@@ -5360,7 +5424,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a00d10b6-d94a-4a3d-aefd-2dfe0565760b",
+                     "jsondocId": "5c6dafbf-226e-4d34-8300-e7140c675964",
                      "name": "metadata",
                      "format": "",
                      "description": "(optional) Organism metadata",
@@ -5369,7 +5433,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3a17d846-7b30-4dcb-ac0a-dd2efd313a15",
+                     "jsondocId": "2a69cd25-ae74-4bf2-a443-152e8fa92105",
                      "name": "returnAllOrganisms",
                      "format": "",
                      "description": "(optional) Return all organisms (true / false) (default true)",
@@ -5381,9 +5445,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganism",
-               "jsondocId": "5a57344a-ce08-4631-b5b9-ecfaa5cf74ab",
+               "jsondocId": "28d02656-f183-4705-bc22-0ff2a6eb733a",
                "bodyobject": {
-                  "jsondocId": "066284da-6347-43ed-891a-7a8783551662",
+                  "jsondocId": "69ab19a0-0396-462b-b423-9817e0a3d96e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5393,7 +5457,7 @@
                "apierrors": [],
                "path": "/organism/addOrganism",
                "response": {
-                  "jsondocId": "997d5ac2-b216-4021-b26e-f9cb21b92f4e",
+                  "jsondocId": "0bfc400a-fad1-4e75-af50-eff5ab1740d9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5406,7 +5470,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0f4348cd-57cb-41cf-a812-db41aa224d5e",
+                     "jsondocId": "5f0df351-98ce-495a-8186-e19853e1bca8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5415,7 +5479,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2457d53f-5683-46fa-9ba9-5b5eb6c5c490",
+                     "jsondocId": "1f5d23a5-dd38-4837-ae1e-899d421536ce",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5424,7 +5488,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97e2f040-45d5-48c0-9dd6-04ef1943323d",
+                     "jsondocId": "92d766b5-9fc0-4130-8b4c-5594f3f5a756",
                      "name": "organism",
                      "format": "",
                      "description": "Common name or ID for the organism",
@@ -5436,9 +5500,9 @@
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
                "methodName": "getSequencesForOrganism",
-               "jsondocId": "86699905-4197-4cf7-a5a1-08cbf3a41154",
+               "jsondocId": "ccaf1110-b2a1-4ff2-87c9-3395bcf19462",
                "bodyobject": {
-                  "jsondocId": "29d4d1e5-3783-453a-a322-745478acf091",
+                  "jsondocId": "06fbd352-86e4-48b9-9b64-d1eab4a4f0f0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5448,7 +5512,7 @@
                "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
                "response": {
-                  "jsondocId": "36a3a8de-e623-4382-895c-9c323d35128b",
+                  "jsondocId": "493104c6-4c1e-43bf-9cf1-6b25eed75818",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5461,7 +5525,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "43561dbe-5e0c-4ff3-a81f-7b486ee741ac",
+                     "jsondocId": "bcda86d0-70d4-4d93-aa13-0be40fcbeae9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5470,7 +5534,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "711b5ec6-08d6-4efa-b21f-85bd5a56b16a",
+                     "jsondocId": "2a7363c3-297a-4507-8793-295ae80e1e11",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5479,7 +5543,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "12805920-a729-43c6-80ae-f46f0124fde5",
+                     "jsondocId": "46bbbdee-04c9-4639-b1d9-1d5b6c301503",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -5488,7 +5552,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d5fb7d33-358d-4acd-86b5-acee49c2f591",
+                     "jsondocId": "4657943f-df06-4e45-8a10-da5db8457c31",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -5497,7 +5561,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66c9f6cb-046b-4ac2-9fff-caa3b43aa71d",
+                     "jsondocId": "a51777bc-93ed-4f02-ad5e-4575add75166",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -5506,7 +5570,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f735772f-9fc9-4939-a555-9745f2853058",
+                     "jsondocId": "bf946c4b-ff51-4a14-a9a9-7842221d9a27",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -5515,7 +5579,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "242198a6-9440-450d-9d19-78cfd235715c",
+                     "jsondocId": "c0e9b357-17b2-4c65-98f2-ad6e791e96f0",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -5524,7 +5588,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7b441e94-f1bf-4a2b-ad04-fd8fe0e10cb9",
+                     "jsondocId": "5722d0db-994c-47c3-a177-5e51fe1af471",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5533,7 +5597,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1450b7d-6a6e-4768-b415-b9a7a7d1bea9",
+                     "jsondocId": "7adc4abc-c592-4168-a9d3-f1c1b9d87fe2",
                      "name": "name",
                      "format": "",
                      "description": "a common name used for the organism",
@@ -5542,7 +5606,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2a041b3b-554a-404e-ab6e-9babf06c36d1",
+                     "jsondocId": "65261612-bfc7-4e60-8bb7-be691ea91c81",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -5551,7 +5615,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3471b763-2cd7-43d3-9917-d6d66802197b",
+                     "jsondocId": "2c09d368-8707-4cd1-a5fb-524a948d4d8a",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5563,9 +5627,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "updateOrganismInfo",
-               "jsondocId": "cf601c3e-a5fe-44d2-8fb2-35e6df12fdd8",
+               "jsondocId": "f4684b5c-fe2b-481e-9df2-586cd443c843",
                "bodyobject": {
-                  "jsondocId": "c0f9e8df-84d9-46f7-800f-55ee3e291e14",
+                  "jsondocId": "106330f5-cbc6-4d6c-b37c-53fcff238a19",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5575,7 +5639,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismInfo",
                "response": {
-                  "jsondocId": "50bd6a34-afc9-4d5c-b5b7-f076cb601084",
+                  "jsondocId": "7234730b-707c-4873-b0fe-c59c3a71860f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5588,7 +5652,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "19c7b2ef-faae-4976-9252-15f05e7c107a",
+                     "jsondocId": "e4fe9c1e-2326-4f82-8d89-ca242fd56fc7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5597,7 +5661,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f9aac6be-695b-4710-8d85-525093baf3a8",
+                     "jsondocId": "363cb159-9ac4-4612-a2a0-545446201811",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5606,7 +5670,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f49a7473-25ce-4cf1-ab1b-15fee9895cd2",
+                     "jsondocId": "0e979cc9-fc7f-4a73-a5be-ca5602a20a6c",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -5615,7 +5679,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b9127d95-656a-4696-9707-9e6c83226e42",
+                     "jsondocId": "8e58f093-c6a8-4568-a7c4-861ca464dcac",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5627,9 +5691,9 @@
                "verb": "POST",
                "description": "Update organism metadata",
                "methodName": "updateOrganismMetadata",
-               "jsondocId": "3607e58e-5917-4a10-acdb-589c6f84f740",
+               "jsondocId": "77dfd1d8-0a25-400d-8f99-0a0d54d1aa8f",
                "bodyobject": {
-                  "jsondocId": "a8697378-1147-48df-90cb-0455e025d72a",
+                  "jsondocId": "8fb1fa96-ccb6-4919-b9b0-e8b2e7089d5c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5639,7 +5703,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismMetadata",
                "response": {
-                  "jsondocId": "a2b6b159-6440-43eb-8d37-2c390df398ca",
+                  "jsondocId": "3bb3f295-14fc-45b6-bc9b-0e0d762a724b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5652,7 +5716,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "bfc667e4-bd3c-45b1-a061-6c7ed79a6e32",
+                     "jsondocId": "17cc14aa-bec1-4c1e-9fa2-ee37bd7cbaa1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5661,7 +5725,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "657608b2-52f5-400b-901f-4fc80a957fc8",
+                     "jsondocId": "a55bf1b0-8ba5-45c3-b8ad-d07a3e97de4e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5670,7 +5734,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f8f8973a-99a2-444c-a6d3-d98777dc09ca",
+                     "jsondocId": "e745c68e-9f5a-4cc7-ba51-20fb679965e3",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) ID or commonName that can be used to uniquely identify an organism",
@@ -5682,9 +5746,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "methodName": "findAllOrganisms",
-               "jsondocId": "46ff16d0-3034-44a4-9c66-3a8704bf7ac1",
+               "jsondocId": "b6977500-7a1c-45c8-82b4-5eddbf9b88f9",
                "bodyobject": {
-                  "jsondocId": "9704c2ef-ad2f-4cef-a04e-3744713c8d62",
+                  "jsondocId": "2d3463f9-e325-4222-871d-427ca0615a75",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5694,7 +5758,7 @@
                "apierrors": [],
                "path": "/organism/findAllOrganisms",
                "response": {
-                  "jsondocId": "54611519-d14c-45f0-96fa-b803e57c8e65",
+                  "jsondocId": "d6a389a5-3fc8-458d-b4c7-af125e0e3f7e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5707,14 +5771,14 @@
          "description": "Methods for managing organisms"
       },
       {
-         "jsondocId": "e4416744-26ff-4651-bd49-9821421ffb18",
+         "jsondocId": "4fb119f9-7ed6-4b97-b3be-dc98a71e5138",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d7e38460-a67a-4983-89c7-b1bdf492ef68",
+                     "jsondocId": "d1e8bb42-4cab-4ca3-b238-1561e34bb9a9",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -5723,7 +5787,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "71c59fea-301d-4d13-a4eb-44405a1bdb61",
+                     "jsondocId": "215ed50e-2fe3-41d7-aa84-9065d41bc9cd",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -5732,7 +5796,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5a8e3c46-066b-4f00-a9c0-5fd6c8512f38",
+                     "jsondocId": "d35b8b6e-c83f-4e43-b182-a7cfe982ba69",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -5741,7 +5805,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65fb9e7c-7dc7-4f57-8d93-c9e93b358d0b",
+                     "jsondocId": "70fb19fe-8cd4-4a84-b228-421a671be232",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -5750,7 +5814,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a1d168de-d329-4404-88aa-20c80d97b3b3",
+                     "jsondocId": "0f8c09d1-745d-437f-bfe0-42d4faa212ae",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -5762,12 +5826,12 @@
                "verb": "GET",
                "description": "Get sequence data within a range",
                "methodName": "sequenceByLocation",
-               "jsondocId": "eecb72c1-60e1-42c7-8bc7-6095cb60ade5",
+               "jsondocId": "efab773c-d326-4dbd-b665-097872d6d63b",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/<organism name>/<sequence name>:<fmin>..<fmax>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "bade745b-7eeb-44a0-8cc6-7e2462d039d0",
+                  "jsondocId": "4a1dc511-863d-4865-83f1-ff125789fd8f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -5780,7 +5844,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8685d8dd-861e-4dbc-bf2a-40b0e515b74e",
+                     "jsondocId": "7cadcf05-ae12-4445-a997-31350a0db9df",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID (required)",
@@ -5789,7 +5853,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6ddcbf21-1781-493d-8f52-5fd8cfef3e54",
+                     "jsondocId": "f3c3a109-7707-49cb-99c4-e8779a4116c4",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name (required)",
@@ -5798,7 +5862,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1d72d941-082e-4064-a994-f9e23d4108c2",
+                     "jsondocId": "d481bff4-b243-4764-b11b-68887d3d88f5",
                      "name": "featureName",
                      "format": "",
                      "description": "The uniqueName (UUID) or given name of the feature (typically transcript) of the element to retrieve sequence from",
@@ -5807,7 +5871,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9858e5a3-130f-4775-8b76-81d93a4ac49b",
+                     "jsondocId": "2222a9b5-9201-491a-9d0c-39e5c3bc32e5",
                      "name": "type",
                      "format": "",
                      "description": "(default genomic) Return type: genomic, cds, cdna, peptide",
@@ -5816,7 +5880,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b00ab53a-e9e3-4174-90fc-242c5767def8",
+                     "jsondocId": "1c0ebadc-4f68-45ae-abf8-aae7c16b641c",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -5828,12 +5892,12 @@
                "verb": "GET",
                "description": "Get sequence data as for a selected name",
                "methodName": "sequenceByName",
-               "jsondocId": "42ec6f09-1bfe-489f-8c25-b73eef0c7ce6",
+               "jsondocId": "55327328-9580-4430-a40a-cb37f45d4d6d",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/<organism name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "51babfd9-ceb4-4e47-8d07-dcdee30e4464",
+                  "jsondocId": "b7549c6f-2b63-4d31-a7b8-1235bbed6675",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -5846,7 +5910,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "724197ab-eccb-4760-824c-1da87bd0922b",
+                     "jsondocId": "d7500ed6-e3f7-40c7-99d7-b73c67f2e0a5",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -5855,7 +5919,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a1c69e13-9d31-415a-a666-3fb243775de2",
+                     "jsondocId": "2f78ecaf-8c18-4d1f-9897-b38c66a6509e",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name (required)",
@@ -5867,12 +5931,12 @@
                "verb": "GET",
                "description": "Remove sequence cache for an organism and sequence",
                "methodName": "clearSequenceCache",
-               "jsondocId": "adaa90c3-0e0e-4f36-b594-f3f17718b7b4",
+               "jsondocId": "38b58e5f-7688-4788-88d9-3d9280751fca",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/cache/clear/<organism name>/<sequence name>",
                "response": {
-                  "jsondocId": "8919c1e4-c56e-4b19-88dd-d4f0e5e6eb33",
+                  "jsondocId": "198e7f6a-7885-4f24-96cb-cfe04806863e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -5884,7 +5948,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "f7a87cf0-fe8f-4d53-8652-58300c2b2be0",
+                  "jsondocId": "623475c7-d87e-4fb9-b863-0cef231d3314",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required) or 'ALL' if admin",
@@ -5895,12 +5959,12 @@
                "verb": "GET",
                "description": "Remove sequence cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "7882265b-68ca-4503-96b7-0a5a48fbf110",
+               "jsondocId": "3c456fc3-92c6-4f24-8f75-fd16ffeff64d",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "9cd689e4-2028-45d8-9641-edbd690dd423",
+                  "jsondocId": "8dc55dfd-c083-476a-88b9-e1613426f5a6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -5913,13 +5977,13 @@
          "description": "Methods for retrieving sequence data"
       },
       {
-         "jsondocId": "15a995cb-f256-4b7c-9328-80c814042dc5",
+         "jsondocId": "d73d8086-fc16-4ad5-a3f7-50979e5a440e",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "7b676d53-c908-4edc-a409-b77bde985290",
+                  "jsondocId": "29892c3e-0845-4837-bbce-461cbc9c233f",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required) or 'ALL' if admin",
@@ -5930,12 +5994,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "d1a9cd4f-4f51-42ff-a4ac-fd8dbda26429",
+               "jsondocId": "232869be-2b67-4a59-9aa6-d85f92b22648",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "69627b82-40f8-4e3a-b6c5-3e75f12392bc",
+                  "jsondocId": "f7ebd67f-263b-44f4-9308-a2259787c6d9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5948,7 +6012,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d4c2804b-7953-4356-87bd-fe95aa93ec2d",
+                     "jsondocId": "e2c920fa-30d6-48dd-b7d3-1b234ae1af81",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -5957,7 +6021,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "134e4f10-7929-454a-be1a-018ebb35dc7f",
+                     "jsondocId": "71bb2560-babb-4645-8b99-fb9efdde4c61",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name (required)",
@@ -5969,12 +6033,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism and track",
                "methodName": "clearTrackCache",
-               "jsondocId": "ba3e94fd-9366-4da5-953a-334ccf223dbc",
+               "jsondocId": "c09edc74-a7ce-4815-a3c3-03ffa8cdc8f0",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>/<track name>",
                "response": {
-                  "jsondocId": "48c65494-67dc-4065-beb4-a01403f01546",
+                  "jsondocId": "12f73783-82e8-49c4-beb7-f5293af663cc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -5987,7 +6051,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "70992cd0-c7e4-406d-9cf0-678a7b68d22e",
+                     "jsondocId": "c7352718-6ba2-47c7-a0c0-2b27c9965522",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -5996,7 +6060,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "541fa418-733e-4105-993c-67c665287922",
+                     "jsondocId": "0b446c6c-0fc4-4b52-9f17-90c36bf8febb",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -6005,7 +6069,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ffa0d394-c5ad-4ab1-af7a-35ce3200d7d6",
+                     "jsondocId": "216b6a92-2564-4cc7-bc91-d5397e6224e7",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -6014,7 +6078,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fbdb1ace-f5c4-4f80-b0fe-c96819766a68",
+                     "jsondocId": "6e434439-296f-4822-b6ee-e8c0086d8ec4",
                      "name": "featureName",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -6023,7 +6087,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "712a9af8-da4b-4c52-a49c-d3c1663b1808",
+                     "jsondocId": "af989d4d-e842-44f6-beb1-e2979201fe53",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6032,7 +6096,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "03b4c472-16e8-49e8-8329-4b465219bd91",
+                     "jsondocId": "363433b1-4f81-4901-aa1b-7ca88e9cc178",
                      "name": "flatten",
                      "format": "",
                      "description": "Brings nested top-level components to the root level.  If not provided or 'false' it will not flatten.  Default is 'gene'.",
@@ -6041,7 +6105,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a280fc46-0a4f-4cd8-8882-69dc66b3dae2",
+                     "jsondocId": "e257fc4f-3bd5-4766-abaf-89e7f0f2ac36",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -6053,12 +6117,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within but only for the selected name",
                "methodName": "featuresByName",
-               "jsondocId": "b9acfb79-996d-44a9-af1b-a7086ca55277",
+               "jsondocId": "f05bc942-2f38-4480-90c1-14d4b98aecb0",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "c6bd56b1-3db0-4d0a-9314-4224a71d23bd",
+                  "jsondocId": "89b3c7fe-c895-43da-84a6-481f26e2a3ce",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -6071,7 +6135,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "44577443-9c7b-4513-80c4-4e56b25bc9d4",
+                     "jsondocId": "f0c4baeb-abb7-40fc-9d47-9cfa388831dd",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -6080,7 +6144,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0032a475-2dc0-474f-b8f2-bc67e8ac7c98",
+                     "jsondocId": "4c1ce615-2e66-4fa7-af8d-1f8102c53d62",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -6089,7 +6153,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3750c3ed-3de2-46a0-89f1-2ca41f768264",
+                     "jsondocId": "8f913c6f-9f7d-48ef-8b75-141a4dba3555",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -6098,7 +6162,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3af51d2c-a3bb-444f-bde1-a40a602cf2ba",
+                     "jsondocId": "01cbd66e-0c0c-41c4-a35a-ff9a69597ca1",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -6107,7 +6171,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3528f244-0e37-4cae-b566-bbf16b10987f",
+                     "jsondocId": "4460ec5d-bbb5-4837-9419-ac43b6680514",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -6116,7 +6180,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff32ac1d-69fb-410d-82aa-91edb7cb5d19",
+                     "jsondocId": "e466beed-b486-4e99-8ea6-495b060908c7",
                      "name": "name",
                      "format": "",
                      "description": "If top-level feature 'name' matches, then annotate with 'selected'=true.  Multiple names can be passed in.",
@@ -6125,7 +6189,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "288024d6-5233-491c-a534-109df86fdce7",
+                     "jsondocId": "ee3b7656-2240-4619-9a92-8b27ea26c6d0",
                      "name": "onlySelected",
                      "format": "",
                      "description": "(default false).  If 'selected'!=1 one, then exclude.",
@@ -6134,7 +6198,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "963e7f2e-62f8-43ae-a883-7d5b7af956a3",
+                     "jsondocId": "ca30796e-7742-440e-94ed-d7fe7a75acd9",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6143,7 +6207,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8c8e191a-ad42-4a2e-8393-aaaa177228a4",
+                     "jsondocId": "c67f6547-08e3-469c-96f6-cf424b20a846",
                      "name": "flatten",
                      "format": "",
                      "description": "Brings nested top-level components to the root level.  If not provided or 'false' it will not flatten.  Default is 'gene'.",
@@ -6152,7 +6216,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b8de4a5e-5689-439d-998e-daf02c866c3d",
+                     "jsondocId": "34dee189-9506-4e58-83b7-31ec41f0f92f",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -6164,12 +6228,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within an range",
                "methodName": "featuresByLocation",
-               "jsondocId": "b9f65006-cf44-495a-976e-5e23afde2ad8",
+               "jsondocId": "7087d3bd-cfe5-4ce6-8e36-f711b402915a",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>:<fmin>..<fmax>.<type>?name=<name>&onlySelected=<onlySelected>&ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "3816dcab-ca75-4fce-adce-6299860c0b21",
+                  "jsondocId": "e58d2f71-1f3e-4cf9-9d19-f3703b02cc23",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -6182,14 +6246,14 @@
          "description": "Methods for retrieving track data"
       },
       {
-         "jsondocId": "141c4632-4df9-4673-b0a4-169704d66b69",
+         "jsondocId": "4d8cf2c8-8ff7-41b2-ba83-e305feb1de4d",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "de411df8-b062-4e68-b925-bc782c6bf493",
+                     "jsondocId": "e7976cee-98ce-40eb-88ea-58e8346ab3b8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6198,7 +6262,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45ef9cf9-54df-4226-bcd8-86892f6003a3",
+                     "jsondocId": "59b68a62-8fe8-4780-b931-eec256a8ba83",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6207,526 +6271,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b6ff6a51-9946-47ea-95c5-24c7379d68b2",
-                     "name": "userId",
-                     "format": "",
-                     "description": "Optionally only user a specific userId as an integer database id or a username string",
-                     "type": "long / string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0ef1b649-0bd9-4655-8b54-ec0fd77cd685",
-                     "name": "start",
-                     "format": "",
-                     "description": "(optional) Result start / offset",
-                     "type": "long / string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b1cf3045-7327-46f0-9bc4-9810304910a0",
-                     "name": "length",
-                     "format": "",
-                     "description": "(optional) Result length",
-                     "type": "long / string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9c0c185f-cccf-4211-8b59-8256ac3bd1bd",
-                     "name": "name",
-                     "format": "",
-                     "description": "(optional) Search name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6695b154-99b5-4e15-86dd-4ee186efdf11",
-                     "name": "sortColumn",
-                     "format": "",
-                     "description": "(optional) Sort column, default 'name'",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b9673e15-f8e6-4c89-9b5d-38a5d1d33c4f",
-                     "name": "sortAscending",
-                     "format": "",
-                     "description": "(optional) Sort column is ascending if true (default false)",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2e56e1ba-e4c0-49e3-ab3a-78f8450c75a8",
-                     "name": "omitEmptyOrganisms",
-                     "format": "",
-                     "description": "(optional) Omits empty organism permissions from return (default false)",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Load all users and their permissions",
-               "methodName": "loadUsers",
-               "jsondocId": "fcd41968-6692-4e53-a096-7ef9b4b287ef",
-               "bodyobject": {
-                  "jsondocId": "830a5445-6bcf-4be6-a967-d9c671ef2083",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/loadUsers",
-               "response": {
-                  "jsondocId": "63415d51-b1a8-401d-a320-0298f68845fb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "13a58492-95a4-4bbb-a8e0-7cec1cfc76dc",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "babf8740-5cb1-4fc8-83c9-fa4a7be06f30",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1f7dc184-b4ec-46f4-a154-f7377dc8f8a5",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cbcf9d59-58d8-445d-87d5-ecbdd04e2aff",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a39926be-8679-4613-a0fb-40c9706fb641",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add user to group",
-               "methodName": "addUserToGroup",
-               "jsondocId": "c134d125-ca7a-4602-9a6b-51d2ec71088f",
-               "bodyobject": {
-                  "jsondocId": "2ad37ca2-d2ab-4737-b43f-6ae62c45a85b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/addUserToGroup",
-               "response": {
-                  "jsondocId": "ba38ea51-d88c-49ac-bec3-607c394c588d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "6e742668-5c28-47a4-83a4-ee3aa0b401bc",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ad301683-0627-4d43-a172-6a58953a1892",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c1b61668-1910-4376-ab14-bddc29761be9",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "74dbd3d7-4761-4d44-a946-591f31da33a9",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a61221cb-7484-4679-8b0a-61c3403cb7b5",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Remove user from group",
-               "methodName": "removeUserFromGroup",
-               "jsondocId": "92ad1fb5-e0d8-41b8-8536-4038dece4eff",
-               "bodyobject": {
-                  "jsondocId": "faa830fe-8366-4f49-88e7-f6f411dfa77f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/removeUserFromGroup",
-               "response": {
-                  "jsondocId": "b7534b98-5beb-459f-ba41-f62f362a9098",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "671f19b7-e249-43d4-b383-6b12158620b9",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7fc5f089-7dd0-4325-803e-632eb9289813",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "374ee991-ed6b-44e1-9dde-bf00952213ed",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to add",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "314552d9-cc90-4577-947a-c35bd4811b96",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "023f9f14-4979-4621-840c-6304570c71a4",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "744b27f2-a34e-4faf-b6e8-10691430ea45",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "User metadata (optional)",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b144d888-422d-4542-b12c-482ec0387d6f",
-                     "name": "role",
-                     "format": "",
-                     "description": "User role USER / ADMIN (optional: default USER) ",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1e3a8c2b-7b18-4286-9a12-7aac77fcd75a",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create user",
-               "methodName": "createUser",
-               "jsondocId": "21e3dc9f-5029-4357-89b5-8d9fc7405164",
-               "bodyobject": {
-                  "jsondocId": "7811cf82-daf6-4e5f-b185-39c620245b4c",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/createUser",
-               "response": {
-                  "jsondocId": "9c2ee224-f831-45ce-9c90-33109a3b820e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "3ef77f27-5155-4b45-a148-3029a9b005d7",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1fa77247-a6e3-4040-8179-72150a81bec5",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ca594667-fee6-4d2a-bdf9-8e427acb77f1",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to delete",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0e814bdc-8f4f-4034-924f-d29d9959e6f6",
-                     "name": "userToDelete",
-                     "format": "",
-                     "description": "Username (email) to delete",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete user",
-               "methodName": "deleteUser",
-               "jsondocId": "9cf32fcd-7ce9-49af-b147-803993490124",
-               "bodyobject": {
-                  "jsondocId": "49c83991-108c-4268-b82a-36816f200a77",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/deleteUser",
-               "response": {
-                  "jsondocId": "5106bd00-f43f-4093-9c5a-ed9fec2a69d3",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "cf2fb07f-930d-407b-9eb4-eb609d4e3b5f",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b9c71b82-1de9-467a-b7e1-260affdf75f8",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d09afaa5-591a-48a7-ac8b-48632a575aec",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to update",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ed4decb3-8f41-446f-8929-c3c45d257a87",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to update",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "188419e9-5ab0-41d6-ab7d-9c51e9ea4d49",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d2d0687a-48c0-4394-8125-575868672161",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1d7b8c97-4fdb-4700-96e1-ce7e046d4d13",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "User metadata (optional)",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0feba106-e29e-4aaf-be84-c98d0deaf1d0",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update user",
-               "methodName": "updateUser",
-               "jsondocId": "7ace71c9-4adf-4e2d-90c5-1eaec9df2090",
-               "bodyobject": {
-                  "jsondocId": "6c65fc0e-37e7-43e4-9fcf-4f8cf5d802fb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/updateUser",
-               "response": {
-                  "jsondocId": "1886483c-982a-4104-8d98-236624c4199e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "7e14f9e2-5c5f-4926-bf45-d91bd7278966",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "8403283a-c822-45d4-8258-ad7fdc2db857",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d3556bc2-0e2e-436e-b38e-b3367702a8bc",
+                     "jsondocId": "11a4596d-ffe0-42a1-b272-5d0358eb01c5",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to modify permissions for",
@@ -6735,7 +6280,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b8733c0c-9891-42a0-a3d8-cca7a77e33d3",
+                     "jsondocId": "91ef9c24-582a-484c-8194-fe028f7e0251",
                      "name": "user",
                      "format": "",
                      "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
@@ -6744,7 +6289,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3b62f757-f36f-4d7e-bf9d-5fe202f82584",
+                     "jsondocId": "9561d880-30cf-4b91-93be-34e457837118",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism to update",
@@ -6753,7 +6298,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c26dc5b8-5349-4936-81f1-4b001ff7aaf5",
+                     "jsondocId": "263710cb-a3e0-4b40-8a06-a79aa877f419",
                      "name": "id",
                      "format": "",
                      "description": "Permission ID to update (can get from userId/organism instead)",
@@ -6762,7 +6307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ac1769bd-cb2c-4ed6-b7b2-ab875bf56d23",
+                     "jsondocId": "9e38b5a9-159e-4cc4-b050-ded5cd12ee31",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -6771,7 +6316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b37f789f-e8ec-4e69-a6f3-5329fda629b8",
+                     "jsondocId": "2700c529-e82a-41a7-aa1a-a87e5c5ebd56",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -6780,7 +6325,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "187456ff-6754-4619-81f9-0ec16463d6e3",
+                     "jsondocId": "ca11ba92-a8a3-4f57-b3d7-5139b4d9ce81",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -6789,7 +6334,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "62315e5d-5a00-455d-b132-0be8d786b8a0",
+                     "jsondocId": "30d9713c-9f00-46c5-ba95-0ca8a2ac01b7",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -6801,9 +6346,9 @@
                "verb": "POST",
                "description": "Update organism permissions",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "8ae4fe99-74a2-4517-8bef-75cba96a8e3c",
+               "jsondocId": "f33b84b7-2c72-4728-bbef-1abb41f43c0f",
                "bodyobject": {
-                  "jsondocId": "2ae1c2cf-b238-4b5a-8d7e-5e6e2b40d904",
+                  "jsondocId": "30665ef8-4356-4dd7-b52e-d0f420e80238",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6813,7 +6358,7 @@
                "apierrors": [],
                "path": "/user/updateOrganismPermission",
                "response": {
-                  "jsondocId": "f5972ac1-ada3-459c-a8af-eb2bbb3c264a",
+                  "jsondocId": "84561100-28d4-4e66-bb08-38b58aeb5592",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -6826,7 +6371,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "bf0ce9fb-2f4f-42fb-8a51-9a571935c520",
+                     "jsondocId": "d5845a7c-0ae3-4413-a631-7bce80cc488c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6835,7 +6380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "33f2962e-6a3c-4574-9599-8b7370d3ab61",
+                     "jsondocId": "d69c9070-2fa2-4fee-ad2f-51c5fb18b221",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6844,7 +6389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e69a1b93-cdfa-4fac-9f1e-64bfca9de00f",
+                     "jsondocId": "782ae202-68a9-4c24-96b4-c3531a2500da",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to fetch",
@@ -6856,9 +6401,9 @@
                "verb": "POST",
                "description": "Get organism permissions for user, returns an array of permission objects",
                "methodName": "getOrganismPermissionsForUser",
-               "jsondocId": "f48229f2-93be-4efe-88f1-a938ce7378b2",
+               "jsondocId": "e177c65c-6e21-4664-ae50-ad2205d0bf8b",
                "bodyobject": {
-                  "jsondocId": "9abab683-2f37-438d-883e-75470b6b0297",
+                  "jsondocId": "5551e0df-2560-4ae3-b755-ce193bd175fc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6868,7 +6413,526 @@
                "apierrors": [],
                "path": "/user/getOrganismPermissionsForUser",
                "response": {
-                  "jsondocId": "03dae59d-3249-4a50-92d8-22b18b6abeba",
+                  "jsondocId": "f9b793e6-0390-41ac-98f2-8e9a8f08ac3b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "11e98234-b915-4b7c-a4d4-3406b3bb3afe",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ac628b82-25f4-41c9-976f-3803d06becd4",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4e06e96d-f85e-400e-aa87-4f9f66274764",
+                     "name": "userId",
+                     "format": "",
+                     "description": "Optionally only user a specific userId as an integer database id or a username string",
+                     "type": "long / string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "867a3253-f24e-4ac8-8778-a4669de9e26d",
+                     "name": "start",
+                     "format": "",
+                     "description": "(optional) Result start / offset",
+                     "type": "long / string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "33135747-fc86-426f-a502-bcbf31a7c71b",
+                     "name": "length",
+                     "format": "",
+                     "description": "(optional) Result length",
+                     "type": "long / string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ea3c0678-75d4-45c7-98b9-c79882500c4d",
+                     "name": "name",
+                     "format": "",
+                     "description": "(optional) Search name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "627fe38f-2c9e-4c63-a514-ac264b209546",
+                     "name": "sortColumn",
+                     "format": "",
+                     "description": "(optional) Sort column, default 'name'",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d870617d-f8d8-4eea-bda5-89f851adc9f5",
+                     "name": "sortAscending",
+                     "format": "",
+                     "description": "(optional) Sort column is ascending if true (default false)",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e22ee4f4-aa25-4627-aa82-2b1838bdf3f0",
+                     "name": "omitEmptyOrganisms",
+                     "format": "",
+                     "description": "(optional) Omits empty organism permissions from return (default false)",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Load all users and their permissions",
+               "methodName": "loadUsers",
+               "jsondocId": "a1922b7e-f6f4-482a-acdc-187457575538",
+               "bodyobject": {
+                  "jsondocId": "eb595585-8a98-416b-807e-9bb94a7b8aa3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/loadUsers",
+               "response": {
+                  "jsondocId": "9732bc24-f791-4a83-a43a-de44bcf1d707",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5d89e41a-56f5-41dd-9c43-899a22abde4a",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7ad4a5c6-31ab-442b-81bb-e95a4cc41bc6",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cab476a8-d0f6-414d-bb44-607100533a4b",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7dafbd31-f252-41b0-ae5c-e03ceaf25abd",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1518a381-6181-4b4c-a88d-11d2086ad71b",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add user to group",
+               "methodName": "addUserToGroup",
+               "jsondocId": "4e0abd78-f3b2-49bf-8bc3-f2318e65a3cf",
+               "bodyobject": {
+                  "jsondocId": "7bc202f9-3edd-47a0-833c-3438d9a7f7e2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/addUserToGroup",
+               "response": {
+                  "jsondocId": "3cf91ba7-ad64-42e3-b672-959347236196",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "ca63d6ef-59ea-4ac1-80ff-6923b2a8e956",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ae5a7757-dcdd-4265-9d87-10397003c032",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dec7f35c-e40a-4278-82d9-e40ad8c3fd37",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8a7ef617-5eaf-4861-8f72-d6fe44bda899",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "40202e8a-d744-4c52-98cd-28db50754321",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Remove user from group",
+               "methodName": "removeUserFromGroup",
+               "jsondocId": "d24bd12e-3fb9-4adc-9e2d-ae02a0d0bcba",
+               "bodyobject": {
+                  "jsondocId": "4cc4e7ca-8f70-49a6-b315-404a2dcfddd9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/removeUserFromGroup",
+               "response": {
+                  "jsondocId": "108094c9-2e26-4341-b693-88b558f850bc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "3c9ef9f8-12a0-45eb-9f08-48e344e4a7d4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5d697e82-d26b-4b41-9c07-4119dad0fd3e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "7e71c156-5281-43b7-bc15-0afe344c82e9",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to add",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8d60dbea-94fa-4e43-8d1d-8141a7eda850",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9137ae70-4d23-4e9f-ad2c-c4e88cb6c4ca",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "575b0a5c-e399-42b8-8e4a-361301de0409",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "User metadata (optional)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5bd8f186-ef9c-4f6a-a15c-e981866424d4",
+                     "name": "role",
+                     "format": "",
+                     "description": "User role USER / ADMIN (optional: default USER) ",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bf272226-7b30-433f-92a5-3cf0583735f2",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create user",
+               "methodName": "createUser",
+               "jsondocId": "4d1ca445-b11c-4de7-95f2-acadc64f5994",
+               "bodyobject": {
+                  "jsondocId": "314f3fe5-a164-4697-964d-d83a4ecc4b4c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/createUser",
+               "response": {
+                  "jsondocId": "aba07497-b971-4d7c-a3fa-94a6be87dc47",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "04e21563-4d3e-4fbe-be7c-9f070c4a7d68",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3b561d3a-40ff-4396-ab2d-bf507b0c32a4",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5094859f-d70a-4250-9c38-0e0a1d2f5476",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fb3a933a-dcab-420b-a2c7-b8c4e65edf5d",
+                     "name": "userToDelete",
+                     "format": "",
+                     "description": "Username (email) to delete",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete user",
+               "methodName": "deleteUser",
+               "jsondocId": "1ea7a2b7-1828-4c85-ac0c-f838b932ece7",
+               "bodyobject": {
+                  "jsondocId": "40cd1696-78a5-4a5b-b1a8-b920da40df1e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/deleteUser",
+               "response": {
+                  "jsondocId": "e1623620-803f-4c63-9e7c-bd2b4bb95fdd",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e5e780ac-73dc-4636-bc76-4aca4ef93b33",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f89e5342-5984-4a2e-b36c-1a4ec6bc1ae5",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e5a961c0-b5ea-49fa-8195-17860d95cbfb",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to update",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e50c6aa8-be71-41d8-9e49-1e8047a9039d",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to update",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b1fb6d25-e2a4-40f5-818b-a8a47b410697",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8807baf6-f2ee-463a-8e95-63e3134855c3",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0af04636-a59c-4100-9b01-ed6e86ea362e",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "User metadata (optional)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a6d0649c-16be-4232-af2a-f3247765639f",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update user",
+               "methodName": "updateUser",
+               "jsondocId": "be74d68e-513a-425a-a084-22f9c148883c",
+               "bodyobject": {
+                  "jsondocId": "fbc71dfb-03b3-42bd-b2d5-211358f60ae5",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateUser",
+               "response": {
+                  "jsondocId": "687298d5-ae35-41c3-b1f6-86661137ebb1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -6879,6 +6943,104 @@
          ],
          "name": "User Services",
          "description": "Methods for managing users"
+      },
+      {
+         "jsondocId": "ac4c8d2a-93ae-4cd9-be17-af0b94c498bc",
+         "methods": [{
+            "headers": [],
+            "pathparameters": [],
+            "queryparameters": [
+               {
+                  "jsondocId": "e392088a-7c3b-463b-95c2-eb413e75615b",
+                  "name": "organismString",
+                  "format": "",
+                  "description": "Organism common name or ID (required)",
+                  "type": "string",
+                  "required": "true",
+                  "allowedvalues": []
+               },
+               {
+                  "jsondocId": "ae4c3b79-9810-45c9-8d7a-47ccd05457ae",
+                  "name": "trackName",
+                  "format": "",
+                  "description": "Track name by label in trackList.json (required)",
+                  "type": "string",
+                  "required": "true",
+                  "allowedvalues": []
+               },
+               {
+                  "jsondocId": "3d3e18a5-17b2-4488-bdec-c2b87e5bbe35",
+                  "name": "sequence",
+                  "format": "",
+                  "description": "Sequence name (required)",
+                  "type": "string",
+                  "required": "true",
+                  "allowedvalues": []
+               },
+               {
+                  "jsondocId": "6522b7d6-b342-49d4-bcfd-64ced6e7af25",
+                  "name": "fmin",
+                  "format": "",
+                  "description": "Minimum range (required)",
+                  "type": "integer",
+                  "required": "true",
+                  "allowedvalues": []
+               },
+               {
+                  "jsondocId": "f8460856-a045-4f4f-8e0a-55d50f965c0e",
+                  "name": "fmax",
+                  "format": "",
+                  "description": "Maximum range (required)",
+                  "type": "integer",
+                  "required": "true",
+                  "allowedvalues": []
+               },
+               {
+                  "jsondocId": "830eb7bd-c1fb-4eb7-b5e5-74ed4d7d6f73",
+                  "name": "type",
+                  "format": "",
+                  "description": ".json (required)",
+                  "type": "string",
+                  "required": "true",
+                  "allowedvalues": []
+               },
+               {
+                  "jsondocId": "66f3b96a-1bf9-48a3-8994-61e89e61adcb",
+                  "name": "includeGenotypes",
+                  "format": "",
+                  "description": "(default: false).  If true, will include genotypes associated with variants from VCF.",
+                  "type": "boolean",
+                  "required": "true",
+                  "allowedvalues": []
+               },
+               {
+                  "jsondocId": "a7287b8b-d325-4b61-bd5b-611b93d8ca1a",
+                  "name": "ignoreCache",
+                  "format": "",
+                  "description": "(default: false).  Use cache for request, if available.",
+                  "type": "boolean",
+                  "required": "true",
+                  "allowedvalues": []
+               }
+            ],
+            "verb": "GET",
+            "description": "Get VCF track data for a given range as JSON",
+            "methodName": "featuresByLocation",
+            "jsondocId": "f7cab9f7-7287-4133-8d16-64b71b5b0e45",
+            "bodyobject": null,
+            "apierrors": [],
+            "path": "/vcf/<organism_name>/<track_name>/<sequence_name>:<fmin>..<fmax>.<type>?includeGenotypes=<includeGenotypes>&ignoreCache=<ignoreCache>",
+            "response": {
+               "jsondocId": "315a889c-8452-4f0e-b2e5-9e4d54813148",
+               "mapValueObject": "",
+               "mapKeyObject": "",
+               "object": "vcf"
+            },
+            "produces": ["application/json"],
+            "consumes": []
+         }],
+         "name": "VCF Services",
+         "description": "Methods for retrieving VCF track data as JSON"
       }
    ],
    "objects": [],


### PR DESCRIPTION
@nathandunn 

To get variant data as JSON,
- `localhost:8080/apollo/vcf/human/variants_track_name/1:15001..16000.json` should give you the variant and its information (by default the genotype is not included)
- `localhost:8080/apollo/vcf/human/variants_track_name/1:15001..16000.json&includeGenotypes=true` should give you the variant, its information and associated genotypes.

Let me know if you the JSON representation needs tweaking or if there is something missing.