### PR TITLE
Migration script fix (apollo1 -> apollo2)

### DIFF
--- a/docs/web_services/examples/groovy/Apollo1Operations.groovy
+++ b/docs/web_services/examples/groovy/Apollo1Operations.groovy
@@ -19,7 +19,12 @@ static def getFeature(url,track,cookieFile,ignorePrefix){
 
     String json = "{ 'operation': 'get_features', 'track': '${prefix}${track}'}"
     def process = ["curl","-b",cookieFile,"-c",cookieFile,"-e",url,"--data",json,"${url}/AnnotationEditorService"].execute()
-    def response = process.text
+    def out = new ByteArrayOutputStream()
+    def err = new ByteArrayOutputStream()
+    process.consumeProcessOutput(out, err)
+    process.waitFor()
+    def response = out.toString()
+    println response
     if(process.exitValue()!=0){
         println process.errorStream.text
     }
@@ -31,7 +36,11 @@ static def getFeature(url,track,cookieFile,ignorePrefix){
 static def doLogin(url, username, password,cookieFile) {
     String json = "{'username': '${username}', 'password': '${password}'}"
     def process = ["curl", "-c", cookieFile, "-H", "Content-Type:application/json", "-d", json, "${url}/Login?operation=login"].execute()
-    def response = process.text
+    def out = new ByteArrayOutputStream()
+    def err = new ByteArrayOutputStream()
+    process.consumeProcessOutput(out, err)
+    process.waitFor()
+    def response = out.toString()
     if (process.exitValue() != 0) {
         println process.errorStream.text
     }

--- a/docs/web_services/examples/groovy/migrate_annotations1to2.groovy
+++ b/docs/web_services/examples/groovy/migrate_annotations1to2.groovy
@@ -59,6 +59,7 @@ JSONArray addTranscriptArray = new JSONArray()
 
 sequenceArray = options.sequence_names.tokenize(',')
 for (String sequence in sequenceArray) {
+    println sequence
     String sequenceName = sequence
     def featuresResponse = Apollo1Operations.getFeature(options.sourceurl,sequenceName,cookieFile,options.ignore_prefix)
     def featuresFromSource  = featuresResponse.features // contains list of mRNAs; Size == number of annotations on chromosome
@@ -99,6 +100,3 @@ for (String sequence in sequenceArray) {
 for(f in featuresMap){
     println f.value + " found in " + f.key
 }
-
-
-


### PR DESCRIPTION
Hi,
I had to modify the script to migrate data from an old apollo 1 instance to a 2.1.0 instance. Here's the patch.
It mainly fixes some IllegalThreadStateException occuring randomly

It works, BUT, I see it doesn't migrate all the names, symbols, dbxrefs that people entered on the old server. Is there a way to migrate this data too? It is for ~700 genes, so people will not like entering it again