### PR TITLE
Use DraggableNeatHTMLFeatures type for gff3 uploaded from jbrowse

### DIFF
--- a/client/apollo/js/main.js
+++ b/client/apollo/js/main.js
@@ -142,7 +142,7 @@ return declare( [JBPlugin, HelpMixin],
         // that the open-file dialog and other things will have them
         // as options
         browser.registerTrackType({
-            type:                 'WebApollo/View/Track/DraggableHTMLFeatures',
+            type:                 'WebApollo/View/Track/DraggableNeatHTMLFeatures',
             defaultForStoreTypes: [ 'JBrowse/Store/SeqFeature/NCList',
                                     'JBrowse/Store/SeqFeature/GFF3',
                                     'WebApollo/Store/SeqFeature/ApolloGFF3'


### PR DESCRIPTION
Here's a little change to use the now-recommended-DraggableNeatHTMLFeatures track type instead of DraggableHTMLFeatures when uploading a GFF3 using the jbrowse upload box.
(Doing this as the DraggableHTMLFeatures has trouble displaying some of our gff files, while DraggableNeatHTMLFeatures display them perfectly)