### PR TITLE
fix a bug on update Organism Permission

### DIFF
--- a/grails-app/services/org/bbop/apollo/PreferenceService.groovy
+++ b/grails-app/services/org/bbop/apollo/PreferenceService.groovy
@@ -143,7 +143,9 @@ class PreferenceService {
             return Organism.findById(Long.parseLong(token))
         } else {
             log.debug "is NOT long "
-            return Organism.findByCommonNameIlike(token)
+            // Cannot use findByCommonNameIlike, because it will fail to update the permission of an organism named orgam
+            // if an organism named Orgam exist. findByCommonNameIlike ignores the case.
+            return Organism.findByCommonName(token)
         }
     }
 


### PR DESCRIPTION
fix a bug on a corner case of web services: updateOrganismPermission will fail to update an organism permission due to looking up the organism in DB ignoring case. 

So if "orgam" and "Orgam" both exist, call updateOrganismPermission on orgam will actually updating the permission for Orgam. 