### PR TITLE
fix for #201: tweak jbrowse tools install to fix CPAN package install

### DIFF
--- a/apollo
+++ b/apollo
@@ -204,16 +204,17 @@ function clean_all(){
 }
 
 function link_jbrowse_tools(){
-	rm -rf bin
-	ln -s jbrowse/bin bin
-	cd jbrowse
-#	./bin/cpanm --notest --local-lib=extlib Bio::GFF3::LowLevel::Parser CGI Devel::Size Digest::Crc32 JSON File::Next Hash::Merge Heap::Simple Heap::Simple::Perl Heap::Simple::XS PerlIO::gzip
-#	./bin/cpanm --notest --local-lib=jbrowse/src/perl5 LWP::UserAgent
-	./bin/cpanm --notest --local-lib=ext-lib Bio::GFF3::LowLevel::Parser CGI Devel::Size Digest::Crc32 JSON File::Next Hash::Merge Heap::Simple Heap::Simple::Perl Heap::Simple::XS PerlIO::gzip
-	cd ..
-	echo "**********************************";
-	echo "JBrowse Tools installed in './bin'";
-	echo "**********************************";
+        rm -rf bin
+        ln -s jbrowse/bin bin
+        EXTLIB=$(pwd)/extlib
+        ./bin/cpanm --local-lib=${EXTLIB}          Bio::GFF3::LowLevel::Parser CGI Devel::Size Digest::Crc32 JSON File::Next Hash::Merge PerlIO::gzip Heap::Simple Heap::Simple::Perl
+        ./bin/cpanm --local-lib=${EXTLIB} --notest Heap::Simple::XS
+        echo "********************************************************************";
+        echo "JBrowse Tools installed in './bin'";
+        echo "Perl dependencies in ${EXTLIB}; add to PERL5LIB thusly:";
+        echo "   export PERL5LIB=${EXTLIB}/lib/perl5:\$PERL5LIB";
+        echo "********************************************************************";
+        unset EXTLIB
 }
 
 if [[ $1 == "devmode" ]];then


### PR DESCRIPTION
tweak jbrowse tools install: cpanm is installed with jbrowse, but
needs to be invoked with path to jbrowse bin directory; restrict
use of --notest to one problematic package (to avoid masking new
issues that may occur in future); install into specific 'exitlib'
directory; and echo a message advising adding the path to PERL5LIB


