### PR TITLE
initial commit of obsolete genomes

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/JbrowseController.groovy
@@ -414,7 +414,7 @@ class JbrowseController {
             id = request.session.getAttribute(FeatureStringEnum.ORGANISM_ID.value);
             jsonObject.put("dataset_id", id);
         }
-        List<Organism> list = permissionService.getOrganismsForCurrentUser()
+        List<Organism> list = permissionService.getOrganismsForCurrentUser().findAll(){ o -> !o.obsolete}
         JSONObject organismObjectContainer = new JSONObject()
         for (organism in list) {
             JSONObject organismObject = new JSONObject()

--- a/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
@@ -255,6 +255,7 @@ class OrganismController {
                         directory: configWrapperService.commonDataDirectory,
                         blatdb: requestObject.blatdb ?: "",
                         genus: requestObject.genus ?: "",
+                        obsolete: false,
                         species: requestObject.species ?: "",
                         metadata: requestObject.metadata ?: "",
                         publicMode: requestObject.publicMode ?: false,
@@ -815,6 +816,7 @@ class OrganismController {
                     , blatdb: organismJson.blatdb
                     , species: organismJson.species
                     , genus: organismJson.genus
+                    , obsolete : false
                     , metadata: organismJson.metadata?organismJson.metadata.toString(): null
                     , nonDefaultTranslationTable: organismJson.nonDefaultTranslationTable ?: null
                     , publicMode: organismJson.publicMode ?: false

--- a/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/OrganismController.groovy
@@ -957,6 +957,7 @@ class OrganismController {
     def updateOrganismInfo() {
         try {
             JSONObject organismJson = permissionService.handleInput(request, params)
+            println "orbanism JSON ${organismJson as JSON}"
             permissionService.checkPermissions(organismJson, PermissionEnum.ADMINISTRATE)
             Organism organism = Organism.findById(organismJson.id)
             if (organism) {
@@ -969,6 +970,7 @@ class OrganismController {
                 organism.metadata = organismJson.metadata ?organismJson.metadata.toString():organism.metadata
                 organism.directory = organismJson.directory
                 organism.publicMode = organismJson.publicMode ?: false
+                organism.obsolete = organismJson.obsolete ?: false
                 organism.nonDefaultTranslationTable = organismJson.nonDefaultTranslationTable ?: null
                 if (checkOrganism(organism)) {
                     organism.save(flush: true, insert: false, failOnError: true)
@@ -1119,6 +1121,7 @@ class OrganismController {
                         species                   : organism.species,
                         valid                     : organism.valid,
                         publicMode                : organism.publicMode,
+                        obsolete                  : organism.obsolete,
                         nonDefaultTranslationTable: organism.nonDefaultTranslationTable,
                         metadata                  : organism.metadata,
                         currentOrganism           : defaultOrganismId != null ? organism.id == defaultOrganismId : false

--- a/grails-app/domain/org/bbop/apollo/Organism.groovy
+++ b/grails-app/domain/org/bbop/apollo/Organism.groovy
@@ -18,7 +18,7 @@ class Organism implements JsonMetadata {
         metadata nullable: true
         commonName nullable: false
         genomeFasta nullable: true
-        obselete nullable: true
+        obsolete nullable: true
         genomeFastaIndex nullable: true
         nonDefaultTranslationTable nullable: true, blank: false
         dataAddedViaWebServices nullable: true
@@ -32,7 +32,7 @@ class Organism implements JsonMetadata {
     String comment;
     Boolean valid;
     boolean publicMode;
-    boolean obselete
+    boolean obsolete
     String blatdb;
     String directory
     String genomeFasta
@@ -75,7 +75,7 @@ class Organism implements JsonMetadata {
 
     static mapping = {
         publicMode defaultValue: true
-        obselete defaultValue: false
+        obsolete defaultValue: false
     }
 
 }

--- a/grails-app/domain/org/bbop/apollo/Organism.groovy
+++ b/grails-app/domain/org/bbop/apollo/Organism.groovy
@@ -18,6 +18,7 @@ class Organism implements JsonMetadata {
         metadata nullable: true
         commonName nullable: false
         genomeFasta nullable: true
+        obselete nullable: true
         genomeFastaIndex nullable: true
         nonDefaultTranslationTable nullable: true, blank: false
         dataAddedViaWebServices nullable: true
@@ -31,6 +32,7 @@ class Organism implements JsonMetadata {
     String comment;
     Boolean valid;
     boolean publicMode;
+    boolean obselete
     String blatdb;
     String directory
     String genomeFasta
@@ -73,6 +75,7 @@ class Organism implements JsonMetadata {
 
     static mapping = {
         publicMode defaultValue: true
+        obselete defaultValue: false
     }
 
 }

--- a/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
+++ b/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
@@ -50,6 +50,7 @@ class AnnotatorService {
                         species        : organism.species,
                         valid          : organism.valid,
                         publicMode     : organism.publicMode,
+                        obsolete       : organism.obsolete,
                         nonDefaultTranslationTable : organism.nonDefaultTranslationTable,
                         currentOrganism: defaultOrganismId != null ? organism.id == defaultOrganismId : false,
                         editable       : organismBooleanMap.get(organism) ?: false

--- a/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
+++ b/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
@@ -37,7 +37,9 @@ class AnnotatorService {
 
 
             JSONArray organismArray = new JSONArray()
-            for (Organism organism in organismList) {
+            println "input list: ${organismList.size()} -> ${ ( organismList as List).findAll(){ o -> !o.obsolete }.size() }"
+
+            for (Organism organism in organismList.findAll(){ o -> !o.obsolete} ) {
                 Integer sequenceCount = sequenceIntegerMap.get(organism) ?: 0
                 JSONObject jsonObject = [
                         id             : organism.id as Long,

--- a/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
+++ b/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
@@ -17,7 +17,7 @@ class AnnotatorService {
     def getAppState(String token) {
         JSONObject appStateObject = new JSONObject()
         try {
-            List<Organism> organismList = permissionService.getOrganismsForCurrentUser()
+            List<Organism> organismList = permissionService.getOrganismsForCurrentUser().findAll(){ o -> !o.obsolete }
             UserOrganismPreference userOrganismPreference = UserOrganismPreference.findByUserAndCurrentOrganismAndClientToken(permissionService.currentUser, true,token,[max: 1, sort: "lastUpdated", order: "desc"])
             log.debug "found organism preference: ${userOrganismPreference} for token ${token}"
             Long defaultOrganismId = userOrganismPreference ? userOrganismPreference.organism.id : null
@@ -37,9 +37,7 @@ class AnnotatorService {
 
 
             JSONArray organismArray = new JSONArray()
-            println "input list: ${organismList.size()} -> ${ ( organismList as List).findAll(){ o -> !o.obsolete }.size() }"
-
-            for (Organism organism in organismList.findAll(){ o -> !o.obsolete} ) {
+            for (Organism organism in organismList.findAll()) {
                 Integer sequenceCount = sequenceIntegerMap.get(organism) ?: 0
                 JSONObject jsonObject = [
                         id             : organism.id as Long,

--- a/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
+++ b/grails-app/services/org/bbop/apollo/AnnotatorService.groovy
@@ -17,7 +17,7 @@ class AnnotatorService {
     def getAppState(String token) {
         JSONObject appStateObject = new JSONObject()
         try {
-            List<Organism> organismList = permissionService.getOrganismsForCurrentUser().findAll(){ o -> !o.obsolete }
+            List<Organism> organismList = permissionService.getOrganismsForCurrentUser()
             UserOrganismPreference userOrganismPreference = UserOrganismPreference.findByUserAndCurrentOrganismAndClientToken(permissionService.currentUser, true,token,[max: 1, sort: "lastUpdated", order: "desc"])
             log.debug "found organism preference: ${userOrganismPreference} for token ${token}"
             Long defaultOrganismId = userOrganismPreference ? userOrganismPreference.organism.id : null

--- a/src/gwt/org/bbop/apollo/gwt/client/MainPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/MainPanel.java
@@ -643,7 +643,21 @@ public class MainPanel extends Composite {
 
     public void setAppState(AppStateInfo appStateInfo) {
         trackPanel.clear();
-        organismInfoList = appStateInfo.getOrganismList();
+
+        Boolean showObsoletes = organismPanel.showObsoleteOrganisms.getValue();
+        if(!showObsoletes){
+           organismInfoList = new ArrayList<>();
+           for(OrganismInfo organismInfo : appStateInfo.getOrganismList()){
+               if(!organismInfo.getObsolete()){
+                   organismInfoList.add(organismInfo);
+               }
+           }
+        }
+        else{
+            organismInfoList = appStateInfo.getOrganismList();
+        }
+
+
         currentSequence = appStateInfo.getCurrentSequence();
         currentOrganism = appStateInfo.getCurrentOrganism();
         currentStartBp = appStateInfo.getCurrentStartBp();

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
@@ -58,6 +58,8 @@ public class OrganismPanel extends Composite {
     @UiField
     CheckBox publicMode;
     @UiField
+    CheckBox obsoleteButton;
+    @UiField
     TextBox genus;
     @UiField
     TextBox species;
@@ -229,6 +231,9 @@ public class OrganismPanel extends Composite {
         publicMode.setValue(organismInfo.getPublicMode());
         publicMode.setEnabled(isEditable);
 
+        obsoleteButton.setValue(organismInfo.getObsolete());
+        obsoleteButton.setEnabled(isEditable);
+
         organismIdLabel.setHTML("Internal ID: " + organismInfo.getId());
 
         nonDefaultTranslationTable.setText(organismInfo.getNonDefaultTranslationTable());
@@ -283,6 +288,16 @@ public class OrganismPanel extends Composite {
     }
 
 
+    @UiHandler("obsoleteButton")
+    public void handleObsoleteButton(ChangeEvent changeEvent) {
+        GWT.log("Handling obsolete change " + obsoleteButton.getValue());
+        if (singleSelectionModel.getSelectedObject() != null) {
+            GWT.log("Handling obsolete not null " + obsoleteButton.getValue());
+            singleSelectionModel.getSelectedObject().setObsolete(obsoleteButton.getValue());
+            updateOrganismInfo();
+        }
+    }
+
     @UiHandler("newButton")
     public void handleAddNewOrganism(ClickEvent clickEvent) {
         creatingNewOrganism = true;
@@ -321,7 +336,7 @@ public class OrganismPanel extends Composite {
         organismInfo.setBlatDb(blatdb.getText());
         organismInfo.setNonDefaultTranslationTable(nonDefaultTranslationTable.getText());
         organismInfo.setPublicMode(publicMode.getValue());
-        organismInfo.setObsolete(false);
+        organismInfo.setObsolete(obsoleteButton.getValue());
 
         createButton.setEnabled(false);
         createButton.setText("Processing");
@@ -468,6 +483,7 @@ public class OrganismPanel extends Composite {
             createButton.setVisible(false);
             cancelButton.setVisible(false);
             duplicateButton.setVisible(isAdmin);
+            obsoleteButton.setVisible(isAdmin);
         } else {
             newButton.setEnabled(isAdmin);
             newButton.setVisible(isAdmin);
@@ -475,6 +491,7 @@ public class OrganismPanel extends Composite {
             cancelButton.setVisible(false);
             deleteButton.setVisible(false);
             duplicateButton.setVisible(false);
+            obsoleteButton.setVisible(false);
         }
     }
 
@@ -487,6 +504,7 @@ public class OrganismPanel extends Composite {
         blatdb.setEnabled(enabled);
         nonDefaultTranslationTable.setEnabled(enabled);
         publicMode.setEnabled(enabled);
+        obsoleteButton.setEnabled(enabled);
     }
 
     //Utility function for clearing the textboxes ("")
@@ -498,6 +516,7 @@ public class OrganismPanel extends Composite {
         blatdb.setText("");
         nonDefaultTranslationTable.setText("");
         publicMode.setValue(false);
+        obsoleteButton.setValue(false);
     }
 
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
@@ -35,6 +35,7 @@ import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.CheckBox;
 import org.gwtbootstrap3.client.ui.CheckBoxButton;
 import org.gwtbootstrap3.client.ui.TextBox;
+import org.gwtbootstrap3.client.ui.constants.AlertType;
 import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
 import org.gwtbootstrap3.extras.bootbox.client.callback.ConfirmCallback;
 
@@ -169,7 +170,12 @@ public class OrganismPanel extends Composite {
             @Override
             public void onDoubleClick(DoubleClickEvent event) {
                 if (singleSelectionModel.getSelectedObject() != null) {
-                    String orgId = singleSelectionModel.getSelectedObject().getId();
+                    OrganismInfo organismInfo = singleSelectionModel.getSelectedObject();
+                    if(organismInfo.getObsolete()){
+                        Bootbox.alert("You will have to make this organism 'active' by unselecting the 'Obsolete' checkbox in the Organism Details panel at the bottom.");
+                        return ;
+                    }
+                    String orgId = organismInfo.getId();
                     if (!MainPanel.getInstance().getCurrentOrganism().getId().equals(orgId)) {
                         OrganismRestService.switchOrganismById(orgId);
                     }

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
@@ -483,6 +483,7 @@ public class OrganismPanel extends Composite {
             createButton.setVisible(false);
             cancelButton.setVisible(false);
             duplicateButton.setVisible(isAdmin);
+            publicMode.setVisible(isAdmin);
             obsoleteButton.setVisible(isAdmin);
         } else {
             newButton.setEnabled(isAdmin);
@@ -491,6 +492,7 @@ public class OrganismPanel extends Composite {
             cancelButton.setVisible(false);
             deleteButton.setVisible(false);
             duplicateButton.setVisible(false);
+            publicMode.setVisible(false);
             obsoleteButton.setVisible(false);
         }
     }

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
@@ -33,6 +33,7 @@ import org.bbop.apollo.gwt.client.resources.TableResources;
 import org.bbop.apollo.gwt.client.rest.OrganismRestService;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.CheckBox;
+import org.gwtbootstrap3.client.ui.CheckBoxButton;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
 import org.gwtbootstrap3.extras.bootbox.client.callback.ConfirmCallback;
@@ -84,6 +85,10 @@ public class OrganismPanel extends Composite {
     TextBox nonDefaultTranslationTable;
     @UiField
     org.gwtbootstrap3.client.ui.Label organismIdLabel;
+    @UiField
+    CheckBoxButton showOnlyPublicOrganisms;
+    @UiField
+    CheckBoxButton showObsoleteOrganisms;
 
     boolean creatingNewOrganism = false; // a special flag for handling the clearSelection event when filling out new organism info
     boolean savingNewOrganism = false; // a special flag for handling the clearSelection event when filling out new organism info
@@ -172,9 +177,7 @@ public class OrganismPanel extends Composite {
             }
         }, DoubleClickEvent.getType());
 
-        List<OrganismInfo> trackInfoList = dataProvider.getList();
-
-        ColumnSortEvent.ListHandler<OrganismInfo> sortHandler = new ColumnSortEvent.ListHandler<OrganismInfo>(trackInfoList);
+        ColumnSortEvent.ListHandler<OrganismInfo> sortHandler = new ColumnSortEvent.ListHandler<OrganismInfo>(organismInfoList);
         dataGrid.addColumnSortHandler(sortHandler);
         sortHandler.setComparator(organismNameColumn, new Comparator<OrganismInfo>() {
             @Override
@@ -344,6 +347,19 @@ public class OrganismPanel extends Composite {
 
         OrganismRestService.createOrganism(new UpdateInfoListCallback(), organismInfo);
         loadingDialog.show();
+    }
+
+    @UiHandler("showOnlyPublicOrganisms")
+    public void handleShowOnlyPublicOrganisms(ClickEvent clickEvent) {
+        showOnlyPublicOrganisms.setValue(!showOnlyPublicOrganisms.getValue());
+        OrganismRestService.loadOrganisms(this.showOnlyPublicOrganisms.getValue(),this.showObsoleteOrganisms.getValue(),new UpdateInfoListCallback());
+    }
+
+
+    @UiHandler("showObsoleteOrganisms")
+    public void handleShowObsoleteOrganisms(ClickEvent clickEvent) {
+        showObsoleteOrganisms.setValue(!showObsoleteOrganisms.getValue());
+        OrganismRestService.loadOrganisms(this.showOnlyPublicOrganisms.getValue(),this.showObsoleteOrganisms.getValue(),new UpdateInfoListCallback());
     }
 
     @UiHandler("duplicateButton")

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.java
@@ -321,6 +321,7 @@ public class OrganismPanel extends Composite {
         organismInfo.setBlatDb(blatdb.getText());
         organismInfo.setNonDefaultTranslationTable(nonDefaultTranslationTable.getText());
         organismInfo.setPublicMode(publicMode.getValue());
+        organismInfo.setObsolete(false);
 
         createButton.setEnabled(false);
         createButton.setText("Processing");

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.ui.xml
@@ -123,7 +123,7 @@
                         </b:Row>
                         <b:Row styleName="{style.row}">
                             <b:Column size="XS_12" styleName="{style.widgetPanel}">
-                                <b:CheckBox ui:field="publicMode" text="Public" enabled="true"
+                                <b:CheckBox ui:field="publicMode" text="Public" visible="false"
                                             styleName="{style.inline-button}"
                                 />
                                 <b:CheckBox ui:field="obsoleteButton" text="Obsolete" visible="false"

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.ui.xml
@@ -40,6 +40,14 @@
 
     </ui:style>
     <gwt:DockLayoutPanel>
+        <gwt:north size="25">
+           <!--<gwt:FlowPanel>-->
+            <b:ButtonGroup dataToggle="BUTTONS">
+                <b:CheckBoxButton ui:field="showOnlyPublicOrganisms" visible="false" value="false" >Show Public Only</b:CheckBoxButton>
+                <b:CheckBoxButton ui:field="showObsoleteOrganisms" value="false" >Show Obsolete</b:CheckBoxButton>
+               </b:ButtonGroup>
+           <!--</gwt:FlowPanel>-->
+        </gwt:north>
         <gwt:center>
             <gwt:DockLayoutPanel>
                 <gwt:north size="25">

--- a/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/OrganismPanel.ui.xml
@@ -119,8 +119,15 @@
                                 <b:Button ui:field="cancelButton" text="Cancel" visible="false"
                                           styleName="{style.inline-button}"
                                 />
+                            </b:Column>
+                        </b:Row>
+                        <b:Row styleName="{style.row}">
+                            <b:Column size="XS_12" styleName="{style.widgetPanel}">
                                 <b:CheckBox ui:field="publicMode" text="Public" enabled="true"
                                             styleName="{style.inline-button}"
+                                />
+                                <b:CheckBox ui:field="obsoleteButton" text="Obsolete" visible="false"
+                                          styleName="{style.inline-button}"
                                 />
                                 <b:Label ui:field="organismIdLabel"/>
                             </b:Column>

--- a/src/gwt/org/bbop/apollo/gwt/client/TrackPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/TrackPanel.java
@@ -482,7 +482,14 @@ public class TrackPanel extends Composite {
         RequestCallback requestCallback = new RequestCallback() {
             @Override
             public void onResponseReceived(Request request, Response response) {
-                JSONValue v = JSONParser.parseStrict(response.getText());
+                JSONValue v ;
+                try {
+                    v = JSONParser.parseStrict(response.getText());
+                } catch (Exception e) {
+                    GWT.log("No organism present: "+response.getText());
+                    return ;
+//                    e.printStackTrace();
+                }
                 JSONObject o = v.isObject();
                 if (o.containsKey(FeatureStringEnum.ERROR.getValue())) {
                     new ErrorDialog("Error Updating User", o.get(FeatureStringEnum.ERROR.getValue()).isString().stringValue(), true, true);

--- a/src/gwt/org/bbop/apollo/gwt/client/dto/OrganismInfo.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/dto/OrganismInfo.java
@@ -28,10 +28,12 @@ public class OrganismInfo implements HasJSON{
     private Boolean valid ;
     private Boolean current;
     private Boolean publicMode;
-    private Boolean canEdit ;
-    private boolean editable;
+    private Boolean obsolete;
     private String nonDefaultTranslationTable ;
 
+
+    // internal GWT variable
+    private boolean editable;
 
     public OrganismInfo(){
 
@@ -130,6 +132,15 @@ public class OrganismInfo implements HasJSON{
         return current;
     }
 
+
+    public Boolean getObsolete() {
+        return obsolete;
+    }
+
+    public void setObsolete(Boolean obsolete) {
+        this.obsolete = obsolete;
+    }
+
     public String getNonDefaultTranslationTable() {
         return nonDefaultTranslationTable;
     }
@@ -165,6 +176,9 @@ public class OrganismInfo implements HasJSON{
         if(valid!=null){
             payload.put("valid",JSONBoolean.getInstance(valid));
         }
+        if(valid!=null){
+            payload.put("obsolete",JSONBoolean.getInstance(obsolete));
+        }
         if(nonDefaultTranslationTable!=null){
             payload.put("nonDefaultTranslationTable",new JSONString(nonDefaultTranslationTable));
         }
@@ -174,6 +188,7 @@ public class OrganismInfo implements HasJSON{
         return payload;
     }
 
+    // internal setting
     public void setEditable(boolean editable) {
         this.editable = editable;
     }

--- a/src/gwt/org/bbop/apollo/gwt/client/dto/OrganismInfoConverter.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/dto/OrganismInfoConverter.java
@@ -47,6 +47,9 @@ public class OrganismInfoConverter {
         if (object.get("publicMode") != null) {
             organismInfo.setPublicMode(object.get("publicMode").isBoolean().booleanValue());
         }
+        if (object.get("obselete") != null) {
+            organismInfo.setObsolete(object.get("obselete").isBoolean().booleanValue());
+        }
         if (object.get("editable") != null) {
             organismInfo.setEditable(object.get("editable").isBoolean().booleanValue());
         }
@@ -97,6 +100,7 @@ public class OrganismInfoConverter {
 
         GWT.log("convertOrganismInfoToJSONObject "+organismInfo.getPublicMode());
         object.put("publicMode", JSONBoolean.getInstance(organismInfo.getPublicMode()));
+        object.put("obsolete", JSONBoolean.getInstance(organismInfo.getObsolete()));
 
         return object;
     }

--- a/src/gwt/org/bbop/apollo/gwt/client/dto/OrganismInfoConverter.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/dto/OrganismInfoConverter.java
@@ -47,8 +47,8 @@ public class OrganismInfoConverter {
         if (object.get("publicMode") != null) {
             organismInfo.setPublicMode(object.get("publicMode").isBoolean().booleanValue());
         }
-        if (object.get("obselete") != null) {
-            organismInfo.setObsolete(object.get("obselete").isBoolean().booleanValue());
+        if (object.get("obsolete") != null) {
+            organismInfo.setObsolete(object.get("obsolete").isBoolean().booleanValue());
         }
         if (object.get("editable") != null) {
             organismInfo.setEditable(object.get("editable").isBoolean().booleanValue());

--- a/src/gwt/org/bbop/apollo/gwt/client/rest/OrganismRestService.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/rest/OrganismRestService.java
@@ -26,6 +26,12 @@ public class OrganismRestService {
         RestService.sendRequest(requestCallback, "organism/findAllOrganisms");
     }
 
+    public static void loadOrganisms(Boolean publicOnly, Boolean showObsoletes, RequestCallback requestCallback) {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("publicOnly",JSONBoolean.getInstance(publicOnly));
+        jsonObject.put("showObsolete",JSONBoolean.getInstance(showObsoletes));
+        RestService.sendRequest(requestCallback, "organism/findAllOrganisms","data="+jsonObject.toString());
+    }
 
     public static void loadOrganisms(final List<OrganismInfo> organismInfoList) {
         RequestCallback requestCallback = new RequestCallback() {


### PR DESCRIPTION
fixes #1967 

- [x] note that "view" is only available if not obsolete
- [x] setCurrentOrganism should respect the filter
- [x] don't show obsolete in drop-down
- [x] provide "obsolete" and "public" filter at top
- [x] duplicate function should make "active"
- [x] provide "obsolete" and non-"obsolete" button
- [x] enable obsolete flag

