### PR TITLE
Fix Search Sequence not displayed when Tools menu is already rendered

### DIFF
--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -357,18 +357,24 @@ return declare( [JBPlugin, HelpMixin],
     initSearchMenu: function()  {
         if (! this.searchMenuInitialized) {
             var webapollo = this;
-            this.browser.addGlobalMenuItem( 'tools',
-                                            new dijitMenuItem(
-                                                {
-                                                    id: 'menubar_apollo_seqsearch',
-                                                    label: "Search sequence",
-                                                    onClick: function() {
-                                                        webapollo.getAnnotTrack().searchSequence();
-                                                    }
-                                                }) );
-            if(!dijitRegistry.byId("dropdownmenu_tools")){
-                this.browser.renderGlobalMenu( 'tools', {text: 'Tools'}, this.browser.menuBar );
-            }
+            this.browser.afterMilestone('initView', function() {
+                var button = new dijitMenuItem(
+                                {
+                                    id: 'menubar_apollo_seqsearch',
+                                    label: "Search sequence",
+                                    onClick: function() {
+                                        webapollo.getAnnotTrack().searchSequence();
+                                    }
+                                }) ;
+                this.browser.addGlobalMenuItem( 'tools', button);
+                var renderedMenu = dijitRegistry.byId("dropdownmenu_tools");
+                if(!renderedMenu){
+                    this.browser.renderGlobalMenu( 'tools', {text: 'Tools'}, this.browser.menuBar );
+                }
+                else {
+                    renderedMenu.addChild(button);
+                }
+            }, this );
 
         }
 


### PR DESCRIPTION
A fix for a little problem I have when enabling the [quick bookmark](https://github.com/TAMU-CPT/bookmarks-jbrowse) jbrowse plugin in my apollo instance: the "Search Sequence" submenu in the "Tools" menu doesn't appear.

It seems like the problem is that the quick bookmarks plugin creates the menu, renders it, then a bit later (as the apollo plugin takes a little more time to load) the apollo adds an item to the menu, but as it's already rendered, it doesn't appear.

I have the feeling that `this.browser.renderGlobalMenu()` should take care of it, but I don't know how to call something like `dijitRegistry.byId()` from it... What do you think?

(should I target the develop branch instead of master?)