### PR TITLE
create an "add variant effect view" and a "remove variant effect view"

### DIFF
--- a/client/apollo/css/webapollo_track_styles.css
+++ b/client/apollo/css/webapollo_track_styles.css
@@ -943,7 +943,7 @@ div.track_webapollo_view_track_annotsequencetrack div.track-label .track-close-b
     height: 16px;
     border-width: 0px 0px 0px 0px;
     border-style: none;
-    background-color: transparent;
+    background-color: #ffa000;
     z-index: 10;
 }
 

--- a/client/apollo/css/webapollo_track_styles.css
+++ b/client/apollo/css/webapollo_track_styles.css
@@ -530,27 +530,55 @@ div.annot-sequence  {
     z-index: 20;  
 }
 
+.Apollo .variant-effect.deletion_artifact,
+.Apollo .variant-effect.plus-deletion_artifact,
+.Apollo .variant-effect.minus-deletion_artifact {
+    border-style: solid;
+    border-color: red;
+    border-width: 2px;
+    height: 100%;
+    background-color: rgba(150,50,50,0.3);
+    /*background-image: url('../img/warning_exclamation.png');*/
+    z-index: 20;
+}
+
 .Apollo .sequence-alteration-artifact.insertion_artifact,
 .Apollo .sequence-alteration-artifact.plus-insertion_artifact,
 .Apollo .sequence-alteration-artifact.minus-insertion_artifact {
-    border-style: solid;
-    border-color: green;
-    border-width: 1px;
+    border: 1px ridge green;
     height: 100%;
     background-color: rgba(0,150,0,0.3);
     z-index: 20;  
 }
 
+.Apollo .variant-effect.insertion_artifact,
+.Apollo .variant-effect.plus-insertion_artifact,
+.Apollo .variant-effect.minus-insertion_artifact {
+    border: 2px groove red;
+    height: 100%;
+    background-color: rgba(50,150,0,0.3);
+    z-index: 20;
+}
+
 .Apollo .sequence-alteration-artifact.substitution_artifact,
 .Apollo .sequence-alteration-artifact.plus-substitution_artifact,
 .Apollo .sequence-alteration-artifact.minus-substitution_artifact {
-    border-style: solid;
-    border-color: blue;
-    border-width: 1px;
+    border: 1px solid blue;
     height: 100%;
     background-color: rgba(250,250,0,0.3);
     z-index: 20;  
 }
+
+
+.Apollo .variant-effect.substitution_artifact,
+.Apollo .variant-effect.plus-substitution_artifact,
+.Apollo .variant-effect.minus-substitution_artifact {
+    border: 2px double red;
+    height: 100%;
+    background-color: rgba(250,250,0,0.3);
+    z-index: 20;
+}
+
 
 .jbrowse .plus-trellis-arrowhead,
 .jbrowse .plus-webapollo-arrowhead,

--- a/client/apollo/js/JSONUtils.js
+++ b/client/apollo/js/JSONUtils.js
@@ -187,7 +187,6 @@ JSONUtils.makeSimpleFeature = function(feature, parent)  {
 *      afeature: sequence alteration in ApolloEditorService JSON format,
 */
 JSONUtils.createJBrowseSequenceAlteration = function( afeature )  {
-    console.log('input feature justification',afeature);
     var loc = afeature.location;
     var uid = afeature.uniquename;
     var justification;

--- a/client/apollo/js/JSONUtils.js
+++ b/client/apollo/js/JSONUtils.js
@@ -187,12 +187,17 @@ JSONUtils.makeSimpleFeature = function(feature, parent)  {
 *      afeature: sequence alteration in ApolloEditorService JSON format,
 */
 JSONUtils.createJBrowseSequenceAlteration = function( afeature )  {
+    console.log('input feature justification',afeature);
     var loc = afeature.location;
     var uid = afeature.uniquename;
     var justification;
+    var variant_effect = false ;
     for (var i = 0; i < afeature.properties.length; i++) {
-        if (afeature.properties[i].type.name === "justification") {
+        if (afeature.properties[i].name === "justification") {
             justification = afeature.properties[i].value;
+        }
+        if (afeature.properties[i].name === "variant_effect") {
+            variant_effect = afeature.properties[i].value;
         }
     }
 
@@ -205,7 +210,8 @@ JSONUtils.createJBrowseSequenceAlteration = function( afeature )  {
             type:     afeature.type.name,
             residues: afeature.residues,
             seq:      afeature.residues,
-            justification: justification
+            justification: justification,
+            variant_effect: variant_effect
         },
         id: uid
     });

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -7364,7 +7364,6 @@ define([
                 this.updateAssociateTranscriptToGeneItem();
                 this.updateDissociateTranscriptFromGeneItem();
                 this.updateViewVariantEffect();
-                this.updateHideVariantEffect();
                 this.updateSetReadthroughStopCodonMenuItem();
                 this.updateMergeMenuItem();
                 this.updateSplitMenuItem();
@@ -7432,23 +7431,6 @@ define([
              */
             updateViewVariantEffect: function(){
                 var menuItem = this.getMenuItem("view_variant_effect");
-                var selected = this.selectionManager.getSelection();
-                menuItem.set("disabled", true);
-                if (selected.length !== 1) {
-                    return;
-                }
-                var currentType = selected[0].feature.get('type');
-                if (JSONUtils.variantTypes.includes(currentType.toUpperCase())) {
-                    // TODO: search for sequence alterations in that space?
-                    menuItem.set("disabled", false);
-                }
-            },
-
-            /**
-             * TODO, scale to multiple, just one for right now
-             */
-            updateHideVariantEffect: function(){
-                var menuItem = this.getMenuItem("hide_variant_effect");
                 var selected = this.selectionManager.getSelection();
                 menuItem.set("disabled", true);
                 if (selected.length !== 1) {

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -1727,7 +1727,7 @@ define([
                         return ;
                 }
 
-                var description = 'Effect of ('+variant_type+') '  + feature.data.name;
+                var description = 'Effect of ' + variant_type + ' '  + feature.data.name;
 
                 var feature = {
                     location: {
@@ -1745,6 +1745,10 @@ define([
                         {
                             tag: "justification",
                             value: description
+                        },
+                        {
+                            tag: "variant_effect",
+                            value: true
                         }
                     ]
                 };
@@ -6947,15 +6951,15 @@ define([
                     });
                     annot_context_menu.addChild(viewVariantEffect);
                     contextMenuItems["view_variant_effect"] = index++;
-                    //
-                    var hideVariantEffect = new dijit.MenuItem({
-                        label: "Hide Variant Effect",
-                        onClick: function () {
-                            thisB.hideVariantEffect();
-                        }
-                    });
-                    annot_context_menu.addChild(hideVariantEffect);
-                    contextMenuItems["hide_variant_effect"] = index++;
+                    // //
+                    // var hideVariantEffect = new dijit.MenuItem({
+                    //     label: "Hide Variant Effect",
+                    //     onClick: function () {
+                    //         thisB.hideVariantEffect();
+                    //     }
+                    // });
+                    // annot_context_menu.addChild(hideVariantEffect);
+                    // contextMenuItems["hide_variant_effect"] = index++;
 
                     annot_context_menu.addChild(new dijit.MenuSeparator());
                     index++;

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -1701,8 +1701,6 @@ define([
                 var alternate_alleles = feature.afeature.alternate_alleles[0].bases;
                 var reference_allele = feature.afeature.reference_allele.bases;
                 var residues = '';
-                var inputLength = 0;
-
 
 
                 var alteration_type = '';
@@ -1729,22 +1727,6 @@ define([
                         return ;
                 }
 
-
-
-
-
-
-                // this.selectionManager.clearSelection();
-                // var transcriptUniqueName;
-                // if (selected[0].feature.parent()) {
-                //     //selected is an exon, get its parent
-                //     var parent = selected[0].feature.parent();
-                //     transcriptUniqueName = parent.afeature.uniquename;
-                // }
-                // else {
-                //     transcriptUniqueName = selected[0].feature.afeature.uniquename;
-                // }
-                //
                 var description = 'Effect of ('+variant_type+') '  + feature.data.name;
 
                 var feature = {
@@ -1778,7 +1760,9 @@ define([
                     "operation": "add_sequence_alteration",
                     "clientToken": track.getClientToken()
                 };
+                this.selectionManager.clearSelection();
                 track.executeUpdateOperation(JSON.stringify(postData));
+                track.changed();
             },
 
             hideVariantEffect: function() {

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -7373,21 +7373,15 @@ define([
             updateViewVariantEffect: function(){
                 var menuItem = this.getMenuItem("view_variant_effect");
                 var selected = this.selectionManager.getSelection();
+                menuItem.set("disabled", true);
                 if (selected.length !== 1) {
-                    menuItem.set("disabled", true);
                     return;
                 }
                 var currentType = selected[0].feature.get('type');
                 if (JSONUtils.variantTypes.includes(currentType.toUpperCase())) {
-                    var viewing_effect = selected[0].feature.get('viewing_effect');
-                    // check if view type is set
-                    if(!viewing_effect){
-                        menuItem.set("disabled", false);
-                        return;
-                    }
+                    // TODO: search for sequence alterations in that space?
+                    menuItem.set("disabled", false);
                 }
-
-                menuItem.set("disabled", true);
             },
 
             /**
@@ -7402,11 +7396,8 @@ define([
                 }
                 var currentType = selected[0].feature.get('type');
                 if (JSONUtils.variantTypes.includes(currentType.toUpperCase())) {
-                    var viewing_effect = selected[0].feature.get('viewing_effect');
-                    // check if view type is set
-                    if(viewing_effect){
-                        menuItem.set("disabled", false);
-                    }
+                    // TODO: search for sequence alterations in that space?
+                    menuItem.set("disabled", false);
                 }
             },
 

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -1767,7 +1767,7 @@ define([
                     ]
                 };
                 if (alteration_type !== "deletion_artifact") {
-                // get alternate_alleles . . .s omehow
+                // get alternate_alleles . . . somehow
                     feature.residues = residues ;
                 }
 

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -1686,6 +1686,52 @@ define([
                 track.executeUpdateOperation(JSON.stringify(postData));
             },
 
+            viewVariantEffect: function() {
+                var track = this;
+                var trackName = this.getUniqueTrackName();
+                var selected = this.selectionManager.getSelection();
+                // this.selectionManager.clearSelection();
+                // var transcriptUniqueName;
+                // if (selected[0].feature.parent()) {
+                //     //selected is an exon, get its parent
+                //     var parent = selected[0].feature.parent();
+                //     transcriptUniqueName = parent.afeature.uniquename;
+                // }
+                // else {
+                //     transcriptUniqueName = selected[0].feature.afeature.uniquename;
+                // }
+                //
+                // var postData = {
+                //     track: trackName,
+                //     features: [{ uniquename: transcriptUniqueName }],
+                //     operation: 'dissociate_transcript_from_gene'
+                // };
+                // track.executeUpdateOperation(JSON.stringify(postData));
+            },
+
+            hideVariantEffect: function() {
+                var track = this;
+                var trackName = this.getUniqueTrackName();
+                var selected = this.selectionManager.getSelection();
+                // this.selectionManager.clearSelection();
+                // var transcriptUniqueName;
+                // if (selected[0].feature.parent()) {
+                //     //selected is an exon, get its parent
+                //     var parent = selected[0].feature.parent();
+                //     transcriptUniqueName = parent.afeature.uniquename;
+                // }
+                // else {
+                //     transcriptUniqueName = selected[0].feature.afeature.uniquename;
+                // }
+                //
+                // var postData = {
+                //     track: trackName,
+                //     features: [{ uniquename: transcriptUniqueName }],
+                //     operation: 'dissociate_transcript_from_gene'
+                // };
+                // track.executeUpdateOperation(JSON.stringify(postData));
+            },
+
             mergeAnnotations: function (selection) {
                 var track = this;
                 var annots = [];
@@ -6833,7 +6879,27 @@ define([
                     });
                     annot_context_menu.addChild(dissociateTranscriptToGeneItem);
                     contextMenuItems["dissociate_transcript_from_gene"] = index++;
+
+                    annot_context_menu.addChild(new dijit.MenuSeparator());
+                    index++;
+
+                    var viewVariantEffect = new dijit.MenuItem({
+                        label: "View Variant Effect",
+                        onClick: function () {
+                            thisB.viewVariantEffect();
+                        }
+                    });
+                    annot_context_menu.addChild(viewVariantEffect);
+                    contextMenuItems["view_variant_effect"] = index++;
                     //
+                    var hideVariantEffect = new dijit.MenuItem({
+                        label: "Hide Variant Effect",
+                        onClick: function () {
+                            thisB.hideVariantEffect();
+                        }
+                    });
+                    annot_context_menu.addChild(hideVariantEffect);
+                    contextMenuItems["hide_variant_effect"] = index++;
 
                     annot_context_menu.addChild(new dijit.MenuSeparator());
                     index++;
@@ -7237,6 +7303,8 @@ define([
                 this.updateSetLongestOrfMenuItem();
                 this.updateAssociateTranscriptToGeneItem();
                 this.updateDissociateTranscriptFromGeneItem();
+                this.updateViewVariantEffect();
+                this.updateHideVariantEffect();
                 this.updateSetReadthroughStopCodonMenuItem();
                 this.updateMergeMenuItem();
                 this.updateSplitMenuItem();
@@ -7296,6 +7364,49 @@ define([
                 }
                 else {
                     menuItem.set("disabled", true);
+                }
+            },
+
+            /**
+             * TODO, scale to multiple, just one for right now
+             */
+            updateViewVariantEffect: function(){
+                var menuItem = this.getMenuItem("view_variant_effect");
+                var selected = this.selectionManager.getSelection();
+                if (selected.length !== 1) {
+                    menuItem.set("disabled", true);
+                    return;
+                }
+                var currentType = selected[0].feature.get('type');
+                if (JSONUtils.variantTypes.includes(currentType.toUpperCase())) {
+                    var viewing_effect = selected[0].feature.get('viewing_effect');
+                    // check if view type is set
+                    if(!viewing_effect){
+                        menuItem.set("disabled", false);
+                        return;
+                    }
+                }
+
+                menuItem.set("disabled", true);
+            },
+
+            /**
+             * TODO, scale to multiple, just one for right now
+             */
+            updateHideVariantEffect: function(){
+                var menuItem = this.getMenuItem("hide_variant_effect");
+                var selected = this.selectionManager.getSelection();
+                menuItem.set("disabled", true);
+                if (selected.length !== 1) {
+                    return;
+                }
+                var currentType = selected[0].feature.get('type');
+                if (JSONUtils.variantTypes.includes(currentType.toUpperCase())) {
+                    var viewing_effect = selected[0].feature.get('viewing_effect');
+                    // check if view type is set
+                    if(viewing_effect){
+                        menuItem.set("disabled", false);
+                    }
                 }
             },
 

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -1769,29 +1769,6 @@ define([
                 track.changed();
             },
 
-            hideVariantEffect: function() {
-                var track = this;
-                var trackName = this.getUniqueTrackName();
-                var selected = this.selectionManager.getSelection();
-                // this.selectionManager.clearSelection();
-                // var transcriptUniqueName;
-                // if (selected[0].feature.parent()) {
-                //     //selected is an exon, get its parent
-                //     var parent = selected[0].feature.parent();
-                //     transcriptUniqueName = parent.afeature.uniquename;
-                // }
-                // else {
-                //     transcriptUniqueName = selected[0].feature.afeature.uniquename;
-                // }
-                //
-                // var postData = {
-                //     track: trackName,
-                //     features: [{ uniquename: transcriptUniqueName }],
-                //     operation: 'dissociate_transcript_from_gene'
-                // };
-                // track.executeUpdateOperation(JSON.stringify(postData));
-            },
-
             mergeAnnotations: function (selection) {
                 var track = this;
                 var annots = [];
@@ -6951,15 +6928,6 @@ define([
                     });
                     annot_context_menu.addChild(viewVariantEffect);
                     contextMenuItems["view_variant_effect"] = index++;
-                    // //
-                    // var hideVariantEffect = new dijit.MenuItem({
-                    //     label: "Hide Variant Effect",
-                    //     onClick: function () {
-                    //         thisB.hideVariantEffect();
-                    //     }
-                    // });
-                    // annot_context_menu.addChild(hideVariantEffect);
-                    // contextMenuItems["hide_variant_effect"] = index++;
 
                     annot_context_menu.addChild(new dijit.MenuSeparator());
                     index++;

--- a/client/apollo/js/View/Track/SequenceTrack.js
+++ b/client/apollo/js/View/Track/SequenceTrack.js
@@ -528,6 +528,7 @@ function( declare,
                                              containerStart, containerEnd) {
                     var featDiv =
                         this.renderFeature(feature, uniqueId, block, scale, labelScale, descriptionScale, containerStart, containerEnd);
+                    console.log('rendering feature',feature,featDiv)
                     $(featDiv).addClass("sequence-alteration-artifact");
 
                     var charSize = this.webapollo.getSequenceCharacterSize();

--- a/client/apollo/js/View/Track/SequenceTrack.js
+++ b/client/apollo/js/View/Track/SequenceTrack.js
@@ -528,8 +528,12 @@ function( declare,
                                              containerStart, containerEnd) {
                     var featDiv =
                         this.renderFeature(feature, uniqueId, block, scale, labelScale, descriptionScale, containerStart, containerEnd);
-                    console.log('rendering feature',feature,featDiv)
-                    $(featDiv).addClass("sequence-alteration-artifact");
+                    if(feature.data.variant_effect){
+                        $(featDiv).addClass("variant-effect");
+                    }
+                    else{
+                        $(featDiv).addClass("sequence-alteration-artifact");
+                    }
 
                     var charSize = this.webapollo.getSequenceCharacterSize();
 

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -402,7 +402,7 @@ jbrowse {
     git {
         url = "https://github.com/gmod/jbrowse"
 //        branch = "1.16.3-release"
-        branch = "dev"
+		branch = "dev"
 //        tag = "15dfd2309f2d508d8bed782d0f68b38dd9927bb4"
         alwaysPull = true
         alwaysRecheck = true

--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -1324,7 +1324,6 @@ class RequestHandlingService {
             // TODO: If so, then we should change all of our integration tests for sequence alterations to have comments
             if (jsonFeature.has(FeatureStringEnum.NON_RESERVED_PROPERTIES.value)) {
                 JSONArray properties = jsonFeature.getJSONArray(FeatureStringEnum.NON_RESERVED_PROPERTIES.value);
-                println "adding properties ${properties as JSON}"
                 for (int j = 0; j < properties.length(); ++j) {
                     JSONObject property = properties.getJSONObject(j)
                     String tag = property.getString(FeatureStringEnum.TAG.value)
@@ -1334,7 +1333,6 @@ class RequestHandlingService {
                             value: value,
                             tag: tag
                     ).save()
-                    println "adding property ${tag} ${value}"
                     featurePropertyService.addProperty(sequenceAlteration, featureProperty)
                     sequenceAlteration.save(flush: true)
                 }

--- a/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
+++ b/grails-app/services/org/bbop/apollo/RequestHandlingService.groovy
@@ -1324,8 +1324,9 @@ class RequestHandlingService {
             // TODO: If so, then we should change all of our integration tests for sequence alterations to have comments
             if (jsonFeature.has(FeatureStringEnum.NON_RESERVED_PROPERTIES.value)) {
                 JSONArray properties = jsonFeature.getJSONArray(FeatureStringEnum.NON_RESERVED_PROPERTIES.value);
+                println "adding properties ${properties as JSON}"
                 for (int j = 0; j < properties.length(); ++j) {
-                    JSONObject property = properties.getJSONObject(i);
+                    JSONObject property = properties.getJSONObject(j)
                     String tag = property.getString(FeatureStringEnum.TAG.value)
                     String value = property.getString(FeatureStringEnum.VALUE.value)
                     FeatureProperty featureProperty = new FeatureProperty(
@@ -1333,6 +1334,7 @@ class RequestHandlingService {
                             value: value,
                             tag: tag
                     ).save()
+                    println "adding property ${tag} ${value}"
                     featurePropertyService.addProperty(sequenceAlteration, featureProperty)
                     sequenceAlteration.save(flush: true)
                 }

--- a/src/gwt/org/bbop/apollo/gwt/client/dto/VariantPropertyInfo.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/dto/VariantPropertyInfo.java
@@ -1,5 +1,6 @@
 package org.bbop.apollo.gwt.client.dto;
 
+import com.google.gwt.json.client.JSONValue;
 import org.bbop.apollo.gwt.shared.FeatureStringEnum;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.json.client.JSONObject;
@@ -18,7 +19,11 @@ public class VariantPropertyInfo {
 
     public VariantPropertyInfo(JSONObject variantPropertyInfoJsonObject) {
         String tag = variantPropertyInfoJsonObject.get(FeatureStringEnum.TAG.getValue()).isString().stringValue();
-        String value = variantPropertyInfoJsonObject.get(FeatureStringEnum.VALUE.getValue()).isString().stringValue();
+        JSONValue testValue = variantPropertyInfoJsonObject.get(FeatureStringEnum.VALUE.getValue());
+        String value = null ;
+        if(testValue!=null){
+            value = variantPropertyInfoJsonObject.get(FeatureStringEnum.VALUE.getValue()).isString().stringValue();
+        }
         this.tag = tag;
         this.value = value;
     }


### PR DESCRIPTION
fixes #1971 

- [x] remove remove variantEffect menu ?!? 
- [x] add flag to SequenceAlterationArtifact (variant effect)
  - [x] add to post data
  - [x] highlight alteration based on effect?
  - [x] remove from export based on effect?
- [x] right-click variant annotation to "view effect" on annotated isoforms 
- [x] add sequence alteration code for the variant effect
- [x] should correctly do update after triggering the alteration code
  - [x] find overlapping features (call store.getFeatures( refSeq, min, max) ) 
  - [x] call setLongestORF .  . on those features . . or call getSequenceTrack(features)
