### PR TITLE
Auto name fix 1991

### DIFF
--- a/docs/web_services/examples/shell/addNames.sh
+++ b/docs/web_services/examples/shell/addNames.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+url=$1
+username=$2
+password=$3
+names=$4
+
+usage() {
+    echo "Sample script for adding names to to web services"
+    echo "Usage:    ./addNames.sh <complete_apollo_URL> <username> <password> <names>"
+    echo "Example:  ./addNeams.sh http://localhost:8080/apollo demo demo 'RCA-1,RCA-2,RCA-4'"
+}
+
+if [[ ! -n "$url" || ! -n "$username" || ! -n "$password" || ! -n "$names" ]]; then
+    usage
+    exit
+fi
+
+echo curl -i -H 'Content-type: application/json' -X POST ${url}/suggestedNames/addNames -d "{'username': '${username}', 'password': '${password}', 'names':['RCA-1,RCA-2']}"
+curl -i -H 'Content-type: application/json' -X POST ${url}/suggestedNames/addNames -d "{'username': '${username}', 'password': '${password}', 'names':['RCA-1,RCA-2']}"

--- a/docs/web_services/examples/shell/addNames.sh
+++ b/docs/web_services/examples/shell/addNames.sh
@@ -8,7 +8,7 @@ names=$4
 usage() {
     echo "Sample script for adding names to to web services"
     echo "Usage:    ./addNames.sh <complete_apollo_URL> <username> <password> <names>"
-    echo "Example:  ./addNeams.sh http://localhost:8080/apollo demo demo 'RCA-1,RCA-2,RCA-4'"
+    echo "Example:  ./addNames.sh http://localhost:8080/apollo demo demo 'RCA-1,RCA-2,RCA-4'"
 }
 
 if [[ ! -n "$url" || ! -n "$username" || ! -n "$password" || ! -n "$names" ]]; then
@@ -16,5 +16,5 @@ if [[ ! -n "$url" || ! -n "$username" || ! -n "$password" || ! -n "$names" ]]; t
     exit
 fi
 
-echo curl -i -H 'Content-type: application/json' -X POST ${url}/suggestedNames/addNames -d "{'username': '${username}', 'password': '${password}', 'names':['RCA-1,RCA-2']}"
-curl -i -H 'Content-type: application/json' -X POST ${url}/suggestedNames/addNames -d "{'username': '${username}', 'password': '${password}', 'names':['RCA-1,RCA-2']}"
+echo curl -i -H 'Content-type: application/json' -X POST ${url}/suggestedName/addNames -d "{'username': '${username}', 'password': '${password}', 'names':[${names}]"
+curl -i -H 'Content-type: application/json' -X POST ${url}/suggestedName/addNames -d "{'username': '${username}', 'password': '${password}', 'names':[$names]}"

--- a/grails-app/conf/BootStrap.groovy
+++ b/grails-app/conf/BootStrap.groovy
@@ -27,6 +27,10 @@ class BootStrap {
         log.info "Driver: ${dataSource.driverClassName}"
         log.info "Dialect: ${dataSource.dialect}"
 
+        System.getenv().each {
+            log.info it.key + "->" + it.value
+        }
+
         domainMarshallerService.registerObjects()
         proxyService.initProxies()
 

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -339,6 +339,7 @@ apollo {
             ['label': "Canned Comments", 'link': "/cannedComment/",'globalRank':org.bbop.apollo.gwt.shared.GlobalPermissionEnum.ADMIN]
             , ['label': "Canned Key", 'link': "/cannedKey/",'globalRank':org.bbop.apollo.gwt.shared.GlobalPermissionEnum.ADMIN]
             , ['label': "Canned Values", 'link': "/cannedValue/",'globalRank':org.bbop.apollo.gwt.shared.GlobalPermissionEnum.ADMIN]
+            , ['label': "Suggested Name", 'link': "/suggestedName/",'globalRank':org.bbop.apollo.gwt.shared.GlobalPermissionEnum.ADMIN]
             , ['label': "Feature Types", 'link': "/featureType/",'globalRank':org.bbop.apollo.gwt.shared.GlobalPermissionEnum.ADMIN]
             , ['label': "Statuses", 'link': "/availableStatus/",'globalRank':org.bbop.apollo.gwt.shared.GlobalPermissionEnum.ADMIN]
             , ['label': "Proxies", 'link': "/proxy/",'globalRank':org.bbop.apollo.gwt.shared.GlobalPermissionEnum.ADMIN]

--- a/grails-app/conf/org/bbop/apollo/SecurityFilters.groovy
+++ b/grails-app/conf/org/bbop/apollo/SecurityFilters.groovy
@@ -29,6 +29,7 @@ class SecurityFilters {
                         || controllerName == "home"
                         || controllerName == "cannedKey"
                         || controllerName == "cannedValue"
+                        || controllerName == "suggestedName"
                         || controllerName == "cannedComment"
                         || controllerName == "availableStatus"
                         || controllerName == "proxy"

--- a/grails-app/controllers/org/bbop/apollo/SuggestedNameController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SuggestedNameController.groovy
@@ -1,0 +1,336 @@
+package org.bbop.apollo
+
+import grails.converters.JSON
+import grails.transaction.Transactional
+import org.bbop.apollo.gwt.shared.FeatureStringEnum
+import org.bbop.apollo.gwt.shared.GlobalPermissionEnum
+import org.bbop.apollo.gwt.shared.PermissionEnum
+import org.codehaus.groovy.grails.web.json.JSONObject
+import org.restapidoc.annotation.RestApi
+import org.restapidoc.annotation.RestApiMethod
+import org.restapidoc.annotation.RestApiParam
+import org.restapidoc.annotation.RestApiParams
+import org.restapidoc.pojo.RestApiParamType
+import org.restapidoc.pojo.RestApiVerb
+
+import static org.springframework.http.HttpStatus.*
+
+@RestApi(name = "Suggested Names Services", description = "Methods for managing suggested names")
+@Transactional(readOnly = true)
+class SuggestedNameController {
+
+    static allowedMethods = [save: "POST", update: "PUT", delete: "DELETE"]
+
+    def permissionService
+
+    def beforeInterceptor = {
+        if (!permissionService.checkPermissions(PermissionEnum.ADMINISTRATE)) {
+            forward action: "notAuthorized", controller: "annotator"
+            return
+        }
+    }
+
+    def index(Integer max) {
+        params.max = Math.min(max ?: 10, 100)
+        def suggestedNames = SuggestedName.list(params)
+        def organismFilterMap = [:]
+        SuggestedNameOrganismFilter.findAllBySuggestedNameInList(suggestedNames).each() {
+            List filterList = organismFilterMap.containsKey(it.suggestedName) ? organismFilterMap.get(it.suggestedName) : []
+            filterList.add(it)
+            organismFilterMap[it.suggestedName] = filterList
+        }
+        respond suggestedNames, model: [suggestedNameInstanceCount: SuggestedName.count(), organismFilters: organismFilterMap]
+    }
+
+    def show(SuggestedName suggestedNameInstance) {
+        respond suggestedNameInstance, model: [organismFilters: SuggestedNameOrganismFilter.findAllBySuggestedName(suggestedNameInstance)]
+    }
+
+    def create() {
+        respond new SuggestedName(params)
+    }
+
+    @Transactional
+    def save(SuggestedName suggestedNameInstance) {
+        if (suggestedNameInstance == null) {
+            notFound()
+            return
+        }
+
+        if (suggestedNameInstance.hasErrors()) {
+            respond suggestedNameInstance.errors, view: 'create'
+            return
+        }
+
+
+        suggestedNameInstance.save()
+
+        if (params.organisms instanceof String) {
+            params.organisms = [params.organisms]
+        }
+
+        params?.organisms.each {
+            Organism organism = Organism.findById(it)
+            new SuggestedNameOrganismFilter(
+                    organism: organism,
+                    suggestedName: suggestedNameInstance
+            ).save()
+        }
+
+        suggestedNameInstance.save flush: true
+
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.created.message', args: [message(code: 'suggestedName.label', default: 'SuggestedName'), suggestedNameInstance.id])
+                redirect suggestedNameInstance
+            }
+            '*' { respond suggestedNameInstance, [status: CREATED] }
+        }
+    }
+
+    def edit(SuggestedName suggestedNameInstance) {
+        respond suggestedNameInstance, model: [organismFilters: SuggestedNameOrganismFilter.findAllBySuggestedName(suggestedNameInstance)]
+    }
+
+    @Transactional
+    def update(SuggestedName suggestedNameInstance) {
+        if (suggestedNameInstance == null) {
+            notFound()
+            return
+        }
+
+        if (suggestedNameInstance.hasErrors()) {
+            respond suggestedNameInstance.errors, view: 'edit'
+            return
+        }
+
+        suggestedNameInstance.save()
+
+        SuggestedNameOrganismFilter.deleteAll(SuggestedNameOrganismFilter.findAllBySuggestedName(suggestedNameInstance))
+
+        if (params.organisms instanceof String) {
+            params.organisms = [params.organisms]
+        }
+
+        params?.organisms.each {
+            Organism organism = Organism.findById(it)
+            new SuggestedNameOrganismFilter(
+                    organism: organism,
+                    suggestedName: suggestedNameInstance
+            ).save()
+        }
+
+        suggestedNameInstance.save(flush: true)
+
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.updated.message', args: [message(code: 'SuggestedName.label', default: 'SuggestedName'), suggestedNameInstance.id])
+                redirect suggestedNameInstance
+            }
+            '*' { respond suggestedNameInstance, [status: OK] }
+        }
+    }
+
+    @Transactional
+    def delete(SuggestedName suggestedNameInstance) {
+
+        if (suggestedNameInstance == null) {
+            notFound()
+            return
+        }
+
+        suggestedNameInstance.delete flush: true
+
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.deleted.message', args: [message(code: 'SuggestedName.label', default: 'SuggestedName'), suggestedNameInstance.id])
+                redirect action: "index", method: "GET"
+            }
+            '*' { render status: NO_CONTENT }
+        }
+    }
+
+    protected void notFound() {
+        request.withFormat {
+            form multipartForm {
+                flash.message = message(code: 'default.not.found.message', args: [message(code: 'suggestedName.label', default: 'SuggestedName'), params.id])
+                redirect action: "index", method: "GET"
+            }
+            '*' { render status: NOT_FOUND }
+        }
+    }
+
+    @RestApiMethod(description = "Create suggested name", path = "/suggestedName/createName", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "name", type = "string", paramType = RestApiParamType.QUERY, description = "Suggested name to add")
+            , @RestApiParam(name = "metadata", type = "string", paramType = RestApiParamType.QUERY, description = "Optional additional information")
+    ]
+    )
+    @Transactional
+    def createName() {
+        JSONObject nameJson = permissionService.handleInput(request, params)
+        try {
+            if (permissionService.isUserGlobalAdmin(permissionService.getCurrentUser(nameJson))) {
+                if (!nameJson.name) {
+                    throw new Exception('empty fields detected')
+                }
+
+                if (!nameJson.metadata) {
+                    nameJson.metadata = ""
+                }
+
+                log.debug "Adding suggested name ${nameJson.name}"
+                SuggestedName name = new SuggestedName(
+                        name: nameJson.name,
+                        metadata: nameJson.metadata
+                ).save(flush: true)
+
+                render name as JSON
+            } else {
+                def error = [error: 'not authorized to add SuggestedName']
+                render error as JSON
+                log.error(error.error)
+            }
+        } catch (e) {
+            def error = [error: 'problem saving SuggestedName: ' + e]
+            render error as JSON
+            e.printStackTrace()
+            log.error(error.error)
+        }
+    }
+
+    @RestApiMethod(description = "Update suggested name", path = "/suggestedName/updateName", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Suggested name ID to update (or specify the old_name)")
+            , @RestApiParam(name = "old_name", type = "string", paramType = RestApiParamType.QUERY, description = "Suggested name to update")
+            , @RestApiParam(name = "new_name", type = "string", paramType = RestApiParamType.QUERY, description = "Suggested name to change to (the only editable option)")
+            , @RestApiParam(name = "metadata", type = "string", paramType = RestApiParamType.QUERY, description = "Optional additional information")
+    ]
+    )
+    @Transactional
+    def updateName() {
+        try {
+            JSONObject nameJson = permissionService.handleInput(request, params)
+            log.debug "Updating suggested name ${nameJson}"
+            if (permissionService.isUserGlobalAdmin(permissionService.getCurrentUser(nameJson))) {
+
+                log.debug "Suggested name ID: ${nameJson.id}"
+                SuggestedName name = SuggestedName.findById(nameJson.id) ?: SuggestedName.findByName(nameJson.old_name)
+
+                if (!name) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to update the suggested name")
+                    render jsonObject as JSON
+                    return
+                }
+
+                name.name = nameJson.new_name
+
+                if (nameJson.metadata) {
+                    name.metadata = nameJson.metadata
+                }
+
+                name.save(flush: true)
+
+                log.info "Success updating suggested name: ${name.id}"
+                render new JSONObject() as JSON
+            } else {
+                def error = [error: 'not authorized to edit suggested name']
+                log.error(error.error)
+                render error as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem editing suggested name: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Remove a suggested name", path = "/suggestedName/deleteName", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Suggested name ID to remove (or specify the name)")
+            , @RestApiParam(name = "name", type = "string", paramType = RestApiParamType.QUERY, description = "Suggested name to delete")
+    ])
+    @Transactional
+    def deleteName() {
+        try {
+            JSONObject nameJson = permissionService.handleInput(request, params)
+            log.debug "Deleting suggested name ${nameJson}"
+            if (permissionService.isUserGlobalAdmin(permissionService.getCurrentUser(nameJson))) {
+
+                SuggestedName name = SuggestedName.findById(nameJson.id) ?: SuggestedName.findByName(nameJson.name)
+
+                if (!name) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the suggested name")
+                    render jsonObject as JSON
+                    return
+                }
+
+                name.delete()
+
+                log.info "Success deleting suggested name: ${nameJson}"
+                render new JSONObject() as JSON
+            } else {
+                def error = [error: 'not authorized to delete suggested name']
+                log.error(error.error)
+                render error as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem deleting suggested name: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Returns a JSON array of all suggested names, or optionally, gets information about a specific suggested name", path = "/suggestedName/showName", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "id", type = "long", paramType = RestApiParamType.QUERY, description = "Name ID to show (or specify a name)")
+            , @RestApiParam(name = "name", type = "string", paramType = RestApiParamType.QUERY, description = "Name to show")
+    ])
+    @Transactional
+    def showName() {
+        try {
+            JSONObject nameJson = permissionService.handleInput(request, params)
+            log.debug "Showing suggested name ${nameJson}"
+            if (!permissionService.hasGlobalPermissions(nameJson, GlobalPermissionEnum.ADMIN)) {
+                render status: UNAUTHORIZED
+                return
+            }
+
+            if (nameJson.id || nameJson.name) {
+                SuggestedName name = SuggestedName.findById(nameJson.id) ?: SuggestedName.findByName(nameJson.name)
+
+                if (!name) {
+                    JSONObject jsonObject = new JSONObject()
+                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the suggested names")
+                    render jsonObject as JSON
+                    return
+                }
+
+                log.info "Success showing name: ${nameJson}"
+                render name as JSON
+            } else {
+                def names = SuggestedName.all
+
+                log.info "Success showing all suggested names"
+                render names as JSON
+            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem showing suggested names: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+}

--- a/grails-app/controllers/org/bbop/apollo/SuggestedNameController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SuggestedNameController.groovy
@@ -398,33 +398,37 @@ class SuggestedNameController {
     @RestApiParams(params = [
             @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
             , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
-            , @RestApiParam(name = "names", type = "string", paramType = RestApiParamType.QUERY, description = "A comma-delimited list of names to add")
+            , @RestApiParam(name = "names", type = "string", paramType = RestApiParamType.QUERY, description = "A comma-delimited list of names to add, with organisms, and types {names:[ {name:'name1':organisms:['bee','cow'],types:['gene','ncRNA']}}")
     ])
     @Transactional
     def addNames() {
         try {
             JSONObject nameJson = permissionService.handleInput(request, params)
-            log.debug "Showing suggested name ${nameJson}"
+            println "Adding suggested names ${nameJson}"
             if (!permissionService.hasGlobalPermissions(nameJson, GlobalPermissionEnum.ADMIN)) {
+                println "DOES NOT have global permissions"
                 render status: UNAUTHORIZED
                 return
             }
 
+            println "doingg names $nameJson"
             if (nameJson.names) {
-                def names = nameJson.names.split(",")
-                for (name in names) {
-                    SuggestedName.findOrSaveByName(name).save()
+//                def names = nameJson.names.split(",")
+                for (name in nameJson.names) {
+//                    SuggestedName name = SuggestedName.findByName(name)
+//                    if(!name)
+                    SuggestedName.findOrSaveByName(name)
                 }
-                log.info "Success showing name: ${nameJson}"
-                render names as JSON
+                println "Success showing name: ${nameJson}"
+                render  nameJson.names as JSON
             } else {
                 def error = [error: 'names not found']
-                log.error(error.error)
+                println(error.error)
                 render error as JSON
             }
         }
         catch (Exception e) {
-            def error = [error: 'problem showing suggested names: ' + e]
+            def error = [error: 'problem adding suggested names: ' + e]
             log.error(error.error)
             render error as JSON
         }

--- a/grails-app/controllers/org/bbop/apollo/SuggestedNameController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SuggestedNameController.groovy
@@ -311,6 +311,18 @@ class SuggestedNameController {
             def names = SuggestedName.findAllByNameIlike(nameJson.query+"%")
 
 
+//            if (featureTypeList) {
+//                cannedCommentList.addAll(CannedComment.executeQuery("select cc from CannedComment cc join cc.featureTypes ft where ft in (:featureTypeList)", [featureTypeList: featureTypeList]))
+//            }
+//            cannedCommentList.addAll(CannedComment.executeQuery("select cc from CannedComment cc where cc.featureTypes is empty"))
+//
+//            // if there are organism filters for these canned comments for this organism, then apply them
+//            List<CannedCommentOrganismFilter> cannedCommentOrganismFilters = CannedCommentOrganismFilter.findAllByCannedCommentInList(cannedCommentList)
+//            if (cannedCommentOrganismFilters) {
+//                CannedCommentOrganismFilter.findAllByOrganismAndCannedCommentInList(sequence.organism, cannedCommentList).each {
+//                    cannedComments.put(it.cannedComment.comment)
+//                }
+//            }
 
 
             render names as JSON

--- a/grails-app/controllers/org/bbop/apollo/SuggestedNameController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/SuggestedNameController.groovy
@@ -201,6 +201,8 @@ class SuggestedNameController {
         }
     }
 
+
+
     @RestApiMethod(description = "Update suggested name", path = "/suggestedName/updateName", verb = RestApiVerb.POST)
     @RestApiParams(params = [
             @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
@@ -286,6 +288,53 @@ class SuggestedNameController {
         }
         catch (Exception e) {
             def error = [error: 'problem deleting suggested name: ' + e]
+            log.error(error.error)
+            render error as JSON
+        }
+    }
+
+    @RestApiMethod(description = "Returns a JSON array of all suggested names, or optionally, gets information about a specific suggested name", path = "/suggestedName/search", verb = RestApiVerb.GET)
+    @RestApiParams(params = [
+            @RestApiParam(name = "featureType", type = "string", paramType = RestApiParamType.QUERY, description = "Feature type")
+            , @RestApiParam(name = "organism", type = "string", paramType = RestApiParamType.QUERY, description = "Organism name")
+            , @RestApiParam(name = "query", type = "string", paramType = RestApiParamType.QUERY, description = "Query value")
+    ])
+    @Transactional
+    def search() {
+        try {
+            JSONObject nameJson = permissionService.handleInput(request, params)
+            log.debug "Showing suggested name ${nameJson}"
+            String featureType = nameJson.featureType
+            println "feature type ${featureType}"
+            Organism organism = Organism.findByCommonName(nameJson.organism)
+            println "organism ${organism}"
+            def names = SuggestedName.findAllByNameIlike(nameJson.query+"%")
+
+
+
+
+            render names as JSON
+//            if (nameJson.query|| nameJson.name) {
+//                SuggestedName name = SuggestedName.findById(nameJson.id) ?: SuggestedName.findByName(nameJson.name)
+//
+//                if (!name) {
+//                    JSONObject jsonObject = new JSONObject()
+//                    jsonObject.put(FeatureStringEnum.ERROR.value, "Failed to delete the suggested names")
+//                    render jsonObject as JSON
+//                    return
+//                }
+//
+//                log.info "Success showing name: ${nameJson}"
+//                render name as JSON
+//            } else {
+//                def names = SuggestedName.all
+//
+//                log.info "Success showing all suggested names"
+//                render names as JSON
+//            }
+        }
+        catch (Exception e) {
+            def error = [error: 'problem showing suggested names: ' + e]
             log.error(error.error)
             render error as JSON
         }

--- a/grails-app/domain/org/bbop/apollo/SuggestedName.groovy
+++ b/grails-app/domain/org/bbop/apollo/SuggestedName.groovy
@@ -1,0 +1,16 @@
+package org.bbop.apollo
+
+class SuggestedName {
+
+    static constraints = {
+        name nullable: false
+        metadata nullable: true
+    }
+
+    String name
+    String metadata
+
+    static hasMany = [
+            featureTypes: FeatureType
+    ]
+}

--- a/grails-app/domain/org/bbop/apollo/SuggestedNameOrganismFilter.groovy
+++ b/grails-app/domain/org/bbop/apollo/SuggestedNameOrganismFilter.groovy
@@ -1,0 +1,10 @@
+package org.bbop.apollo
+
+class SuggestedNameOrganismFilter extends OrganismFilter {
+
+    SuggestedName suggestedName
+
+    static constraints = {
+        suggestedName nullable: false
+    }
+}

--- a/grails-app/views/suggestedName/_form.gsp
+++ b/grails-app/views/suggestedName/_form.gsp
@@ -1,0 +1,47 @@
+<%@ page import="org.bbop.apollo.SuggestedName" %>
+
+
+
+<div class="fieldcontain ${hasErrors(bean: suggestedNameInstance, field: 'name', 'error')} required">
+	<label for="name">
+		<g:message code="suggestedName.name.label" default="Name" />
+		<span class="required-indicator">*</span>
+	</label>
+	<g:textField name="name" required="" value="${suggestedNameInstance?.name}"/>
+
+</div>
+
+<div class="fieldcontain ${hasErrors(bean: suggestedNameInstance, field: 'metadata', 'error')} ">
+	<label for="metadata">
+		<g:message code="suggestedName.metadata.label" default="Metadata" />
+		
+	</label>
+	<g:textField name="metadata" value="${suggestedNameInstance?.metadata}"/>
+
+</div>
+
+<div class="fieldcontain ${hasErrors(bean: suggestedNameInstance, field: 'featureTypes', 'error')} ">
+	<label for="featureTypes">
+		<g:message code="suggestedName.featureTypes.label" default="Feature Types" />
+		
+	</label>
+	<g:select name="featureTypes" from="${org.bbop.apollo.FeatureType.list()}"
+              multiple="multiple"
+              optionKey="id" size="10"
+              optionValue="display"
+              value="${suggestedNameInstance?.featureTypes*.id}" class="many-to-many"/>
+
+</div>
+
+<div class="fieldcontain ${hasErrors(bean: suggestedNameInstance, field: 'organisms', 'error')} ">
+	<label for="organisms">
+		<g:message code="suggestedName.organisms.label" default="Organisms" />
+
+	</label>
+	<g:select name="organisms" from="${org.bbop.apollo.Organism.list()}"
+			  multiple="multiple"
+			  optionKey="id" size="10"
+			  optionValue="commonName"
+			  value="${organismFilters?.organism?.id}" class="many-to-many"/>
+
+</div>

--- a/grails-app/views/suggestedName/create.gsp
+++ b/grails-app/views/suggestedName/create.gsp
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="layout" content="main">
+		<g:set var="entityName" value="${message(code: 'suggestedName.label', default: 'SuggestedName')}" />
+		<title><g:message code="default.create.label" args="[entityName]" /></title>
+	</head>
+	<body>
+		<a href="#create-suggestedName" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+		<div class="nav" role="navigation">
+			<ul>
+				<li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+				<li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]" /></g:link></li>
+			</ul>
+		</div>
+		<div id="create-suggestedName" class="content scaffold-create" role="main">
+			<h1><g:message code="default.create.label" args="[entityName]" /></h1>
+			<g:if test="${flash.message}">
+			<div class="message" role="status">${flash.message}</div>
+			</g:if>
+			<g:hasErrors bean="${suggestedNameInstance}">
+			<ul class="errors" role="alert">
+				<g:eachError bean="${suggestedNameInstance}" var="error">
+				<li <g:if test="${error in org.springframework.validation.FieldError}">data-field-id="${error.field}"</g:if>><g:message error="${error}"/></li>
+				</g:eachError>
+			</ul>
+			</g:hasErrors>
+			<g:form url="[resource:suggestedNameInstance, action:'save']" >
+				<fieldset class="form">
+					<g:render template="form"/>
+				</fieldset>
+				<fieldset class="buttons">
+					<g:submitButton name="create" class="save" value="${message(code: 'default.button.create.label', default: 'Create')}" />
+				</fieldset>
+			</g:form>
+		</div>
+	</body>
+</html>

--- a/grails-app/views/suggestedName/edit.gsp
+++ b/grails-app/views/suggestedName/edit.gsp
@@ -1,0 +1,41 @@
+<%@ page import="org.bbop.apollo.SuggestedName" %>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="layout" content="main">
+		<g:set var="entityName" value="${message(code: 'suggestedName.label', default: 'SuggestedName')}" />
+		<title><g:message code="default.edit.label" args="[entityName]" /></title>
+	</head>
+	<body>
+		<a href="#edit-suggestedName" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+		<div class="nav" role="navigation">
+			<ul>
+				<li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+				<li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]" /></g:link></li>
+				<li><g:link class="create" action="create"><g:message code="default.new.label" args="[entityName]" /></g:link></li>
+			</ul>
+		</div>
+		<div id="edit-suggestedName" class="content scaffold-edit" role="main">
+			<h1><g:message code="default.edit.label" args="[entityName]" /></h1>
+			<g:if test="${flash.message}">
+			<div class="message" role="status">${flash.message}</div>
+			</g:if>
+			<g:hasErrors bean="${suggestedNameInstance}">
+			<ul class="errors" role="alert">
+				<g:eachError bean="${suggestedNameInstance}" var="error">
+				<li <g:if test="${error in org.springframework.validation.FieldError}">data-field-id="${error.field}"</g:if>><g:message error="${error}"/></li>
+				</g:eachError>
+			</ul>
+			</g:hasErrors>
+			<g:form url="[resource:suggestedNameInstance, action:'update']" method="PUT" >
+				<g:hiddenField name="version" value="${suggestedNameInstance?.version}" />
+				<fieldset class="form">
+					<g:render template="form"/>
+				</fieldset>
+				<fieldset class="buttons">
+					<g:actionSubmit class="save" action="update" value="${message(code: 'default.button.update.label', default: 'Update')}" />
+				</fieldset>
+			</g:form>
+		</div>
+	</body>
+</html>

--- a/grails-app/views/suggestedName/index.gsp
+++ b/grails-app/views/suggestedName/index.gsp
@@ -1,0 +1,64 @@
+
+<%@ page import="org.bbop.apollo.SuggestedName" %>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="layout" content="main">
+		<g:set var="entityName" value="${message(code: 'suggestedName.label', default: 'SuggestedName')}" />
+		<title><g:message code="default.list.label" args="[entityName]" /></title>
+	</head>
+	<body>
+		<a href="#list-suggestedName" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+		<div class="nav" role="navigation">
+			<ul>
+				<li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+				<li><g:link class="create" action="create"><g:message code="default.new.label" args="[entityName]" /></g:link></li>
+			</ul>
+		</div>
+		<div id="list-suggestedName" class="content scaffold-list" role="main">
+			<h1><g:message code="default.list.label" args="[entityName]" /></h1>
+			<g:if test="${flash.message}">
+				<div class="message" role="status">${flash.message}</div>
+			</g:if>
+			<table>
+			<thead>
+					<tr>
+					
+						<g:sortableColumn property="name" title="${message(code: 'suggestedName.name.label', default: 'Name')}" />
+
+						%{--<g:sortableColumn property="metadata" title="${message(code: 'suggestedName.featureTypes.label', default: 'Feature Types')}" />--}%
+						<th>Feature Types</th>
+						<th>Organisms</th>
+						<g:sortableColumn property="metadata" title="${message(code: 'suggestedName.metadata.label', default: 'Metadata')}" />
+					
+					</tr>
+				</thead>
+				<tbody>
+				<g:each in="${suggestedNameInstanceList}" status="i" var="suggestedNameInstance">
+					<tr class="${(i % 2) == 0 ? 'even' : 'odd'}">
+					
+						<td><g:link action="show" id="${suggestedNameInstance.id}">${fieldValue(bean: suggestedNameInstance, field: "name")}</g:link></td>
+
+						<td>
+							<g:each in="${suggestedNameInstance.featureTypes.sort() { a,b -> a.display <=> b.display }}" var="featureType">
+								${featureType.type}:${featureType.name}
+							</g:each>
+						</td>
+						<td>
+							<g:each in="${organismFilters.get(suggestedNameInstance)}" var="filter">
+								<g:link controller="organism" id="${filter.organism.id}">${filter.organism.commonName}</g:link>
+							</g:each>
+						</td>
+
+						<td>${fieldValue(bean: suggestedNameInstance, field: "metadata")}</td>
+					
+					</tr>
+				</g:each>
+				</tbody>
+			</table>
+			<div class="pagination">
+				<g:paginate total="${suggestedNameInstanceCount ?: 0}" />
+			</div>
+		</div>
+	</body>
+</html>

--- a/grails-app/views/suggestedName/show.gsp
+++ b/grails-app/views/suggestedName/show.gsp
@@ -1,0 +1,91 @@
+<%@ page import="org.bbop.apollo.SuggestedName" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="layout" content="main">
+    <g:set var="entityName" value="${message(code: 'suggestedName.label', default: 'SuggestedName')}"/>
+    <title><g:message code="default.show.label" args="[entityName]"/></title>
+</head>
+
+<body>
+<a href="#show-suggestedName" class="skip" tabindex="-1"><g:message code="default.link.skip.label"
+                                                                    default="Skip to content&hellip;"/></a>
+
+<div class="nav" role="navigation">
+    <ul>
+        <li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+        <li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]"/></g:link></li>
+        <li><g:link class="create" action="create"><g:message code="default.new.label"
+                                                              args="[entityName]"/></g:link></li>
+    </ul>
+</div>
+
+<div id="show-suggestedName" class="content scaffold-show" role="main">
+    <h1><g:message code="default.show.label" args="[entityName]"/></h1>
+    <g:if test="${flash.message}">
+        <div class="message" role="status">${flash.message}</div>
+    </g:if>
+    <ol class="property-list suggestedName">
+
+        <g:if test="${suggestedNameInstance?.name}">
+            <li class="fieldcontain">
+                <span id="name-label" class="property-label"><g:message code="suggestedName.name.label"
+                                                                           default="Name"/></span>
+
+                <span class="property-value" aria-labelledby="name-label"><g:fieldValue
+                        bean="${suggestedNameInstance}" field="name"/></span>
+
+            </li>
+        </g:if>
+
+        <g:if test="${suggestedNameInstance?.metadata}">
+            <li class="fieldcontain">
+                <span id="metadata-label" class="property-label"><g:message code="suggestedName.metadata.label"
+                                                                            default="Metadata"/></span>
+
+                <span class="property-value" aria-labelledby="metadata-label"><g:fieldValue
+                        bean="${suggestedNameInstance}" field="metadata"/></span>
+
+            </li>
+        </g:if>
+
+        <g:if test="${suggestedNameInstance?.featureTypes}">
+            <li class="fieldcontain">
+                <span id="featureTypes-label" class="property-label"><g:message code="suggestedName.featureTypes.label"
+                                                                                default="Feature Types"/></span>
+
+                <g:each in="${suggestedNameInstance.featureTypes}" var="f">
+                    <span class="property-value" aria-labelledby="featureTypes-label"><g:link controller="featureType"
+                                                                                              action="show"
+                                                                                              id="${f.id}">${f?.name}</g:link></span>
+                </g:each>
+
+            </li>
+        </g:if>
+
+        <g:if test="${organismFilters}">
+            <li class="fieldcontain">
+                <span id="organisms-label" class="property-label"><g:message code="suggestedName.organisms.label"
+                                                                             default="Organisms"/></span>
+
+                <g:each in="${organismFilters}" var="f">
+                    <span class="property-value" aria-labelledby="organisms-label"><g:link controller="organism"
+                                                                                           action="show"
+                                                                                           id="${f.id}">${f?.organism.commonName}</g:link></span>
+                </g:each>
+            </li>
+        </g:if>
+
+    </ol>
+    <g:form url="[resource: suggestedNameInstance, action: 'delete']" method="DELETE">
+        <fieldset class="buttons">
+            <g:link class="edit" action="edit" resource="${suggestedNameInstance}"><g:message
+                    code="default.button.edit.label" default="Edit"/></g:link>
+            <g:actionSubmit class="delete" action="delete"
+                            value="${message(code: 'default.button.delete.label', default: 'Delete')}"
+                            onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');"/>
+        </fieldset>
+    </g:form>
+</div>
+</body>
+</html>

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.java
@@ -50,19 +50,19 @@ public class GeneDetailPanel extends Composite {
     @UiField
     TextBox userField;
 
-    private SuggestedNameOracle suggestedNameOracle;
+    private SuggestedNameOracle suggestedNameOracle = new SuggestedNameOracle();
 
     public GeneDetailPanel() {
-        nameField = new SuggestBox(new SuggestedNameOracle());
+        nameField = new SuggestBox(suggestedNameOracle);
 
         initWidget(ourUiBinder.createAndBindUi(this));
 
-        nameField.addValueChangeHandler(new ValueChangeHandler<String>() {
-            @Override
-            public void onValueChange(ValueChangeEvent<String> event) {
-                handleNameChange();
-            }
-        });
+//        nameField.addValueChangeHandler(new ValueChangeHandler<String>() {
+//            @Override
+//            public void onValueChange(ValueChangeEvent<String> event) {
+//                handleNameChange();
+//            }
+//        });
 
         nameField.addSelectionHandler(new SelectionHandler<SuggestOracle.Suggestion>() {
             @Override

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.java
@@ -2,19 +2,26 @@ package org.bbop.apollo.gwt.client;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ChangeEvent;
-import com.google.gwt.http.client.*;
-import com.google.gwt.i18n.client.Dictionary;
-import com.google.gwt.json.client.*;
+import com.google.gwt.event.logical.shared.SelectionEvent;
+import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.Response;
+import com.google.gwt.json.client.JSONParser;
+import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.*;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.SuggestOracle;
+import com.google.gwt.user.client.ui.Widget;
 import org.bbop.apollo.gwt.client.dto.AnnotationInfo;
 import org.bbop.apollo.gwt.client.event.AnnotationInfoChangeEvent;
 import org.bbop.apollo.gwt.client.rest.AnnotationRestService;
 import org.bbop.apollo.gwt.client.rest.RestService;
-import org.gwtbootstrap3.client.ui.*;
+import org.gwtbootstrap3.client.ui.SuggestBox;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
 
@@ -30,8 +37,8 @@ public class GeneDetailPanel extends Composite {
     }
 
     private static AnnotationDetailPanelUiBinder ourUiBinder = GWT.create(AnnotationDetailPanelUiBinder.class);
-    @UiField
-    TextBox nameField;
+    @UiField(provided = true)
+    SuggestBox nameField;
     @UiField
     TextBox symbolField;
     @UiField
@@ -43,13 +50,29 @@ public class GeneDetailPanel extends Composite {
     @UiField
     TextBox userField;
 
+    private SuggestedNameOracle suggestedNameOracle;
 
     public GeneDetailPanel() {
+        nameField = new SuggestBox(new SuggestedNameOracle());
+
         initWidget(ourUiBinder.createAndBindUi(this));
+
+        nameField.addValueChangeHandler(new ValueChangeHandler<String>() {
+            @Override
+            public void onValueChange(ValueChangeEvent<String> event) {
+                handleNameChange();
+            }
+        });
+
+        nameField.addSelectionHandler(new SelectionHandler<SuggestOracle.Suggestion>() {
+            @Override
+            public void onSelection(SelectionEvent<SuggestOracle.Suggestion> event) {
+                handleNameChange();
+            }
+        });
     }
 
-    @UiHandler("nameField")
-    void handleNameChange(ChangeEvent e) {
+    private void handleNameChange() {
         String updatedName = nameField.getText();
         internalAnnotationInfo.setName(updatedName);
         updateGene();
@@ -117,8 +140,7 @@ public class GeneDetailPanel extends Composite {
             locationText += ")";
             locationField.setText(locationText);
             locationField.setVisible(true);
-        }
-        else{
+        } else {
             locationField.setVisible(false);
         }
 

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.java
@@ -14,6 +14,7 @@ import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.SuggestOracle;
 import com.google.gwt.user.client.ui.Widget;
@@ -102,6 +103,7 @@ public class GeneDetailPanel extends Composite {
     private void updateGene() {
         final AnnotationInfo updatedInfo = this.internalAnnotationInfo;
         enableFields(false);
+
         RequestCallback requestCallback = new RequestCallback() {
             @Override
             public void onResponseReceived(Request request, Response response) {
@@ -125,6 +127,8 @@ public class GeneDetailPanel extends Composite {
      */
     public void updateData(AnnotationInfo annotationInfo) {
         this.internalAnnotationInfo = annotationInfo;
+        suggestedNameOracle.setOrganismName(MainPanel.getInstance().getCurrentOrganism().getName());
+        suggestedNameOracle.setFeatureType("sequence:"+annotationInfo.getType());
         nameField.setText(internalAnnotationInfo.getName());
         symbolField.setText(internalAnnotationInfo.getSymbol());
         descriptionField.setText(internalAnnotationInfo.getDescription());

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.ui.xml
@@ -24,7 +24,7 @@
             <b:Column size="XS_12" styleName="{style.widgetPanel}">
                 <b:InputGroup >
                     <b:InputGroupAddon>Name</b:InputGroupAddon>
-                    <b:TextBox autoComplete="false" ui:field="nameField" />
+                    <b:SuggestBox  ui:field="nameField" />
                 </b:InputGroup>
             </b:Column>
         </b:Row>

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -18,7 +18,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.cellview.client.DataGrid;
 import com.google.gwt.user.cellview.client.TextColumn;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwt.view.client.SelectionChangeEvent;

--- a/src/gwt/org/bbop/apollo/gwt/client/SuggestedNameOracle.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/SuggestedNameOracle.java
@@ -1,0 +1,38 @@
+package org.bbop.apollo.gwt.client;
+
+import com.google.gwt.user.client.ui.SuggestOracle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SuggestedNameOracle extends SuggestOracle {
+
+
+    @Override
+    public void requestSuggestions(final Request suggestRequest, final Callback suggestCallback) {
+
+        List<Suggestion> suggestionList = new ArrayList<>();
+
+        // always suggest thyself
+        suggestionList.add(new Suggestion() {
+            @Override
+            public String getDisplayString() {
+                return suggestRequest.getQuery();
+            }
+
+            @Override
+            public String getReplacementString() {
+                return suggestRequest.getQuery();
+            }
+        });
+
+
+
+
+
+        Response r = new Response();
+        r.setSuggestions(suggestionList);
+        suggestCallback.onSuggestionsReady(suggestRequest, r);
+
+    }
+}

--- a/src/gwt/org/bbop/apollo/gwt/client/SuggestedNameOracle.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/SuggestedNameOracle.java
@@ -1,6 +1,15 @@
 package org.bbop.apollo.gwt.client;
 
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.http.client.RequestBuilder;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.RequestException;
+import com.google.gwt.json.client.JSONArray;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONParser;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.SuggestOracle;
+import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -8,31 +17,74 @@ import java.util.List;
 public class SuggestedNameOracle extends SuggestOracle {
 
 
+    private String organismName;
+    private String featureType;
+
+
     @Override
     public void requestSuggestions(final Request suggestRequest, final Callback suggestCallback) {
 
-        List<Suggestion> suggestionList = new ArrayList<>();
+        final List<Suggestion> suggestionList = new ArrayList<>();
 
-        // always suggest thyself
-        suggestionList.add(new Suggestion() {
-            @Override
-            public String getDisplayString() {
-                return suggestRequest.getQuery();
-            }
-
-            @Override
-            public String getReplacementString() {
-                return suggestRequest.getQuery();
-            }
-        });
+        final String queryString = suggestRequest.getQuery();
 
 
+        String url = Annotator.getRootUrl() + "suggestedName/search";
+        url += "?query=" + suggestRequest.getQuery();
+        url += "&organism=" + organismName;
+        url += "&featureType=" + featureType;
+        RequestBuilder rb = new RequestBuilder(RequestBuilder.GET, url);
+
+        try {
+            rb.sendRequest(null, new RequestCallback() {
+                @Override
+                public void onResponseReceived(com.google.gwt.http.client.Request request, com.google.gwt.http.client.Response response) {
+                    // always suggest thyself
+                    suggestionList.add(new Suggestion() {
+                        @Override
+                        public String getDisplayString() {
+                            return queryString;
+                        }
+
+                        @Override
+                        public String getReplacementString() {
+                            return queryString;
+                        }
+                    });
+
+                    JSONArray jsonArray = JSONParser.parseStrict(response.getText()).isArray();
+                    for (int i = 0; i < jsonArray.size(); i++) {
+                        // always suggest thyself
+                        JSONObject jsonObject = jsonArray.get(i).isObject();
+                        final String name = jsonObject.get("name").isString().stringValue();
+                        suggestionList.add(new Suggestion() {
+                            @Override
+                            public String getDisplayString() {
+                                // TODO: add mathcing string
+//                                String displayString = queryString
+                                return name;
+                            }
+
+                            @Override
+                            public String getReplacementString() {
+                                return name;
+                            }
+                        });
+                    }
+                    Response r = new Response();
+                    r.setSuggestions(suggestionList);
+                    suggestCallback.onSuggestionsReady(suggestRequest, r);
+                }
+
+                @Override
+                public void onError(com.google.gwt.http.client.Request request, Throwable exception) {
+                    Bootbox.alert("There was an error with the request: " + exception.getMessage());
+                }
+            });
 
 
-
-        Response r = new Response();
-        r.setSuggestions(suggestionList);
-        suggestCallback.onSuggestionsReady(suggestRequest, r);
-
+        } catch (RequestException e) {
+            Bootbox.alert("Request exception via " + e);
+        }
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/SuggestedNameOracle.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/SuggestedNameOracle.java
@@ -87,4 +87,20 @@ public class SuggestedNameOracle extends SuggestOracle {
             Bootbox.alert("Request exception via " + e);
         }
     }
+
+    public String getOrganismName() {
+        return organismName;
+    }
+
+    public void setOrganismName(String organismName) {
+        this.organismName = organismName;
+    }
+
+    public String getFeatureType() {
+        return featureType;
+    }
+
+    public void setFeatureType(String featureType) {
+        this.featureType = featureType;
+    }
 }

--- a/web-app/js/restapidoc/restapidoc.json
+++ b/web-app/js/restapidoc/restapidoc.json
@@ -2,14 +2,14 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
-         "jsondocId": "09b167ab-2a64-474b-b66b-801d7bb82da7",
+         "jsondocId": "d2e7e66f-b116-4fdc-a8e1-b64483a0d17a",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4e49aa73-4857-412f-b60c-730a79a62b2a",
+                     "jsondocId": "420d9bd5-c30b-434a-98b4-22d42196fbc5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -18,7 +18,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2664ae5a-620b-4e20-9a58-bde74332d0f9",
+                     "jsondocId": "14aed3fd-0215-44af-be94-924a08e03c02",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -27,7 +27,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ce0b0265-c57f-47f3-abb3-45e9ac59e228",
+                     "jsondocId": "243aee5a-19e7-4a75-993d-8b7e1afcbb68",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -36,7 +36,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1efcafdc-2dab-4046-a622-afa29beac288",
+                     "jsondocId": "5d1fee93-b6ab-44db-862c-e8269fd5dbab",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -45,7 +45,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0df912d4-9ceb-47dd-aaa7-27bfdffb4f28",
+                     "jsondocId": "eee383bb-a1ed-4949-bb80-1f9a37e7fd61",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
@@ -57,9 +57,9 @@
                "verb": "POST",
                "description": "Set name of a feature",
                "methodName": "setName",
-               "jsondocId": "f9c16a15-ef3b-4836-a3f7-f1918d90006c",
+               "jsondocId": "5902a7bc-fb8c-42e2-ae99-7ab226e55a35",
                "bodyobject": {
-                  "jsondocId": "1fc5b0f5-714d-468a-bd53-4d79778fa683",
+                  "jsondocId": "9efd4fd2-e583-49e3-8fdd-4e5e137e10b6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -69,7 +69,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setName",
                "response": {
-                  "jsondocId": "4aa604c0-4e7f-4f3d-8b50-431ad4ee85ec",
+                  "jsondocId": "433020de-ed96-4747-9430-42806e0f86d8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -82,7 +82,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b212e205-de4b-43af-83fb-9ffb0fb9256f",
+                     "jsondocId": "e88a6295-af07-48a5-9026-d5615c287e00",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -91,7 +91,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c5067129-fe80-4b08-8e9e-8ad1d9ae2305",
+                     "jsondocId": "abd607ae-3ca1-40c1-bc29-32830ed1921f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -100,7 +100,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "62e11174-6d37-44f7-a1a2-a77a3c8dbdd1",
+                     "jsondocId": "77a1a03a-a287-48f2-b870-1c1680128e32",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -109,7 +109,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "42952689-9a44-4c28-891a-a4f5e76786dc",
+                     "jsondocId": "56fc40b8-1523-4a4b-b88a-a440d014e221",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -118,153 +118,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "172072ff-f1ce-4c83-9bef-a543d67d053e",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get comments",
-               "methodName": "getComments",
-               "jsondocId": "77989959-4ee2-4603-b6e5-97adeb960e0a",
-               "bodyobject": {
-                  "jsondocId": "b7affd85-e143-4316-bf77-783ff033938d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getComments",
-               "response": {
-                  "jsondocId": "c0562607-fb4a-41f1-ae16-a6338b8b58cf",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "b1f334e4-1aea-4cfa-b750-9a3194964511",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "01ee258f-51cb-4303-aa39-86082b8445b7",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d41a76ee-05e2-4e10-ad35-e5e3618eeaea",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a4cc1d17-c696-4d03-aa9e-bbd5a84e4c71",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e4cf4cf4-f3d5-49c2-849d-dc7830dc9f0b",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set description for a feature",
-               "methodName": "setDescription",
-               "jsondocId": "b3c20905-3482-4e7e-8b12-233760b0bae3",
-               "bodyobject": {
-                  "jsondocId": "0cd29374-1af0-4258-b959-a09e7bcf125f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setDescription",
-               "response": {
-                  "jsondocId": "b45f8ee7-9407-4c8b-8d0c-9417ecd46b0b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "b370ac2d-acc7-4fa1-ac45-5ba3f9e2cfd5",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0771269f-6096-4c41-9ab5-46757f683bd2",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1c75777c-c965-4130-b16a-16c6c991b843",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "722a1166-b78c-4360-91d3-0dee7c3ee211",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d21722e1-3ebd-43f0-8a83-c47031ecf5bf",
+                     "jsondocId": "5c635da7-ae24-43f0-b21b-5c59c2d90e92",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
@@ -276,9 +130,9 @@
                "verb": "POST",
                "description": "Set status of a feature",
                "methodName": "setStatus",
-               "jsondocId": "5cd13cf3-db13-4d0e-941e-41fa9df6d917",
+               "jsondocId": "80450ae3-f081-4943-abc8-e25f396f55de",
                "bodyobject": {
-                  "jsondocId": "249820ff-dc28-44c0-ab97-435d2e3fc423",
+                  "jsondocId": "de377ae0-b36d-4c1f-b5f5-ad8775a100f7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -288,7 +142,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setStatus",
                "response": {
-                  "jsondocId": "90c823df-39b0-438e-b758-97685127dd1f",
+                  "jsondocId": "e12e91b7-d361-40a0-b536-c59fcca5c276",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -301,7 +155,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4adfe712-7a98-410b-b757-34badf3f70a4",
+                     "jsondocId": "49009356-c651-488d-b1d5-a97b9f687011",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -310,7 +164,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "23c9de14-849a-432f-a4e1-7bfabc656367",
+                     "jsondocId": "c9a1ec82-2c61-4b57-ba63-cbe60bf5bdce",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -319,7 +173,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1295332-4824-4b0b-a339-0a6e7a925bbd",
+                     "jsondocId": "d618d430-d4b6-4392-998d-5596aff2f034",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -328,7 +182,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f8bd714-f842-47fd-813b-958123af452f",
+                     "jsondocId": "d2a8f23c-75fb-4044-80fa-82cc9c5ade5d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -337,21 +191,21 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "633be3c5-0afb-49ec-9fce-9c7c4261b05b",
+                     "jsondocId": "4178bb09-01c0-4c21-96ec-b67812f993b5",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Add attribute (key,value pair) to feature",
-               "methodName": "addAttribute",
-               "jsondocId": "23d757f9-6086-46cf-93b4-2d431beaf377",
+               "description": "Get comments",
+               "methodName": "getComments",
+               "jsondocId": "35466539-7ca8-4256-8037-7c31c1a73c18",
                "bodyobject": {
-                  "jsondocId": "58c13f56-af00-4109-aaf7-9fd2ce2ca45b",
+                  "jsondocId": "2a76393b-3203-4495-8945-0077a530aa97",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -359,9 +213,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/addAttribute",
+               "path": "/annotationEditor/getComments",
                "response": {
-                  "jsondocId": "d42ec141-ad80-492d-bcab-a723fabadbd9",
+                  "jsondocId": "5aa4e92b-8cbc-428e-9847-ac42fcba9930",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -374,7 +228,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "63cfb63b-c39d-4336-9636-9ccff98e2a87",
+                     "jsondocId": "a17027f9-bbc5-491c-9aff-aa94969bd651",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -383,7 +237,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "390cf2f2-7953-4831-96a9-081cb10407c4",
+                     "jsondocId": "ea1b6357-3815-4986-ba4d-7da905e9d0d0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -392,7 +246,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2b6d41a4-c173-4e04-ab73-c9031a37b09d",
+                     "jsondocId": "2ea66bc2-4bb1-49c6-8adc-0f679bd70584",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -401,7 +255,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "df2e5c4a-ae3e-4fa5-b6db-24b655d08ed5",
+                     "jsondocId": "efca5b9c-05fd-49af-aa38-a3257969e15a",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -410,7 +264,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "08aa62d0-9e2a-499d-9628-0a882e2d7f35",
+                     "jsondocId": "eb819c41-2318-4cc3-bd59-4a62756a98b4",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
@@ -422,9 +276,9 @@
                "verb": "POST",
                "description": "Set symbol of a feature",
                "methodName": "setSymbol",
-               "jsondocId": "dd52bd40-bfc8-41f8-b6b2-7daf1badfa5a",
+               "jsondocId": "54fea7d6-2e07-4f3c-94a6-06b1fd26c47d",
                "bodyobject": {
-                  "jsondocId": "0fe57372-338d-4c95-bf00-6b1b8fc5adbf",
+                  "jsondocId": "8407da68-0082-42ff-947b-6c8fe9f69642",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -434,7 +288,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setSymbol",
                "response": {
-                  "jsondocId": "4cf34595-4b17-437a-a3a2-302ee208dda8",
+                  "jsondocId": "8236b757-7f96-482a-8020-078e5a536940",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -447,7 +301,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a16d0141-67ee-4074-852b-0cea12a4b880",
+                     "jsondocId": "33669fd5-18fd-44be-91ae-49e0219adff5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -456,7 +310,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "df0e693d-8d20-44da-9dc6-1d5d4299d238",
+                     "jsondocId": "2d02ee01-c8e5-46c8-8ac0-6942bd5a9691",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -465,16 +319,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "86c720ce-6355-4039-8138-b0b0a12b2247",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "eb965d8a-50e9-4b50-8ab4-9204c8deab4c",
+                     "jsondocId": "e14e0e51-84f0-43b4-8621-36a8345ebe5b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -483,39 +328,30 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "87387731-67c8-44ac-9cbe-530e016ca1db",
-                     "name": "suppressHistory",
+                     "jsondocId": "6b96147b-447a-4c58-ae5b-42c645f37a73",
+                     "name": "organism",
                      "format": "",
-                     "description": "Suppress the history of this operation",
-                     "type": "boolean",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f00a68e5-58ce-4fd4-a308-c61cd17764b1",
-                     "name": "suppressEvents",
-                     "format": "",
-                     "description": "Suppress instant update of the user interface",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "644cd34b-e530-4656-8e7d-9ea92fa10de9",
+                     "jsondocId": "7c460182-bc8f-477f-95a3-867da39c7f80",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Set exon feature boundaries",
-               "methodName": "setExonBoundaries",
-               "jsondocId": "89b62f55-91ee-4de5-ae29-07d8fcc0b2a4",
+               "description": "Add attribute (key,value pair) to feature",
+               "methodName": "addAttribute",
+               "jsondocId": "f56db8ef-25aa-44f3-8cd7-50b3ac4410fa",
                "bodyobject": {
-                  "jsondocId": "aa850e50-0835-4cc2-86f9-8b53f187d774",
+                  "jsondocId": "ffaf001a-45d1-400d-b89c-cdcebab13cb9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -523,9 +359,82 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setExonBoundaries",
+               "path": "/annotationEditor/addAttribute",
                "response": {
-                  "jsondocId": "3cf993bb-8e44-4d04-a1d1-afe39846cd9a",
+                  "jsondocId": "37255d27-b5b4-444c-8da9-49d8e7be8d3f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "98b137af-a678-431f-b3d0-0464a6bfc2bb",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b7d329ef-ec9a-425e-97ee-635e27709c38",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "058fbc4f-88d2-4c72-affa-371874cea583",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0d187fb0-3d69-4f85-bd4e-b82a6b729875",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2a7d6f0e-d4a1-4bc4-a4ef-76fd1b966143",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set description for a feature",
+               "methodName": "setDescription",
+               "jsondocId": "6d479000-c6b5-4fb4-a51f-8658e14aaa53",
+               "bodyobject": {
+                  "jsondocId": "53544aa4-87cd-413a-938d-3cedfdbf2a6f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setDescription",
+               "response": {
+                  "jsondocId": "42577366-4aae-4222-aebd-fea7ffc88704",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -540,9 +449,9 @@
                "verb": "POST",
                "description": "Returns a translation table as JSON",
                "methodName": "getTranslationTable",
-               "jsondocId": "8ccc055e-f5d6-4a76-bea9-e2888f7bff61",
+               "jsondocId": "44373bfd-c8ba-41c0-b62b-7c81117b9849",
                "bodyobject": {
-                  "jsondocId": "8e34b693-ef52-44d6-9507-c8383448a551",
+                  "jsondocId": "2fb684ec-6282-4a2e-a5d9-2b02d4e9de6a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -552,7 +461,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getTranslationTable",
                "response": {
-                  "jsondocId": "4aff2c88-be3e-446e-8a85-f533d2620cb7",
+                  "jsondocId": "a280e9be-c6e9-499e-be6a-522ed194a244",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -565,7 +474,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a70bf95e-09ba-4ca6-9f79-f3eb9052f484",
+                     "jsondocId": "da5f1f66-157c-4ca9-8047-13e080275fea",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -574,7 +483,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d2a29cc-3ce5-49e7-80c5-0cdd3d09cded",
+                     "jsondocId": "7d74fe7a-e0dc-49dd-ac3f-77c93001eb42",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -583,7 +492,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "613de8c6-1875-42e8-b531-a04bf38150af",
+                     "jsondocId": "889c415e-c231-45fc-a6cf-03904822b014",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -592,7 +501,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6268ef2c-9bf2-43d6-a640-d3a32a57fa7b",
+                     "jsondocId": "8f6ab958-82f0-4620-b52e-09cebc7b093e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -601,7 +510,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c58fba76-07c8-4a6b-bdf1-1a0591403409",
+                     "jsondocId": "5bfe6922-5a91-4968-8d6f-0f9a42ce7015",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -610,7 +519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4caa0ae-5344-4a8a-82ed-08a4b1a0f92b",
+                     "jsondocId": "acd6562b-4823-480d-89f0-ffb33226ce27",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -619,7 +528,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f0965c2e-346b-4082-a502-9f8787c07fae",
+                     "jsondocId": "a6325522-dd32-49d8-b5dc-9d3a2495c70c",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -631,9 +540,9 @@
                "verb": "POST",
                "description": "Add non-coding genomic feature",
                "methodName": "addFeature",
-               "jsondocId": "dc08a9c0-4790-47b9-ac50-d55ac9c48d49",
+               "jsondocId": "5c1d5030-1ae2-4c21-9535-d02d779f6ce3",
                "bodyobject": {
-                  "jsondocId": "8fa2f8f2-ab46-4eab-92b1-95f3ee9c5a72",
+                  "jsondocId": "ce7c4fd3-5f89-42ba-befa-080b84c081c8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -643,7 +552,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addFeature",
                "response": {
-                  "jsondocId": "f81a8371-35cc-4134-9b86-12b2176be409",
+                  "jsondocId": "ecc95e33-479d-466c-ae1f-b2313407b1a2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -656,7 +565,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "eb6b25dc-dea0-4f2a-809b-f03dbd3f23a2",
+                     "jsondocId": "62c891b8-696a-4367-9c3c-15c9dfe6b650",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -665,7 +574,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "adae7af9-e091-455e-babe-40ba5bb6aa70",
+                     "jsondocId": "e930ee02-2240-4513-8269-0ce45d66b381",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -674,7 +583,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1ad332b-d876-4f23-bc59-48b4f75e10dc",
+                     "jsondocId": "c86dcea3-276e-48bd-af20-86b051bba553",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -683,7 +592,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6b96643c-cc26-4b44-ba24-29c44029a494",
+                     "jsondocId": "4c0af33a-5d83-4f87-a4bd-13e007011dd3",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -692,7 +601,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aeb546eb-7af7-4024-bc27-cd4250a1e7ab",
+                     "jsondocId": "bf4d8c6a-5912-4d77-8ab7-e383a4f0f132",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -701,7 +610,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9813ff5d-3ade-4949-bdb3-758b1b45975c",
+                     "jsondocId": "bb0e7246-e69d-4e47-90b9-1dd5db315203",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -710,7 +619,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "868f7060-2249-4103-a7c7-b9c27c7fcbe9",
+                     "jsondocId": "ad543aed-d1ca-47a1-adda-bf365903f602",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -722,9 +631,9 @@
                "verb": "POST",
                "description": "Add an exon",
                "methodName": "addExon",
-               "jsondocId": "1bc1937c-66eb-4cec-abae-31819e467eec",
+               "jsondocId": "61456aa0-1120-476b-a7ad-4231a9fe869f",
                "bodyobject": {
-                  "jsondocId": "4c6b9b66-b5a8-4ad0-8d34-6072f113a849",
+                  "jsondocId": "cf676df1-f649-4d04-978f-4d702e59ca66",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -734,7 +643,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addExon",
                "response": {
-                  "jsondocId": "fdcaf57b-45f7-40c1-97a7-23431044f832",
+                  "jsondocId": "7711c7fa-138c-482c-b69a-ba1824ad7f07",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -747,7 +656,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f0fcac56-43fa-4b81-8ccc-ab8cc1be11df",
+                     "jsondocId": "3c898d11-ff50-4754-93db-b73221215f20",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -756,7 +665,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6eaf83e4-13c4-4061-876a-7f86b7b0b9fe",
+                     "jsondocId": "c291c7be-d38a-4f57-b00a-92932c652bd2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -765,7 +674,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "364e9e3c-93d3-4c2f-a483-8626430aae48",
+                     "jsondocId": "dd7e2fbd-85aa-445a-ac47-3b57b1753dd8",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -774,7 +683,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db63bfde-7db9-4928-9c94-e33fbfe3427a",
+                     "jsondocId": "865f9384-33ce-4c9b-81c8-8318869adc2f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -783,7 +692,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d76d9789-9130-4274-b46a-5f8f127a8be9",
+                     "jsondocId": "4ba9ba90-8155-440e-b552-0b3ae616e514",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -795,9 +704,9 @@
                "verb": "POST",
                "description": "Add comments",
                "methodName": "addComments",
-               "jsondocId": "d5f4f43a-5bd4-4e7d-ad38-8096dc52edb0",
+               "jsondocId": "b660fbb5-6b55-4207-8b78-03e0df83e1f5",
                "bodyobject": {
-                  "jsondocId": "0779be52-57a1-4e03-b85a-b180de7e7b8b",
+                  "jsondocId": "bc6a78b5-f3ca-469e-a7d4-d6d368a5fa8c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -807,7 +716,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addComments",
                "response": {
-                  "jsondocId": "4ce89f66-afd1-4395-b474-2ec00a649f15",
+                  "jsondocId": "b95244d4-573b-4d46-8ec6-8954b43eec9d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -820,7 +729,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5bda2b23-a000-4851-a188-618689551659",
+                     "jsondocId": "ca4ef648-f584-43b5-aaa1-dfa696f2a17e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -829,7 +738,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0dea5968-fffa-4e6c-a860-dca202981962",
+                     "jsondocId": "95eaa71d-45f8-4870-a4bc-762ad5b6ffbb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -838,7 +747,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f6c1a27c-dca3-4841-b340-1f134dbd196e",
+                     "jsondocId": "bb4bbe96-b9fd-4b61-878a-c8f243146402",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -847,7 +756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "516c43a5-13e1-4e1b-a00e-e899bb0f6d34",
+                     "jsondocId": "3a4d084a-06a3-480c-99a4-8c21596b595b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -856,7 +765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9b8c264a-034f-4673-8eb9-2e56745aa734",
+                     "jsondocId": "8bf85707-a5cd-4dcb-a33f-3cbd99d4b4b1",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -868,9 +777,9 @@
                "verb": "POST",
                "description": "Delete comments",
                "methodName": "deleteComments",
-               "jsondocId": "6881ae88-f8ba-45a2-970e-8e46402defd2",
+               "jsondocId": "7c37ca0b-14ff-40e1-8652-9101c75ec007",
                "bodyobject": {
-                  "jsondocId": "99bd9d56-e36b-4b9b-a82a-39959d6ca303",
+                  "jsondocId": "19c71f44-e2ea-48ea-b0e2-ec3b5becc94f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -880,7 +789,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteComments",
                "response": {
-                  "jsondocId": "e0b41d47-b281-44f0-80ec-7fd9a4249920",
+                  "jsondocId": "cf74550c-cdf5-4f8d-9394-87a95eda217c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -893,7 +802,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0c9cdd48-5f08-4880-a5eb-004c302459e5",
+                     "jsondocId": "fa7df018-1121-42cd-919b-485ced41f2f3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -902,7 +811,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c78054f0-de3c-4e14-86dd-bae9b157cf62",
+                     "jsondocId": "b706260a-3c1d-4b46-8222-9239f6f1e0ac",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -911,7 +820,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6760247c-765f-4e01-9724-3457f217f63d",
+                     "jsondocId": "ce259cc5-2614-461f-9206-f99c2cccceb1",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -920,7 +829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f03e0f79-a941-4461-ba9d-eb1710f14bfa",
+                     "jsondocId": "d18581f9-04ac-4153-9d2c-6b1f28837bb8",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -929,7 +838,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8a87223b-da80-4657-ab78-ed6670da82ff",
+                     "jsondocId": "e1e7f616-74c4-49ec-9ff3-2d12c931933b",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -941,9 +850,9 @@
                "verb": "POST",
                "description": "Update comments",
                "methodName": "updateComments",
-               "jsondocId": "1ee512d0-f998-445b-8d5c-fca9dcea46e9",
+               "jsondocId": "29ec5b0c-b3f9-4b30-9631-620744316ca1",
                "bodyobject": {
-                  "jsondocId": "1a631fbd-2d7b-4316-ab02-861455b42410",
+                  "jsondocId": "faca1e71-3e1e-4642-8dcb-f9129248b02c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -953,7 +862,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateComments",
                "response": {
-                  "jsondocId": "c941dd3c-0672-491f-ada7-cce9e0104042",
+                  "jsondocId": "cb6a4465-fe9e-489d-b1d9-c7d672c78fad",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -966,7 +875,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b9e7852a-7d2c-4af7-a7ff-433b8a343f38",
+                     "jsondocId": "1c20a444-9717-4617-85b7-2090416a39a2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -975,7 +884,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "303e908e-b38c-4ca5-98f2-db8841cdb763",
+                     "jsondocId": "7d9876ac-0f53-4f26-b853-745b48bdb863",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -984,7 +893,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "034fac58-d3ff-48ed-94e9-1fad8c6a4790",
+                     "jsondocId": "842c86a0-500c-4f22-8966-1ab45dc017e6",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -993,7 +902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ec48d3b6-b6fb-44bb-8660-5e28ab7e1861",
+                     "jsondocId": "1b2baa1a-2158-4f58-9afc-aa8656dbf664",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1002,7 +911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7d79bc62-e89f-49da-8faa-848ac8f3981d",
+                     "jsondocId": "31772023-926e-4aaa-a060-ed77e3dfc415",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1011,7 +920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d150401e-d861-4e97-aff1-e89448777ad7",
+                     "jsondocId": "0f2f6d10-4324-4e77-b2c3-13dc765e613a",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1020,7 +929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fa400e70-4671-4f4a-bdd3-0775c46e2880",
+                     "jsondocId": "c7d58286-d6f0-4fd8-ae5c-db37a7e3c12a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -1032,9 +941,9 @@
                "verb": "POST",
                "description": "Add transcript",
                "methodName": "addTranscript",
-               "jsondocId": "62dfa961-9b51-444e-ae5b-f906ce4e1e90",
+               "jsondocId": "012d07a6-4cf9-445c-8fc6-1c8bf239cc4d",
                "bodyobject": {
-                  "jsondocId": "5fa66edf-6971-4351-afdb-7af8490b7bc1",
+                  "jsondocId": "4f3de025-2763-45d1-904a-546db49feb6e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1044,7 +953,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addTranscript",
                "response": {
-                  "jsondocId": "a0d85a1e-90cc-48b5-a36a-616873f32a6f",
+                  "jsondocId": "032b1bb2-2566-43f1-9c5a-8dfd4ea3bf65",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1057,7 +966,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "65dc5e0e-bfb5-4766-9229-8da7cb60671b",
+                     "jsondocId": "b39ffb0d-a2ea-4cbf-97c8-4a0365c3390c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1066,7 +975,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b8d09fda-406c-45ae-8e64-6a15d17c5c5c",
+                     "jsondocId": "c1dc847b-2d42-4656-8d52-c818342446b4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1075,7 +984,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fb136835-76e6-45de-a4b6-fdd59dd965ae",
+                     "jsondocId": "d843c0bb-ff9c-45aa-a1b6-f1b69682f88f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1084,7 +993,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8464f379-d2f5-4431-993e-86818a7a34fe",
+                     "jsondocId": "1f746b22-aab2-4cad-8e29-a9c234711524",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1093,7 +1002,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9916ba1d-8f9e-476d-a229-3b36113c515b",
+                     "jsondocId": "777574f8-9102-4a0f-8820-f0e7376ecb41",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1102,7 +1011,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3bd22132-dc3f-4a2b-be29-d46a9cd78e6e",
+                     "jsondocId": "7e2b594e-c028-4053-af4c-ca41cdb19b38",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1111,7 +1020,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e206fcfd-28b1-4af6-aa0a-68134519cf23",
+                     "jsondocId": "f9a70398-dcb5-408f-9e36-9e744d4af38e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
@@ -1123,9 +1032,9 @@
                "verb": "POST",
                "description": "Duplicate transcript",
                "methodName": "duplicateTranscript",
-               "jsondocId": "2ebc7969-4d9d-4ea3-b290-3f449a2e9ac0",
+               "jsondocId": "f62b79c5-a5ca-4c2d-b319-ef1a85d03541",
                "bodyobject": {
-                  "jsondocId": "726607d1-9f0b-4293-bda8-25873c255324",
+                  "jsondocId": "a9f57258-d4dc-4d1d-8455-9d33c4a52992",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1135,7 +1044,7 @@
                "apierrors": [],
                "path": "/annotationEditor/duplicateTranscript",
                "response": {
-                  "jsondocId": "5ebe2706-674b-4f34-ab17-5735b3ce32f8",
+                  "jsondocId": "50abfdca-30e9-41ac-9e34-d375e7bafe91",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1148,7 +1057,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6fe6f92e-9862-4dca-af8f-232177fdd3ba",
+                     "jsondocId": "65149d3b-f3eb-4d28-b40b-e4d66302af4d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1157,7 +1066,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "946539ae-2df2-448e-82be-a4d262882f37",
+                     "jsondocId": "2c43e3c4-717e-45a4-b259-28bc4a5cb732",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1166,7 +1075,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7190399d-c505-45ac-a710-6d11dd23b6c9",
+                     "jsondocId": "4c1d185f-2a49-4ff1-a307-ad1fc24daf15",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1175,7 +1084,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "03f6884f-c6f6-4b9a-b2ac-4581f4727502",
+                     "jsondocId": "14f85e0e-888d-4faa-8282-3fd7e3a90608",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1184,7 +1093,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5389c1d9-7502-427a-aa6a-1e57e79ccba7",
+                     "jsondocId": "a9238d99-cc04-4123-9028-c2cf935cc2a3",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -1196,9 +1105,9 @@
                "verb": "POST",
                "description": "Set translation start",
                "methodName": "setTranslationStart",
-               "jsondocId": "b3f87434-fda6-4894-b0b3-bfc96d3d8365",
+               "jsondocId": "9bd76795-8313-4558-b282-a7cbf4cae25f",
                "bodyobject": {
-                  "jsondocId": "99d650b4-34bc-490d-94c1-2fc988d4b854",
+                  "jsondocId": "b27faf77-90eb-4863-9282-4747f5f8f044",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1208,7 +1117,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationStart",
                "response": {
-                  "jsondocId": "9bc9740d-22e7-489b-abdf-fcf38fd88b0d",
+                  "jsondocId": "1fc91592-a9ed-464f-a182-83eebba6ae36",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1221,7 +1130,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "cbab1aee-28f9-4824-ba0f-3653489ae958",
+                     "jsondocId": "6f6bc260-07a3-4593-99a5-68b19db19a2f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1230,7 +1139,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4459628-2bc3-495b-8ea2-3a282797650b",
+                     "jsondocId": "181a3537-bd80-4be2-a7ec-2356bba4aec4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1239,7 +1148,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3831fd90-3aaf-4981-bd87-856faec1e6c5",
+                     "jsondocId": "16f56f54-b1b0-4c54-a1e2-3438cdc50a46",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1248,7 +1157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c43bad0f-d50b-4fd3-8c80-200e2c2085c5",
+                     "jsondocId": "33419aba-2321-4e7f-8efc-7ae18232392d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1257,7 +1166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aed96e3a-4908-4a94-9977-a59dc7a4239a",
+                     "jsondocId": "3052ae2f-b2d7-44e5-b09b-ded8b389ef09",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
@@ -1269,9 +1178,9 @@
                "verb": "POST",
                "description": "Set translation end",
                "methodName": "setTranslationEnd",
-               "jsondocId": "047d127c-3efa-4c6d-a18b-5158d29a4556",
+               "jsondocId": "1d1d7c25-9a72-444c-a0bd-c24595edaf49",
                "bodyobject": {
-                  "jsondocId": "b51dd193-e095-407c-b7da-932c4be9b0e6",
+                  "jsondocId": "c849de54-8960-4102-8d26-aa90c8990fa1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1281,7 +1190,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationEnd",
                "response": {
-                  "jsondocId": "762e4c67-be42-4c6f-bb91-54551e7e3b86",
+                  "jsondocId": "e8828847-defd-411f-816c-7ace077e8643",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1294,7 +1203,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "774bbaac-4eb3-4b48-950c-41eede624b0f",
+                     "jsondocId": "f39cd48b-520f-439d-843e-6db1f5cc5676",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1303,7 +1212,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f3ceec97-27d1-4a34-ad0b-292278444a93",
+                     "jsondocId": "272748b6-4394-4ce0-b9f8-c0365f0ba58c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1312,7 +1221,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "40e0e94a-5d6a-4481-8e28-a300b71f5c4a",
+                     "jsondocId": "c9e81879-f345-4cdd-9018-d41971bff001",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1321,7 +1230,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "156566e1-a896-4416-9277-2f97308a6eae",
+                     "jsondocId": "a7c48703-8cab-4d42-b649-9d60f69467f1",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1330,7 +1239,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "daeabc66-5434-4e16-a501-75ac5b1296f6",
+                     "jsondocId": "ad8241d7-8f2b-4e16-92d8-4051846e1923",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
@@ -1342,9 +1251,9 @@
                "verb": "POST",
                "description": "Set longest ORF",
                "methodName": "setLongestOrf",
-               "jsondocId": "8b2e752d-12be-411f-a32b-bfa047f7afd7",
+               "jsondocId": "7a94f272-0233-4dca-838a-0207d51de296",
                "bodyobject": {
-                  "jsondocId": "9f1ed6d7-616f-47db-8af0-a2e54b5bf5e0",
+                  "jsondocId": "6da52481-aa9d-49d4-ba5b-4c2e9b75fad1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1354,7 +1263,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setLongestOrf",
                "response": {
-                  "jsondocId": "794eb419-8d61-45d9-8955-c319e3084ed8",
+                  "jsondocId": "99e11722-6217-421b-bc59-2ff237c67fd1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1367,7 +1276,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "55dd69e5-1286-4f1f-abe6-eb934f204a72",
+                     "jsondocId": "c7cc6643-5a78-46a9-9f54-03a70613899e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1376,7 +1285,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0da7e49e-a715-487f-b38b-c6a242458b48",
+                     "jsondocId": "f4c7d888-c008-417f-96cb-a87f5ab1f2ae",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1385,7 +1294,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7637fe5d-eef8-424d-b01e-6f030979d0fe",
+                     "jsondocId": "e889b7c4-f1f6-412d-bcfb-3a88008f037d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1394,7 +1303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7badef49-ef7d-42a6-8827-7ef0ca1eaacc",
+                     "jsondocId": "34dca390-dc4f-43aa-81d7-04c672cf03d0",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1403,7 +1312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14a59b0c-ed85-4d16-814a-143be6a717ef",
+                     "jsondocId": "1748192b-05f1-40e7-bce3-9ee8f6783ca2",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -1415,9 +1324,9 @@
                "verb": "POST",
                "description": "Set boundaries of genomic feature",
                "methodName": "setBoundaries",
-               "jsondocId": "ea767ab9-0c7f-43f5-a174-fb677b2c8a78",
+               "jsondocId": "e07439af-264a-4c75-9fc1-84edfe94e84b",
                "bodyobject": {
-                  "jsondocId": "bccfc7c8-101f-44d7-bc58-d3789ae5f459",
+                  "jsondocId": "abd71cbb-b10f-46dc-82f4-6db21f0b3f36",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1427,7 +1336,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setBoundaries",
                "response": {
-                  "jsondocId": "d05abdd8-a74a-44b5-b693-0d4f3db5884e",
+                  "jsondocId": "67e77f2c-d735-454a-84a3-3c511196e3e5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1440,7 +1349,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d8a098c3-7faa-487e-b8a5-57584d5949bd",
+                     "jsondocId": "1e716e54-69ee-4749-9c9b-0da003c3875a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1449,7 +1358,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bce0841e-bfc2-4d7a-99d9-1322629689ca",
+                     "jsondocId": "ee2965f9-c638-4587-930b-a16ac15c2ca7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1458,7 +1367,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9ee188b4-cec7-4c0d-b3fd-bad85ec8ce71",
+                     "jsondocId": "27f95b4a-14fe-4bcf-92a2-cd9811192862",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1467,7 +1376,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c2251337-6409-4ce8-a93b-f45610bbf545",
+                     "jsondocId": "054c7b93-3b4f-4456-b35b-cf4bd89e7adc",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1479,9 +1388,9 @@
                "verb": "POST",
                "description": "Get all annotated features for a sequence",
                "methodName": "getFeatures",
-               "jsondocId": "a0384163-ef6e-4dca-ba5f-007d6a3d42b4",
+               "jsondocId": "0a950127-74ba-4d92-8b93-af0248312913",
                "bodyobject": {
-                  "jsondocId": "5d81337b-db95-41cc-bda4-1689919f6901",
+                  "jsondocId": "5ae59b0c-18cf-4e12-bed3-cbed9c85493a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1491,7 +1400,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getFeatures",
                "response": {
-                  "jsondocId": "cb45219c-44ba-441c-9390-a34cbbb01d75",
+                  "jsondocId": "7e0e5382-25ca-4cf3-bb6b-e6825aef75cb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1504,7 +1413,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6e97379b-802d-4840-a1a0-c9d97e31ac89",
+                     "jsondocId": "3a2eaa74-0db9-4188-9d45-fd40eb4ef7eb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1513,7 +1422,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "52285ed1-4f79-4cca-93d3-b522d6ff5d08",
+                     "jsondocId": "ed83f0bf-7e78-42fc-9aff-5c5a8d6db957",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1522,7 +1431,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d9fb4330-ef63-4692-98c1-14a65dabf231",
+                     "jsondocId": "38fbe71d-ed3a-4948-a644-123425f7ac50",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1531,7 +1440,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "861663e6-dbc4-4902-a270-48806f1b8cfb",
+                     "jsondocId": "99f24e08-a120-43c5-9e2c-0de4d7392f8b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1543,9 +1452,9 @@
                "verb": "POST",
                "description": "Get sequence alterations for a given sequence",
                "methodName": "getSequenceAlterations",
-               "jsondocId": "34d0e883-524a-4363-8e3c-694dd6ba0e4f",
+               "jsondocId": "2a2d9f75-49b9-4386-8714-a60e25fc5f4f",
                "bodyobject": {
-                  "jsondocId": "7656a9ba-414f-4714-8c3a-cea6b26c6c8a",
+                  "jsondocId": "392795e0-16a1-4859-8b6d-5cdd68a744e6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1555,7 +1464,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequenceAlterations",
                "response": {
-                  "jsondocId": "dd2a84aa-9108-4ecb-8485-09c35b5efea6",
+                  "jsondocId": "3c2e4c23-8142-447c-b77c-07319ca02deb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1568,7 +1477,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c4d567b3-411c-4e1f-ab36-cb4a19293940",
+                     "jsondocId": "3ad442f2-d605-493b-997e-80f179d49480",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1577,7 +1486,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2d16bfe8-c0c7-462d-93a4-b841c0efe94b",
+                     "jsondocId": "1bad3882-3598-488b-b24c-b4c7efaad6ce",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1586,7 +1495,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "47552aa6-ce38-463b-a7fe-231fc23c6472",
+                     "jsondocId": "8ff0ece0-495c-4fea-beac-f054ee808d45",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1595,7 +1504,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "52bae1fa-abae-4048-8740-24a588532e63",
+                     "jsondocId": "96527feb-b658-49d5-94fe-65012c84ca1d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1604,7 +1513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c46690e2-b3ff-41f5-899e-01b7a375261c",
+                     "jsondocId": "74e1538d-a7ce-4852-86b3-6bc95dcc61ca",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -1616,9 +1525,9 @@
                "verb": "POST",
                "description": "Delete attribute (key,value pair) for feature",
                "methodName": "deleteAttribute",
-               "jsondocId": "fcc0f50b-2d85-4caa-9d12-686de49feee1",
+               "jsondocId": "ce040723-ab26-43cf-9b63-e07fd06477fb",
                "bodyobject": {
-                  "jsondocId": "fc61ac06-b87f-445d-baa2-d2c64e7f5b1d",
+                  "jsondocId": "04af35bb-2c93-4a5c-b443-c62174710733",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1628,7 +1537,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteAttribute",
                "response": {
-                  "jsondocId": "825df5bf-d97b-4a18-a19f-8f0b471d96ed",
+                  "jsondocId": "de1681a6-591f-453d-b53f-87d055106d43",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1641,7 +1550,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "35cf0d0f-78b0-4d14-b1d9-1f606476410b",
+                     "jsondocId": "0533b364-4ac7-4e62-8542-0496c5d86d42",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1650,7 +1559,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8e9a92c0-9143-4746-874b-3aa68dbde84a",
+                     "jsondocId": "cc9f97fa-f7c2-4caa-8f00-29d278a85ec6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1659,7 +1568,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e1b061d-615a-4421-9cea-788dca683141",
+                     "jsondocId": "4d89a15c-1674-4f7d-8113-7050652ca082",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1668,7 +1577,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c07b68c6-8b4d-4538-a6ac-b170f4ecab07",
+                     "jsondocId": "fd294f14-81f9-47c1-8838-b0dc62a03539",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1677,7 +1586,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "48130207-03ed-42ef-855d-b386fcd90ca8",
+                     "jsondocId": "e83cd028-e550-46d9-b572-b14c37e93701",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.",
@@ -1689,9 +1598,9 @@
                "verb": "POST",
                "description": "Update attribute (key,value pair) for feature",
                "methodName": "updateAttribute",
-               "jsondocId": "0e9d4dd9-c3c9-4292-86b2-008f4c8a9143",
+               "jsondocId": "4da09004-4be1-44fd-be7c-42789bde9abe",
                "bodyobject": {
-                  "jsondocId": "c8ae6109-6bb0-4535-8262-c3ecc5f3e805",
+                  "jsondocId": "f055cb33-202c-47d6-ad8a-f7c9fde66d92",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1701,7 +1610,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateAttribute",
                "response": {
-                  "jsondocId": "0720bac2-abdf-4175-bab5-6043e05055d3",
+                  "jsondocId": "f77396da-5df5-4c55-af42-e0421ca5f867",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1714,7 +1623,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8bf155bf-f08a-4f27-9f96-4d7f1deb1e0a",
+                     "jsondocId": "f07bda86-1876-45b1-8c5b-6627736fff24",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1723,7 +1632,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "61a31a38-4d0b-422f-ab30-6cdfd277af28",
+                     "jsondocId": "7b70ed79-3176-4440-b205-62ee3593da8d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1732,7 +1641,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2a8c78a4-2df8-47cd-9ba7-aac968f3bc5e",
+                     "jsondocId": "afa9bc7e-8072-4563-bbd7-ede65722b1bf",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1741,7 +1650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4643d158-7b7e-4c3c-ae01-8884156fec76",
+                     "jsondocId": "f1806ce0-c8e6-4bea-b04c-7a0076677405",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1750,7 +1659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "545e60eb-6186-4602-9fc8-e2cae8503e4c",
+                     "jsondocId": "a9fba830-d67e-4087-a959-a37ecb6d3128",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1762,9 +1671,9 @@
                "verb": "POST",
                "description": "Add dbxref (db,id pair) to feature",
                "methodName": "addDbxref",
-               "jsondocId": "4bdbeaae-ea93-4160-bd96-d532bdb072df",
+               "jsondocId": "a0bce3a2-4f1f-4dc4-bb79-946bbd34c29e",
                "bodyobject": {
-                  "jsondocId": "25487ea7-dbb0-4ba4-931c-32ac44f3e623",
+                  "jsondocId": "e12659a7-fe7c-44da-8246-71e2edd004ad",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1774,7 +1683,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addDbxref",
                "response": {
-                  "jsondocId": "0ed16e2f-bd44-429b-bc2f-12b7d9db7ccf",
+                  "jsondocId": "3a0ae9c2-15c6-4d14-96ee-fc8f234509f5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1787,7 +1696,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3df12df6-ae7d-42ba-9715-6cc4fbc9c411",
+                     "jsondocId": "cbd44cb4-8b1f-4f55-ad67-e84ef6c53aed",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1796,7 +1705,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a218876a-c667-4011-a6f3-179e72b469ff",
+                     "jsondocId": "c5ab16b7-3e17-4769-879e-8c5d7dda88a4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1805,7 +1714,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d84250b-8c41-418f-8642-4510566c7a98",
+                     "jsondocId": "22ee6be4-d8d1-494f-bd59-d6f39b028784",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1814,7 +1723,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "007bd1ad-70de-4fd0-b1c2-5b94e3c61d9b",
+                     "jsondocId": "fa2d6f48-0177-42cb-a345-9ad545a81c9c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1823,7 +1732,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "53c0d240-a4bc-43c0-9252-2ff98ab7fc9c",
+                     "jsondocId": "c1ee1340-9722-4969-bc90-2350a4148bb2",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.",
@@ -1835,9 +1744,9 @@
                "verb": "POST",
                "description": "Update dbxrefs (db,id pairs) for a feature",
                "methodName": "updateDbxref",
-               "jsondocId": "1944ae72-2689-421d-8509-e3c0b2eb1378",
+               "jsondocId": "dc24f181-bc21-4e2b-81df-234ba5fe4b38",
                "bodyobject": {
-                  "jsondocId": "adc9c291-647a-4d7c-833d-e7263dcd53d4",
+                  "jsondocId": "61ca64df-81bb-450d-84a1-1a80d9bf1f9e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1847,7 +1756,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateDbxref",
                "response": {
-                  "jsondocId": "b6d3fde1-b246-41dd-85cf-06cb24acaab9",
+                  "jsondocId": "f79d9945-0b71-40c2-a844-6486f1044c69",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1860,7 +1769,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b5bc98f8-dc85-4184-b979-fbed4ac0b80c",
+                     "jsondocId": "3b114d39-8b8e-41b2-8f71-e1ddf53e9a8c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1869,7 +1778,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ea457775-b853-4b32-aacc-2959d998f569",
+                     "jsondocId": "1fa82231-76c5-46a3-91d4-53b666afe891",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1878,7 +1787,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1bfbf628-7c97-4e1a-aef8-2ccb0ce66fa0",
+                     "jsondocId": "268206d8-f488-45a0-af9e-88dda299418b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1887,7 +1796,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff3490fd-c0f4-4c7c-81f2-ce0aedf72bbb",
+                     "jsondocId": "58e412e9-30a8-4c3d-9855-5aabafb5eb7d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1896,7 +1805,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b7ca12a-bfef-4d58-bfba-e7ff8726a9fe",
+                     "jsondocId": "ef4fdee8-deba-459b-92bc-a34e70c8e4af",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1908,9 +1817,9 @@
                "verb": "POST",
                "description": "Delete dbxrefs (db,id pairs) for a feature",
                "methodName": "deleteDbxref",
-               "jsondocId": "2cbd52a9-2fa2-4cf8-b35f-303b07594658",
+               "jsondocId": "7b7536e3-f178-4f34-aa49-abed2c9a8f6d",
                "bodyobject": {
-                  "jsondocId": "53301bf5-031c-47b2-b33b-d8bb1356fa4d",
+                  "jsondocId": "9b97d330-8901-4482-a2df-89636b7b9cca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1920,7 +1829,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteDbxref",
                "response": {
-                  "jsondocId": "6b5bd222-fa72-4ef7-8274-3b68f6732d2a",
+                  "jsondocId": "d45cbe9a-5002-4ff3-a84c-9f2501d532fc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1933,7 +1842,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "404b93e6-34dd-40cf-89e1-34c7300e54cc",
+                     "jsondocId": "e2e84118-7876-48f2-879f-13625d921011",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1942,7 +1851,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "093bd5c5-a160-461b-b46e-30cd1d34402c",
+                     "jsondocId": "315e1c59-8058-4e48-88e4-bb85bf0e30fd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1951,7 +1860,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "75a83ced-fcd5-432d-afb3-716205348e3b",
+                     "jsondocId": "b401881d-0842-407b-8ab3-f203b4601df9",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1960,7 +1869,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7f0cb037-4dd0-42ab-a117-c74f06db4af7",
+                     "jsondocId": "59450da9-bc47-4668-98f1-0da72b786e73",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1969,7 +1878,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "58313436-f128-44f1-aa73-57ae06232c85",
+                     "jsondocId": "02847467-8621-4b1a-935d-5e94cb808282",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
@@ -1981,9 +1890,9 @@
                "verb": "POST",
                "description": "Set readthrough stop codon",
                "methodName": "setReadthroughStopCodon",
-               "jsondocId": "6b377a8e-4385-4b86-8138-63f9d60af708",
+               "jsondocId": "44b8c3ec-60e5-44d3-8372-f8bfbee6e58c",
                "bodyobject": {
-                  "jsondocId": "e5e6d461-ee25-4e3d-bf1c-26670a090341",
+                  "jsondocId": "85b59697-37eb-4eaf-85f2-28a148679df3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1993,7 +1902,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setReadthroughStopCodon",
                "response": {
-                  "jsondocId": "a0b7459d-8be6-46c0-8b23-5f38dea91c2d",
+                  "jsondocId": "7d261301-719f-4001-9677-fc7399fcc236",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2006,7 +1915,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "82adaa72-0bd1-4d2d-b3db-0fee1319c249",
+                     "jsondocId": "9d8b5f10-5f33-4a46-a6e8-0208e732c3a7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2015,7 +1924,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e32000f6-5022-4fc1-b5a8-4928dcba331c",
+                     "jsondocId": "f9a42051-ffb2-4eed-bc87-ebc33a7a535e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2024,7 +1933,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "50446f77-e588-49e5-9507-77c90ad3bc56",
+                     "jsondocId": "3921232c-6652-4c50-973c-161f82434b5e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2033,7 +1942,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d4d1ed63-fe9a-4ae7-9d6c-36cbc617a628",
+                     "jsondocId": "f57b570f-e3f4-4781-abb9-dfbc2571f58e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2042,7 +1951,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ee90c9b2-3196-4b86-b42f-0e1e70e92bfb",
+                     "jsondocId": "10cd5d51-e293-4cce-a26a-59a8c26f5c71",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
@@ -2054,9 +1963,9 @@
                "verb": "POST",
                "description": "Add sequence alteration",
                "methodName": "addSequenceAlteration",
-               "jsondocId": "c0994c9c-1757-4310-a1d8-c54fa3238dff",
+               "jsondocId": "f24ef9af-a275-45f3-9249-bc3f9c2394fa",
                "bodyobject": {
-                  "jsondocId": "fa3e653c-2607-42ab-b4ea-af2574fdcce7",
+                  "jsondocId": "ec273547-9d38-4d2b-926a-8467729c0b0a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2066,7 +1975,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addSequenceAlteration",
                "response": {
-                  "jsondocId": "a897cbd6-494b-4a62-8dae-069823e47fd4",
+                  "jsondocId": "424c322f-12a9-4e3e-bc73-4a417d45d5fb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2079,7 +1988,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "eaea92ee-ee70-4e6e-979b-d4ff719f9af6",
+                     "jsondocId": "c2f132a5-4e19-4c92-a77f-fcc8d8d811dd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2088,7 +1997,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b0ae7f88-7916-4399-9bf3-3a4d66b26d31",
+                     "jsondocId": "b017f55d-c0f0-44ee-8b82-812c5a1887b1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2097,7 +2006,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "249d513d-d64e-4e0c-9ed9-91283f8c0b4a",
+                     "jsondocId": "55039104-235c-474c-b348-ee3e2b33b57f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2106,7 +2015,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ac6c27fd-2ccf-4a72-b65c-4b34ee70eb8d",
+                     "jsondocId": "97e646de-6efd-47d2-9b6f-099c1484a135",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2115,7 +2024,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "20581a83-9686-4ba1-bd8d-0b1cbd369836",
+                     "jsondocId": "75119974-1039-4a82-a0e7-37c64c876c78",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
@@ -2127,9 +2036,9 @@
                "verb": "POST",
                "description": "Delete sequence alteration",
                "methodName": "deleteSequenceAlteration",
-               "jsondocId": "9d7e3fee-3ef7-4797-9141-31f09efed59e",
+               "jsondocId": "34a8c86e-956b-4d21-8f80-6e07e6cee064",
                "bodyobject": {
-                  "jsondocId": "6964dae5-d1db-4c21-8fbe-a51c5ff30a48",
+                  "jsondocId": "7e5826e3-031e-4d91-b5f7-5962eef77d8b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2139,7 +2048,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteSequenceAlteration",
                "response": {
-                  "jsondocId": "f623fdca-f4e5-4d9e-a5b8-9c9a1547dfe0",
+                  "jsondocId": "2105b710-aaa4-4a6d-9a9a-d4818e6da3cd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2152,7 +2061,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "285f57bd-b861-4070-b740-632b912c946c",
+                     "jsondocId": "586f6aa7-498b-43d7-b077-7ee56188a68d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2161,7 +2070,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4d9281e-7e01-4f54-8331-2746e15d06b2",
+                     "jsondocId": "57b8b6de-f507-4aa5-819d-c4b95cb18c26",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2170,7 +2079,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "056e66ff-2115-4476-92aa-57c76ab22aca",
+                     "jsondocId": "514f819c-c42b-472c-852e-a524573ac537",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2179,7 +2088,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1a2730c3-e0b6-4133-9f0f-8670f0c1071e",
+                     "jsondocId": "4ffe7b3a-ff7b-4e00-8911-decadec46bea",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2188,7 +2097,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "64b7ae20-71cc-4997-9f24-ee2f00496d84",
+                     "jsondocId": "7b57cde6-cb2f-4356-aa8f-ba23358a0f71",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
@@ -2200,9 +2109,9 @@
                "verb": "POST",
                "description": "Flip strand",
                "methodName": "flipStrand",
-               "jsondocId": "71264a7a-5ec9-47d2-bb3c-9198d71e356e",
+               "jsondocId": "ae79622b-c5a6-44f5-9005-13e717b41162",
                "bodyobject": {
-                  "jsondocId": "ea048897-592c-4c17-9793-b061d6b850e6",
+                  "jsondocId": "4f64f453-03a8-4d5a-8d9c-d205f4f381af",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2212,7 +2121,7 @@
                "apierrors": [],
                "path": "/annotationEditor/flipStrand",
                "response": {
-                  "jsondocId": "87d8168c-7ad8-4eed-9eb6-746bdc999494",
+                  "jsondocId": "38ce23a9-b98e-4fc8-98e4-4c0bb3c96ec8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2225,7 +2134,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a1f3f183-85f9-4b57-9bcb-21db97d6239f",
+                     "jsondocId": "16926c64-08b7-4881-b2c1-f77da49e026a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2234,7 +2143,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "664a7137-7ff0-47a5-870e-17a2cb6aab5b",
+                     "jsondocId": "0f462daf-9f5a-42dd-bc5d-d91ad7b9f9a3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2243,7 +2152,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "673c9deb-3716-4204-8ee1-e82f129e9f79",
+                     "jsondocId": "cd821e77-136f-40b4-91ed-4c2477a120d4",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2252,7 +2161,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ba033f8c-49ed-4a6b-8d2e-9706eb1c3c80",
+                     "jsondocId": "20624b6e-8e1d-495e-af01-d47d9c97021e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2261,7 +2170,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b33f6ef2-85b2-4079-996f-02ecb434000d",
+                     "jsondocId": "f9a261ba-7745-4e4e-a3e2-46b91dcb56b5",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
@@ -2273,9 +2182,9 @@
                "verb": "POST",
                "description": "Merge exons",
                "methodName": "mergeExons",
-               "jsondocId": "73fcf32b-9b2a-48bc-9d5f-fb539b855146",
+               "jsondocId": "bf4a5ac8-008d-44f8-b908-5ba40a7dddc8",
                "bodyobject": {
-                  "jsondocId": "db4b56c7-6c8b-46b0-a0e4-128cc60f26fd",
+                  "jsondocId": "4f52900a-182d-4b09-ad59-f998ab9cab89",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2285,7 +2194,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeExons",
                "response": {
-                  "jsondocId": "d657f44e-cbe0-4b6d-866d-36aee840cde6",
+                  "jsondocId": "20964f1a-247e-42a3-badd-465479b3ac90",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2298,7 +2207,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8ad6ed98-58e2-458c-ad8a-909c10ec7cb1",
+                     "jsondocId": "305f3ff6-b0ad-4726-bd79-a4967709a89a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2307,7 +2216,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3ccaca6a-b662-455f-a571-f4b759aa8345",
+                     "jsondocId": "8eec350d-5948-4cad-9531-b741a544fef0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2316,7 +2225,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9cf9fd7a-40ce-48f5-a01c-cb0068a534a8",
+                     "jsondocId": "85ebf266-9144-4f0b-9c8e-66ec33709a6c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2325,7 +2234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2021323a-d4b1-43e3-bfec-87868725acd0",
+                     "jsondocId": "bfffbc38-9a4a-4263-b9c5-72e7d94b185b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2334,7 +2243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63726746-2574-407a-80ab-8bad22684eb4",
+                     "jsondocId": "10d4c83b-bd10-4749-a720-ba7b43a1f30d",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -2346,9 +2255,9 @@
                "verb": "POST",
                "description": "Split exons",
                "methodName": "splitExon",
-               "jsondocId": "5f3918dc-f622-423f-a317-b90de09eb222",
+               "jsondocId": "efc8f2a7-9c81-4896-ae2f-0c9b939df419",
                "bodyobject": {
-                  "jsondocId": "f05c276a-3fb4-4527-9b4b-db35c8770c5c",
+                  "jsondocId": "6859ec1e-e062-4755-9ded-b5b5f65bda8c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2358,7 +2267,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitExon",
                "response": {
-                  "jsondocId": "04ae004e-e80a-4a79-81b1-6aa628a5347c",
+                  "jsondocId": "1e851a34-30c0-4bb0-8b30-6607c6814955",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2371,7 +2280,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "086e0cba-6847-4ef1-bf08-2f94b642a5d3",
+                     "jsondocId": "4d20ff17-9391-442a-8a57-d54498e69ed3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2380,7 +2289,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "755cbf4f-5346-4dc5-8ffe-4ab892444284",
+                     "jsondocId": "f1fc2941-687f-4af5-9c2d-0a267c1701ab",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2389,7 +2298,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "76e9a34f-8503-4e57-9e98-cb0dd62e2906",
+                     "jsondocId": "2f850636-75a5-4130-b5df-3e254aa088f6",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2398,7 +2307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bf0fdc96-9366-4da7-b4a1-9d1a46297a36",
+                     "jsondocId": "666879cc-85ca-47a6-839d-96c3e8176ccd",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2407,7 +2316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b7c6e3eb-f6e4-48cc-8846-0ff2de959929",
+                     "jsondocId": "2be42e45-9f69-450b-8895-8dbaad15ed21",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
@@ -2419,9 +2328,9 @@
                "verb": "POST",
                "description": "Delete feature",
                "methodName": "deleteFeature",
-               "jsondocId": "9529ad14-18cc-4509-b8aa-bb3cf47b02f7",
+               "jsondocId": "cf6e2afc-2938-48b2-9cd4-c785aa07f027",
                "bodyobject": {
-                  "jsondocId": "4bc2f1a6-f9ea-4b1a-87c2-26c65dc9d53f",
+                  "jsondocId": "38df42fd-da91-49b0-94d3-cbee543090a0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2431,7 +2340,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeature",
                "response": {
-                  "jsondocId": "e47d03c3-cd9a-439b-85a8-b1cb135c0163",
+                  "jsondocId": "96356cd1-5723-479c-bef3-0250a94315fe",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2444,7 +2353,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f4c3d5c6-c451-4266-8c36-203cf7be7500",
+                     "jsondocId": "16e4b0c3-2a89-4368-b5c3-735a7d8406c1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2453,7 +2362,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02ea73b7-a0a9-4143-a9f1-5eae60e86065",
+                     "jsondocId": "6c25c3cc-7e7e-482d-9079-be8340218706",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2462,7 +2371,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d151b9ed-ee77-46be-92ba-ae118e744f82",
+                     "jsondocId": "22996e52-ded7-401e-8c0b-58078d5823a3",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2471,7 +2380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b69224b8-b7f7-49af-9e0b-bd98ad4212d0",
+                     "jsondocId": "225f5269-990b-4ef9-9147-a48cdc6957c9",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2480,7 +2389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e9272606-3f1c-470e-aa2c-1f512a738039",
+                     "jsondocId": "f0959613-4b11-4806-b0f6-9334a71c2e54",
                      "name": "sequence",
                      "format": "",
                      "description": "JSONArray of sequence id object to delete defined by {id:<sequence.id>} ",
@@ -2492,9 +2401,9 @@
                "verb": "POST",
                "description": "Delete variant effects for sequences",
                "methodName": "deleteVariantEffectsForSequences",
-               "jsondocId": "f449c3f7-a261-42b5-ba24-d5c2bcd8815f",
+               "jsondocId": "09dd8a19-3177-4a4c-adda-c42c3bd69aee",
                "bodyobject": {
-                  "jsondocId": "1e6308f0-91cb-4f26-b421-c6fb0893b470",
+                  "jsondocId": "176aef41-d4b4-4a28-9e8c-a8337414f761",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2504,7 +2413,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteVariantEffectsForSequences",
                "response": {
-                  "jsondocId": "4c77589f-57d9-484c-92cd-894abef949db",
+                  "jsondocId": "645a5422-dc9e-4433-a12e-cef498431473",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2517,7 +2426,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1755bfa0-faea-43a2-9024-703bee55401e",
+                     "jsondocId": "a5742244-d0c5-4718-9c3a-9ce0896106a9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2526,7 +2435,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "72db9f15-ca52-40dc-8dd8-83db0ff2690c",
+                     "jsondocId": "f83d9f23-daaa-40fd-845f-16d0c61f151a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2535,7 +2444,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "68cf27a8-b76d-4b97-bfd4-1adba75fa1bb",
+                     "jsondocId": "7e93afa6-a1c5-40be-a4c8-fd2f602d114d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2544,7 +2453,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "573a6eaa-fc87-4145-8b0e-bebd67e69129",
+                     "jsondocId": "b477a74f-33f0-431e-aa46-635000ed3741",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2553,7 +2462,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "af2e8bfa-ea95-4ec1-9543-f04ff703a7a0",
+                     "jsondocId": "c5908962-efdf-4659-bc45-1656e066c9de",
                      "name": "sequence",
                      "format": "",
                      "description": "JSONArray of sequence id object to delete defined by {id:<sequence.id>} ",
@@ -2565,9 +2474,9 @@
                "verb": "POST",
                "description": "Delete features for sequences",
                "methodName": "deleteFeaturesForSequences",
-               "jsondocId": "6a651011-b6a5-4bad-99ac-785f3d8f5d3e",
+               "jsondocId": "0ac8d791-d4e7-437d-ba0a-599985f0875d",
                "bodyobject": {
-                  "jsondocId": "9c2b12b7-c517-46f5-92f3-475a411de015",
+                  "jsondocId": "b26f0f1a-e400-439d-b5d2-879c94488737",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2577,7 +2486,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeaturesForSequences",
                "response": {
-                  "jsondocId": "704cf0e7-76e1-486e-b89e-0fe1c54bc798",
+                  "jsondocId": "99e4975c-0965-4ce4-adf3-f3b03bc58807",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2590,7 +2499,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f9bb2a2a-65f7-4b45-b5f0-dbba2ec5097f",
+                     "jsondocId": "448f36ca-f180-47f7-9223-367a170e6eb4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2599,7 +2508,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55ac9276-6b31-4f78-8f29-2982b6aac227",
+                     "jsondocId": "b7812c82-1538-4c29-9f9e-3bd150c6ff0b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2608,7 +2517,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9bdb150-a63c-4c13-a9de-69d7d35670e3",
+                     "jsondocId": "ae235a11-def9-4ef6-94b8-ecc28d1da18a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2617,7 +2526,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a74b85c6-d745-47e6-b53a-175f356176c5",
+                     "jsondocId": "201e07fd-e0ad-445e-bc27-8f92c8f8bc7c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2626,7 +2535,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c3f8efd-bdfc-49fa-b666-1b7b06d24d0a",
+                     "jsondocId": "6ce598f6-0b38-48ac-aa9c-f59e7415f2b5",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
@@ -2638,9 +2547,9 @@
                "verb": "POST",
                "description": "Delete exons",
                "methodName": "deleteExon",
-               "jsondocId": "7efb2dba-dbf9-47ef-83c7-0b0b5779fa78",
+               "jsondocId": "efbbff65-1e98-4eaf-8ae3-7f51071e6fe7",
                "bodyobject": {
-                  "jsondocId": "4da67549-1b6d-4360-80ca-badd9992c018",
+                  "jsondocId": "52161f55-a4de-46f2-beda-4463606a3bac",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2650,7 +2559,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteExon",
                "response": {
-                  "jsondocId": "502f176e-e305-4ecd-aac5-b6405a61f8ae",
+                  "jsondocId": "796426e3-11fe-4ab2-b2a7-0a6f6506c960",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2663,7 +2572,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b25ce1c6-88b9-4aba-983b-276663448ee4",
+                     "jsondocId": "41b56f4b-e60f-42c5-9e08-d0a3bbcf0cfa",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2672,7 +2581,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f6fa2246-bc81-4ff3-90b7-0d28864a9126",
+                     "jsondocId": "ff68e3f4-f209-41fe-a636-65def7ce918f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2681,7 +2590,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f3d90365-680e-4704-923f-08b3cf2d162f",
+                     "jsondocId": "e281ab3c-b341-4428-aa3c-e2a79d8d8729",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2690,7 +2599,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "29dd470b-d170-4eed-962d-891d33d7539b",
+                     "jsondocId": "08993855-996e-4303-a693-cdd042aee4ec",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2699,7 +2608,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "68c357ee-0ac9-4ab2-a06b-9ecb10544bc6",
+                     "jsondocId": "efb616c1-99d8-42ec-ad5b-3b17bd580496",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -2711,9 +2620,9 @@
                "verb": "POST",
                "description": "Make intron",
                "methodName": "makeIntron",
-               "jsondocId": "b12401e2-bdcf-4263-ac03-135cd9957b72",
+               "jsondocId": "dffeaaf2-5c50-4fa4-b5b4-38cc9c60dc0f",
                "bodyobject": {
-                  "jsondocId": "b9ee835b-6014-4e9c-b721-ad4da16324da",
+                  "jsondocId": "a82ac8d2-a7a9-4c0d-9aa3-ddd304d093dd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2723,7 +2632,7 @@
                "apierrors": [],
                "path": "/annotationEditor/makeIntron",
                "response": {
-                  "jsondocId": "9ca69d0d-a24e-4c4c-be38-dc5a4bd59ed1",
+                  "jsondocId": "5b219ecb-5a13-497d-9215-4dcd68f5a52d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2736,7 +2645,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "736405b3-65c4-4747-a4d4-cfeae2a93d2a",
+                     "jsondocId": "3ebbc076-0789-4be1-9109-33f57a9c8d2d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2745,7 +2654,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9435882c-8715-4eaf-b86c-a042695abbb9",
+                     "jsondocId": "5a95616a-4629-4b6b-a905-ad128cee4bc9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2754,7 +2663,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "10471cd6-b267-45d0-be85-1606de92c363",
+                     "jsondocId": "0a676103-3c28-4498-9fe0-a00070168d0c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2763,7 +2672,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bae7a1ad-efcc-483a-9ea7-382ea8032c63",
+                     "jsondocId": "22517ce9-a3b3-4292-b9bd-edef1948e171",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2772,7 +2681,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c074828f-69e4-422c-b80f-ffe5fa09c78d",
+                     "jsondocId": "503bc59a-0abe-4409-a8f2-e98059c06131",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2784,9 +2693,9 @@
                "verb": "POST",
                "description": "Split transcript",
                "methodName": "splitTranscript",
-               "jsondocId": "d8a45439-77b2-457e-986a-367a90d14087",
+               "jsondocId": "8e1ca587-edad-4c90-b1b0-7f1ca9828bc4",
                "bodyobject": {
-                  "jsondocId": "cc1a7e78-2972-47f4-a658-e1474f463405",
+                  "jsondocId": "b51804ad-3cd1-41a5-9f04-8204f862e75b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2796,7 +2705,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitTranscript",
                "response": {
-                  "jsondocId": "0146553b-b354-4280-b2eb-e7a2ec2bff15",
+                  "jsondocId": "263176de-58d5-45d2-830c-5a9415c7e338",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2809,7 +2718,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "62982a62-6374-4d68-8003-4a786be04035",
+                     "jsondocId": "b8ebd238-83a5-461c-aa63-abd597754a54",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2818,7 +2727,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e5dd7af0-98dc-4cb9-bf5c-445f62f7e81b",
+                     "jsondocId": "caf2603c-d9cd-4341-993c-4c64e88728d5",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2827,7 +2736,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c0723aeb-46b0-495e-b750-61c9cb4f90e5",
+                     "jsondocId": "76fa58c5-d344-4604-9e41-483f66ce1b56",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2836,7 +2745,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "df926463-48b1-43ca-b26d-c6d737bd941a",
+                     "jsondocId": "763d422a-747a-46bf-b795-e1c9e62810e0",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2845,7 +2754,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d5eafbc-21d2-4007-bb88-9fa52c589777",
+                     "jsondocId": "7fa6aab3-c801-427f-946c-f4d206364def",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2857,9 +2766,9 @@
                "verb": "POST",
                "description": "Merge transcripts",
                "methodName": "mergeTranscripts",
-               "jsondocId": "ccf61312-83a0-4840-a316-981875eb3b88",
+               "jsondocId": "3d8491d7-4d0c-4aa1-a371-af6dfc1d97a3",
                "bodyobject": {
-                  "jsondocId": "d7c7a0d3-9b82-47d2-913a-e836cc670188",
+                  "jsondocId": "319ccbc5-d59d-4d62-8d56-549bd3cb508a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2869,7 +2778,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeTranscripts",
                "response": {
-                  "jsondocId": "e41c382d-ac00-47de-86d7-be275bb5abfb",
+                  "jsondocId": "c75063be-0de7-4b2f-8a77-cd19a976e7fd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2882,7 +2791,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "dc0bd4c2-3d52-4a39-a363-fb7db5680d9b",
+                     "jsondocId": "ee47bc10-6342-4950-9c21-9653b41d7259",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2891,7 +2800,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b4e326ef-8b5a-42ad-a0d2-f4f9823de07b",
+                     "jsondocId": "9a7f04dd-4eea-4ba8-8687-b64271dab943",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2900,7 +2809,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c2980d79-e911-4c96-8dbc-876d14578ef8",
+                     "jsondocId": "521dd847-60d9-4c33-ba93-a99d77ce2920",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2909,7 +2818,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e18f0d5-4bc5-4aad-ad4d-e1c1596a4710",
+                     "jsondocId": "f9b35838-8524-433c-8db2-85eaa08d1d3c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2918,7 +2827,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e97c96c4-a67d-4bbc-aa36-878b7a4205ec",
+                     "jsondocId": "3de37e77-eb8d-476c-a904-90b2ecaff068",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2930,9 +2839,9 @@
                "verb": "POST",
                "description": "Get sequences for features",
                "methodName": "getSequence",
-               "jsondocId": "f968478e-05f2-489d-9eb4-f441a802876f",
+               "jsondocId": "87b02bc5-ce51-4347-804d-66cc6ebd5b02",
                "bodyobject": {
-                  "jsondocId": "acb7efc7-29a4-4a7f-9eac-a15154750db7",
+                  "jsondocId": "890c956d-ec62-46db-9845-d91885c2fedf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2942,7 +2851,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequences",
                "response": {
-                  "jsondocId": "a0873964-5a16-4b25-a239-3d9215528523",
+                  "jsondocId": "ebdec96b-09da-47df-9197-a72482365b3c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2951,7 +2860,7 @@
                "consumes": ["application/json"]
             },
             {
-               "jsondocId": "aec7a2ef-0841-479b-94e2-8acdb1be5350",
+               "jsondocId": "f3f2de3f-a4e6-4ef2-ab0f-17108b37997a",
                "bodyobject": null,
                "apierrors": [],
                "path": "/annotationEditor/getSequenceSearchTools",
@@ -2959,7 +2868,7 @@
                "pathparameters": [],
                "queryparameters": [],
                "response": {
-                  "jsondocId": "58448e99-50ca-4969-96cd-ef1c1cedca08",
+                  "jsondocId": "1374a595-54bc-4f9a-91ad-1f40aee10471",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2974,7 +2883,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "11d95279-a6b4-403e-ae79-eaeefcab7026",
+                     "jsondocId": "ab9f75d6-ffeb-4a6a-a135-18beb108df0c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2983,7 +2892,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7ef2459e-b90c-4a56-84bc-2dd86e7999e2",
+                     "jsondocId": "bcc6d448-5546-4167-8e53-99f1b1a94ced",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2995,9 +2904,9 @@
                "verb": "POST",
                "description": "Get canned comments",
                "methodName": "getCannedComments",
-               "jsondocId": "81d57810-05b6-455c-bee0-0f929cac825f",
+               "jsondocId": "f14aac84-17d6-45de-8bf5-c7ed280faf90",
                "bodyobject": {
-                  "jsondocId": "a561559f-7005-4ad0-bbda-0d7354ec6927",
+                  "jsondocId": "e0e648d0-6aaf-4045-83e3-f3dd2153c40a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3007,7 +2916,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getCannedComments",
                "response": {
-                  "jsondocId": "c1f36527-1820-41d6-ba82-a3143b4138c6",
+                  "jsondocId": "0950b86d-8f6d-4005-b8b6-f7c72bb37dae",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3020,7 +2929,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9338232e-26c1-4d21-ab91-34062a33b0c2",
+                     "jsondocId": "c63e4bd6-473a-4dd4-8a3a-3780d8b837cc",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3029,7 +2938,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bc779e2b-6434-4776-8d5c-cb82d66f6ed7",
+                     "jsondocId": "5e4308b3-fdd7-49ea-961b-1cd15acab4bd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3038,7 +2947,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65c9671d-a32f-458c-a20e-43ec18eef4e1",
+                     "jsondocId": "24400999-28ea-46a9-86a2-e509f2bb37d6",
                      "name": "client_token",
                      "format": "",
                      "description": "Organism ID/Name or Client-generated ",
@@ -3047,7 +2956,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "843d966d-18a6-4985-bfe8-0504ffd11de8",
+                     "jsondocId": "e9319d31-b258-4aa6-96ff-a324b4c65142",
                      "name": "search",
                      "format": "",
                      "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
@@ -3059,9 +2968,9 @@
                "verb": "POST",
                "description": "Search sequences",
                "methodName": "searchSequence",
-               "jsondocId": "6cbfb95a-a80d-463c-85c3-5b55b7c693e4",
+               "jsondocId": "a6b5eb66-1b95-4a4a-9a1a-ffea8a0940fa",
                "bodyobject": {
-                  "jsondocId": "ebcdc724-b086-4e16-a00b-215e4ef36e23",
+                  "jsondocId": "cff8424e-5883-4ef7-92f8-464e5d11e044",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3071,7 +2980,7 @@
                "apierrors": [],
                "path": "/annotationEditor/searchSequences",
                "response": {
-                  "jsondocId": "13442941-403c-4035-ab58-73c3d13c9a53",
+                  "jsondocId": "ac6ee475-8328-41ad-9216-7cf3b4070d9b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3084,7 +2993,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4a146190-2090-484f-886b-12f3881b4a9e",
+                     "jsondocId": "c0f119ac-2d16-4d9a-837a-c3ad5422f7a1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3093,7 +3002,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2abdec67-24e0-40c2-b0fe-9024401bafc0",
+                     "jsondocId": "09b1884e-ee21-4c82-8fd1-20456f594938",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3102,7 +3011,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "298d567d-3631-4f27-b918-ed769ea1102b",
+                     "jsondocId": "be704645-ebea-4f03-9113-4476aeba9f6e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -3114,9 +3023,9 @@
                "verb": "POST",
                "description": "Get gff3",
                "methodName": "getGff3",
-               "jsondocId": "76e00dac-66b5-4c83-9cce-d82c0db916dc",
+               "jsondocId": "6ba58013-19e5-4ac9-bf5b-f981b8213adf",
                "bodyobject": {
-                  "jsondocId": "cf631769-a8fb-4a35-af14-d27ac81b06a8",
+                  "jsondocId": "c52151a1-75b9-416b-8838-d0e58ec1538c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3126,7 +3035,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getGff3",
                "response": {
-                  "jsondocId": "51606e9e-286c-475b-9d34-f84eb6282e0e",
+                  "jsondocId": "a565d714-3072-430e-b799-78af36240cec",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3139,7 +3048,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e036d405-5479-41c4-b1d0-1c1b2ed0f15d",
+                     "jsondocId": "0bd39c1e-67eb-4a78-bcfc-929b31d34bb4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3148,7 +3057,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b074fd61-afdc-4bcd-9e2a-75fbfcb5d270",
+                     "jsondocId": "89db7bdf-e6e4-4e0f-9e8d-284051e9ad4d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3157,7 +3066,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "162de632-ff51-4c66-8bf7-5b7248d6554b",
+                     "jsondocId": "18546711-5f5a-4d7e-92a3-43229b63cd67",
                      "name": "days",
                      "format": "",
                      "description": "Number of past days to retrieve annotations from.",
@@ -3169,9 +3078,9 @@
                "verb": "POST",
                "description": "Get genes created or updated in the past, Returns JSON hash gene_name:organism",
                "methodName": "getRecentAnnotations",
-               "jsondocId": "e04fb87f-a9b9-459a-a691-083516790ca9",
+               "jsondocId": "92ec0845-91aa-48c6-9cbc-e5925006a5ea",
                "bodyobject": {
-                  "jsondocId": "6a28b338-c1d1-442b-9fab-95dd4de99f82",
+                  "jsondocId": "848cf144-f532-4ff6-ad62-ff036dfeed18",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3181,7 +3090,98 @@
                "apierrors": [],
                "path": "/annotationEditor/getRecentAnnotations",
                "response": {
-                  "jsondocId": "8a296b94-226c-405e-81dd-98889791e682",
+                  "jsondocId": "3b6de79d-b4b6-460b-8c89-a0114fbcc17e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "56a764c8-aab1-44a9-93ac-eef2ac956080",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6f7f0149-d0e2-4f75-8c73-949401dedade",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3fbe27f7-44b5-4c15-b341-d9ecfbbdfec3",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c3f0deaf-d9c9-4fd3-8733-3c26f0c1c8a8",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d3c941d3-de96-483d-8a7a-1f00b53aa1d9",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "75fad5b4-18f0-40ee-8e65-adaba61c211b",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5a0be5b7-fd21-441f-a2b7-09aa6543506e",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set exon feature boundaries",
+               "methodName": "setExonBoundaries",
+               "jsondocId": "b6f511d1-0b3b-4173-bbc7-53e16fc0a084",
+               "bodyobject": {
+                  "jsondocId": "605aa38f-196c-406d-affa-745cb827a356",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setExonBoundaries",
+               "response": {
+                  "jsondocId": "05d48fe7-258b-4cb3-9cc5-46368d126743",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3194,14 +3194,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "c0a011ea-eac2-4612-ae24-b30f28f374ae",
+         "jsondocId": "179995d6-966a-4047-a00e-400dac9defb6",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "01c9801a-642e-4b61-8e9c-7e75d5049095",
+                     "jsondocId": "801b073e-e5e6-4f65-8779-0fd49d40187e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3210,7 +3210,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "10777b6c-88cc-47e1-abcc-2efc8aa1ecfb",
+                     "jsondocId": "d06e9b7d-1e09-4dab-98c4-9f87805e6186",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3219,7 +3219,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "324d1356-adc7-4c3e-9015-54220c5e2954",
+                     "jsondocId": "337ed74d-7945-4c9d-a160-1fc54e46bae6",
                      "name": "uniquename",
                      "format": "",
                      "description": "Uniquename (UUID) of the feature we are editing",
@@ -3228,7 +3228,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2715c368-4960-4be2-8750-f3bb1870a3d8",
+                     "jsondocId": "71db1ebd-82f9-4b31-95e0-c1dcb234c6be",
                      "name": "name",
                      "format": "",
                      "description": "Updated feature name",
@@ -3237,7 +3237,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db2a0fbe-ce03-4ad8-9a7d-5eca2eb10df3",
+                     "jsondocId": "63718346-389e-4858-99e1-5a16b78b4324",
                      "name": "symbol",
                      "format": "",
                      "description": "Updated feature symbol",
@@ -3246,7 +3246,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b793983a-4e80-4a92-a195-4aca43b0177a",
+                     "jsondocId": "699c9a6f-5e68-4b0e-9a73-7d33da27a92a",
                      "name": "description",
                      "format": "",
                      "description": "Updated feature description",
@@ -3258,9 +3258,9 @@
                "verb": "POST",
                "description": "Update shallow feature properties",
                "methodName": "updateFeature",
-               "jsondocId": "12f1d890-fa22-4d3f-b4fa-bea905edf5f9",
+               "jsondocId": "782e2e82-bcbb-404e-a3a3-60b8bfae11f6",
                "bodyobject": {
-                  "jsondocId": "7da07312-319d-4d61-b948-74f8f56b0521",
+                  "jsondocId": "857872b0-c7dc-4078-9f4a-c8cd02b3ab4f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3270,7 +3270,7 @@
                "apierrors": [],
                "path": "/annotator/updateFeature",
                "response": {
-                  "jsondocId": "e8246da7-1e53-4dcd-8716-b80ca059625d",
+                  "jsondocId": "7a482bbf-7859-4995-acde-1e8f96155887",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3283,7 +3283,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "784997c8-ba56-4915-8306-333b971aa6d8",
+                     "jsondocId": "6863a278-9aa5-4413-b720-0ca3a758c3f8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3292,7 +3292,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "564772fc-527e-4f2e-b1ed-b0d099b52c08",
+                     "jsondocId": "45762636-1c0e-4317-aae4-aeb0531a2350",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3301,7 +3301,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9d24b784-824d-43a7-adec-568313707f4b",
+                     "jsondocId": "ef04aa86-3cf4-4cc6-8aca-0538a7a5ba35",
                      "name": "uniquename",
                      "format": "",
                      "description": "Uniquename (UUID) of the exon we are editing",
@@ -3310,7 +3310,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d2752036-d289-49d7-a7eb-5ca7d2d9c9eb",
+                     "jsondocId": "f8cbdd57-433d-44ec-8a64-9e7efcb6fa2b",
                      "name": "fmin",
                      "format": "",
                      "description": "fmin for Exon Location",
@@ -3319,7 +3319,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "625120ca-a117-405a-b31b-3a252dbc73a0",
+                     "jsondocId": "05da3548-8b86-4d44-8709-5cab1ac4f71c",
                      "name": "fmax",
                      "format": "",
                      "description": "fmax for Exon Location",
@@ -3328,7 +3328,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6cb05123-e2b2-4aa6-b2d0-2343a1dc514c",
+                     "jsondocId": "c6c1c99c-0d9d-462c-b86f-4fe9c9461aed",
                      "name": "strand",
                      "format": "",
                      "description": "strand for Feature Location 1 or -1",
@@ -3340,9 +3340,9 @@
                "verb": "POST",
                "description": "Update exon boundaries",
                "methodName": "setExonBoundaries",
-               "jsondocId": "c2ee4802-0de7-498e-9377-be7d1543f2ba",
+               "jsondocId": "06fd36d0-1d9b-459d-a255-29131e33c6e7",
                "bodyobject": {
-                  "jsondocId": "de14e021-4e2e-40ac-9f8b-b36055d833df",
+                  "jsondocId": "3138779e-4e28-40d5-93b6-fa28692588b3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3352,7 +3352,7 @@
                "apierrors": [],
                "path": "/annotator/setExonBoundaries",
                "response": {
-                  "jsondocId": "067bf072-3eb1-4f01-a62e-7216782600f8",
+                  "jsondocId": "366c842a-6437-4bf8-918c-0e0a0fa56adc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3365,7 +3365,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "55247522-ff18-4093-b7da-163aa92714ef",
+                     "jsondocId": "f727158c-03eb-4f1d-baa9-68e8a77244dd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3374,7 +3374,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d69bd3b6-4099-410a-b400-fbaf975c0291",
+                     "jsondocId": "5c6f0b67-3333-460d-a7ca-7cf2d0b6cdbf",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3383,7 +3383,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "be3bdd1b-1d23-4b88-94ce-dba63ab06a40",
+                     "jsondocId": "c05a35e5-2d03-4d4c-8b1e-6623102d0114",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -3392,7 +3392,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0a737f6b-ca99-4c5e-9beb-c96826aa580a",
+                     "jsondocId": "865c1692-93dd-40f7-a834-99d37de0efcf",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -3404,9 +3404,9 @@
                "verb": "POST",
                "description": "Get annotators report for group",
                "methodName": "getAnnotatorsReportForGroup",
-               "jsondocId": "3ea71c26-48e1-4bd6-a4e5-9f2cd9214f62",
+               "jsondocId": "10cac025-dca7-408d-b8f1-158c80711189",
                "bodyobject": {
-                  "jsondocId": "074c9a8c-325c-4af7-aafb-edd300932f07",
+                  "jsondocId": "29af9ad9-8362-4c78-a28d-49539ace3ede",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3416,7 +3416,7 @@
                "apierrors": [],
                "path": "/group/getAnnotatorsReportForGroup",
                "response": {
-                  "jsondocId": "2fa1c27a-2627-4f35-9f77-c86772c75ce3",
+                  "jsondocId": "2ecdaec6-a13b-40d7-affd-9390990eecce",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3429,14 +3429,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "ae09ca75-f4f8-48b3-9626-240e86801188",
+         "jsondocId": "cd1464b0-6dd6-4c99-838f-cd8610546097",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2e55f6bc-26f1-4f6b-8684-4125676bd429",
+                     "jsondocId": "4523694c-8252-4127-b8b6-f9c289213c62",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3445,7 +3445,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c82f67c-705e-4895-bd88-0b77d070a947",
+                     "jsondocId": "8666a4ca-213c-46d5-b5ad-47a9fe36f3b1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3454,7 +3454,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a560fde0-17eb-42c4-975b-68d62c009d2c",
+                     "jsondocId": "23b31997-392d-4eae-9083-242b560ec154",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to update (or specify the old_value)",
@@ -3463,7 +3463,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0348e6ef-0885-463d-a845-369f5b44f19d",
+                     "jsondocId": "afd5e9e6-63d6-47c9-bf6b-bae81137e06b",
                      "name": "old_value",
                      "format": "",
                      "description": "Status name to update",
@@ -3472,7 +3472,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "139cc9e7-87b1-42fc-a77d-dfbdc3957e58",
+                     "jsondocId": "5aa1d5ab-8f79-48e4-94c7-7ce23eba5713",
                      "name": "new_value",
                      "format": "",
                      "description": "Status name to change to (the only editable option)",
@@ -3484,9 +3484,9 @@
                "verb": "POST",
                "description": "Update status",
                "methodName": "updateStatus",
-               "jsondocId": "db56c6f1-4b36-4bfc-8fd9-b7dab13b7aac",
+               "jsondocId": "3a4fab6d-50c1-4ba7-abcc-00c5142ec7e3",
                "bodyobject": {
-                  "jsondocId": "b0d9b0dd-47b7-4752-a92c-6b4d526fc9c1",
+                  "jsondocId": "b5283ac1-e7a2-4b6c-8fdd-05c4379dca97",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3496,7 +3496,7 @@
                "apierrors": [],
                "path": "/availableStatus/updateStatus",
                "response": {
-                  "jsondocId": "c26cf632-6da0-440d-accb-f6b94f58415e",
+                  "jsondocId": "ecf70577-6f8c-4ebd-b6b7-e84db762e5be",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3509,7 +3509,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1ef25cd3-65a4-43ae-8562-6ef5ab86c847",
+                     "jsondocId": "611993b0-4ce7-4dae-b1c5-02ec58cae726",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3518,7 +3518,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97fb5f91-e465-4206-a4b0-b68771a765d4",
+                     "jsondocId": "6e4688e2-ef8c-4e76-b5d5-0c023dce12d6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3527,7 +3527,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1b1726c-8380-42c8-8e06-1dea694958be",
+                     "jsondocId": "5083f3d1-70e0-4289-b637-3fce74f6a796",
                      "name": "value",
                      "format": "",
                      "description": "Status name to add",
@@ -3539,9 +3539,9 @@
                "verb": "POST",
                "description": "Create status",
                "methodName": "createStatus",
-               "jsondocId": "280a9077-a3cf-4754-927f-cd01e65d989b",
+               "jsondocId": "e8e24e4f-99e9-45e5-a799-d503f0fa41be",
                "bodyobject": {
-                  "jsondocId": "4e2276c7-acdc-4199-8585-b051e526ed99",
+                  "jsondocId": "d8dec70b-f022-4e2f-ac74-c6e1629bc36b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3551,7 +3551,7 @@
                "apierrors": [],
                "path": "/availableStatus/createStatus",
                "response": {
-                  "jsondocId": "c0207425-0682-4367-a683-9f8efa0f5521",
+                  "jsondocId": "b8855bc9-faf9-4fb9-9547-bbb7809fa24e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3564,7 +3564,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "51bab2d6-5b32-4c15-a800-769eb3ebb855",
+                     "jsondocId": "6169677b-12dc-42d8-a683-e0582dd2c8ed",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3573,7 +3573,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "03553f2c-1789-4b29-8e45-2995f38f3ac3",
+                     "jsondocId": "980214b2-0c07-4e9c-8862-c26a94b6ee17",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3582,7 +3582,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c973c8b2-07a3-49d3-8972-b0422c4aa56e",
+                     "jsondocId": "522da91a-d7b2-49e2-a4b6-0ba97cf62976",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to remove (or specify the name)",
@@ -3591,7 +3591,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "24778fb3-4da7-45a1-8c26-abd531e3c5b5",
+                     "jsondocId": "959ebc23-a5d0-4dd6-8f5d-1b6909b79b73",
                      "name": "value",
                      "format": "",
                      "description": "Status name to delete",
@@ -3603,9 +3603,9 @@
                "verb": "POST",
                "description": "Remove a status",
                "methodName": "deleteStatus",
-               "jsondocId": "18399fc4-a949-4ee9-ac1a-3afeea4bd187",
+               "jsondocId": "4079cf03-45c1-41de-befc-12a58ab9ca14",
                "bodyobject": {
-                  "jsondocId": "30056074-30c4-41cd-9094-d23fba41cb71",
+                  "jsondocId": "e4950a76-ddd4-47e1-bd95-1cffefff3c9d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3615,7 +3615,7 @@
                "apierrors": [],
                "path": "/availableStatus/deleteStatus",
                "response": {
-                  "jsondocId": "a6b21b9e-2e01-4b18-8e18-5132f931b04e",
+                  "jsondocId": "b0964fbf-2fec-4cba-8fdc-82ebf3bae817",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3628,7 +3628,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "876b6d87-4c96-4bdc-a7f4-b171e4895e32",
+                     "jsondocId": "54b9b077-3e8e-4dbf-a0a8-4abf35b6cf56",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3637,7 +3637,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d2db549e-3185-40e4-b879-b74a2fe8f1d5",
+                     "jsondocId": "839065b3-4dd6-423e-85f5-998c48561b02",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3646,7 +3646,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e1af610a-b657-43fe-bced-df8135d9b266",
+                     "jsondocId": "6ba3843f-5966-464d-8f8d-291455916fcc",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to show (or specify a name)",
@@ -3655,7 +3655,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3080d7ca-92c1-4bc5-bc7e-5436a3af1df8",
+                     "jsondocId": "93a66d9f-4f2e-4bdd-ac1b-c0190d1eadef",
                      "name": "name",
                      "format": "",
                      "description": "Status name to show",
@@ -3667,9 +3667,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all statuses, or optionally, gets information about a specific status",
                "methodName": "showStatus",
-               "jsondocId": "61627bb7-3da0-498b-b1c9-e32ed53939d2",
+               "jsondocId": "b17ab8aa-4326-46bf-a586-ce4816f58fe6",
                "bodyobject": {
-                  "jsondocId": "065982f5-f0da-4877-92e8-837af1801316",
+                  "jsondocId": "62f3a697-6487-4bf0-8d4f-8a3f37952abe",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3679,7 +3679,7 @@
                "apierrors": [],
                "path": "/availableStatus/showStatus",
                "response": {
-                  "jsondocId": "3c0d69b8-73dd-4dfb-bba5-6891721b7391",
+                  "jsondocId": "8ce886ac-cc43-46ed-b955-d50c8e5b2c78",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3692,14 +3692,14 @@
          "description": "Methods for managing available statuses"
       },
       {
-         "jsondocId": "5c7fa0df-f294-4177-ad8e-4742f8867601",
+         "jsondocId": "ce2d3375-6ecc-4eed-abac-9e30758c34d8",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "80001877-c98d-4ee5-866e-4d55fcb5e77c",
+                     "jsondocId": "6025607c-d43e-4ad8-90ee-41330056fbe5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3708,7 +3708,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "098584d9-1a95-4e65-9b5e-c2fc85fd00ce",
+                     "jsondocId": "2f408981-5440-47bb-aa00-b8d52c34f6dc",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3717,7 +3717,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0827e1f9-5635-4ccd-b508-5dbef27f7208",
+                     "jsondocId": "810d05d9-8955-4ced-8966-8da7d23779c0",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to add",
@@ -3726,7 +3726,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d9ab1560-a198-4928-ba2b-1a70e57da276",
+                     "jsondocId": "3cb92d25-5fc1-491e-a7eb-32443af85739",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3738,9 +3738,9 @@
                "verb": "POST",
                "description": "Create canned comment",
                "methodName": "createComment",
-               "jsondocId": "df61dfda-b25a-42fd-9dfa-03888f6ba680",
+               "jsondocId": "4a1517e5-69e3-42bb-b90a-3827f3a7ef77",
                "bodyobject": {
-                  "jsondocId": "088bb74d-35fc-4027-bcab-8f97d70e42b1",
+                  "jsondocId": "379ec40c-033e-4597-8d25-2777ac1e7c51",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3750,7 +3750,7 @@
                "apierrors": [],
                "path": "/cannedComment/createComment",
                "response": {
-                  "jsondocId": "1fd4f52a-7c75-4f68-a4fb-8f67c9e4bba1",
+                  "jsondocId": "cfd8c94a-6375-4f6c-bc7a-bdedf6bfebf4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3763,7 +3763,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3fc591ca-b7b3-4972-9058-d54d38633592",
+                     "jsondocId": "5b881586-3595-4823-9c1a-010bd23a90b2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3772,7 +3772,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dcda4eed-a6ff-4e26-ad47-4e2649fcef2c",
+                     "jsondocId": "6a6ef634-27c2-48f6-9000-ccec90fcd16b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3781,7 +3781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ddc613c1-51b6-492f-b786-bf96d2a3a9ac",
+                     "jsondocId": "ef25af42-0c12-4e80-80e8-5b11c21226e0",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to update (or specify the old_comment)",
@@ -3790,7 +3790,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3357d315-4169-408d-850d-34085f1f181e",
+                     "jsondocId": "eba812e2-a627-4176-ac17-bd4e9facdc1e",
                      "name": "old_comment",
                      "format": "",
                      "description": "Canned comment to update",
@@ -3799,7 +3799,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1d98a1e-2b7b-4af8-a13f-b467eb84ea98",
+                     "jsondocId": "b9317203-7bc1-4f89-9ec1-c225c50b99fe",
                      "name": "new_comment",
                      "format": "",
                      "description": "Canned comment to change to (the only editable option)",
@@ -3808,7 +3808,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "23e87619-1aa0-4458-a171-527094646958",
+                     "jsondocId": "25ec6ae9-510e-4a3f-b789-ad899e0bfe4e",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3820,9 +3820,9 @@
                "verb": "POST",
                "description": "Update canned comment",
                "methodName": "updateComment",
-               "jsondocId": "910b5aa5-f8fc-46fd-8422-2a54eb8b1a60",
+               "jsondocId": "dc149696-3097-4e51-93ee-cf5dafead786",
                "bodyobject": {
-                  "jsondocId": "04273c80-f3ec-45d8-bc21-dd3ffea5a933",
+                  "jsondocId": "bc6d642c-9abc-4b8c-b183-ade7d360f74c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3832,7 +3832,7 @@
                "apierrors": [],
                "path": "/cannedComment/updateComment",
                "response": {
-                  "jsondocId": "f4548ea1-a556-4c99-9746-e17be58003ad",
+                  "jsondocId": "3032e5c8-e5da-47e5-9842-cb9ae1f4445c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3845,7 +3845,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ecd339d9-2ee6-4075-9948-9ea0046cf462",
+                     "jsondocId": "0fbbd87b-7b7c-4ec0-a0ba-bd8b0c24e784",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3854,7 +3854,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8ea3ed10-f16d-4799-96e5-0d9a261850e5",
+                     "jsondocId": "96e0367d-093c-4d92-a732-da33cf1136cb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3863,7 +3863,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65881cf4-3e2c-4c43-9283-5077a50ef243",
+                     "jsondocId": "5928f9ff-c3c9-497a-b495-1ba9da90c491",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to remove (or specify the name)",
@@ -3872,7 +3872,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8f7ee641-befd-4124-852c-02789b275718",
+                     "jsondocId": "34959cc0-7e03-437f-b4f1-2d4d343ea9bf",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to delete",
@@ -3884,9 +3884,9 @@
                "verb": "POST",
                "description": "Remove a canned comment",
                "methodName": "deleteComment",
-               "jsondocId": "54fe1842-5487-40a6-84e5-b32debd62eed",
+               "jsondocId": "2992181d-7eb8-4ee7-9860-d47133a14c7c",
                "bodyobject": {
-                  "jsondocId": "9e425e8d-c158-454e-8aed-afc0e9fdf106",
+                  "jsondocId": "0d2d0f18-8119-4310-8e60-8cbf613f8a7d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3896,7 +3896,7 @@
                "apierrors": [],
                "path": "/cannedComment/deleteComment",
                "response": {
-                  "jsondocId": "685d7073-3879-47b4-97f7-fa6ac99d3f81",
+                  "jsondocId": "496c01fd-d834-4b12-b354-96de33d07f95",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3909,7 +3909,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9687c3e8-67a5-4b57-89e5-6024eaf8145a",
+                     "jsondocId": "9d617ed5-ab12-4904-8f42-19be7b4b5112",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3918,7 +3918,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d4eba90-f2be-4ccd-a019-ac01ee90fb76",
+                     "jsondocId": "0838027b-783c-4ede-9a56-cc3fd7a0e90d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3927,7 +3927,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "40e52308-6f2f-446d-ace1-0beff66d4316",
+                     "jsondocId": "d252f2fc-c969-4ded-84d9-35e0dc26b06c",
                      "name": "id",
                      "format": "",
                      "description": "Comment ID to show (or specify a comment)",
@@ -3936,7 +3936,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7a9ca1cf-3d59-4468-a847-eca74f2d00ca",
+                     "jsondocId": "f0b7a0ab-06cf-4fca-a3dd-a3a7ad87333b",
                      "name": "comment",
                      "format": "",
                      "description": "Comment to show",
@@ -3948,9 +3948,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned comments, or optionally, gets information about a specific canned comment",
                "methodName": "showComment",
-               "jsondocId": "477a9bd9-4a58-48af-ba01-84bf851ce616",
+               "jsondocId": "9e9c7f96-ee5e-451e-a7ec-934ac8ec5841",
                "bodyobject": {
-                  "jsondocId": "81c4b7d4-a530-4b2d-8f3e-44f1e1ddb1d9",
+                  "jsondocId": "343fe327-8605-4470-9e0a-e4692114d70f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3960,7 +3960,7 @@
                "apierrors": [],
                "path": "/cannedComment/showComment",
                "response": {
-                  "jsondocId": "993995dc-8beb-4e84-a830-cfb90d982857",
+                  "jsondocId": "7cfebb24-c83a-4c49-a083-c5c0833bf6d4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3973,14 +3973,14 @@
          "description": "Methods for managing canned comments"
       },
       {
-         "jsondocId": "41ded2dd-0f37-41be-b072-872e5503b472",
+         "jsondocId": "6ed7d912-e737-4c4a-a400-394ecb427bb3",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0684437e-3739-4a69-8d11-db86e98b4ffe",
+                     "jsondocId": "c72084a6-b769-48b0-814e-12e623dbc9ff",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3989,7 +3989,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "83265564-2de4-4ee7-a907-14098234af91",
+                     "jsondocId": "6f126cbd-fa62-4ab6-b466-7445bf497bad",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3998,7 +3998,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c0479c30-257e-4fa9-8283-bf3f58be6293",
+                     "jsondocId": "7e2bfb01-609f-4ab6-8137-fe2685da4a17",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to update (or specify the old_key)",
@@ -4007,7 +4007,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d8201df1-053f-4922-9e14-d055c6bb0253",
+                     "jsondocId": "c1c818d0-d1d7-4130-8dfb-9c88f83aed40",
                      "name": "old_key",
                      "format": "",
                      "description": "Canned key to update",
@@ -4016,7 +4016,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84ae1659-9220-4f45-b225-43b3fac1a16e",
+                     "jsondocId": "4ea71b98-b895-4179-893f-1f42df666987",
                      "name": "new_key",
                      "format": "",
                      "description": "Canned key to change to (the only editable option)",
@@ -4025,7 +4025,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b3091177-0d0f-45d5-9b7c-e7e4b6874dbf",
+                     "jsondocId": "cc58e5eb-a407-4440-97e0-f4e606ad2aba",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4037,9 +4037,9 @@
                "verb": "POST",
                "description": "Update canned key",
                "methodName": "updateKey",
-               "jsondocId": "4cabb821-d5f0-439e-96d4-8faea8489c64",
+               "jsondocId": "39bd4a2b-d74d-42ce-b734-53991514958a",
                "bodyobject": {
-                  "jsondocId": "345436e7-6744-4e59-8b80-7c6663731d10",
+                  "jsondocId": "83884057-7791-4ba6-9483-ac79e76b28b5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4049,7 +4049,7 @@
                "apierrors": [],
                "path": "/cannedKey/updateKey",
                "response": {
-                  "jsondocId": "09e48b26-c499-479e-afdc-9cd71bcb6c6e",
+                  "jsondocId": "ce8f5b3c-e612-4cad-aa0d-f15164b8b6cc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4062,7 +4062,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fbc4030e-9c40-4d4b-9b4d-26f359d603df",
+                     "jsondocId": "8df69412-2b20-4d44-b90a-17d2ebc1565d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4071,7 +4071,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fc501589-c319-4780-a5b2-0bdaf024de18",
+                     "jsondocId": "af80cb2b-1bef-493d-be29-f350621568ef",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4080,7 +4080,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "64f452be-f743-4ac3-be31-b8affd981603",
+                     "jsondocId": "db25aafb-7a7d-420d-aadb-da9a75a5fc76",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to add",
@@ -4089,7 +4089,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97e32e04-4b24-486e-a48d-a87ec7acc2df",
+                     "jsondocId": "c4fa4c8b-ad51-45e2-8201-cdc288beb974",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4101,9 +4101,9 @@
                "verb": "POST",
                "description": "Create canned key",
                "methodName": "createKey",
-               "jsondocId": "06db1782-0a91-4a7a-b1a2-d7400a25aa92",
+               "jsondocId": "4012649e-8256-4180-acd4-76023061adda",
                "bodyobject": {
-                  "jsondocId": "f7c93387-ce3d-4ce9-aef9-09f98bf6db62",
+                  "jsondocId": "ce59925d-b9af-4ee7-970b-aa8b33ae17db",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4113,7 +4113,7 @@
                "apierrors": [],
                "path": "/cannedKey/createKey",
                "response": {
-                  "jsondocId": "3532aa60-5eff-483b-9e99-b3ce35d8615e",
+                  "jsondocId": "ddabdc8d-912d-4fb7-92d0-e274ee476353",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4126,7 +4126,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6f9e8c70-3276-4eb9-852c-f662ace5b145",
+                     "jsondocId": "c5255753-3315-4956-9b0d-4b0f37554f6c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4135,7 +4135,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9698715-0e70-409e-9e9f-bcb3327264af",
+                     "jsondocId": "3c128470-15d6-423b-bc21-a14e14b636fa",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4144,7 +4144,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dc550de2-fcf8-4049-a4c8-437183fdf6a5",
+                     "jsondocId": "2c07947a-423b-4ca1-a6c1-3bc9a6b6bc46",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to remove (or specify the name)",
@@ -4153,7 +4153,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "89b08b9f-9367-412c-8af5-8d11aaf0276c",
+                     "jsondocId": "ad9442b5-7660-4e01-88ea-a5f83e33660d",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to delete",
@@ -4165,9 +4165,9 @@
                "verb": "POST",
                "description": "Remove a canned key",
                "methodName": "deleteKey",
-               "jsondocId": "ef5cc0be-2703-4fca-aa53-4a306ceaf1a5",
+               "jsondocId": "0bf01791-d4e4-4660-9c84-0132174a4a3f",
                "bodyobject": {
-                  "jsondocId": "468ff6f4-ab34-4efe-82dd-f72738bd5b1b",
+                  "jsondocId": "0f82244d-8d38-46cb-a3c0-07bd2616cc96",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4177,7 +4177,7 @@
                "apierrors": [],
                "path": "/cannedKey/deleteKey",
                "response": {
-                  "jsondocId": "53db5a82-8c12-497d-8f38-d9c5b095f7ab",
+                  "jsondocId": "13c7e43d-f84a-48d0-b864-064b966d8b28",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4190,7 +4190,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "502ae3ae-75d4-49af-a2ea-cd705681da49",
+                     "jsondocId": "f7832400-6660-45dd-b0cc-242654f4311e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4199,7 +4199,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "78eceacc-6a00-4167-957b-550c133fae21",
+                     "jsondocId": "ae4a9f6c-2128-49a8-bd0f-15d51091c6f7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4208,7 +4208,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ae97d67-0eaf-48c2-9d26-5ea8b04d2909",
+                     "jsondocId": "534a5b0f-0103-41a7-a8f7-d1909fffbe20",
                      "name": "id",
                      "format": "",
                      "description": "Key ID to show (or specify a key)",
@@ -4217,7 +4217,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e58f8749-2936-45df-8259-29d80ca86a63",
+                     "jsondocId": "58da0c15-4e34-4724-b368-da9358461214",
                      "name": "key",
                      "format": "",
                      "description": "Key to show",
@@ -4229,9 +4229,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned keys, or optionally, gets information about a specific canned key",
                "methodName": "showKey",
-               "jsondocId": "30b24f57-0c0f-4e84-b9c1-ad39e60925fa",
+               "jsondocId": "881b39c5-4e66-48cd-b8fd-e96bf75e11b5",
                "bodyobject": {
-                  "jsondocId": "a958df39-e056-4f45-94d1-907f3d5624b9",
+                  "jsondocId": "586f07a2-4b85-4bc6-abde-dddcddb887db",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4241,7 +4241,7 @@
                "apierrors": [],
                "path": "/cannedKey/showKey",
                "response": {
-                  "jsondocId": "0cc229e1-d796-464c-8f2c-a977c59fd2d9",
+                  "jsondocId": "98269122-f2ef-4ea1-a2d5-fa8accb236ca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4254,14 +4254,14 @@
          "description": "Methods for managing canned keys"
       },
       {
-         "jsondocId": "a616a496-b2ae-4fff-bade-bcb3ff380897",
+         "jsondocId": "8e9aa8ea-eebf-4689-b8aa-8f81292124ff",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8a8089d5-7c5d-41e9-9904-a28ed0009c14",
+                     "jsondocId": "914e931d-1325-4236-924b-c9ad33501bf0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4270,7 +4270,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0023eaa2-c6ea-4a0b-ba8e-31da91ceeb23",
+                     "jsondocId": "2a91e33e-e7fa-4c06-af32-2d818ee8c565",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4279,7 +4279,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "741ffc9c-fac6-4ada-98e1-2c9e02b8352b",
+                     "jsondocId": "3096e3de-2207-4011-8e08-f35f32e5b3ec",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to add",
@@ -4288,7 +4288,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b9babdbd-f1e6-4f1d-abff-147c841782a5",
+                     "jsondocId": "6c9834ac-65ac-475f-9361-c1110263f9dc",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4300,9 +4300,9 @@
                "verb": "POST",
                "description": "Create canned value",
                "methodName": "createValue",
-               "jsondocId": "5d5894c7-9c21-48f7-bfdc-7ff25b6300c7",
+               "jsondocId": "3445f1e1-49cf-4644-a030-20d2c3cfdbdf",
                "bodyobject": {
-                  "jsondocId": "18e08b2c-dc88-4de5-88cc-73f2c79bfa77",
+                  "jsondocId": "3523d617-da87-4386-9b70-bcc623861e20",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4312,7 +4312,7 @@
                "apierrors": [],
                "path": "/cannedValue/createValue",
                "response": {
-                  "jsondocId": "6f026206-56c7-4634-afdc-adaedd796d05",
+                  "jsondocId": "15e7c9c5-82e5-44f4-b4d5-f638146acb14",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4325,7 +4325,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "af147b71-702c-4213-8cca-75b48099af6a",
+                     "jsondocId": "e2e8748a-14f2-4c01-8463-aea6c704f73d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4334,7 +4334,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e9a48ea2-7da6-4563-a753-4c6f06109f44",
+                     "jsondocId": "bd745ba9-3cad-4c08-872f-e5dbc2868778",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4343,7 +4343,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "be2a0c36-0fc9-4fc7-9b51-8b54a6b399b8",
+                     "jsondocId": "b37e0ab9-ce74-4b84-b45a-f55fbd7a0cfe",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to update (or specify the old_value)",
@@ -4352,7 +4352,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "11fb7cfc-8bc6-4893-977e-a12b3c84485f",
+                     "jsondocId": "c143fe13-3e71-4361-9b9a-e2dbf4e0a006",
                      "name": "old_value",
                      "format": "",
                      "description": "Canned value to update",
@@ -4361,7 +4361,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "58a950de-2640-41c2-8c40-c24e39d96e7c",
+                     "jsondocId": "e2684402-8bc3-46e9-96aa-9488585ded02",
                      "name": "new_value",
                      "format": "",
                      "description": "Canned value to change to (the only editable option)",
@@ -4370,7 +4370,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "adcc1a40-3a5c-49e2-8aac-7368596f7c11",
+                     "jsondocId": "dc601f67-bde3-496f-9e30-71323dac7ee6",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4382,9 +4382,9 @@
                "verb": "POST",
                "description": "Update canned value",
                "methodName": "updateValue",
-               "jsondocId": "fda9bfbb-202d-4daf-ae2c-ebb404cae3bd",
+               "jsondocId": "e398eff8-4761-4664-921e-96d2a4b506c9",
                "bodyobject": {
-                  "jsondocId": "95074843-c059-4149-935a-805f31f5a375",
+                  "jsondocId": "6e5c30f8-898c-45c2-a29e-7a42aa9ea7f3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4394,7 +4394,7 @@
                "apierrors": [],
                "path": "/cannedValue/updateValue",
                "response": {
-                  "jsondocId": "d8839c27-8cec-4c12-95d2-84ebe87580c4",
+                  "jsondocId": "92f85fe7-e707-43a0-b330-2cfdf42e851b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4407,7 +4407,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b1eeca6d-afda-4e09-97fb-65cec2a4382b",
+                     "jsondocId": "05c665b8-f616-4ab4-9a01-6a15bcadf8f8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4416,7 +4416,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9fb0d20d-f5f5-4b75-b8b4-6ad9c2115c53",
+                     "jsondocId": "285e4f70-b06d-43f6-a722-b1899446f90e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4425,7 +4425,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e5886267-b356-45ed-ac8c-64f04a845616",
+                     "jsondocId": "7a9bd1fb-7b58-47db-aa25-f1e8ec8fe0d9",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to remove (or specify the name)",
@@ -4434,7 +4434,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "20dfb37b-6955-4062-96c3-5ab9c098ea19",
+                     "jsondocId": "3cc18989-a48f-426c-b412-312559d4cd38",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to delete",
@@ -4446,9 +4446,9 @@
                "verb": "POST",
                "description": "Remove a canned value",
                "methodName": "deleteValue",
-               "jsondocId": "a32674d2-67d2-4de6-bbdf-59cb37c761b3",
+               "jsondocId": "a8bc3679-1674-4cc1-ac83-0c656b29f81a",
                "bodyobject": {
-                  "jsondocId": "e8c047fe-7074-4eea-98ef-91704d9e4a7a",
+                  "jsondocId": "7ed646cc-b99f-46c9-be30-99f0cc658e26",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4458,7 +4458,7 @@
                "apierrors": [],
                "path": "/cannedValue/deleteValue",
                "response": {
-                  "jsondocId": "67061fb1-7359-4d6a-8ab3-1eaf6c87dd4c",
+                  "jsondocId": "c6272dc0-1598-4c1f-ba85-380cc1bc9ebe",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4471,7 +4471,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b93906ae-425e-44af-926f-c238f057f759",
+                     "jsondocId": "fcd22dea-8ee0-4ae6-9527-cb9434b0e705",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4480,7 +4480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "227effe1-25d6-4313-ac6d-248190299f1b",
+                     "jsondocId": "121d5ad3-adc6-49be-aecb-97dcc5e5fe14",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4489,7 +4489,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "418d8470-a152-4c89-ace9-966338700ada",
+                     "jsondocId": "510f2c06-b97e-4789-bccb-4f955d7cb30e",
                      "name": "id",
                      "format": "",
                      "description": "Value ID to show (or specify a value)",
@@ -4498,7 +4498,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2176f17f-be78-45a3-b023-04201683c318",
+                     "jsondocId": "b0b372b6-d608-40f7-a9c8-02c9ee155417",
                      "name": "value",
                      "format": "",
                      "description": "Value to show",
@@ -4510,9 +4510,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned values, or optionally, gets information about a specific canned value",
                "methodName": "showValue",
-               "jsondocId": "b2e376fe-e8cb-44f2-8c33-80007b204c74",
+               "jsondocId": "42f32808-5f5f-4e7f-8d0c-617174384551",
                "bodyobject": {
-                  "jsondocId": "f5eb3ebe-ee1f-4bd3-8b66-7d22bc9723ef",
+                  "jsondocId": "33c7549b-ccdb-4cd5-bdd9-1d4ba54ab896",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4522,7 +4522,7 @@
                "apierrors": [],
                "path": "/cannedValue/showValue",
                "response": {
-                  "jsondocId": "ff50b0e4-df5b-4530-bb69-c0829a7aa6a8",
+                  "jsondocId": "3dc77f5f-6f26-4dbf-92fd-9d3144ce1f4e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4535,14 +4535,14 @@
          "description": "Methods for managing canned values"
       },
       {
-         "jsondocId": "0cda5479-6310-46f7-85db-f415fa34ce08",
+         "jsondocId": "90df3a74-8ca7-4ca0-b5ca-c14832c68aff",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "cf294741-6fc4-4762-a14b-41397db79d22",
+                     "jsondocId": "aa2d03b3-1b9d-4d9b-a207-1a66a2365043",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4551,7 +4551,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "348da249-1462-4ca5-858b-bdd4cda4189e",
+                     "jsondocId": "26178af4-1770-4909-a66a-8288398c7df6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4560,7 +4560,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "70bd0fe0-f99b-4bf8-b2ea-7ad864837ba3",
+                     "jsondocId": "7f07a85c-9904-4232-8586-d4809efd4c10",
                      "name": "name",
                      "format": "",
                      "description": "Group name to add, or a comma-delimited list of names",
@@ -4572,9 +4572,9 @@
                "verb": "POST",
                "description": "Create group",
                "methodName": "createGroup",
-               "jsondocId": "a3f94581-3a7f-425a-9a6e-89aee995b174",
+               "jsondocId": "53ceb2f0-59d5-4790-a94b-aa20ceea6a40",
                "bodyobject": {
-                  "jsondocId": "aec09a31-8935-4cb5-8dd6-010794234334",
+                  "jsondocId": "5f5932a9-a491-4d38-9463-92b1d2340938",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4584,7 +4584,7 @@
                "apierrors": [],
                "path": "/group/createGroup",
                "response": {
-                  "jsondocId": "80b761c8-39ed-43f2-95f7-a37cc5ec7485",
+                  "jsondocId": "85b204e6-2715-4eda-bd64-2caaa46d6d91",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4597,7 +4597,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1f52f82c-a480-4f1e-bb21-897c72c97de3",
+                     "jsondocId": "896e6fbb-cded-4a29-b423-a7a0ba851100",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4606,7 +4606,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cb566c16-1ed2-4910-8f00-3fd0e10c8ac2",
+                     "jsondocId": "45886dc3-93a2-4b3a-a168-35c9b32afd2a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4615,7 +4615,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "211d14f1-4e9e-4f88-ba77-c5dbdfd93dae",
+                     "jsondocId": "c368c224-1169-46e7-bc30-d984f43311c5",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -4624,7 +4624,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a0033dca-2978-4208-8f67-a19f21a5b1f1",
+                     "jsondocId": "cc87f872-ed21-4183-b0e3-95bdece9ddd7",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -4636,9 +4636,9 @@
                "verb": "POST",
                "description": "Get organism permissions for group",
                "methodName": "getOrganismPermissionsForGroup",
-               "jsondocId": "e8e00d06-626d-4b03-8b09-f66d02a38075",
+               "jsondocId": "ebfbeae5-2b70-43e0-8c2a-b3c786bf63b1",
                "bodyobject": {
-                  "jsondocId": "a95c6ba3-7146-461e-8629-2535fcf2a6e8",
+                  "jsondocId": "108dd9c2-b1ed-4532-85e0-06e0ec469e6a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4648,7 +4648,7 @@
                "apierrors": [],
                "path": "/group/getOrganismPermissionsForGroup",
                "response": {
-                  "jsondocId": "fe652bf8-01ce-481e-a80e-58d988c27a07",
+                  "jsondocId": "d35540af-4512-4c39-b29e-3231727f4f91",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4661,7 +4661,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "541066a9-f358-483b-aa22-d398af865c0a",
+                     "jsondocId": "be8976a7-dcf8-4ca4-b1ae-f382cf666ff5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4670,7 +4670,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "15f56c50-fb1d-416b-8267-9eb2bf037bd7",
+                     "jsondocId": "0f7e17da-77f7-4440-8ccf-f6c12f450717",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4679,7 +4679,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26853190-f5bd-4e2d-9c21-089db260e7e2",
+                     "jsondocId": "e5134325-42b6-4f5a-82d7-bb75675df83b",
                      "name": "groupId",
                      "format": "",
                      "description": "Optional only load a specific groupId",
@@ -4691,9 +4691,9 @@
                "verb": "POST",
                "description": "Load all groups",
                "methodName": "loadGroups",
-               "jsondocId": "36091f1d-cc69-49fd-91d0-360aa28282d2",
+               "jsondocId": "bc83ae03-68a6-4681-82dd-73871bd3b556",
                "bodyobject": {
-                  "jsondocId": "bff64721-7353-422a-8cb5-da92231e4f05",
+                  "jsondocId": "428f9cf6-6f96-4ad7-8880-138438714796",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4703,7 +4703,7 @@
                "apierrors": [],
                "path": "/group/loadGroups",
                "response": {
-                  "jsondocId": "0dec05ce-099e-485f-b057-ea9298b116d9",
+                  "jsondocId": "9feb1486-c2a9-40d8-8349-6451fa7f8c42",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4716,7 +4716,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "53498e5e-fb71-42e9-b8e5-68ede8da957b",
+                     "jsondocId": "4cd52872-fe30-48db-b465-09a921e75008",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4725,7 +4725,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d95d1d35-b955-483f-a3ab-cc57995df01d",
+                     "jsondocId": "2109a0ff-9a7d-4878-afe9-6cec8307e6eb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4734,7 +4734,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "abd997aa-5b63-418c-b4d1-dc634a47827a",
+                     "jsondocId": "99b0418b-7f6b-4d62-9078-014584e51d92",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to remove (or specify the name)",
@@ -4743,7 +4743,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "06667693-190e-4526-879c-d29a2dce253b",
+                     "jsondocId": "d77d062c-d76c-4eb2-9811-8fe0816b541f",
                      "name": "name",
                      "format": "",
                      "description": "Group name or comma-delimited list of names to remove",
@@ -4755,9 +4755,9 @@
                "verb": "POST",
                "description": "Delete a group",
                "methodName": "deleteGroup",
-               "jsondocId": "9e6df8b3-0a0f-440b-95b2-2eef4a2fa817",
+               "jsondocId": "ae9cfa3b-b67d-45e5-b050-e3bf1473c664",
                "bodyobject": {
-                  "jsondocId": "7c7de9a4-defb-409d-a8b7-6b2680de9eac",
+                  "jsondocId": "883b4084-bd73-4926-a4c5-2e92a5d72a46",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4767,7 +4767,7 @@
                "apierrors": [],
                "path": "/group/deleteGroup",
                "response": {
-                  "jsondocId": "1bffcd31-dd9b-4a74-863a-3d4690ea62a6",
+                  "jsondocId": "b0868a53-3fd0-4ab5-a91d-4ea5d1753375",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4780,7 +4780,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1a7391a2-7c78-4192-ba1a-ebbeda3a9bcb",
+                     "jsondocId": "c512f884-fa81-4840-89bf-1cec5f00ec4f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4789,7 +4789,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "914bed14-7233-45ee-bf33-5bb9dbade3cf",
+                     "jsondocId": "04c72a95-d0af-4d0d-99a2-45688bac8448",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4798,7 +4798,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "694a5773-e980-4ef4-9f62-12d855a4c3d5",
+                     "jsondocId": "33778a45-d81c-463d-96fe-01c630333f63",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to update",
@@ -4807,7 +4807,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0e269905-b435-4379-a200-278756b09195",
+                     "jsondocId": "db162fe4-a393-4c30-a344-ac778015db90",
                      "name": "name",
                      "format": "",
                      "description": "Group name to change to (the only editable optoin)",
@@ -4819,9 +4819,9 @@
                "verb": "POST",
                "description": "Update group",
                "methodName": "updateGroup",
-               "jsondocId": "ac3756c4-b333-475c-9d0c-c288fc3d23e6",
+               "jsondocId": "79ac9fa5-c9fb-482a-b1c4-452480d644cb",
                "bodyobject": {
-                  "jsondocId": "0fe17e78-1f41-418d-9849-45794aeeae64",
+                  "jsondocId": "63a81fe2-2184-42d9-9701-3a04709d5745",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4831,7 +4831,7 @@
                "apierrors": [],
                "path": "/group/updateGroup",
                "response": {
-                  "jsondocId": "8b298f0c-3575-4542-b596-e2ced7d3e1c9",
+                  "jsondocId": "db133e26-de1f-4b6a-bb45-d73139458b47",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4844,7 +4844,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9857a8e7-e886-4809-96ec-6a2fdeb656b8",
+                     "jsondocId": "a741330c-4d44-4fc6-8de2-0f3050b5df78",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4853,7 +4853,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "70568050-22b5-4eb8-a2ec-43dd480052fa",
+                     "jsondocId": "9032d523-aa1e-4de0-b8ae-8ef8bf7940da",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4862,7 +4862,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "856de891-629b-4356-b1dd-6d5d4da18657",
+                     "jsondocId": "c39e4526-9d19-4188-a192-0d9c2b00c6fc",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to modify permissions for (must provide this or 'name')",
@@ -4871,7 +4871,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e2ac32e-e7d1-482f-8ae4-621fdc7e40d0",
+                     "jsondocId": "c015a896-74b0-4609-907e-5c4303e27fc7",
                      "name": "name",
                      "format": "",
                      "description": "Group name to modify permissions for (must provide this or 'groupId')",
@@ -4880,7 +4880,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b1f58d6-83f7-4c7e-99d3-a40e0a5c7ce3",
+                     "jsondocId": "daea601c-4fc7-4824-aec4-3c853f265d70",
                      "name": "organism",
                      "format": "",
                      "description": "Organism common name",
@@ -4889,7 +4889,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "83c75084-b31a-435e-9c97-18fb9e009b5a",
+                     "jsondocId": "ad082b4a-649c-40a2-bcfe-c2e8b00f8d8d",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -4898,7 +4898,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "40ec5c0d-693f-42c6-a971-8fd516c79435",
+                     "jsondocId": "ba144e99-23da-4acd-acbe-6be37bcbced3",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -4907,7 +4907,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ad2cefb5-4bb6-454d-b377-1dcb468e263d",
+                     "jsondocId": "3d5bf8b1-f121-4b76-91fa-41231486a0d6",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -4916,7 +4916,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "89ec0556-e2ed-4b4d-8e16-80201fd58072",
+                     "jsondocId": "94e953a3-10c3-43d9-856b-b567f0eb6d99",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -4928,9 +4928,9 @@
                "verb": "POST",
                "description": "Update organism permission",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "2eaa288b-fafa-45e7-82ef-f0793fd4bb24",
+               "jsondocId": "2a1ca422-735e-4694-ad04-21819dd6739c",
                "bodyobject": {
-                  "jsondocId": "df09b2d3-7225-4fa5-98b9-0bf001f4e370",
+                  "jsondocId": "3c828f9f-118a-45f8-a9d7-cdcd847a688c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4940,7 +4940,7 @@
                "apierrors": [],
                "path": "/group/updateOrganismPermission",
                "response": {
-                  "jsondocId": "eda3daf7-59ea-48bb-a607-4da9a9476856",
+                  "jsondocId": "fbd1936e-cba8-4aad-a440-5f86145abb3b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4953,7 +4953,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8202a44a-1c60-4054-8757-291df2a90755",
+                     "jsondocId": "d073ac0f-e306-42cf-8026-6af0bb97288e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4962,7 +4962,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "99fa8fcb-0103-43ad-82e2-46033055e79b",
+                     "jsondocId": "99a38d92-8f84-4bf0-b324-d04a3925f4e7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4971,7 +4971,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "04830d9e-0dc8-4598-8f96-10d373f1bf36",
+                     "jsondocId": "2fc16224-2d98-403c-a55c-665e17c2b7ee",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -4980,7 +4980,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c82f5244-68d7-4945-8324-3d8fd59ae714",
+                     "jsondocId": "225cf0bb-4101-4978-8d1a-17ad187d4764",
                      "name": "users",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -4989,7 +4989,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "157021c4-84f7-432b-85c3-91515109e412",
+                     "jsondocId": "76864756-4743-4657-8e69-d12650ac2de5",
                      "name": "memberships",
                      "format": "",
                      "description": "Bulk memberships (instead of users and groupId) to update of the form: [ {groupId: <groupId>,users: [\"user1\", \"user2\", \"user3\"]}, {groupId:<another-groupId>, users: [\"user2\", \"user8\"]}]",
@@ -5001,9 +5001,9 @@
                "verb": "POST",
                "description": "Update group membership",
                "methodName": "updateMembership",
-               "jsondocId": "86452129-12b2-4642-b2f5-c55255fb55cf",
+               "jsondocId": "68992ad3-488e-4dac-ab31-85a7153704ac",
                "bodyobject": {
-                  "jsondocId": "491be53b-f126-4c13-8d14-8a3cbdac511d",
+                  "jsondocId": "a84a7a49-f659-41e4-8da4-631ad5904f29",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5013,7 +5013,7 @@
                "apierrors": [],
                "path": "/group/updateMembership",
                "response": {
-                  "jsondocId": "429e1b92-167b-4109-94ac-672cc566bf42",
+                  "jsondocId": "4086170b-cec8-4330-8f31-724ca00ca9fd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5026,7 +5026,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "af29d5cd-a63f-4d97-9467-b00f58ac2f8b",
+                     "jsondocId": "0a125302-2542-45e0-af80-ea6710915828",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5035,7 +5035,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1e89f5ea-a503-4623-b5d6-1f6f84c5c213",
+                     "jsondocId": "d7449703-14f8-4f87-ba34-438640ec10dd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5044,7 +5044,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f2685672-d055-46f9-9713-8c8254904277",
+                     "jsondocId": "ddda9687-9539-4db5-b478-7bdbce3bfb06",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -5053,7 +5053,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c331c71e-6302-4de2-8742-a574473663c3",
+                     "jsondocId": "c1d86592-536a-48a2-87f5-e7a65708729a",
                      "name": "users",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -5065,9 +5065,9 @@
                "verb": "POST",
                "description": "Update group admin",
                "methodName": "updateGroupAdmin",
-               "jsondocId": "5590036f-5408-4647-bde4-3aeee3f2e027",
+               "jsondocId": "f074d28c-9db9-4d52-816d-42ea49faa68a",
                "bodyobject": {
-                  "jsondocId": "09adefa6-b91e-4232-b9e3-25a90baecce6",
+                  "jsondocId": "04406aa4-b280-40f4-a8dd-4afc4e612992",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5077,7 +5077,7 @@
                "apierrors": [],
                "path": "/group/updateGroupAdmin",
                "response": {
-                  "jsondocId": "c0f121ad-d36a-4dce-8e56-4d1083fc40d7",
+                  "jsondocId": "73c569fe-923c-48f5-8d2d-184d6a135fc0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5090,7 +5090,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b40e1ba8-d830-4cf1-9cce-6e3660502b3f",
+                     "jsondocId": "4f5ab162-265e-4068-8381-224ee91d4116",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5099,7 +5099,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e9110465-74eb-4528-a06d-d508d642a111",
+                     "jsondocId": "e3533b9c-f398-4fb7-ab6b-46adb2c0afcb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5108,7 +5108,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "33186421-3136-4d73-98fc-5993184efbc8",
+                     "jsondocId": "76290215-b306-4b0a-a248-ff8b16a9f0d1",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -5120,9 +5120,9 @@
                "verb": "POST",
                "description": "Get group admins, returns group admins as JSONArray",
                "methodName": "getGroupAdmin",
-               "jsondocId": "8c706a6a-daab-4643-a7ab-67e18dc927b8",
+               "jsondocId": "d851b3ec-5f6d-4031-b56f-d368546ecbe2",
                "bodyobject": {
-                  "jsondocId": "b6b741a7-c533-42fc-a541-afd6e0cfbc77",
+                  "jsondocId": "b9978f9d-71fe-49df-b359-8f81aec925f6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5132,7 +5132,7 @@
                "apierrors": [],
                "path": "/group/getGroupAdmin",
                "response": {
-                  "jsondocId": "b532cf9f-59c1-41bd-a38d-0c2909baf0d1",
+                  "jsondocId": "676e865b-943a-4a5c-90bf-b07c6936d026",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5145,7 +5145,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "69e3c4b3-73d9-42d4-a43e-982ce361ef87",
+                     "jsondocId": "08b43597-56c8-40c8-9e76-c3c45240191c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5154,7 +5154,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5e23be36-6f6e-4172-a23f-69c4827165d9",
+                     "jsondocId": "6fce1e8e-ee5f-4083-8d09-af27e5dd50d3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5163,7 +5163,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "593e3ee5-539b-43b6-9045-dff69f82af68",
+                     "jsondocId": "8d12b090-797e-47dc-8d73-62e8d5625e8d",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -5175,9 +5175,9 @@
                "verb": "POST",
                "description": "Get creator metadata for group, returns userId as JSONObject",
                "methodName": "getGroupCreator",
-               "jsondocId": "5b669eb4-6371-45cd-9b21-6fd00055b376",
+               "jsondocId": "04878a7c-d524-4737-b9d3-d9584ddeaa5f",
                "bodyobject": {
-                  "jsondocId": "25be8dbe-21f4-4c4a-a281-58341abd9b30",
+                  "jsondocId": "abb6ba1d-7c60-40eb-aedc-7a92b1bfe028",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5187,7 +5187,7 @@
                "apierrors": [],
                "path": "/group/getGroupCreator",
                "response": {
-                  "jsondocId": "9fbe680e-c77d-4fc6-8869-210c9c5c62bd",
+                  "jsondocId": "59520a0f-cc5a-44fd-a487-6bc6e70aff0e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5200,13 +5200,13 @@
          "description": "Methods for managing groups"
       },
       {
-         "jsondocId": "ce825744-4dcd-4ffe-970a-3e00bbbe76d3",
+         "jsondocId": "ae3603ef-4b22-4ac4-965d-3bae4ffb5a86",
          "methods": [{
             "headers": [],
             "pathparameters": [],
             "queryparameters": [
                {
-                  "jsondocId": "6d7a813e-c95f-45a2-a0c6-384b69ea148f",
+                  "jsondocId": "293bbe4d-cea8-4778-83d8-728e219b59af",
                   "name": "username",
                   "format": "",
                   "description": "",
@@ -5215,7 +5215,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "7d68170d-122d-4c0b-b29f-3d2974bd4bde",
+                  "jsondocId": "832fbd96-4996-4bb4-9dad-88aa111ebe64",
                   "name": "password",
                   "format": "",
                   "description": "",
@@ -5224,7 +5224,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "df89bd2c-a1db-4e77-ba27-fafb1960b044",
+                  "jsondocId": "4bf6fb0c-46fa-4b37-8581-59464e6890d2",
                   "name": "date",
                   "format": "",
                   "description": "Date to query yyyy-MM-dd:HH:mm:ss or yyyy-MM-dd",
@@ -5233,7 +5233,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "f527546f-51d9-4401-b166-6c15716280bc",
+                  "jsondocId": "dc8b52fd-0eed-4968-b6ea-3e5225ec0303",
                   "name": "afterDate",
                   "format": "",
                   "description": "Search after or on the given date.",
@@ -5242,7 +5242,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "bdf1e3cf-4e48-4621-b14b-6b0349e186dd",
+                  "jsondocId": "3eefc0c3-058d-401d-8ff2-8d665896cde4",
                   "name": "beforeDate",
                   "format": "",
                   "description": "Search before or on the given date.",
@@ -5251,7 +5251,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "fc6c1046-0405-4131-8484-40778e9e2d1d",
+                  "jsondocId": "abdce62a-91bd-406e-a58f-e40aee97b1c5",
                   "name": "max",
                   "format": "",
                   "description": "Max to return",
@@ -5260,7 +5260,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "177e2b5b-ee6f-41af-b521-30669b02aab3",
+                  "jsondocId": "42c26442-8ad8-4060-9ae5-3f167a69d51c",
                   "name": "sort",
                   "format": "",
                   "description": "Sort parameter (lastUpdated).  See FeatureEvent object/table.",
@@ -5269,7 +5269,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "67591ecd-4c73-4fd9-909e-66e69f9b9fee",
+                  "jsondocId": "02ac3b13-4cc9-47cf-a7be-f1bdeafcce34",
                   "name": "order",
                   "format": "",
                   "description": "desc/asc sort order by sort param",
@@ -5281,9 +5281,9 @@
             "verb": "POST",
             "description": "Returns a JSON representation of all current Annotations before or after a given date.",
             "methodName": "findChanges",
-            "jsondocId": "0d70dc01-cacd-4663-8927-d0ac44240478",
+            "jsondocId": "147bbffc-e823-4c3c-b819-386b97bd50e8",
             "bodyobject": {
-               "jsondocId": "ca4ca83d-e237-48a2-8181-e916b79690ae",
+               "jsondocId": "db7b7fd3-3210-4644-b223-443b2e18be1d",
                "mapValueObject": "",
                "mapKeyObject": "",
                "multiple": "Unknow",
@@ -5293,7 +5293,7 @@
             "apierrors": [],
             "path": "/featureEvent/findChanges",
             "response": {
-               "jsondocId": "c605a3f6-9cd0-4ea7-ac4d-62f78132005a",
+               "jsondocId": "d71396af-36ac-495c-becb-8af8aebd96a4",
                "mapValueObject": "",
                "mapKeyObject": "",
                "object": "feature event"
@@ -5305,14 +5305,14 @@
          "description": "Methods for querying history"
       },
       {
-         "jsondocId": "d76c9745-ee7a-47ea-94a0-eb3f2de2f9ff",
+         "jsondocId": "064d89b9-9bd0-44ba-9677-3aa6974c0c90",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7ff758ef-2b22-4a4b-9a69-1ff108f0a5a4",
+                     "jsondocId": "43d013b2-bf64-4467-86e1-700b2da39f7b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5321,7 +5321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "30e4625e-e8a1-47e2-b4b2-7c1ed0bcbae9",
+                     "jsondocId": "1e210aa1-704e-4894-b22b-3c7eca30d8d4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5330,7 +5330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b55ca4f2-5021-428f-b161-9a360dffd4f8",
+                     "jsondocId": "66568942-e44e-49da-aec2-ae7d8cecc2c9",
                      "name": "type",
                      "format": "",
                      "description": "Type of annotated genomic features to export 'FASTA','GFF3','CHADO'.",
@@ -5339,7 +5339,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "11640d20-f4bd-491e-aa0a-50717cceed7b",
+                     "jsondocId": "bf4b2490-d90b-43d7-80fd-113f56b6f273",
                      "name": "seqType",
                      "format": "",
                      "description": "Type of output sequence 'peptide','cds','cdna','genomic'.",
@@ -5348,7 +5348,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "43c55dc0-ebb6-4417-ae41-98357a2d4a32",
+                     "jsondocId": "aa67e7a7-feab-4c28-8f48-2a38bd084462",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -5357,7 +5357,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63d85551-455c-43fd-9d1d-aacaa05b3b74",
+                     "jsondocId": "8fe95cbe-a819-4f28-b0da-3e95edc38b54",
                      "name": "sequences",
                      "format": "",
                      "description": "Names of references sequences to add (default is all).",
@@ -5366,7 +5366,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1843b61-8b53-40cc-a9e5-f2c3a0ea6954",
+                     "jsondocId": "0374e715-24f1-43a1-a6fc-fe646c86ac1a",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism that sequences belong to (will default to last organism).",
@@ -5375,7 +5375,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e937847c-6882-42a2-aba2-b329cac954cb",
+                     "jsondocId": "c7427e9f-74a3-44e9-809f-6e1a13a8dc01",
                      "name": "output",
                      "format": "",
                      "description": "Output method 'file','text'",
@@ -5384,7 +5384,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "90fd7ecb-900a-45df-a54e-6ba503a7ffb2",
+                     "jsondocId": "1d8cd35e-cc4a-492a-babd-60719d3c429c",
                      "name": "exportAllSequences",
                      "format": "",
                      "description": "Export all reference sequences for an organism (over-rides 'sequences')",
@@ -5393,7 +5393,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ce8bb22b-af1b-42a9-a23d-465209971c6b",
+                     "jsondocId": "359582c6-5f22-4d46-b37d-1cb28813df97",
                      "name": "region",
                      "format": "",
                      "description": "Highlighted genomic region to export in form sequence:min..max  e.g., chr3:1001..1034",
@@ -5405,9 +5405,9 @@
                "verb": "POST",
                "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "methodName": "write",
-               "jsondocId": "b59cf5c7-823c-488b-a9f1-80e5cd94d5c5",
+               "jsondocId": "fbb184f2-02bf-446b-bd2d-14ebdaaaa754",
                "bodyobject": {
-                  "jsondocId": "8557c41c-cfe6-4a96-9900-d2d8ba25bde8",
+                  "jsondocId": "90012e04-9b7b-4bb9-bd80-79d96482a50a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5417,7 +5417,7 @@
                "apierrors": [],
                "path": "/IOService/write",
                "response": {
-                  "jsondocId": "9648b587-44c3-4b1a-9e2c-7164389aa664",
+                  "jsondocId": "6dce4270-7e5b-4284-ad11-b39f1fbec33f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -5430,7 +5430,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b9028757-0841-43e8-b067-3c076620038f",
+                     "jsondocId": "7472a142-d8d1-4482-96fb-8746bf00ca2c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5439,7 +5439,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "921d8077-8753-418e-992e-949f7a11c845",
+                     "jsondocId": "1d697e10-1742-4a7c-ab09-25e603c15af3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5448,7 +5448,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "595d89aa-597f-41ac-bd6c-d181a63c5995",
+                     "jsondocId": "262d1a74-c520-4b99-8313-1ea7d61997be",
                      "name": "uuid",
                      "format": "",
                      "description": "UUID that holds the key to the stored download.",
@@ -5457,7 +5457,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ccea7bea-ed29-479c-b56f-a5cf22353f9a",
+                     "jsondocId": "b24665c0-9ec4-49e9-ab15-7f99110559c2",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -5469,9 +5469,9 @@
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
                "methodName": "download",
-               "jsondocId": "922374f7-3bb0-4f7a-b84c-f36e02b318d9",
+               "jsondocId": "273019d9-b555-441c-9be5-2f39d56d7fdc",
                "bodyobject": {
-                  "jsondocId": "b3a85419-d396-4ecf-b050-c4f8ab1b84d1",
+                  "jsondocId": "d4484b36-368d-4426-8ed3-6e6624624f62",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5481,7 +5481,7 @@
                "apierrors": [],
                "path": "/IOService/download",
                "response": {
-                  "jsondocId": "abcc4bc4-5870-4aca-a5ee-5d2fb9c0cb90",
+                  "jsondocId": "559e08d9-7727-42ee-bb38-8fa992f1b9a0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -5494,14 +5494,14 @@
          "description": "Methods for bulk importing and exporting sequence data"
       },
       {
-         "jsondocId": "8923c902-df50-4823-ab89-7bad6053d325",
+         "jsondocId": "55f708be-ca2c-4692-afab-4ef60f0b5191",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "27d080d9-5e2d-4f47-a219-b2f495afc3ce",
+                     "jsondocId": "37c72783-0c6b-4784-8ad1-41f53ac06ab2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5510,7 +5510,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1be43a8-0c2d-4e37-9bf8-1ffe95522d78",
+                     "jsondocId": "aaf4a92b-e664-4910-94cd-ebea3daa0fd2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5519,7 +5519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "389837b7-f124-4aa3-a453-1b9188e70a86",
+                     "jsondocId": "ee1ebc8c-2de2-49c7-a4fe-33d87262b0f3",
                      "name": "organism",
                      "format": "",
                      "description": "Pass an Organism JSON object with an 'id' that corresponds to the organism to be removed",
@@ -5531,9 +5531,9 @@
                "verb": "POST",
                "description": "Remove an organism",
                "methodName": "deleteOrganism",
-               "jsondocId": "a840339b-a607-4819-8ed4-0d849f17fc91",
+               "jsondocId": "0069e08e-7831-4308-b8cd-d948daca9186",
                "bodyobject": {
-                  "jsondocId": "f16f8a31-d953-435c-851f-8f4dc5de5a7c",
+                  "jsondocId": "5090df6e-98b8-45ff-a74c-de71875d92a9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5543,7 +5543,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganism",
                "response": {
-                  "jsondocId": "45662c6e-17ac-472e-afce-499f67d5bdab",
+                  "jsondocId": "6c99b15b-f977-476e-99d2-b818f87fea1f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5556,7 +5556,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c5f7871d-d05a-46dc-b164-3d75107c4f0d",
+                     "jsondocId": "cb9e8c8d-4eae-4b90-b5ee-08d58a80b2c1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5565,7 +5565,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db778023-93ae-4963-a318-7d4ace37a5cf",
+                     "jsondocId": "e00ca6e9-8406-475a-a9b4-de143c5cfd4d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5574,7 +5574,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55d4cdfe-95d2-4846-a42b-e266b536ab78",
+                     "jsondocId": "54289b06-262c-4a22-a3cc-d86cde79d5c2",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5586,9 +5586,9 @@
                "verb": "POST",
                "description": "Delete an organism along with its data directory and returns a JSON object containing properties of the deleted organism",
                "methodName": "deleteOrganismWithSequence",
-               "jsondocId": "16328a36-b283-439c-8ca7-725c9ba99a38",
+               "jsondocId": "6e3bf610-6578-4b3e-b835-7cf075cc4488",
                "bodyobject": {
-                  "jsondocId": "f4e04f3f-7b1b-4897-87e5-81e7a01ac8e7",
+                  "jsondocId": "f95c860b-10f6-416f-81ce-82b55812236c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5598,7 +5598,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismWithSequence",
                "response": {
-                  "jsondocId": "e8a7353d-7612-42ba-ad76-78b3fdb81027",
+                  "jsondocId": "b5bdf458-b1e4-4aec-a082-317f9381dd66",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5611,7 +5611,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e0e4c09d-74c7-4bee-a910-71815bc7a1a5",
+                     "jsondocId": "ec415a98-5013-4989-9ca6-4ebb227d4e69",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5620,7 +5620,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55759649-ed0b-472e-9327-67dc43211f37",
+                     "jsondocId": "59b3eb72-7d7c-457d-819d-31f47a87ae12",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5629,7 +5629,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5942e1dd-e97c-488a-a45c-b0c7184fc00e",
+                     "jsondocId": "f106da8e-bf3a-42d2-8d31-cce6408a6214",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism.",
@@ -5638,7 +5638,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "efc937ef-299e-4fae-a87b-66d4c4b42ad7",
+                     "jsondocId": "637f3051-363a-4258-8c69-306d90e9587b",
                      "name": "sequences",
                      "format": "",
                      "description": "(optional) Comma-delimited sequence names on that organism if only certain sequences should be deleted.",
@@ -5650,9 +5650,9 @@
                "verb": "POST",
                "description": "Remove features from an organism",
                "methodName": "deleteOrganismFeatures",
-               "jsondocId": "4ff144da-de63-433b-8de2-c4ee0c57b027",
+               "jsondocId": "20c40549-ee18-4fa9-941c-f861dc299241",
                "bodyobject": {
-                  "jsondocId": "0911d7ac-92e6-4a9a-b629-83862d9d9ffb",
+                  "jsondocId": "f57179f0-97c9-4268-9b9c-ac47307699cf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5662,7 +5662,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
                "response": {
-                  "jsondocId": "d1752ad4-6180-42d9-a776-a8ba6f7fe431",
+                  "jsondocId": "f074639d-6e3b-4434-a0e0-f8ea8c33884f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5675,7 +5675,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ed70e718-4c30-4887-a9bf-10794beafd5a",
+                     "jsondocId": "75b1d057-313a-401a-858d-6653c005cb57",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5684,7 +5684,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0700923d-5ff4-4c52-be2f-12aa1e84aab5",
+                     "jsondocId": "05024152-0087-4547-a3b6-f05093c7893d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5693,7 +5693,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55960b2f-0bd7-4878-83dd-56a32165ce79",
+                     "jsondocId": "e7df1035-e4d9-430f-a790-9d4b8ea11082",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -5702,7 +5702,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "48b05d99-9f5a-443f-a917-ebceef6b96b1",
+                     "jsondocId": "d29f7ead-b2d3-49c2-a98c-9a41267f92d3",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -5711,7 +5711,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f4fed2f-83b3-4a25-8ee3-ab64fcec040d",
+                     "jsondocId": "80a796d4-d5e2-4fae-b7eb-e173e3361e33",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -5720,7 +5720,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3ff145f3-eb12-4971-8ecd-4253748ffa9c",
+                     "jsondocId": "136f60b8-55b9-4faf-8868-545075d137b9",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5729,7 +5729,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e5c8494-421a-4410-972b-4381bec26adb",
+                     "jsondocId": "10ea6eee-4358-47ce-9bae-10f45aaed99c",
                      "name": "commonName",
                      "format": "",
                      "description": "commonName for an organism",
@@ -5738,7 +5738,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1786da1a-13ff-43ad-b5d8-ab73e6fbd753",
+                     "jsondocId": "ca80d949-7cfa-4eae-b478-c418212dbf1b",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -5747,7 +5747,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0cc7f624-ffa2-417d-a38f-734a68690acc",
+                     "jsondocId": "a679c00a-e0cc-43eb-a398-4439169ef4c4",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5756,7 +5756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dae05112-dafe-494a-b9e6-b1137fca8779",
+                     "jsondocId": "7dfd6b7b-8865-4e46-b1da-8f548215ac9f",
                      "name": "organismData",
                      "format": "",
                      "description": "zip or tar.gz compressed data directory",
@@ -5765,7 +5765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d0f8cae-1f0c-464a-86ee-5cfed1d89b49",
+                     "jsondocId": "345b5b7b-09a9-4924-9420-0c5f0cabf24b",
                      "name": "sequenceData",
                      "format": "",
                      "description": "FASTA file (optionally compressed) to automatically upload with",
@@ -5777,9 +5777,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganismWithSequence",
-               "jsondocId": "9015881a-158f-49e6-839e-fe67829b3fec",
+               "jsondocId": "36fe0a07-8a84-4f71-8026-eb8ac0e5410e",
                "bodyobject": {
-                  "jsondocId": "a07d0d3e-ab99-45fd-b688-c86776fc83c9",
+                  "jsondocId": "485f42f6-b57c-4768-921c-f5c2c2043d81",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5789,7 +5789,7 @@
                "apierrors": [],
                "path": "/organism/addOrganismWithSequence",
                "response": {
-                  "jsondocId": "dff589b6-534d-4db7-b5d6-a7dc18a52f45",
+                  "jsondocId": "8062f825-8128-4869-9b99-7c4d4798e2da",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5802,7 +5802,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "82776302-c9b0-4e19-bc02-c9d4740e369a",
+                     "jsondocId": "f1ec2bcc-c6a4-484d-871c-ba918b2791c3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5811,7 +5811,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c13eaaec-2413-4b4f-93c6-76e90c753c2a",
+                     "jsondocId": "828f7a51-3469-4cee-9237-b73dad62192e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5820,7 +5820,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "862b8478-097e-4f96-8769-6893370a1b36",
+                     "jsondocId": "c891fa3a-f2f9-4df2-9a9e-ea86e4d4e89d",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5829,7 +5829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "23ac0ebd-7d8d-4c04-832e-372d39457d89",
+                     "jsondocId": "a1b1bb5a-bcc1-405b-b064-606a65f71da9",
                      "name": "trackLabel",
                      "format": "",
                      "description": "Name of track",
@@ -5841,9 +5841,9 @@
                "verb": "POST",
                "description": "Removes an added track from an existing organism returning a JSON object containing all tracks for the current organism.",
                "methodName": "removeTrackFromOrganism",
-               "jsondocId": "a4e4a4d2-790b-4259-aee7-6ba0ab1473a2",
+               "jsondocId": "734637af-83eb-4197-a0cd-0877f0e95e73",
                "bodyobject": {
-                  "jsondocId": "592cf614-daf8-4f0e-af25-e84c160e68d3",
+                  "jsondocId": "0d065d80-136e-4ba5-8281-2300164d1ca0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5853,7 +5853,7 @@
                "apierrors": [],
                "path": "/organism/removeTrackFromOrganism",
                "response": {
-                  "jsondocId": "4bba8b8b-900e-4a5a-b718-6effa749b3e1",
+                  "jsondocId": "a5dbed6f-7bf5-46cb-acd7-d6f933b5fd33",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5866,7 +5866,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d9158ecd-64c3-47a9-ac8b-348ed021b290",
+                     "jsondocId": "725ccca2-82c8-4c56-800c-88c1cfccd36b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5875,7 +5875,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97fe47e9-b3c3-461e-b29b-dd938cf04754",
+                     "jsondocId": "f1874286-6488-4429-9771-c8d1951b7b25",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5884,7 +5884,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3c9da0c9-b47e-496b-b810-f8db0dd84e71",
+                     "jsondocId": "9d72641d-922e-458a-bf16-207e30a2a332",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5893,7 +5893,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "37ff5680-7bd3-44b2-8bb1-fca8c71774e0",
+                     "jsondocId": "d71971c7-f73f-42e8-9f7a-1e31157e6975",
                      "name": "trackData",
                      "format": "",
                      "description": "zip or tar.gz compressed track data",
@@ -5902,7 +5902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3d1f3d2f-f92b-4ccf-957d-ffb91ad96cf3",
+                     "jsondocId": "f84f3b4e-5d42-43e4-9f65-bd6ec55a5837",
                      "name": "trackFile",
                      "format": "",
                      "description": "track file (*.bam, *.vcf, *.bw, *gff)",
@@ -5911,7 +5911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1740238-efbe-4d4c-ab59-b256e0c7110d",
+                     "jsondocId": "ff0c85a4-f3bb-44be-8882-0e8f1555fff5",
                      "name": "trackFileIndex",
                      "format": "",
                      "description": "index (*.bai, *.tbi)",
@@ -5920,7 +5920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84734709-d088-4563-a0ad-30d119092d06",
+                     "jsondocId": "8425203e-835a-449b-bf44-eac60087e4a7",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -5932,9 +5932,9 @@
                "verb": "POST",
                "description": "Adds a track to an existing organism returning a JSON object containing all tracks for the current organism.",
                "methodName": "addTrackToOrganism",
-               "jsondocId": "6a2d4ccd-e10a-4c15-996f-5eb35f3d4095",
+               "jsondocId": "779a7c9f-8465-4aa3-b505-d88e91a5cc02",
                "bodyobject": {
-                  "jsondocId": "4b794390-bc35-47a6-bf10-8f50b3f9c674",
+                  "jsondocId": "66c58fb2-6c24-4fae-8560-82de58ab2d78",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5944,7 +5944,7 @@
                "apierrors": [],
                "path": "/organism/addTrackToOrganism",
                "response": {
-                  "jsondocId": "456eb395-8843-43fc-bdae-bc7c159b6abd",
+                  "jsondocId": "aed1022d-7436-4777-975a-76f685704d47",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5957,7 +5957,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1717a911-cbcd-45d9-9df9-fb968ac6a8b0",
+                     "jsondocId": "4cb385d8-9040-4fe3-a973-ee43b1751825",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5966,7 +5966,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "48b8833b-4477-44b5-b711-ebdf021a3232",
+                     "jsondocId": "c4168214-523a-49e3-a684-c825e474aff4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5975,7 +5975,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b5f02371-0f85-4972-96bc-f576f25ec141",
+                     "jsondocId": "f9dda5d7-ba02-457f-b750-5d67a5b42c97",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5984,7 +5984,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "134e381c-d341-4e9a-9f06-1a7b00ff28c2",
+                     "jsondocId": "d54d8428-e55a-4619-bcd2-4db02ccf3306",
                      "name": "trackLabel",
                      "format": "",
                      "description": "Track label corresponding to the track that is to be deleted",
@@ -5996,9 +5996,9 @@
                "verb": "POST",
                "description": "Deletes a track from an existing organism and returns a JSON object of the deleted track's configuration",
                "methodName": "deleteTrackFromOrganism",
-               "jsondocId": "cffd17fd-5e0e-407d-9b3a-61c870cbca5e",
+               "jsondocId": "3472c305-7673-4324-9169-3d903d71b5d9",
                "bodyobject": {
-                  "jsondocId": "f036f2c1-c685-48f9-9bfb-ac670a7c5d54",
+                  "jsondocId": "cc19eead-f6d9-4e03-975b-9015030fde10",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6008,7 +6008,7 @@
                "apierrors": [],
                "path": "/organism/deleteTrackFromOrganism",
                "response": {
-                  "jsondocId": "b2b967d9-3861-4f19-ae8e-c7fc7009b24a",
+                  "jsondocId": "33b9fcd5-5b38-4f12-9f14-ee752de043c4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6021,7 +6021,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d29c53ad-466a-4db2-87b2-069aacae49c3",
+                     "jsondocId": "76a64729-0015-4caf-aff5-42dbf280a0bf",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6030,7 +6030,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1ea9226-de0b-4018-8d2b-35f3f703b167",
+                     "jsondocId": "6b3a3b32-0e9b-4cbc-a689-86915c772d4f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6039,7 +6039,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b5a4bda8-a5fc-4e88-bdb5-41ca55c927a7",
+                     "jsondocId": "0d3c7d8a-2ddf-4fa0-82a4-c4cd66960399",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -6048,7 +6048,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9ab94f48-ebe3-4bd9-b092-511278d42393",
+                     "jsondocId": "7a56c73d-7ca0-46d8-8d93-3ad612fef063",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -6060,9 +6060,9 @@
                "verb": "POST",
                "description": "Update a track in an existing organism returning a JSON object containing old and new track configurations",
                "methodName": "updateTrackForOrganism",
-               "jsondocId": "c9747c62-7ada-4aef-9a2f-e7c2a8b39501",
+               "jsondocId": "2bbd6d1d-17b7-46c2-aa3e-7e22cefa87c8",
                "bodyobject": {
-                  "jsondocId": "1bea906c-620e-445d-a0c9-d7ee4693af34",
+                  "jsondocId": "1e50dc85-6bab-4a93-91e0-04cf57fa1756",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6072,7 +6072,7 @@
                "apierrors": [],
                "path": "/organism/updateTrackForOrganism",
                "response": {
-                  "jsondocId": "5b77b674-6f41-4c8d-85f7-aef9da2c1b79",
+                  "jsondocId": "c325c696-882d-42dc-814c-d836e91f895e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6085,7 +6085,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f473825d-3b9a-4c87-ba47-6d6a4cc6d3f4",
+                     "jsondocId": "3089ef3c-0e70-41b7-a0c4-fc502f3f4bdc",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6094,7 +6094,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d2bf0862-e713-444f-93ec-ee16656b2005",
+                     "jsondocId": "547e2ff2-6314-4b12-880f-ef424488b87c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6103,7 +6103,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66f205a2-8d08-43fe-ae3b-e84a162a752c",
+                     "jsondocId": "68794421-8a03-41ee-b3ec-2ed6ab93940d",
                      "name": "directory",
                      "format": "",
                      "description": "Filesystem path for the organisms data directory (required)",
@@ -6112,7 +6112,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "666e373b-f148-4d4a-a3fd-7dfc2ae952e4",
+                     "jsondocId": "e365a1fe-32d4-4cd1-b94b-39435284adc3",
                      "name": "commonName",
                      "format": "",
                      "description": "A name used for the organism",
@@ -6121,7 +6121,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "511cdfb0-4afb-4fd4-ac93-f4cd597cc07c",
+                     "jsondocId": "bd68f777-788c-4dc4-8969-9ec09db0d40d",
                      "name": "species",
                      "format": "",
                      "description": "(optional) Species name",
@@ -6130,7 +6130,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "042fc23d-2da5-4e59-b2f2-d51b9054ba86",
+                     "jsondocId": "b2297b97-b4bc-4de4-9e7d-9d321b4e3092",
                      "name": "genus",
                      "format": "",
                      "description": "(optional) Species genus",
@@ -6139,7 +6139,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "51236c1d-c832-45b1-9872-371661c6eba0",
+                     "jsondocId": "49bc2dec-5b3f-410b-9850-bb992ff11b79",
                      "name": "blatdb",
                      "format": "",
                      "description": "(optional) Filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -6148,7 +6148,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d0801a83-a955-496d-80b7-e4eb5892c06e",
+                     "jsondocId": "693d6e5d-d192-4ede-80a3-ee397c6778d3",
                      "name": "publicMode",
                      "format": "",
                      "description": "(optional) A flag for whether the organism appears as in the public genomes list (default false)",
@@ -6157,7 +6157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1f93c974-8501-44f0-87b6-bf3ed474c0d5",
+                     "jsondocId": "34eeffa2-02da-431c-90f4-76e5b411cf28",
                      "name": "metadata",
                      "format": "",
                      "description": "(optional) Organism metadata",
@@ -6166,7 +6166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2a54e98f-3a43-4b6c-8256-e66d463892da",
+                     "jsondocId": "166f94a7-50a7-4cbf-be6a-8ba71d4065f4",
                      "name": "returnAllOrganisms",
                      "format": "",
                      "description": "(optional) Return all organisms (true / false) (default true)",
@@ -6178,9 +6178,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganism",
-               "jsondocId": "3c69d6ec-adf7-49c6-bc7c-4fdd8e737f8a",
+               "jsondocId": "d8800429-8fb3-45d9-b25a-9587bb4ab005",
                "bodyobject": {
-                  "jsondocId": "32a776a0-51be-4064-bbf1-6abb1ce53858",
+                  "jsondocId": "e8d36a78-7881-478e-9d52-dfc362329c88",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6190,7 +6190,7 @@
                "apierrors": [],
                "path": "/organism/addOrganism",
                "response": {
-                  "jsondocId": "93119481-4477-4211-9614-4b544f20d98a",
+                  "jsondocId": "3ac9b62c-031a-423d-a41f-c8ff8273b5b0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6203,7 +6203,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9ae8c66b-84dd-430f-ac45-9bd4ba1f7d58",
+                     "jsondocId": "5ff1098b-0e5a-4d25-bebf-da1673603777",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6212,7 +6212,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fe0e1773-581b-4260-92cc-32180e3b5d1b",
+                     "jsondocId": "41490ae1-9a45-4beb-a359-b1c2a4d32e06",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6221,7 +6221,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "18b1da14-cd53-406d-af41-4f9e0e99b95d",
+                     "jsondocId": "83fae56c-011e-41db-8328-1e835f554c80",
                      "name": "organism",
                      "format": "",
                      "description": "Common name or ID for the organism",
@@ -6233,9 +6233,9 @@
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
                "methodName": "getSequencesForOrganism",
-               "jsondocId": "169b9c2f-4918-4784-9ce3-8a100697a0a1",
+               "jsondocId": "70748f2b-d766-490c-bd31-41f46dfccb28",
                "bodyobject": {
-                  "jsondocId": "42391a59-758d-4e98-8446-c4e3cbb42aa2",
+                  "jsondocId": "09722be3-7287-4ec5-9e4f-86c018e8ebc8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6245,7 +6245,7 @@
                "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
                "response": {
-                  "jsondocId": "c69de90a-7797-42ee-bc4b-78a1dbc3b8cd",
+                  "jsondocId": "f34a0c0c-5393-4c64-8121-6eabc80c1208",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6258,7 +6258,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f9bf8d35-f767-46b6-9fc9-066fa0f9755d",
+                     "jsondocId": "436505da-6120-48a7-b851-91787694d39a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6267,7 +6267,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "37ef523e-265a-4058-8ad1-d3e7b6498e83",
+                     "jsondocId": "582caea6-3631-4f1e-ab4b-31cf11b11962",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6276,7 +6276,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aa498f67-7f2f-4e2c-bcd2-61267ce2d7f0",
+                     "jsondocId": "7ae30476-0b4b-475e-a819-b9230f0e066e",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -6285,7 +6285,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e65d1d66-714d-41f1-9534-5f0f0bfdb634",
+                     "jsondocId": "b4818cc8-dbfe-4147-a4fe-6260f623011e",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -6294,7 +6294,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f89bffb9-3ece-4cb1-a2cb-0281bbcffea9",
+                     "jsondocId": "b210f137-2bc3-449c-b524-e3d24664f4c4",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -6303,7 +6303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44cf9bd0-e19f-4a44-acaf-0341d2802690",
+                     "jsondocId": "e011ed0f-0b77-4b54-a30c-ace3dac85e3f",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -6312,7 +6312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff202f68-680b-41f0-846c-eef0788f2c2e",
+                     "jsondocId": "0af6523a-236e-41d0-acad-01b1a9720ef3",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -6321,7 +6321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2fb3ae05-6abb-444b-a0ce-3bac17daedc0",
+                     "jsondocId": "5ee30453-8afc-4db7-8250-b4974c003a7d",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -6330,7 +6330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "372670d5-7709-440a-ad76-297b0c08fec0",
+                     "jsondocId": "a391fc04-c809-4759-bcab-7cc47b567b70",
                      "name": "name",
                      "format": "",
                      "description": "a common name used for the organism",
@@ -6339,7 +6339,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dbb3dc64-fb59-4dbd-b6d7-486160ab8c81",
+                     "jsondocId": "e6b3206c-c914-4e59-86bb-d752abf77f58",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -6348,7 +6348,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f46cce73-89f5-4899-8322-d94071104c5c",
+                     "jsondocId": "d3ac47b2-fd9c-49de-8ed6-123b3ebe4896",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -6360,9 +6360,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "updateOrganismInfo",
-               "jsondocId": "f1d61588-468b-4895-9b33-f363c5b1e941",
+               "jsondocId": "368b88fa-3032-4edb-9086-e89d8bec06bd",
                "bodyobject": {
-                  "jsondocId": "633f18b2-3aa9-47e8-8c63-af71bfe4c37a",
+                  "jsondocId": "3e3d5afd-458e-4377-abac-1e6df75f3111",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6372,7 +6372,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismInfo",
                "response": {
-                  "jsondocId": "0c0cb7da-a8a6-456a-9c86-a5b70c213a37",
+                  "jsondocId": "e2aaa7e4-d1bb-4d11-b9d1-3a61f5730c25",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6385,7 +6385,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "364deff3-d335-4721-a7e5-8413ab193286",
+                     "jsondocId": "089b1a3b-1fec-4c15-b09f-a6269665d599",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6394,7 +6394,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ee04b509-9099-45d2-976c-61653ee03f78",
+                     "jsondocId": "4e311d03-9e05-4b93-a458-e4eec5e50a87",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6403,7 +6403,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e23eb9b8-519e-4baa-bdd2-61c4d52f424a",
+                     "jsondocId": "5046dd2a-c054-4deb-aa4f-35bd08d42d1f",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -6412,7 +6412,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "92262182-1e0e-4d2e-8c99-738f5587045c",
+                     "jsondocId": "0117931d-3a74-4e23-8f54-2bc8635196b6",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -6424,9 +6424,9 @@
                "verb": "POST",
                "description": "Update organism metadata",
                "methodName": "updateOrganismMetadata",
-               "jsondocId": "0d095b13-8089-4330-959a-8a27648c70b9",
+               "jsondocId": "11f4f5cf-c363-4dfc-bd72-d9c3e65805de",
                "bodyobject": {
-                  "jsondocId": "923a8148-b20a-4235-9334-ae127b21f203",
+                  "jsondocId": "ca632972-8ae5-43ec-995a-99b128714de7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6436,7 +6436,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismMetadata",
                "response": {
-                  "jsondocId": "d8568c90-8905-4377-b5d9-fa7c7468b1a4",
+                  "jsondocId": "8fc81f4a-d7cb-40f0-b8cb-8a91577303ea",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6449,7 +6449,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "70592d7a-4272-498a-85df-e479a5950dee",
+                     "jsondocId": "75e529ee-5fd4-4cf1-9183-55437996382e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6458,7 +6458,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c6fdd1f9-f042-4af3-8660-60237be246e9",
+                     "jsondocId": "25775dfa-8949-4798-bf83-956ee3d0b2e2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6467,7 +6467,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cd2cee61-2648-463e-a72c-7995879e1ecf",
+                     "jsondocId": "051c46e8-702b-47ca-b285-a8f4bba4720f",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -6479,9 +6479,9 @@
                "verb": "POST",
                "description": "Get creator metadata for organism, returns userId as String",
                "methodName": "getOrganismCreator",
-               "jsondocId": "8d252c9b-21e8-4530-ba33-e6056b4a700b",
+               "jsondocId": "caeb2e5b-a9d2-416c-98da-d120e59bdee4",
                "bodyobject": {
-                  "jsondocId": "e1500874-b617-4640-b8ca-5689930081d7",
+                  "jsondocId": "7f2a7de5-e09d-4ee6-be02-ae4bc5816d5d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6491,7 +6491,7 @@
                "apierrors": [],
                "path": "/organism/getOrganismCreator",
                "response": {
-                  "jsondocId": "871d86eb-69ba-4ac6-969a-26894ce096b2",
+                  "jsondocId": "f1320c12-0283-481a-a526-adbd3365ae76",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6504,7 +6504,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e0368f61-7a63-4b62-863f-2cb041700689",
+                     "jsondocId": "83f74a61-755f-4793-ae22-63c76f45c8dd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6513,7 +6513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c971d619-4064-4009-9149-07c122784b66",
+                     "jsondocId": "49fede6a-d0e0-4e4b-b91a-ac5a1ccb32cb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6522,7 +6522,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "128dcec8-6bf2-4b6a-a4dc-03f6ee77f653",
+                     "jsondocId": "71a81572-c8f5-4d77-9a63-48fd57772d1c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) ID or commonName that can be used to uniquely identify an organism",
@@ -6534,9 +6534,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "methodName": "findAllOrganisms",
-               "jsondocId": "fcc595bc-edba-473c-b0a1-288d3da6907d",
+               "jsondocId": "0e84ad31-aa89-48c2-a89c-d0e0d96019de",
                "bodyobject": {
-                  "jsondocId": "854aa854-d55d-4414-afa5-eb10bf725638",
+                  "jsondocId": "2e81769c-fa75-4d4f-baab-6a4c71558bb1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6546,7 +6546,7 @@
                "apierrors": [],
                "path": "/organism/findAllOrganisms",
                "response": {
-                  "jsondocId": "7875506a-dcb0-442f-a9c5-fc9dc2f06f59",
+                  "jsondocId": "6ea2cfbd-2623-4727-b6cc-a5134dee65bb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6559,14 +6559,14 @@
          "description": "Methods for managing organisms"
       },
       {
-         "jsondocId": "c88c4c47-70a7-4aba-a386-5adfd0c65dca",
+         "jsondocId": "321eea7c-f268-43dc-a597-1e07a84bb465",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b7fcc998-ae14-4129-be24-ad1ab8a1d06b",
+                     "jsondocId": "e2595b08-3cfb-43d0-b4c0-05248dcc34fd",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -6575,7 +6575,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "182917bd-e8dc-4ac7-a83e-f3fc58afc98e",
+                     "jsondocId": "be1034e3-e9a3-4082-a26d-f3fadb226f9c",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -6584,7 +6584,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8b0dac6a-fdd8-4efc-a544-48fbb563e211",
+                     "jsondocId": "f6f1f054-3e7b-420d-b3d1-9f14c0eabdf9",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -6593,7 +6593,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "89f1e41c-cf78-47e5-be80-16d2db90a15b",
+                     "jsondocId": "40b96b67-17d0-4a1f-aeea-e221ba21e8e1",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -6602,7 +6602,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02e725a1-5339-46ff-9e2e-16413ad4e08c",
+                     "jsondocId": "880a4ba9-586f-4cbc-bd0c-47c8db82ea52",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6614,12 +6614,12 @@
                "verb": "GET",
                "description": "Get sequence data within a range",
                "methodName": "sequenceByLocation",
-               "jsondocId": "541e87ce-a710-4acd-80f2-21f10a1b8b9c",
+               "jsondocId": "5a0b50c4-cf30-4f94-9828-edf3da528c42",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/<organism name>/<sequence name>:<fmin>..<fmax>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "5a39c1e2-fe00-43b9-95f1-b61fdf7bcb1e",
+                  "jsondocId": "f7336b06-d146-4f78-9257-757790002801",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6632,7 +6632,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b9f86b7b-ced9-42cb-bdeb-38130ccbaa31",
+                     "jsondocId": "dc002a3e-5399-45ea-8899-441d3a100f69",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID (required)",
@@ -6641,7 +6641,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7bacc10-ec20-4f38-af2a-2a7f7d099e51",
+                     "jsondocId": "cc951c91-4dd6-4cec-921f-38882429ea8b",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name (required)",
@@ -6650,7 +6650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "682607c4-f3e6-4f71-a1c6-a69b115a7b5d",
+                     "jsondocId": "e74542c4-4a38-4064-b555-28bd1400abb5",
                      "name": "featureName",
                      "format": "",
                      "description": "The uniqueName (UUID) or given name of the feature (typically transcript) of the element to retrieve sequence from",
@@ -6659,7 +6659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8bfaa37a-2261-420c-955a-6184ef808b0e",
+                     "jsondocId": "10539ea0-9418-4b12-b929-5121f26c97ac",
                      "name": "type",
                      "format": "",
                      "description": "(default genomic) Return type: genomic, cds, cdna, peptide",
@@ -6668,7 +6668,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e8dae7d5-4ecf-4a7f-b4f9-d0b015d914bd",
+                     "jsondocId": "d152be49-37ff-4d99-94be-944761dc3e11",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6680,12 +6680,12 @@
                "verb": "GET",
                "description": "Get sequence data as for a selected name",
                "methodName": "sequenceByName",
-               "jsondocId": "33980d63-8b93-4726-b7a5-eca68eb762da",
+               "jsondocId": "42c57781-5395-4d38-8803-101c4c559825",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/<organism name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "2875ba19-85b4-4d05-8d99-570edc858207",
+                  "jsondocId": "76a74d46-ff2d-4b79-a2ab-059db6cf0fd4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6698,7 +6698,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "858f2d75-2489-4c9a-922f-2ca3b3cdcc16",
+                     "jsondocId": "08833d8b-f523-4367-8201-8fe96b074cc0",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -6707,7 +6707,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "702c4119-ee69-4361-b0df-ebc81b6c1dc8",
+                     "jsondocId": "04a1a904-7de7-4d8d-aca6-557894d251d2",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name (required)",
@@ -6719,12 +6719,12 @@
                "verb": "GET",
                "description": "Remove sequence cache for an organism and sequence",
                "methodName": "clearSequenceCache",
-               "jsondocId": "b1b0b645-e05a-46ce-9e44-36d0eaf9fe03",
+               "jsondocId": "93f8857f-c7e1-48e9-84d5-aa9c75f5cdae",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/cache/clear/<organism name>/<sequence name>",
                "response": {
-                  "jsondocId": "0117afef-0926-459e-a00e-7901b7bed6c7",
+                  "jsondocId": "7f49afcc-cbdd-448d-93c3-aec6695da5c4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6736,7 +6736,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "b9cb8a56-1271-47a3-8d55-52ca344af17f",
+                  "jsondocId": "816e0cd6-e722-403c-b764-602ccf807a78",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required) or 'ALL' if admin",
@@ -6747,12 +6747,12 @@
                "verb": "GET",
                "description": "Remove sequence cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "9e95929c-f430-4440-b0d2-cda8a2bd6388",
+               "jsondocId": "827d5feb-a4a8-4a06-b986-2dc934c4773c",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "59d573e4-9a15-4ef6-8d63-9ae1a384462a",
+                  "jsondocId": "7042e247-61e9-4f12-8924-46fbd49a1a28",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6765,13 +6765,294 @@
          "description": "Methods for retrieving sequence data"
       },
       {
-         "jsondocId": "e6280d5e-e3e2-42f1-895e-39d8287b0a96",
+         "jsondocId": "82da2702-ccdb-4e52-a2bf-c110e1d7210b",
+         "methods": [
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "ca345df2-4e0a-4e68-abbe-2494d5c91a0a",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c856fcc9-69b8-4267-84eb-5975acb85e10",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "573b2011-eaf4-4b19-9fec-0574f38dc66f",
+                     "name": "name",
+                     "format": "",
+                     "description": "Suggested name to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "653a93a6-c984-4a3b-88ae-fc3d2317d409",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create suggested name",
+               "methodName": "createName",
+               "jsondocId": "3eaccb4b-d8b9-4024-854c-ff779bc0eb80",
+               "bodyobject": {
+                  "jsondocId": "2dbaf933-99b4-4958-b558-2e2967be33f2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "suggested name"
+               },
+               "apierrors": [],
+               "path": "/suggestedName/createName",
+               "response": {
+                  "jsondocId": "efeda75f-6f0a-43df-a918-23e5120b94df",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "suggested name"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "1027bceb-e9b0-400a-9f81-4ad2b48e0418",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0b2992c9-2f76-435c-9f59-ab0b717befc4",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "90e07910-7d82-4127-bad7-698dacbb9158",
+                     "name": "id",
+                     "format": "",
+                     "description": "Suggested name ID to update (or specify the old_name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6bc1d8de-4d6f-4e59-933c-65bf2b99afcb",
+                     "name": "old_name",
+                     "format": "",
+                     "description": "Suggested name to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "91e7ebd4-0123-473d-86b4-dc0414d19440",
+                     "name": "new_name",
+                     "format": "",
+                     "description": "Suggested name to change to (the only editable option)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "79ec372a-13b8-4aa3-b067-acffd9beafbe",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update suggested name",
+               "methodName": "updateName",
+               "jsondocId": "f6db6360-1519-4ac8-a86a-ffd0650cdd16",
+               "bodyobject": {
+                  "jsondocId": "19489b40-b259-4f17-894a-e84538aada0d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "suggested name"
+               },
+               "apierrors": [],
+               "path": "/suggestedName/updateName",
+               "response": {
+                  "jsondocId": "51095465-8089-45fc-8f42-231ae8d3cdd6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "suggested name"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "777f2276-7fa4-4824-b6ab-e91a4d020a5b",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6d68b27a-c9d0-40ed-bf3d-b991ead1a392",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "53b4d8a1-8212-4513-b687-09f4b655e13a",
+                     "name": "id",
+                     "format": "",
+                     "description": "Suggested name ID to remove (or specify the name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4a3e1135-b919-4384-b6f2-8b48239e21f9",
+                     "name": "name",
+                     "format": "",
+                     "description": "Suggested name to delete",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Remove a suggested name",
+               "methodName": "deleteName",
+               "jsondocId": "827ed84f-8f6f-41be-b266-45d15310d419",
+               "bodyobject": {
+                  "jsondocId": "cb5c13a1-a3a6-455f-8971-6fa4d91e9cba",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "suggested name"
+               },
+               "apierrors": [],
+               "path": "/suggestedName/deleteName",
+               "response": {
+                  "jsondocId": "1e92585a-ec73-439a-8174-b0ca214b1e2c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "suggested name"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "36c42c3f-5de6-4007-92cd-a2d403e84cf8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1820033b-8aa2-453b-84d8-9c818967de18",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "450a0ac3-bf56-46bf-aa4c-ab0bcb5a66ed",
+                     "name": "id",
+                     "format": "",
+                     "description": "Name ID to show (or specify a name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "571f1611-1d01-4e50-a2c2-b8b5b464b43a",
+                     "name": "name",
+                     "format": "",
+                     "description": "Name to show",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Returns a JSON array of all suggested names, or optionally, gets information about a specific suggested name",
+               "methodName": "showName",
+               "jsondocId": "39a4d0b8-9db4-424a-b203-a1711a4a101d",
+               "bodyobject": {
+                  "jsondocId": "a66ef085-e605-4194-b351-4580c3a066a4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "suggested name"
+               },
+               "apierrors": [],
+               "path": "/suggestedName/showName",
+               "response": {
+                  "jsondocId": "a5586ff3-edf2-4a8c-ad44-64af6cbe6b55",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "suggested name"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            }
+         ],
+         "name": "Suggested Names Services",
+         "description": "Methods for managing suggested names"
+      },
+      {
+         "jsondocId": "18208c8e-e68a-409c-af4b-faa3f25a8621",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "ac986d75-4594-4edc-a8c2-8783ac94a4be",
+                  "jsondocId": "6a0552d2-888e-48fe-92ba-fae97c295c63",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required) or 'ALL' if admin",
@@ -6782,12 +7063,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "a0196885-7bdb-429c-9db2-970d72cc3288",
+               "jsondocId": "cb11ef8b-4aaf-43c0-9725-334d581007fd",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "a9aa95ff-4369-451a-85fa-2f936f92fb7f",
+                  "jsondocId": "8114c63e-c63b-4cbc-87fb-95b8f5fb93a6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -6800,7 +7081,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0efc442e-322f-4fcb-a94d-ddb5f2258476",
+                     "jsondocId": "a8e00618-310e-4b74-90cf-e0f71e2cff04",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -6809,7 +7090,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7d530d4-7380-4e6b-a962-d3e571fd211c",
+                     "jsondocId": "4533e7d0-17c5-493c-93ae-d492b55e6d8e",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name (required)",
@@ -6821,12 +7102,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism and track",
                "methodName": "clearTrackCache",
-               "jsondocId": "b6acc32e-ae61-4c18-85db-7942c6b3ca36",
+               "jsondocId": "49e9e611-192c-42cb-97c0-e6a9b1b200ae",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>/<track name>",
                "response": {
-                  "jsondocId": "99fe020d-edaf-4a9d-b759-5fb827ac08d9",
+                  "jsondocId": "4c4a0aaf-843b-4307-8f7d-afd0e9e0163e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -6838,7 +7119,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "2621fae8-fe20-495f-b971-f942e02881b8",
+                  "jsondocId": "39c94269-2e23-4c85-a4ec-74596624c92d",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required)",
@@ -6849,12 +7130,12 @@
                "verb": "GET",
                "description": "List all tracks for an organism",
                "methodName": "getTracks",
-               "jsondocId": "35ed3548-d9ce-43b6-97b9-fc3e802b2d22",
+               "jsondocId": "7f0d9353-c9f1-483b-bd7f-3ae789cf1cee",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/list/<organism name>",
                "response": {
-                  "jsondocId": "be8d76ed-5158-4646-bbb1-4b5a36f43089",
+                  "jsondocId": "ae05f846-10dd-428f-abb0-446ef230d344",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -6867,7 +7148,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "27b7cb8f-8095-434c-a437-a0fb268abb29",
+                     "jsondocId": "3a3d6314-5668-4abd-be0b-7cb999944387",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -6876,7 +7157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e1960d6b-05cc-43ea-9c71-0e25be8458b7",
+                     "jsondocId": "69fa8ea5-7928-47cb-8f2a-cf9de47e7e59",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -6885,7 +7166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1b353b71-6797-418b-8f5b-357552ec8b5d",
+                     "jsondocId": "e66d7d42-6075-4483-a004-6c88767b2ae4",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -6894,7 +7175,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7d92814d-0ade-4507-a463-b8876848c0c3",
+                     "jsondocId": "0d850670-61ba-46ea-bb7b-c961cf65fdfe",
                      "name": "featureName",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -6903,7 +7184,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f808a601-0872-4f18-81c0-a06bcc8490fc",
+                     "jsondocId": "efab8cbe-1a09-412c-a94b-dd8231551afd",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6912,7 +7193,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "93b2f967-32e1-4421-9961-e3168ed4bd31",
+                     "jsondocId": "471465f0-a8b6-4b13-8193-37ca6264637c",
                      "name": "flatten",
                      "format": "",
                      "description": "Brings nested top-level components to the root level.  If not provided or 'false' it will not flatten.  Default is 'gene'.",
@@ -6921,7 +7202,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e64bec8b-186b-4cc0-aadd-19f5bbcc543a",
+                     "jsondocId": "d96556f4-eb51-41cc-b0e1-f9f90571da92",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -6933,12 +7214,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within but only for the selected name",
                "methodName": "featuresByName",
-               "jsondocId": "52cc5ef7-086b-4b40-a126-2f6f5e7b465e",
+               "jsondocId": "af9de509-e77c-4f77-b39c-d981308d1676",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "a002eff4-eee6-46c4-936f-4f325dad3066",
+                  "jsondocId": "57636270-a299-4313-9602-648cd5f0989b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -6951,7 +7232,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0d92ad0c-1747-498f-b286-d7032a539f61",
+                     "jsondocId": "b7652fdc-3707-4947-85bb-3cbac628f9e6",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -6960,7 +7241,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a4cfbe62-f738-4dbb-8f02-1de196d4b835",
+                     "jsondocId": "25345e81-c8db-40ba-96c8-e2fc28399363",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -6969,7 +7250,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84839d41-12f8-4389-809f-0d9513d1ec5b",
+                     "jsondocId": "f8608522-1192-430d-a49c-f29f996091da",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -6978,7 +7259,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "da2ff211-5153-4a90-bd78-7c1951a0a310",
+                     "jsondocId": "15c58f90-54c0-4333-98cb-281d8e210907",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -6987,7 +7268,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f734b0d9-f0f7-4a1e-9064-1f3e40914525",
+                     "jsondocId": "8cad546b-6c98-4ded-9141-241d436162ee",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -6996,7 +7277,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e93cb6c5-c13d-452a-976c-243d19beb8dc",
+                     "jsondocId": "6113fd91-8a02-4a4c-af2c-b97763c1531b",
                      "name": "name",
                      "format": "",
                      "description": "If top-level feature 'name' matches, then annotate with 'selected'=true.  Multiple names can be passed in.",
@@ -7005,7 +7286,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b6b855f5-d7bc-413f-a107-8e50e62b8103",
+                     "jsondocId": "ceb3e23a-77e9-4ca9-aaa2-1337c54da3ec",
                      "name": "onlySelected",
                      "format": "",
                      "description": "(default false).  If 'selected'!=1 one, then exclude.",
@@ -7014,7 +7295,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "455b257c-a59f-428b-b54d-1055b2b76275",
+                     "jsondocId": "5be78ccc-fe32-400d-929e-9be7525be119",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -7023,7 +7304,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a7c042c9-3644-41d3-a44f-fb3213658f5e",
+                     "jsondocId": "bc71e655-6bce-4535-98fa-748a4f74186d",
                      "name": "flatten",
                      "format": "",
                      "description": "Brings nested top-level components to the root level.  If not provided or 'false' it will not flatten.  Default is 'gene'.",
@@ -7032,7 +7313,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "03ef3422-b690-445a-b3db-09ab13708a2c",
+                     "jsondocId": "cefcf450-1ad3-4496-817e-0cbf6f2a4c70",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -7044,12 +7325,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within an range",
                "methodName": "featuresByLocation",
-               "jsondocId": "ec930909-68a7-4a9d-83f9-004870f1a02d",
+               "jsondocId": "61bbd5a2-3261-4d89-8551-ad2e70b36896",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>:<fmin>..<fmax>.<type>?name=<name>&onlySelected=<onlySelected>&ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "a9ea855f-cbd2-4976-9365-0635728c72a9",
+                  "jsondocId": "bb9b686e-ab23-4c14-9c98-fa6353fbc4ae",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7062,14 +7343,14 @@
          "description": "Methods for retrieving track data"
       },
       {
-         "jsondocId": "09faf7f5-8761-444a-9b54-8489f6575e54",
+         "jsondocId": "ef945d05-4ef0-4d66-9415-f4bdff610acd",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "195ac9e6-e9bd-48de-a258-1f990acccb55",
+                     "jsondocId": "17b10f07-0b4b-4fc3-811e-c971d868c2a9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7078,7 +7359,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d957d1f1-8fd9-42ab-9c89-b5e59b3a750f",
+                     "jsondocId": "4e1396a5-e20b-430c-9852-7a03a90fdfa2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7087,773 +7368,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "036d346c-6956-44ae-acd9-9afb4b80463d",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to fetch",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get organism permissions for user, returns an array of permission objects",
-               "methodName": "getOrganismPermissionsForUser",
-               "jsondocId": "f65e71dd-79e1-46a0-ac32-48559181b5fe",
-               "bodyobject": {
-                  "jsondocId": "7a88d4f9-12ea-45e6-9491-0c0bfe58f207",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/getOrganismPermissionsForUser",
-               "response": {
-                  "jsondocId": "53db4297-7719-4a9e-a75c-b165c393a9f6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "495f4fa0-8182-4cee-99d4-2cbf200e4d42",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9d869f4b-0877-4be4-b4e2-b65a823d3f39",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "80f1c635-bfd8-4ded-8e7a-572f9b18e7e4",
-                     "name": "userId",
-                     "format": "",
-                     "description": "Optionally only user a specific userId as an integer database id or a username string",
-                     "type": "long / string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "8beb9b8e-4e53-475e-873b-8ed2e15d8951",
-                     "name": "start",
-                     "format": "",
-                     "description": "(optional) Result start / offset",
-                     "type": "long / string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "53a941c8-c453-4f03-96cd-ac284763ed9c",
-                     "name": "length",
-                     "format": "",
-                     "description": "(optional) Result length",
-                     "type": "long / string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2b8fad1b-6888-4cc0-86ff-2afb765111c0",
-                     "name": "name",
-                     "format": "",
-                     "description": "(optional) Search name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f4369caf-4182-471d-833d-832e2b87b9ba",
-                     "name": "sortColumn",
-                     "format": "",
-                     "description": "(optional) Sort column, default 'name'",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "60398377-3bd0-4f9c-ba98-744eff823930",
-                     "name": "sortAscending",
-                     "format": "",
-                     "description": "(optional) Sort column is ascending if true (default false)",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e80dad32-a40a-48c3-8cac-3068ad5689ad",
-                     "name": "omitEmptyOrganisms",
-                     "format": "",
-                     "description": "(optional) Omits empty organism permissions from return (default false)",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "af4ae168-bd82-4601-9c19-b9466ccb66da",
-                     "name": "showInactiveUsers",
-                     "format": "",
-                     "description": "(optional) Shows inactive users without permissions (default false)",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Load all users and their permissions",
-               "methodName": "loadUsers",
-               "jsondocId": "cf83c590-1c96-4f9d-b671-4782db633c5b",
-               "bodyobject": {
-                  "jsondocId": "d3960b8d-8924-4cb9-8fe1-eb45f667d67b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/loadUsers",
-               "response": {
-                  "jsondocId": "bc2ed5d2-be40-4ca9-9fd7-07bb6a543446",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "64256775-0a56-4a25-a63c-83d6a7274262",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c9d627e7-dbe6-442a-ba10-54c99d4c3e1a",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "89076d3e-c6a6-4c37-8980-7274bb41b722",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "35685fe3-20cd-4956-9083-5ba44bad2a7f",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ebdcb330-c47b-403a-8a72-21f431122e16",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add user to group",
-               "methodName": "addUserToGroup",
-               "jsondocId": "2a9764ba-56bf-454e-864b-aaf9777af047",
-               "bodyobject": {
-                  "jsondocId": "19e288fa-15b9-4278-9142-476afc275bf1",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/addUserToGroup",
-               "response": {
-                  "jsondocId": "1ef2414e-9c03-478a-8d48-62dd7ed2931d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "f9e2c021-b652-439e-8a05-a912182c92d4",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5dbb5466-04c0-413c-96f8-aaa213d568aa",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a6d980c5-cc01-4a74-932c-dd899336929f",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "497d7da2-a09b-4ccd-8596-5dce51fa365f",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2fb249f7-4681-4561-aef3-13467273612d",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Remove user from group",
-               "methodName": "removeUserFromGroup",
-               "jsondocId": "a8ba62c6-fa16-4e50-812f-584965c0ef9c",
-               "bodyobject": {
-                  "jsondocId": "c6ab6eeb-e010-4e4b-9426-ae651efea7c8",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/removeUserFromGroup",
-               "response": {
-                  "jsondocId": "c30f778c-8fd2-40b3-8be9-5e3bcfbbe2a1",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "c0d750dd-a0bd-43ab-8310-bc9551c3f6b1",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "72fda543-e1b3-45ed-aa20-b2a7df6a4a8e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b39b1718-be2c-4c31-bd04-95e4284fe24f",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to add",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1c1e74f4-5f1a-44ad-8d81-c599aa492625",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "42aef65a-cba2-4738-9bec-ff9dd2cd7ede",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a0cdd22f-c80e-4034-9ada-f2aa5e6e1d38",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "User metadata (optional)",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0efed6fe-159f-4024-a765-e548144eab49",
-                     "name": "role",
-                     "format": "",
-                     "description": "User role USER / ADMIN (optional: default USER) ",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "940315a2-0974-43f5-b3b6-ac122295524d",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create user",
-               "methodName": "createUser",
-               "jsondocId": "d3f08dd2-228d-47eb-9d47-9635b98b8250",
-               "bodyobject": {
-                  "jsondocId": "ebeece61-a1ea-4362-afd0-5f87ceb4fa27",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/createUser",
-               "response": {
-                  "jsondocId": "f982560e-2601-4fb2-a7e0-73370f608edc",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "426c08e6-893f-4c9b-b8af-582f6fc975c4",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c3bf3273-ad47-4ee2-a87c-f2ce0b34ce04",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ca0df9a1-dbb1-43bc-9391-b8ab9447e202",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to delete",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "301776cd-bb7c-40ab-9df6-37e82abe5ae8",
-                     "name": "userToDelete",
-                     "format": "",
-                     "description": "Username (email) to inactivate",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Inactivate user, removing all permsissions and setting flag",
-               "methodName": "inactivateUser",
-               "jsondocId": "a9146a07-2451-44a4-97d8-eac5456fb9dd",
-               "bodyobject": {
-                  "jsondocId": "b5628252-fe67-45d0-a2c6-69a5af04667b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/inactivateUser",
-               "response": {
-                  "jsondocId": "7fddcea0-ecfd-4952-8d38-687fd5d82bbb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "7922a7ff-788c-45d1-895c-81c21c804ee5",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9fed8937-4b86-4ce7-be9c-3ce1c8126803",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b628b11b-f923-4d4a-bc07-0f8cf6c9cda0",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to delete",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ae5dc646-f447-4e14-a113-f44b68a0258e",
-                     "name": "userToActivate",
-                     "format": "",
-                     "description": "Username (email) to inactivate",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Activate user",
-               "methodName": "activateUser",
-               "jsondocId": "2783d3ec-5495-4d90-b79f-36a15da729b3",
-               "bodyobject": {
-                  "jsondocId": "3c631e18-6cb5-4d26-af8a-a00a15986ce6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/activateUser",
-               "response": {
-                  "jsondocId": "bc8eb9f9-a644-4860-80af-537cb94d04be",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "fbebc91f-c95a-4eea-9e53-0ebde3de7911",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "dfbcd023-f614-4726-8fa3-f9ae9f598ad3",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4cef3d72-e062-4e15-8c07-dfbf49accc17",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to delete",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "8f2fca9c-07ac-45b7-b57f-3e57108ae44e",
-                     "name": "userToDelete",
-                     "format": "",
-                     "description": "Username (email) to delete",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete user",
-               "methodName": "deleteUser",
-               "jsondocId": "13512067-ec8e-443f-b976-40d829662316",
-               "bodyobject": {
-                  "jsondocId": "ddc46538-0771-4008-b4a8-fb9776e577d9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/deleteUser",
-               "response": {
-                  "jsondocId": "f1b4cd3b-5ea3-4916-82a0-6345addeeffa",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "914f44f9-785c-4272-b8d9-59b699e367f4",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "057ad693-cd26-4752-8b07-1f3618c9621e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1fb478d5-44c7-4bca-8a7d-a8b0e2878c23",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to update",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7a297331-cca4-4d7f-8b72-7ec3b8dfa043",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to update",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0baf3cc2-0c18-4fcd-8bd1-9f0b9a4501dd",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b9a251f1-c6d7-4a5e-82a2-60ab4aac19f7",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "96a44261-14f1-4da4-ae45-eef223ff0f52",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "User metadata (optional)",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "788e3c3f-2768-4f7e-8ef6-c60395df3094",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update user",
-               "methodName": "updateUser",
-               "jsondocId": "9cf74baf-773e-40aa-9e90-85b443f90268",
-               "bodyobject": {
-                  "jsondocId": "4ac08491-e139-4e87-b01f-72bfec3bd2a8",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/updateUser",
-               "response": {
-                  "jsondocId": "5aa6052a-dd09-4a0e-a882-bd98b1b2fd76",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "c3ff7217-283e-4f27-8ecb-b51705198e79",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f870a0a8-b7a8-4c47-a400-7f1fa10624cc",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a9e75123-7785-46b7-bdeb-632a6c67ca70",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get creator metadata for user, returns creator userId as JSONObject",
-               "methodName": "getUserCreator",
-               "jsondocId": "4841628b-4fee-400c-b2d5-0cc605556967",
-               "bodyobject": {
-                  "jsondocId": "465416c5-5666-497b-8d9a-02f1eb14ed5d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/getUserCreator",
-               "response": {
-                  "jsondocId": "d4a04893-1dcb-43c8-bcc8-530d7c6c6934",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "f333207b-482a-4699-a9da-04488e0d9e91",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5f7afd9b-0ab4-4ef4-807a-5cda05b79ddb",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "12df7578-25b4-4e58-8e75-f360423f1248",
+                     "jsondocId": "48b4dabd-2b76-4399-9d1e-11767b1c16f1",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to modify permissions for",
@@ -7862,7 +7377,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cab73443-05ed-41df-98eb-3a639322f699",
+                     "jsondocId": "fe21d986-bb3d-4058-95f2-028b48926ec0",
                      "name": "user",
                      "format": "",
                      "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
@@ -7871,7 +7386,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fab4148f-ced9-4399-b8af-801fe3c40ad4",
+                     "jsondocId": "788cbea0-8c56-4476-b550-53320927acf3",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism to update",
@@ -7880,7 +7395,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b245343-dc8f-478f-8568-fbbdc06beb0b",
+                     "jsondocId": "31424aff-383c-4352-8b9a-497b146f52c0",
                      "name": "id",
                      "format": "",
                      "description": "Permission ID to update (can get from userId/organism instead)",
@@ -7889,7 +7404,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d415fa0c-4f01-43b8-8d83-8be073193f97",
+                     "jsondocId": "79351f25-64ba-49c7-b657-e66d82c5b723",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -7898,7 +7413,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ca051aa1-8425-4b2c-a432-a762fd770564",
+                     "jsondocId": "f1b9caad-3f4c-4084-873e-5aa0a192e3ca",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -7907,7 +7422,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b56009b0-7a77-4690-96c7-65ec51510cc5",
+                     "jsondocId": "988fd3b7-6e2e-4f69-80ef-e8a79a71c436",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -7916,7 +7431,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66e77ec1-cc89-4d60-8cbd-06d1176f843e",
+                     "jsondocId": "a3f55bf9-55f0-479d-924e-d46742fb6d81",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -7928,9 +7443,9 @@
                "verb": "POST",
                "description": "Update organism permissions",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "9224a01f-9011-4d19-9194-fab834db8d82",
+               "jsondocId": "a4d80784-12f7-46a0-83bc-370048bf52a8",
                "bodyobject": {
-                  "jsondocId": "c3727ae9-d634-4bad-803a-175a3a9cdfca",
+                  "jsondocId": "641d44da-fc3d-4785-836e-28e755d72866",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7940,7 +7455,773 @@
                "apierrors": [],
                "path": "/user/updateOrganismPermission",
                "response": {
-                  "jsondocId": "51be7705-1e9e-4ef8-b969-ea538449c457",
+                  "jsondocId": "c31e3f1d-b5bf-4e8f-b099-cf2c6551628c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "dad31dcd-126d-4af9-a277-cc3ed2ae1957",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8a799b78-df34-4938-a214-fc2b75fa3817",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5b5c8725-dc1f-4e42-ad46-ac03f4bf308d",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to fetch",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for user, returns an array of permission objects",
+               "methodName": "getOrganismPermissionsForUser",
+               "jsondocId": "2bda81ad-744e-4a24-9af5-9b2beb03ce80",
+               "bodyobject": {
+                  "jsondocId": "e1bd474e-a087-47f6-b4bd-0d60012f53b9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/getOrganismPermissionsForUser",
+               "response": {
+                  "jsondocId": "5a2226c5-09ee-435d-a706-cc938a7c3fa1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "63355736-ad70-4fed-b0d0-bde9ce77ff8e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e0a3b7f2-6c13-4820-b730-ee8d104aa357",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "97fcac50-37ca-4d0e-8aed-2c8b411c8cde",
+                     "name": "userId",
+                     "format": "",
+                     "description": "Optionally only user a specific userId as an integer database id or a username string",
+                     "type": "long / string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fa70d737-0ca2-44e4-955f-d69746cc1fa6",
+                     "name": "start",
+                     "format": "",
+                     "description": "(optional) Result start / offset",
+                     "type": "long / string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1e29ea59-7e63-454b-8550-8d0dcf765c77",
+                     "name": "length",
+                     "format": "",
+                     "description": "(optional) Result length",
+                     "type": "long / string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "28fdedee-5dda-4ed0-8243-45b43f3e9c1e",
+                     "name": "name",
+                     "format": "",
+                     "description": "(optional) Search name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "64eb7ca2-ebcb-4d26-97c9-6073a4666720",
+                     "name": "sortColumn",
+                     "format": "",
+                     "description": "(optional) Sort column, default 'name'",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "619db896-f0e7-41c1-b40f-bff1320d2c64",
+                     "name": "sortAscending",
+                     "format": "",
+                     "description": "(optional) Sort column is ascending if true (default false)",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "93ce555a-120f-4fe1-92eb-758ac488893b",
+                     "name": "omitEmptyOrganisms",
+                     "format": "",
+                     "description": "(optional) Omits empty organism permissions from return (default false)",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "96b2f7b4-82be-4818-867d-f65a36b3f1ee",
+                     "name": "showInactiveUsers",
+                     "format": "",
+                     "description": "(optional) Shows inactive users without permissions (default false)",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Load all users and their permissions",
+               "methodName": "loadUsers",
+               "jsondocId": "098b60f7-dba9-42db-9816-bce9a7615fd8",
+               "bodyobject": {
+                  "jsondocId": "6230a52b-db66-4134-92a1-18d3d358140c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/loadUsers",
+               "response": {
+                  "jsondocId": "6286e36b-7dfb-4beb-b748-1ccd1abc19cc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "46e7eb17-255b-434a-8708-c581e5beb4ed",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fe0818d1-3db6-4602-91be-3268cb626b15",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f6fea25a-00a1-4a87-83fe-8137c4558cb4",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8e7807ce-59ea-4e62-9f65-3a5b81cc1311",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "68fe410a-c479-4472-a99c-a42452b600fb",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add user to group",
+               "methodName": "addUserToGroup",
+               "jsondocId": "0a61f477-a853-4fa2-8488-f32b15997bb0",
+               "bodyobject": {
+                  "jsondocId": "4c977456-d6a7-4e64-9642-18ea5a2501d6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/addUserToGroup",
+               "response": {
+                  "jsondocId": "35da3038-449c-47a9-b51a-7bbc93e5b26c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "af74c643-1467-4094-b8dd-f343f0e3b555",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fb8c4226-c760-4ed8-bc9c-2db7f83e9bf5",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "114bb994-9063-4467-8de2-4ce06bbcba03",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "782b21ba-79e9-4e54-a990-f4975bb55a0e",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "337959da-daf1-4261-b7f8-7d8c87e85aac",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Remove user from group",
+               "methodName": "removeUserFromGroup",
+               "jsondocId": "70e72f49-a62f-480e-ac27-f03a32bb7c56",
+               "bodyobject": {
+                  "jsondocId": "de19664d-34b4-4ec1-81f2-77ef06415218",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/removeUserFromGroup",
+               "response": {
+                  "jsondocId": "fd0112cb-613b-49e9-8b39-adb76f4611f4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "fd5d1fbd-2382-45d7-9c26-33dde02451f9",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5bc28212-5325-4833-8e80-df71425fe6c8",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2e3b69d5-c76e-48d3-8adc-fe3af7d2f1fe",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to add",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "38bc67f3-23b2-417f-a768-52bfaf062c0e",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "daf78c86-2995-41b9-9a5d-502d74dd1f6d",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cc477385-548e-4799-8fff-b43bc95e2382",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "User metadata (optional)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6479ef43-1046-415d-baaa-5a7c820c23a8",
+                     "name": "role",
+                     "format": "",
+                     "description": "User role USER / ADMIN (optional: default USER) ",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "60091f05-4d52-4cad-b17a-f3e6167224ad",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create user",
+               "methodName": "createUser",
+               "jsondocId": "55c0bb88-15f0-4d94-8f17-60aed48003b6",
+               "bodyobject": {
+                  "jsondocId": "82fa1113-dd2e-4d16-9770-b604a3b57114",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/createUser",
+               "response": {
+                  "jsondocId": "a68052e2-0dcd-4937-bace-f9598366339a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "2eac8b9d-2bb3-419b-9819-543a7f90d755",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b278111d-e4e8-42f6-b815-bdb33ec857b2",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "80f2240c-305e-4e3c-9997-65113cf165d5",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2b151d82-bfbd-4fcf-8ddb-1f4a4d8a5b4c",
+                     "name": "userToDelete",
+                     "format": "",
+                     "description": "Username (email) to inactivate",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Inactivate user, removing all permsissions and setting flag",
+               "methodName": "inactivateUser",
+               "jsondocId": "f32e1907-2334-491f-b44e-2d3e1c7ee77d",
+               "bodyobject": {
+                  "jsondocId": "30b18c7f-cd30-45aa-996a-89e0aa8eea37",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/inactivateUser",
+               "response": {
+                  "jsondocId": "b6b367c3-1abf-41f7-be86-a9426627b1c1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "861a81bf-af32-4f5f-9c40-9de65cd89f85",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "facf8a1b-531e-423a-9d19-6958936c204b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4ecfddb4-b5c0-48a8-a040-46b665005b4e",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8c39f60a-2646-4e5f-b9a5-216c4d3ae674",
+                     "name": "userToActivate",
+                     "format": "",
+                     "description": "Username (email) to inactivate",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Activate user",
+               "methodName": "activateUser",
+               "jsondocId": "97bff0e7-134f-439a-95dd-4b55358064ab",
+               "bodyobject": {
+                  "jsondocId": "02638313-1dc5-42f0-a5aa-b61c68e7cf21",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/activateUser",
+               "response": {
+                  "jsondocId": "c253eed5-5ba4-43a5-bfb2-e7067522d7cf",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "45d558ea-3cbe-4fa2-b501-633addd7a638",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "63802d18-e033-4b1a-8bdd-dbbf78311af9",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e37a9bbb-fb10-47ce-821c-a138626ae7c0",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ebb800f1-4d6a-40cf-8efe-b1835a3db14a",
+                     "name": "userToDelete",
+                     "format": "",
+                     "description": "Username (email) to delete",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete user",
+               "methodName": "deleteUser",
+               "jsondocId": "3e2e2f5b-3347-4d34-ab40-ffff963d5653",
+               "bodyobject": {
+                  "jsondocId": "1165c1e3-1871-46cd-8137-df8cb046af30",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/deleteUser",
+               "response": {
+                  "jsondocId": "e9354d65-7522-44d1-8233-80859bad64c6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "46a97e03-ee7d-4cb0-823d-16976b0c55a6",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d0143ee6-3b79-48b4-8ebd-e7700796b3ea",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a9bea061-d37f-46dc-80bf-28432b2ad682",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to update",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e49c2411-bfdd-46b8-b22a-9224299ebb54",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to update",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cde0d3ce-c658-4f2d-bf39-ea328abfb814",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "20641c4e-c081-4094-ba3c-fd33fabf9504",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9efe27dd-5f32-46e7-8b4a-d2183d92a7e5",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "User metadata (optional)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8202cb7c-450c-4046-b2af-037c235ff5e9",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update user",
+               "methodName": "updateUser",
+               "jsondocId": "4f02f0d0-5f90-4f00-aa3d-3f77b4b16374",
+               "bodyobject": {
+                  "jsondocId": "ad886346-b891-46c7-b606-4c4a83e726c6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateUser",
+               "response": {
+                  "jsondocId": "4909af4b-8543-4fb1-b8be-a20e36f8da9a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "f56ed934-40eb-4067-af2b-37253c6337a9",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "06228df4-e216-4429-8d7e-8a5f47e811e8",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4d2852b6-fad6-431d-a4f4-817f8cdb6a5c",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get creator metadata for user, returns creator userId as JSONObject",
+               "methodName": "getUserCreator",
+               "jsondocId": "d6692c20-4bb6-4368-a6cf-51436bac2c1d",
+               "bodyobject": {
+                  "jsondocId": "3edac37f-db82-4b33-8ee7-18a823f0ba0e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/getUserCreator",
+               "response": {
+                  "jsondocId": "34fda8d5-1b3d-488b-8569-b0a564545c3f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7953,13 +8234,13 @@
          "description": "Methods for managing users"
       },
       {
-         "jsondocId": "450deb57-e928-4b04-977c-095b2f4dcaa3",
+         "jsondocId": "9b9499e3-fd46-4d61-8e16-1feaec4c305a",
          "methods": [{
             "headers": [],
             "pathparameters": [],
             "queryparameters": [
                {
-                  "jsondocId": "85aad7eb-e500-4d58-95e7-8508f6bb00e0",
+                  "jsondocId": "dca7c3ea-6f49-42f0-b572-b1aa47a02fcb",
                   "name": "organismString",
                   "format": "",
                   "description": "Organism common name or ID (required)",
@@ -7968,7 +8249,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "8f89299c-a2d3-49de-b85d-99464ff4c66a",
+                  "jsondocId": "78012aac-5458-4288-8dee-c85cbaf259e5",
                   "name": "trackName",
                   "format": "",
                   "description": "Track name by label in trackList.json (required)",
@@ -7977,7 +8258,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "99af9287-3a08-445c-8c11-8fe151fe1cd2",
+                  "jsondocId": "2629eba9-6313-4450-aa5c-0b31e6079e74",
                   "name": "sequence",
                   "format": "",
                   "description": "Sequence name (required)",
@@ -7986,7 +8267,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "e4b6fde9-8905-485b-9f7a-93e4a343fee4",
+                  "jsondocId": "84ff1f66-b739-4bb4-a469-6c3e075de49d",
                   "name": "fmin",
                   "format": "",
                   "description": "Minimum range (required)",
@@ -7995,7 +8276,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "c640b5e6-fd38-485c-a78f-15fd507607ac",
+                  "jsondocId": "3c5293b2-43e7-4e9d-bc08-6414c110ad86",
                   "name": "fmax",
                   "format": "",
                   "description": "Maximum range (required)",
@@ -8004,7 +8285,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "481b8c84-a211-4867-8cef-a5f7eff69bdb",
+                  "jsondocId": "dd2a556a-3c83-41cb-ae7c-41fa78a9690f",
                   "name": "type",
                   "format": "",
                   "description": ".json (required)",
@@ -8013,7 +8294,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "13d295e7-cb2b-41d5-9e16-06bafa4fb172",
+                  "jsondocId": "e64aec20-60d7-4133-a1d7-dcb3ed6da339",
                   "name": "includeGenotypes",
                   "format": "",
                   "description": "(default: false).  If true, will include genotypes associated with variants from VCF.",
@@ -8022,7 +8303,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "c722367b-ab96-4024-b874-c12d5c13f097",
+                  "jsondocId": "fecd5992-c672-4aba-bb89-01dc3aeecfa1",
                   "name": "ignoreCache",
                   "format": "",
                   "description": "(default: false).  Use cache for request, if available.",
@@ -8034,12 +8315,12 @@
             "verb": "GET",
             "description": "Get VCF track data for a given range as JSON",
             "methodName": "featuresByLocation",
-            "jsondocId": "53e7fadc-a9c9-43b1-8962-40e1de5c3f94",
+            "jsondocId": "cb0c332f-e34a-4aa3-92d5-185e3989702c",
             "bodyobject": null,
             "apierrors": [],
             "path": "/vcf/<organism_name>/<track_name>/<sequence_name>:<fmin>..<fmax>.<type>?includeGenotypes=<includeGenotypes>&ignoreCache=<ignoreCache>",
             "response": {
-               "jsondocId": "dab61f1f-48eb-4345-82ec-fbcf1e14ddf5",
+               "jsondocId": "dc12cda6-2065-42ff-a842-7aa82915f208",
                "mapValueObject": "",
                "mapKeyObject": "",
                "object": "vcf"

--- a/web-app/js/restapidoc/restapidoc.json
+++ b/web-app/js/restapidoc/restapidoc.json
@@ -2,14 +2,14 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
-         "jsondocId": "3ee862e1-b1eb-4ff4-b17e-3fbcd189dd8f",
+         "jsondocId": "82beddf1-f7d0-40d9-92ac-ffdf7f8f9336",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "96e36c19-3a1c-4fcd-8f16-8099e611818c",
+                     "jsondocId": "a4cf6b6f-6b7f-4d67-8bc2-fa7993a855c1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -18,7 +18,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4010f009-a4b8-47fb-a526-da1dcd0dc483",
+                     "jsondocId": "46a6787a-6a29-47ba-ab86-b88521480634",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -27,7 +27,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c52dfb62-3f77-4564-bc45-f38200a6092a",
+                     "jsondocId": "8f34a3eb-2a2d-4a9b-be63-2603fba3e8c9",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -36,7 +36,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "80c4dd59-949d-4076-8520-22cd7861761f",
+                     "jsondocId": "630b78cd-4814-4cb9-b682-76a288f12f7f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -45,7 +45,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "81f8478b-ecd0-4144-92d6-6d9ece210a61",
+                     "jsondocId": "1be4285b-ff3e-49ae-92a7-67bdd0e6d32a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
@@ -57,9 +57,9 @@
                "verb": "POST",
                "description": "Set name of a feature",
                "methodName": "setName",
-               "jsondocId": "7cc28174-4a10-4b97-ae62-a14c99c66408",
+               "jsondocId": "0d5cbdf4-7387-45bd-8e1e-59a9a5f1545e",
                "bodyobject": {
-                  "jsondocId": "2db53aec-1362-4224-9bdb-50d4672f017d",
+                  "jsondocId": "fd332abe-7d63-4ba0-999f-143474691b9a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -69,7 +69,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setName",
                "response": {
-                  "jsondocId": "7b83ac77-b27e-4c8a-881b-90473932bcea",
+                  "jsondocId": "0eb1b76a-e73b-424c-8b5b-2308d756a53d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -82,7 +82,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0d88047b-b173-4fc9-ab76-ffbad8a55c09",
+                     "jsondocId": "a9825c33-7e84-4684-8b61-9623e2bfb82a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -91,7 +91,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6775e24d-a670-43d5-b0f8-cb6120050e1b",
+                     "jsondocId": "dc570a33-1aee-498e-9d42-88bfff9d3ae5",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -100,7 +100,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "299187b3-4daa-49ec-a446-34b9202c835a",
+                     "jsondocId": "747359a1-a56a-4fa5-b431-c8a32c1e263d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -109,7 +109,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "69e2ea81-9b58-414d-8f06-ad4438d623a5",
+                     "jsondocId": "73822b9a-6126-4ded-a220-47b7ead988eb",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -118,153 +118,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "637f6b48-ccc0-421a-925f-f9aa59e3e362",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set description for a feature",
-               "methodName": "setDescription",
-               "jsondocId": "7ec61aa0-efb8-4975-8b8e-9212afb2198e",
-               "bodyobject": {
-                  "jsondocId": "d7e07579-efeb-4eb4-b2ba-e562af3f9ae5",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setDescription",
-               "response": {
-                  "jsondocId": "e714b858-f3b4-41e7-981c-a6fdb6e8b075",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "caaa1a64-146e-4760-af89-4a603d6e0239",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9bbb1a45-63cd-46b9-8298-ca615744208a",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bd8da46f-aec7-4f88-b5d1-273788179e7e",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "09e9c9a8-4701-4d88-a147-3002cc666c69",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4b1409f2-fd49-4152-9281-41f38461317b",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get comments",
-               "methodName": "getComments",
-               "jsondocId": "2d3ab09c-0336-4078-acf7-f6a5b18157ef",
-               "bodyobject": {
-                  "jsondocId": "317be7ee-79fa-4864-a5e3-860976ff6429",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getComments",
-               "response": {
-                  "jsondocId": "ba7c01ef-b597-487f-bf2f-d00615d41204",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "836c73a2-8b62-4f05-81f8-f344c10f8ce1",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f95e310b-132c-454f-a3ea-ef754849601c",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f6d3c45b-abbc-4dde-9269-e3477cf624ea",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2d67bf36-ec9d-4e05-843f-6113a206cdd9",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2c6b66c9-59ef-4f8d-ab10-125a219c0517",
+                     "jsondocId": "104f41af-a9ec-41ba-bae5-4630c808e4d1",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
@@ -276,9 +130,9 @@
                "verb": "POST",
                "description": "Set status of a feature",
                "methodName": "setStatus",
-               "jsondocId": "0bf1c2cf-50db-44c4-b974-7f96bb0228f8",
+               "jsondocId": "e5a04e10-61a2-47cd-ada6-3f9716484240",
                "bodyobject": {
-                  "jsondocId": "4c90d386-e707-4cdf-aaa2-435952b991ac",
+                  "jsondocId": "67a1ebd9-d2d5-4f55-a9df-e3c398ee67f9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -288,7 +142,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setStatus",
                "response": {
-                  "jsondocId": "85f5c880-3f19-401d-afe5-7e3e3eaa308e",
+                  "jsondocId": "02c85d22-1397-4a99-979a-9aeed229c7cf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -301,7 +155,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d48452ef-0cb8-4b03-9c1d-17519c9f55c0",
+                     "jsondocId": "bf0dae60-8419-41af-aa5b-e6bb0e8c887c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -310,7 +164,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff73450a-2057-4ad2-8052-2166d453a707",
+                     "jsondocId": "829c5566-ff63-499c-97db-8d9276c40bce",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -319,16 +173,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b4f668b3-70b7-4892-9e09-e01012708a2e",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4e4af089-cc05-44f1-8627-e4e7883d9a92",
+                     "jsondocId": "d19c2b8a-1cea-4f11-8df7-23883b46a8e0",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -337,39 +182,30 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a990cec0-bc0a-4cae-a491-06af1402bdb5",
-                     "name": "suppressHistory",
+                     "jsondocId": "28ebc3bf-bebe-494a-b4bd-5454bd1dcbe1",
+                     "name": "organism",
                      "format": "",
-                     "description": "Suppress the history of this operation",
-                     "type": "boolean",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
                      "required": "true",
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1a266b6f-fdfa-4e76-8ce1-19d59460cf87",
-                     "name": "suppressEvents",
-                     "format": "",
-                     "description": "Suppress instant update of the user interface",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cd34e5bd-310f-4ee7-9661-58ee7a04456f",
+                     "jsondocId": "b6d3472b-4640-415d-99ff-51dc299f573e",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Set exon feature boundaries",
-               "methodName": "setExonBoundaries",
-               "jsondocId": "388fd505-2317-4f7e-b6de-e54fd4f01803",
+               "description": "Get comments",
+               "methodName": "getComments",
+               "jsondocId": "2dd7c1a3-3f48-4372-b20e-43c824e40aa0",
                "bodyobject": {
-                  "jsondocId": "aa7dfdf8-23f2-456b-904a-679b1d2c5886",
+                  "jsondocId": "58e04d28-5819-4eaa-b0e8-c7b8e633c382",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -377,9 +213,155 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setExonBoundaries",
+               "path": "/annotationEditor/getComments",
                "response": {
-                  "jsondocId": "e0b463bc-4a36-4707-9a78-4d9facb19fd8",
+                  "jsondocId": "d32bec53-0952-4f35-abb5-74fba48eb9b4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6cbddb69-8d5d-4c73-a6d2-5473842a3a7e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6c17b375-3664-44b8-9190-577028f001b6",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "688bfb53-ee9b-4895-9c9d-20512ac92a20",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a7cc31f1-bf84-4509-b2b3-329aea786f4d",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "42a59657-c9f9-4fc4-be61-1666ea18772f",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set description for a feature",
+               "methodName": "setDescription",
+               "jsondocId": "ac4ceb5b-0872-4daa-b416-086a8f011a3b",
+               "bodyobject": {
+                  "jsondocId": "f0e6fa11-4a14-4f7c-a7c4-34f934fcfca4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setDescription",
+               "response": {
+                  "jsondocId": "a37d801b-3972-45ff-a087-a7a91527ce21",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "96f2867a-cb55-461b-b5a2-ffb91c6c61c9",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4cbe8d3b-8f19-4663-a7f7-68c4ca9a96cc",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "966df864-6e93-40c3-afaa-0ee1709cd9ff",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "952fafd2-6718-4a45-b07e-110aaf8d3555",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b20de0b4-6581-4e2c-9730-4aa8ad75077b",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set symbol of a feature",
+               "methodName": "setSymbol",
+               "jsondocId": "b55f13b9-e2bf-4a78-9b2d-8b5805118cee",
+               "bodyobject": {
+                  "jsondocId": "9df7b80d-8389-4e25-9a02-0cdd9a42d8a9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setSymbol",
+               "response": {
+                  "jsondocId": "a4ab7260-e9ff-42fe-9c96-86217e673c54",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -394,9 +376,9 @@
                "verb": "POST",
                "description": "Returns a translation table as JSON",
                "methodName": "getTranslationTable",
-               "jsondocId": "98ddcbaa-f7dc-488a-b7d7-86bceef6ec4a",
+               "jsondocId": "a17e5c5c-ba2a-4803-83fe-94eac7f75b34",
                "bodyobject": {
-                  "jsondocId": "cfaaf700-6050-46a0-b6cc-a724bf3e9200",
+                  "jsondocId": "e5a12573-617f-4a1a-9b7d-b03ef8301bdf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -406,7 +388,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getTranslationTable",
                "response": {
-                  "jsondocId": "16605cde-a94f-4353-a640-2174edb43d7e",
+                  "jsondocId": "88e55df7-4570-414c-9f36-e7615e304850",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -419,7 +401,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "28f0cd02-6fa7-4525-97e8-8c71c675cd40",
+                     "jsondocId": "8ee718d8-b22e-4df5-b8c8-c1ea2f77e8a3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -428,7 +410,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "278ce69c-7e67-4aee-9c92-9c8a08d687e0",
+                     "jsondocId": "972e3046-56f8-4687-bfc7-b66333ba1c39",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -437,7 +419,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "047b69ab-11b5-40f0-9013-794aed8f0da2",
+                     "jsondocId": "600076ae-65e4-4066-a9d5-9dc75052fbd3",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -446,7 +428,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a88a074f-63cd-4043-80b0-d3eb107b28aa",
+                     "jsondocId": "dd7868cf-9775-4ef6-90a6-c4c6f8392a92",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -455,7 +437,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "52407837-9df8-4eb9-85bb-fec6c7fd855b",
+                     "jsondocId": "0dc5c067-7a6e-4fc4-8d5d-534c13d3238c",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -464,7 +446,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "936d0470-4e41-46a4-bee8-9a3b278da3e8",
+                     "jsondocId": "afbb8eaf-ba85-4e1f-839c-e034a37b0d15",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -473,7 +455,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dc9d7eb5-7f95-4c45-816b-efc50743ae2f",
+                     "jsondocId": "f6c7723c-9494-4bd8-bb71-b1b405ee18b7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -485,9 +467,9 @@
                "verb": "POST",
                "description": "Add non-coding genomic feature",
                "methodName": "addFeature",
-               "jsondocId": "b98399fb-0837-4f2a-bf84-c461c3ed967f",
+               "jsondocId": "771c432b-54af-4ea0-9717-a132d9335749",
                "bodyobject": {
-                  "jsondocId": "f5808386-2ed1-4e8e-9e6e-4cad2d9c37a8",
+                  "jsondocId": "2ffbd0ad-bfad-4ce1-b00f-97e27dcc1e75",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -497,7 +479,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addFeature",
                "response": {
-                  "jsondocId": "7d4fc94e-8d12-423a-8709-39c2cec8df5d",
+                  "jsondocId": "2bba4840-610b-40d1-b53b-caf7eea86095",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -510,7 +492,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "01e82474-7d41-4688-816a-6661963059c8",
+                     "jsondocId": "490062ab-894e-4366-b5dc-7f600d5415a5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -519,7 +501,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4492c179-af2e-4820-8b4e-ec6973e942b1",
+                     "jsondocId": "df75639b-5ac6-4e2e-8c27-b207e09885d4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -528,7 +510,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0ac04460-ec5c-46e5-8c09-18a4600afa11",
+                     "jsondocId": "3b170f67-d042-48ed-8d5b-58da4aad131e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -537,7 +519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6929ba4a-cd5a-4647-be78-5efd46bb1b03",
+                     "jsondocId": "266e6618-1e0b-4464-ae92-9cbe72a107bf",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -546,7 +528,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "09846394-659f-4ab6-b872-52f78750f457",
+                     "jsondocId": "71225d39-632a-411e-827d-02a6b5fc4b66",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -555,7 +537,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ddb0774a-71f3-4eb8-8ecb-2159d63ddd6e",
+                     "jsondocId": "9288268a-e27c-47c4-baa7-ced06927e0a2",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -564,7 +546,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "af720103-3e5b-4b7e-9557-5d87b93fbc38",
+                     "jsondocId": "e154bb35-bd1c-4691-ad95-70ea3424b8fa",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -576,9 +558,9 @@
                "verb": "POST",
                "description": "Add an exon",
                "methodName": "addExon",
-               "jsondocId": "508105d3-2949-424d-a8df-09b601a61987",
+               "jsondocId": "333d64c9-65d9-4475-bbf6-29e340e335e3",
                "bodyobject": {
-                  "jsondocId": "9c571836-742d-4a65-9821-8af86fd8a474",
+                  "jsondocId": "fb5fe125-7422-46b1-8080-7d4b6b0e1030",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -588,7 +570,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addExon",
                "response": {
-                  "jsondocId": "e565e423-0691-48e2-872c-bf757bc3a1bc",
+                  "jsondocId": "1648bfdf-7c59-4af7-86f0-9b39582cc7fc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -601,7 +583,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a24998e0-2d31-4dbd-9f4b-8067df2fb0a5",
+                     "jsondocId": "f69ee927-8fa5-47bb-86f4-dd7758d196bd",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -610,7 +592,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "73fbdda0-bcef-4e1b-8eed-54780c2e4846",
+                     "jsondocId": "5109ae5b-5905-449f-90b2-1ae5a0dd864c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -619,7 +601,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "90ba5405-7607-4702-af87-bdad03179a06",
+                     "jsondocId": "feb3d40b-3be7-482a-aabf-08fb3985323d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -628,7 +610,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e194763f-7f0e-4f4d-bdc2-f280aba22885",
+                     "jsondocId": "f5b32254-0729-4eb2-a6ef-a4f73c40d828",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -637,7 +619,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84ffb070-4596-44ba-ae31-237cd94f4b0d",
+                     "jsondocId": "b2cb8f1a-adb8-409a-ba84-26753f1cdf41",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -649,9 +631,9 @@
                "verb": "POST",
                "description": "Add comments",
                "methodName": "addComments",
-               "jsondocId": "8cb00dbc-d375-4750-bf0b-977ffd9d1527",
+               "jsondocId": "a4465bd1-d018-4b19-b6ad-c85da5c88024",
                "bodyobject": {
-                  "jsondocId": "f655d21f-d0dc-4571-b6c2-6f2b93c453d3",
+                  "jsondocId": "17cca271-5fbb-49f9-9584-69bad80ab78e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -661,7 +643,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addComments",
                "response": {
-                  "jsondocId": "a0d6a5de-8a0d-45d5-961a-71b58ed7f752",
+                  "jsondocId": "f8bd17fa-ac2e-4b6a-9464-480391e9a3e9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -674,7 +656,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f4fb31d4-5759-4e08-bf90-127b6d7481ab",
+                     "jsondocId": "135b9b46-aa83-4d9e-9a60-8260e85b119e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -683,7 +665,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "57829e05-2540-4cad-ae07-5f6ee0b8a329",
+                     "jsondocId": "f4ee2134-be4d-4e97-b73a-fb4890a8b815",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -692,7 +674,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8fdea555-6b62-4c7a-96a2-154c3b0e9c02",
+                     "jsondocId": "84d699e1-8ceb-4c12-b906-658483e254aa",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -701,7 +683,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ed1d827a-a9b5-4573-9a30-c1885f982ded",
+                     "jsondocId": "a6796fee-7761-4df4-a1c5-39a88e200cdd",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -710,7 +692,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "683aa43d-30aa-4c00-9861-b10e2c4b60bd",
+                     "jsondocId": "f4dd76dd-79c2-4b51-b537-997472277b76",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -722,9 +704,9 @@
                "verb": "POST",
                "description": "Delete comments",
                "methodName": "deleteComments",
-               "jsondocId": "d7bd0716-6e5e-46f0-b555-e848cd9b9f80",
+               "jsondocId": "2e0d5346-ff52-4e08-bc73-857224f1e4ad",
                "bodyobject": {
-                  "jsondocId": "2e38524f-a133-4e33-bf27-69fe63d41085",
+                  "jsondocId": "08e121d6-c335-4a36-a9ae-670d8461ea22",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -734,7 +716,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteComments",
                "response": {
-                  "jsondocId": "1e1a95b0-cbe2-42fb-a0a7-b68864458859",
+                  "jsondocId": "927bb70d-d9a4-4fd7-9e4e-790b8b89f6a7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -747,7 +729,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a2065fdf-3ef4-43a3-bec5-582b48aac66b",
+                     "jsondocId": "cc961d96-ae06-46ca-9150-cdc966ec4a80",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -756,7 +738,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "83fd1e17-6b7a-40b2-8635-50341a420b13",
+                     "jsondocId": "ba00dc26-c31f-4131-b0d6-a56c5f18c4a4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -765,7 +747,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c897bcc0-d61e-4a24-9dd2-9c1fb159428b",
+                     "jsondocId": "1b195dc4-b243-44e8-8c2f-6cca405544b6",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -774,7 +756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d65daef-5c50-4737-a34d-f11715c34279",
+                     "jsondocId": "9b3f3cc9-4b46-4dec-a39c-f98d94fc135d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -783,7 +765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "241810ec-cb68-4a8b-89c2-6fc48a6d6dc5",
+                     "jsondocId": "4bb81130-667e-4c45-8e7e-47c02335f2cf",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -795,9 +777,9 @@
                "verb": "POST",
                "description": "Update comments",
                "methodName": "updateComments",
-               "jsondocId": "5d8ec1ed-eceb-4a58-a8e6-18170f40dc83",
+               "jsondocId": "a6b96e0e-5679-4d5b-859d-db3ed24d8b68",
                "bodyobject": {
-                  "jsondocId": "65fc9c86-16d3-4160-bb7d-140bf049acdd",
+                  "jsondocId": "b706cdb8-ce3d-4647-ae76-fea5f30ac249",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -807,7 +789,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateComments",
                "response": {
-                  "jsondocId": "bde1aee4-bb5f-4d9e-b24c-dcc24a35a6ed",
+                  "jsondocId": "aae881aa-777d-4dc1-b0f6-2279c664833e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -820,7 +802,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "576eaa6f-3914-4751-bcb8-51bcf28acaca",
+                     "jsondocId": "eb074e47-837b-4009-9d5d-649a0c83edb7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -829,7 +811,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d208eceb-24a1-425f-a4cd-2069ba8754dd",
+                     "jsondocId": "e8107b3d-996c-42f4-9b4a-1c11b44a88f8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -838,7 +820,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a65a6567-e847-4b84-b4db-3e6973e1a5f1",
+                     "jsondocId": "e5e6fc92-05d4-4ff1-af72-d7c0a83a7429",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -847,7 +829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7ceff62-2228-4131-9df1-181188c5430b",
+                     "jsondocId": "17e057d0-e370-4825-873a-43ba9226b4d7",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -856,7 +838,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0533126e-f5f8-4b9a-a1ef-547f34415626",
+                     "jsondocId": "680cd427-8d53-45ad-a742-7894283ff64b",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -865,7 +847,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0bd12dbb-a134-43ff-860c-921082c72552",
+                     "jsondocId": "e3dc6c64-43f2-432b-b293-3cfb7410a50e",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -874,7 +856,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0bc722de-83f7-42d6-9b01-b140f50bad1e",
+                     "jsondocId": "d559e25d-acde-4b9a-9da8-97e0003707ad",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -886,9 +868,9 @@
                "verb": "POST",
                "description": "Add transcript",
                "methodName": "addTranscript",
-               "jsondocId": "e82ae8a0-cbb6-42f2-8d84-3ddeca2fd3d3",
+               "jsondocId": "5180ca2c-91d4-4d31-995b-72d067515472",
                "bodyobject": {
-                  "jsondocId": "7fe9a434-fba4-4c4e-89e5-361d6cddb6cc",
+                  "jsondocId": "891ef90e-1d78-4eec-987e-3eda152814eb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -898,7 +880,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addTranscript",
                "response": {
-                  "jsondocId": "60a3086b-5b58-400c-916c-dbe537e5bde3",
+                  "jsondocId": "f99769aa-655e-4de6-bc9a-0673feb82e8f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -911,7 +893,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8bc17f13-b2b4-4193-bdd3-43436b55b619",
+                     "jsondocId": "bd41efbe-0eef-428d-b5fa-216a823fd5e9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -920,7 +902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a4be5652-962b-412d-810f-7385136ffb9e",
+                     "jsondocId": "032359fe-779e-4df6-8495-1168f9bee354",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -929,7 +911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fd0cbb3d-d8c4-44bb-8704-a28a7ce0cb3f",
+                     "jsondocId": "df8bc88d-46ad-40aa-a063-ce117516df61",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -938,7 +920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "842de2ba-e59d-420a-8757-830f336d4ee0",
+                     "jsondocId": "33dd5381-3c26-4723-b579-37733a31eee0",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -947,7 +929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5d292876-9c8f-48af-8ca8-467af8927a4e",
+                     "jsondocId": "cfa86559-3956-4a43-a03b-acbd9e5a8e1b",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -956,7 +938,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c602968b-ca32-4256-8ddc-13228423c172",
+                     "jsondocId": "582159ba-2886-41aa-9c57-fb59bf882e63",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -965,7 +947,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9b558c22-136c-45f6-a6e8-baa4eab46049",
+                     "jsondocId": "2826b6b5-2326-4910-a90a-22dd632965f3",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
@@ -977,9 +959,9 @@
                "verb": "POST",
                "description": "Duplicate transcript",
                "methodName": "duplicateTranscript",
-               "jsondocId": "64d1a542-a886-4a0e-8936-286208dc1940",
+               "jsondocId": "ce11ebca-1cf6-45fd-9628-f9165bf78d8e",
                "bodyobject": {
-                  "jsondocId": "38ee83cc-12fe-4e92-8110-ea1ae496af09",
+                  "jsondocId": "69f8d00e-f4d5-455f-82f9-f4418a175c3e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -989,7 +971,7 @@
                "apierrors": [],
                "path": "/annotationEditor/duplicateTranscript",
                "response": {
-                  "jsondocId": "0408da57-6bac-4a61-bb6e-0342e7b10e3a",
+                  "jsondocId": "d2b288b8-4aed-44a5-ae56-c70eae285700",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1002,7 +984,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8557788e-15cf-4eca-9b02-17849455db23",
+                     "jsondocId": "34c67444-acb0-4953-bf75-e1399ba2ba91",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1011,7 +993,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "42e00201-4540-4c7b-92d3-e0ede5266735",
+                     "jsondocId": "a0ea82ed-3723-49ea-aeb6-81e2e17fe564",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1020,7 +1002,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4cf64abe-1b91-4775-b40f-0134923ccbf7",
+                     "jsondocId": "a981070c-81e1-401d-8176-10a1da74a873",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1029,7 +1011,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8fcf22a7-311e-491d-8ee7-25bf1adc1967",
+                     "jsondocId": "77d7da0f-f69a-4f9d-8544-71fc4485e815",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1038,7 +1020,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f990f07-c0fc-4936-a4ce-c8bee93ea030",
+                     "jsondocId": "345f0413-14aa-4246-9a2f-3a0e19f97027",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -1050,9 +1032,9 @@
                "verb": "POST",
                "description": "Set translation start",
                "methodName": "setTranslationStart",
-               "jsondocId": "a9ea5aad-3530-4fc1-b09a-9948d6b45f0f",
+               "jsondocId": "cce630cc-2b4b-4d46-a886-adaea6cfacbb",
                "bodyobject": {
-                  "jsondocId": "585d550a-dec3-461a-9005-b4b78d08a7ba",
+                  "jsondocId": "231511b2-9bd2-44f2-b7cf-9ce84e8f05e1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1062,7 +1044,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationStart",
                "response": {
-                  "jsondocId": "11a6b90a-2f16-45a2-ab91-8b98fc866639",
+                  "jsondocId": "e42fa0f1-7df3-46b6-8f19-17e6e9a55ab9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1075,7 +1057,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e901e27a-3127-4741-940d-b9cad57111a4",
+                     "jsondocId": "806a012d-fe8e-40fb-a7f1-3ad68f624f01",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1084,7 +1066,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ec94082e-19b8-4c0b-aa11-271efd0c9848",
+                     "jsondocId": "acec129d-ea3d-4d90-906a-e200afdd6503",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1093,7 +1075,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e440ac50-3965-4f9a-b538-7f8003e9b9de",
+                     "jsondocId": "69095f33-a28c-43d9-80a8-ebf953ce3330",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1102,7 +1084,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "333f9770-7ee9-4fc2-a6e4-f39641b34374",
+                     "jsondocId": "33a741f0-1a73-4403-ace0-27e8623b7e99",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1111,7 +1093,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dcdbc9b0-eeb6-4749-b31a-55dabfa004ac",
+                     "jsondocId": "b5583e25-176d-4293-83b4-d74dc693ae95",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
@@ -1123,9 +1105,9 @@
                "verb": "POST",
                "description": "Set translation end",
                "methodName": "setTranslationEnd",
-               "jsondocId": "f32071ba-3cd2-4b54-aa6b-68f59247ce2c",
+               "jsondocId": "3898c445-c905-46c3-9644-c238277c892a",
                "bodyobject": {
-                  "jsondocId": "48a83041-bc04-44d0-8e21-f4df57f4136b",
+                  "jsondocId": "738e7939-11e9-48b5-83d4-ff7b878f20f8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1135,7 +1117,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationEnd",
                "response": {
-                  "jsondocId": "490906d5-1768-4648-8343-2a5a6b842338",
+                  "jsondocId": "8ec56a80-d20a-4e13-9de6-4b69984cd61a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1148,7 +1130,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5ed67f7f-8cdc-4cca-b9c4-752547bda6c1",
+                     "jsondocId": "1c3989e0-661f-4a6c-874e-1c6f67279c71",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1157,7 +1139,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "78e87394-1dc3-4e0f-8897-837d2a61eed9",
+                     "jsondocId": "58584f69-1d98-4501-b922-1d8f819461d9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1166,7 +1148,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c02220bd-1225-4b6c-a696-3d0a4c7db500",
+                     "jsondocId": "65db6c8d-8b5b-4d97-ba18-e26ccfb02f7a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1175,7 +1157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26bc79f3-ef99-4cd7-a769-8d2411a3c21a",
+                     "jsondocId": "d8594899-7ebf-4507-914e-2998366eefba",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1184,7 +1166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "21a50f7d-03c8-4665-835c-9dad5a519aa0",
+                     "jsondocId": "e524bdba-3bde-46c1-8e80-7aaf389468c7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
@@ -1196,9 +1178,9 @@
                "verb": "POST",
                "description": "Set longest ORF",
                "methodName": "setLongestOrf",
-               "jsondocId": "30810d55-3360-4bea-86e9-f0abe3e2de9a",
+               "jsondocId": "60eb05ac-df41-4422-93c6-2e888227704d",
                "bodyobject": {
-                  "jsondocId": "57ccc650-19f0-4637-bfe9-c469df2b5128",
+                  "jsondocId": "327e86c6-6287-4a71-ab54-481143994571",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1208,7 +1190,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setLongestOrf",
                "response": {
-                  "jsondocId": "e18a5145-545b-4b9a-96de-0e12df609624",
+                  "jsondocId": "209aca42-4e5f-4b98-8be9-4e4dd6002e82",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1221,7 +1203,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "648dfda6-6fff-47db-ab7a-0c2ff3f059d0",
+                     "jsondocId": "a7efdba0-4686-43a9-9787-a879537b1041",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1230,7 +1212,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "39984b3c-b441-488a-a5df-63d39a30942c",
+                     "jsondocId": "a0cee971-ee00-4eaf-8244-c003f01b577f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1239,7 +1221,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e4dba01f-5a27-41c2-9f0c-a2e05fec4483",
+                     "jsondocId": "1ad09247-784c-4971-91b1-eecbd12f2dcc",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1248,7 +1230,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7e1a1265-31ad-43bc-96c0-1d22bd5f60e1",
+                     "jsondocId": "f8350c9d-d3a2-4ee9-b0ad-ea6b0b80a342",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1257,7 +1239,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7513c4e9-70b1-4d73-a888-6ab21d2262bc",
+                     "jsondocId": "caa75dfb-4cc0-4e96-a1c3-c838dbd1c141",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -1269,9 +1251,9 @@
                "verb": "POST",
                "description": "Set boundaries of genomic feature",
                "methodName": "setBoundaries",
-               "jsondocId": "c5acdabf-95e7-4bc6-b6ad-c9cc6f892e58",
+               "jsondocId": "5fc7ff7f-68d6-4e0e-8ac6-8d7567b56c4c",
                "bodyobject": {
-                  "jsondocId": "1715e4b6-e280-4459-b0ec-949973487b4c",
+                  "jsondocId": "a027f5f1-de73-4a8d-93f2-4f2773df6d11",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1281,7 +1263,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setBoundaries",
                "response": {
-                  "jsondocId": "8c4e9a17-0b92-408e-891d-bd081b2ee6cb",
+                  "jsondocId": "4454794a-b38d-4ccc-be28-a28c27addd87",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1294,7 +1276,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "652f98a1-03c1-41a4-9368-cd8882b1f392",
+                     "jsondocId": "bfd27563-a777-49dc-8b75-59563d0f51cb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1303,7 +1285,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c5d1812-57fb-44d2-ba2a-699ec0014672",
+                     "jsondocId": "4200b28a-01f3-4f37-a91e-88d1fc9afd8e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1312,7 +1294,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "50569d01-d1a7-497e-88bb-f39e9ad84566",
+                     "jsondocId": "b338f724-e88e-4297-baee-b1302b31160c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1321,7 +1303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6eb7815b-d652-441e-a83f-7a5a714fe846",
+                     "jsondocId": "da49490d-a4ce-4871-a72f-5d8d19b10bb9",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1333,9 +1315,9 @@
                "verb": "POST",
                "description": "Get all annotated features for a sequence",
                "methodName": "getFeatures",
-               "jsondocId": "d87638c0-b52d-4333-857b-2260e428f2d8",
+               "jsondocId": "cf5e0404-26fc-49e1-b259-54b330520aa8",
                "bodyobject": {
-                  "jsondocId": "59099be9-e2fe-4743-9307-b3e1bea307c9",
+                  "jsondocId": "13e37d39-fdff-4966-a0e6-aa5b4769b064",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1345,7 +1327,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getFeatures",
                "response": {
-                  "jsondocId": "989b7c35-c054-40cf-8168-1963bfab6219",
+                  "jsondocId": "a35d499b-3c6f-4339-a43b-ae1e40abc52f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1358,7 +1340,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2e6d461f-7b96-4ae8-8f35-5f9f6a33dad7",
+                     "jsondocId": "c7baf2b5-53a5-4eb4-9f92-d66a06761774",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1367,7 +1349,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "01187c81-86d1-4e36-81f5-d694b2fafff9",
+                     "jsondocId": "e5f4abbd-292c-463e-810e-81d3b5f42662",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1376,7 +1358,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e5084686-5570-476e-a206-1c8654be90f3",
+                     "jsondocId": "b5cdcd69-f73c-4547-b716-2e7f9773eec4",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1385,7 +1367,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7fe3a3b0-d988-41c0-942f-cc31205657d5",
+                     "jsondocId": "847b2632-efbb-4034-b0a0-2b5b852cab64",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1397,9 +1379,9 @@
                "verb": "POST",
                "description": "Get sequence alterations for a given sequence",
                "methodName": "getSequenceAlterations",
-               "jsondocId": "9808e5d3-5a91-4713-bd10-0d38b1b96466",
+               "jsondocId": "59232b06-ae8a-43e3-ac68-1d95a0753f3a",
                "bodyobject": {
-                  "jsondocId": "889c65d7-7e0c-4e38-b391-af43f2cd036b",
+                  "jsondocId": "2a728ce7-ee8d-4749-9277-a49610b749ed",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1409,7 +1391,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequenceAlterations",
                "response": {
-                  "jsondocId": "1b7481f7-e2c3-4305-aad0-559991b75e93",
+                  "jsondocId": "d31bd2f2-da6f-4310-bd62-d4c77fcb7499",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1422,7 +1404,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "90206a07-3b4a-4797-b89e-5dd3228c1f1b",
+                     "jsondocId": "83397646-4a41-4901-8903-e70bf94430ed",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1431,7 +1413,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "259d983d-160b-4963-87cb-c799fa8ac734",
+                     "jsondocId": "c23a4724-0e38-4215-ab9b-b7073f24763b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1440,7 +1422,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "affecfa9-86c0-4d35-8064-424da30a14c2",
+                     "jsondocId": "ef7fd81b-32a8-4845-ab76-bf77b5248693",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1449,7 +1431,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e451faae-d9ca-4782-be23-c54894540ca1",
+                     "jsondocId": "bbdb4658-e5f8-42e6-be1b-c5133eeeb7d6",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1458,7 +1440,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "329ba98c-6cc7-46e6-8e13-5828b8c8760a",
+                     "jsondocId": "381a250c-526a-4269-b6e4-b128dc93cffe",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -1470,9 +1452,9 @@
                "verb": "POST",
                "description": "Delete attribute (key,value pair) for feature",
                "methodName": "deleteAttribute",
-               "jsondocId": "d5a9ace9-19eb-4294-93c7-38a095be4da0",
+               "jsondocId": "4ffaf8be-0a07-4c97-a45e-c84751d1c5dc",
                "bodyobject": {
-                  "jsondocId": "a30a6b17-25c9-4763-9ff3-c3e5c9c4e75f",
+                  "jsondocId": "b9c896eb-dd28-4979-a7f7-8d9f18fa7cfd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1482,7 +1464,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteAttribute",
                "response": {
-                  "jsondocId": "287ddd52-7418-4f1e-aaf3-205a8ee0b18f",
+                  "jsondocId": "d6f81c9b-e02a-495d-93a5-728173d9434a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1495,7 +1477,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e2c1376a-4ad4-4994-a9c6-e6fd161e434b",
+                     "jsondocId": "3e2dfea1-5182-47dc-a96c-b4fa2ee46d6e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1504,7 +1486,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c633209f-abcf-4cf5-949f-afbbdb2d1e2c",
+                     "jsondocId": "6ac7f0c8-e1ac-4b72-b190-260b9d9af04c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1513,7 +1495,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e0bb796a-6706-47fd-a1b0-636110dd7f4b",
+                     "jsondocId": "8f9f8788-cdcc-4409-904f-b93d7ac82d68",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1522,7 +1504,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2e7820b5-557e-4a33-acbe-0ac94936a0f2",
+                     "jsondocId": "b828281a-e382-48f3-986c-41fb381f2d79",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1531,7 +1513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44f1f7f6-44c9-490a-a4fa-1521d4989828",
+                     "jsondocId": "e25694a6-b30d-4778-9597-485aa07dd646",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.",
@@ -1543,9 +1525,9 @@
                "verb": "POST",
                "description": "Update attribute (key,value pair) for feature",
                "methodName": "updateAttribute",
-               "jsondocId": "677c7e87-2ada-492d-8411-ce04640a3202",
+               "jsondocId": "950ca0ab-88b6-4b41-a26f-62945bd31b47",
                "bodyobject": {
-                  "jsondocId": "7c22361e-8941-4a8f-9e78-c0a4d0a795fa",
+                  "jsondocId": "7032b6aa-79df-4d63-a66e-2123aae3f866",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1555,7 +1537,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateAttribute",
                "response": {
-                  "jsondocId": "d9f269e7-83c8-4e6f-b002-114e87f6826f",
+                  "jsondocId": "705054fe-eee1-4859-be81-8727319257a4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1568,7 +1550,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "47ad893f-714c-4fe7-bf7b-f6ee954f637d",
+                     "jsondocId": "94476d9f-0b9c-4bf9-9487-a24054eb18a0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1577,7 +1559,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66b93833-bd13-4ecb-8f34-337af691f597",
+                     "jsondocId": "bed31c65-9f91-4f50-9e91-5bec75172826",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1586,7 +1568,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5fa807bf-4e67-4c6e-a2b2-3bb7e4165372",
+                     "jsondocId": "29829a84-be95-4256-ac49-5ce846d1774b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1595,7 +1577,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "809d81d0-699f-42af-a729-8e6636fb7eb4",
+                     "jsondocId": "f79e8a5c-ef1b-45e1-99de-120abd4e0199",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1604,7 +1586,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4a460492-d635-4685-9548-d7761d74f75a",
+                     "jsondocId": "ce0c0477-5847-4267-ac66-7b7430fc93db",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1616,9 +1598,9 @@
                "verb": "POST",
                "description": "Add dbxref (db,id pair) to feature",
                "methodName": "addDbxref",
-               "jsondocId": "16603b4b-5a10-4773-b68b-309b709f2c8e",
+               "jsondocId": "4ff44081-7089-4c28-bcd4-79394b883fbb",
                "bodyobject": {
-                  "jsondocId": "97f748aa-ddf8-4b2a-a99a-3ea598093a4b",
+                  "jsondocId": "e85f3d31-a2d1-45a8-bcbe-2e89fc5927fb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1628,7 +1610,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addDbxref",
                "response": {
-                  "jsondocId": "0cd9680a-1499-4ad8-b0e1-24f67e3f85f7",
+                  "jsondocId": "f6e4ee31-8f5a-4f89-8475-eddfea271951",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1641,7 +1623,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "daf14d9c-c6ee-46b4-a7f2-9ae72c15f0af",
+                     "jsondocId": "ad908d0f-87c3-4802-901c-9921fcad5853",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1650,7 +1632,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3cfd421f-3711-464f-a746-3be4aac6a24f",
+                     "jsondocId": "3699e764-c6c9-4bec-8f22-5aa892a83ad9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1659,7 +1641,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b19871c5-c760-4152-8510-24130b59e065",
+                     "jsondocId": "e31f65c3-7967-4ee2-a98d-24252677021b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1668,7 +1650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26c7c93e-6171-4051-99ce-bdfe7cc30f5d",
+                     "jsondocId": "e01342bc-5825-484f-82e0-fb4f33dba97e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1677,7 +1659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c3876a2b-9c0e-4a13-9144-f556e6dfea0c",
+                     "jsondocId": "a1eff926-533c-434d-ab58-e949ccfb37d7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.",
@@ -1689,9 +1671,9 @@
                "verb": "POST",
                "description": "Update dbxrefs (db,id pairs) for a feature",
                "methodName": "updateDbxref",
-               "jsondocId": "4283cba4-6767-499a-be41-f76fb4d49fd1",
+               "jsondocId": "018c444f-1735-4549-86f9-5420a3e72a30",
                "bodyobject": {
-                  "jsondocId": "1ced0cd4-a9c2-44e3-9bed-129e317b81cb",
+                  "jsondocId": "40d6adb2-9bcb-40b8-9bff-7db8baafab4a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1701,7 +1683,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateDbxref",
                "response": {
-                  "jsondocId": "ecebbc82-26b6-4003-95d3-73ac3d4eebd5",
+                  "jsondocId": "7b8bc0a9-395f-4f1a-a02b-fffe51eb54db",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1714,7 +1696,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "feef06c7-15eb-4c4a-9edd-1b3a46c3ce06",
+                     "jsondocId": "7335ae74-a901-4391-b5da-cf6a25491590",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1723,7 +1705,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f8036d12-1809-464f-a92c-027eb8086ba8",
+                     "jsondocId": "11ed6be6-96a9-4791-94ef-624841e0ff68",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1732,7 +1714,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "16467b6d-0d0f-4479-ab2b-4ff023af8ead",
+                     "jsondocId": "ef921e0c-27d3-4992-a254-faac2e9ebc13",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1741,7 +1723,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d032bdf4-efdd-4dea-ba0c-761e867c8f5a",
+                     "jsondocId": "67453961-ad70-4669-a2f0-3111224b0c4a",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1750,7 +1732,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8041cb39-b34c-40d4-8e7f-a3e277665c0c",
+                     "jsondocId": "17667519-f971-4f2d-9364-4bae00f9f82e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1762,9 +1744,9 @@
                "verb": "POST",
                "description": "Delete dbxrefs (db,id pairs) for a feature",
                "methodName": "deleteDbxref",
-               "jsondocId": "2b8c0e78-f3b5-4520-8a0a-8dd3656b4f5b",
+               "jsondocId": "a1c3e5f8-17c7-4563-a5ac-d6a339ec64ce",
                "bodyobject": {
-                  "jsondocId": "ba763185-cabc-4609-8e8e-7765f6c3e042",
+                  "jsondocId": "30b99635-78a9-4326-aa92-0269eeb02f4a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1774,7 +1756,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteDbxref",
                "response": {
-                  "jsondocId": "920fe44b-078e-44fd-a1d8-bb53fc6d32ce",
+                  "jsondocId": "18db7749-a3d4-4230-b64b-c1290ff132ef",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1787,7 +1769,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1fdf89c4-31ff-4805-b5d3-30b321b86acd",
+                     "jsondocId": "fc8765f8-ace2-4d1b-bf21-abc750ba9cbb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1796,7 +1778,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0f9832da-6448-4f8e-be00-9b183fc55382",
+                     "jsondocId": "9f0d6487-d878-4686-a81b-5206cf33d213",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1805,7 +1787,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "841ad0c0-13e0-4013-a499-70c9931248c0",
+                     "jsondocId": "7911b024-2678-4b3e-b222-0a59cad1655d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1814,7 +1796,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "594a93b2-021c-490c-83cb-d06b6a4a7a1e",
+                     "jsondocId": "6113f688-3cac-4f56-9303-2dbf513b208c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1823,7 +1805,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5cf2a996-11ef-4589-b669-e34e90b9d301",
+                     "jsondocId": "a4a3ea6f-702f-48de-aa3f-b1a846862d5b",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
@@ -1835,9 +1817,9 @@
                "verb": "POST",
                "description": "Set readthrough stop codon",
                "methodName": "setReadthroughStopCodon",
-               "jsondocId": "91355a0f-32cf-49f4-8a31-a76ed0a7c943",
+               "jsondocId": "464ad51b-855b-431f-9ef7-7db390445b30",
                "bodyobject": {
-                  "jsondocId": "3bd518f9-1ba7-4710-81d4-ce16716086c5",
+                  "jsondocId": "3d6e182e-5c7a-493a-b44b-c825ba6420de",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1847,7 +1829,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setReadthroughStopCodon",
                "response": {
-                  "jsondocId": "8cce8ff8-0388-4978-85a6-b5f35524c967",
+                  "jsondocId": "d9f63bf2-0112-499b-becd-0d5497fa609e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1860,7 +1842,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ddb8234c-51a5-46bd-9a54-ab1527e1377c",
+                     "jsondocId": "9b51bf0e-9ff7-4bae-b5a8-25f651db1db3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1869,7 +1851,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6dbe5357-721d-45aa-af89-9242ec1f2d56",
+                     "jsondocId": "3e4e4c1b-6165-4abe-851b-0fe64705d6d0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1878,7 +1860,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7088dc9f-745e-433f-be79-5563b7877c67",
+                     "jsondocId": "3153bcaa-ead4-4193-8476-d04015dae8df",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1887,7 +1869,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dd8e84a9-8f8a-4b65-81d7-f3151edba302",
+                     "jsondocId": "e560a383-36ac-4792-8474-756433d69a1f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1896,7 +1878,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1741f400-0e92-46cc-bd71-d7fdee890edd",
+                     "jsondocId": "ab4fdc41-02ff-41f8-bd4f-cb43147a6035",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
@@ -1908,9 +1890,9 @@
                "verb": "POST",
                "description": "Add sequence alteration",
                "methodName": "addSequenceAlteration",
-               "jsondocId": "fd35cef9-56da-4260-9ff4-bd955dce1ff1",
+               "jsondocId": "5d764c35-2f69-44ae-a8be-e634701c3ab8",
                "bodyobject": {
-                  "jsondocId": "e59b8c9c-aa67-46ab-b4d4-d67eb001e2c2",
+                  "jsondocId": "df21a748-24f7-4047-ab0a-f49627360491",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1920,7 +1902,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addSequenceAlteration",
                "response": {
-                  "jsondocId": "c0b52c6c-ac68-4ac0-b768-560382fb9114",
+                  "jsondocId": "97c3a225-def0-4683-85c9-ddd378ccf3d7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1933,7 +1915,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1c2e0a04-c5ea-452b-9cf4-b7db1c1b6e1c",
+                     "jsondocId": "04b4dc8e-7c57-453a-abda-1c784a43e963",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1942,7 +1924,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0b99d565-44e6-47e1-b48f-2d545700c5bf",
+                     "jsondocId": "2e7684a5-f42f-439d-b432-d42a4de4d55b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1951,7 +1933,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ddacfb00-1978-43bf-8ba2-9f888e0be14c",
+                     "jsondocId": "c57b551a-fc01-4ac5-804d-fe38b74ec3f4",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1960,7 +1942,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ad3ea2b9-ab8c-43e2-807b-12346f451938",
+                     "jsondocId": "1267a815-7679-4b20-9ff3-30cde056e74b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1969,7 +1951,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8192f220-a813-4f0d-b065-dc5fd1aae0c2",
+                     "jsondocId": "3142d52b-0e62-4cc6-a402-c86bed54bfcf",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
@@ -1981,9 +1963,9 @@
                "verb": "POST",
                "description": "Delete sequence alteration",
                "methodName": "deleteSequenceAlteration",
-               "jsondocId": "3f3584ca-2766-4493-9ccc-457f937e7fc9",
+               "jsondocId": "a22d45eb-13d4-4e8b-8a33-c50b4408ce1b",
                "bodyobject": {
-                  "jsondocId": "956fdf7e-95b4-41e9-872a-1123f974f50e",
+                  "jsondocId": "5812de7d-9952-4703-961c-40916b4acbfb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1993,7 +1975,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteSequenceAlteration",
                "response": {
-                  "jsondocId": "21237f36-fd2e-4521-94c7-152d434f9640",
+                  "jsondocId": "6c5d171d-422a-4d5b-bc8f-b16d128e134a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2006,7 +1988,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "eeca74d9-65a5-49b1-bb8e-03943f301664",
+                     "jsondocId": "597d5d22-f44c-402b-b99b-72eb5ce16851",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2015,7 +1997,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "156fc171-8607-4d55-9cf9-a7caf41b5730",
+                     "jsondocId": "75f5d3a4-767b-44f6-853f-f901a0499413",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2024,7 +2006,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c072b755-a3d6-49f2-bd97-dd90a1a00c67",
+                     "jsondocId": "114ae544-e429-4268-a7f0-5d533d0621cf",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2033,7 +2015,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b33870af-3aab-45a6-a175-c14fd80a4f9d",
+                     "jsondocId": "c9bde135-ed2b-417b-8f73-c0b922763ae9",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2042,7 +2024,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ec16184-83a2-442d-90a7-7448fe9f8e01",
+                     "jsondocId": "c8c14977-a96c-43b2-92a8-0c7bf13c2b39",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
@@ -2054,9 +2036,9 @@
                "verb": "POST",
                "description": "Flip strand",
                "methodName": "flipStrand",
-               "jsondocId": "2dbf76f4-a25f-4dd9-93b5-318f11a9f915",
+               "jsondocId": "631d3da3-4eed-43fa-aea5-acf732d62467",
                "bodyobject": {
-                  "jsondocId": "aee8b1b1-4ba4-49bb-95b6-b11d6032e055",
+                  "jsondocId": "59371de5-68be-41b7-847f-135de5dbd8b3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2066,7 +2048,7 @@
                "apierrors": [],
                "path": "/annotationEditor/flipStrand",
                "response": {
-                  "jsondocId": "cbd037a9-a04f-40ac-8d98-2b3e15673240",
+                  "jsondocId": "8067c174-3652-4374-8a9d-69bccb8d4809",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2079,7 +2061,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ea248b61-6f60-4026-b158-e7f6270b288b",
+                     "jsondocId": "eff76cc6-408e-4587-b422-e9dbd4f24b80",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2088,7 +2070,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "af8959df-e138-4446-99a6-4102d418e5d0",
+                     "jsondocId": "5fce52bf-e388-4c34-89f6-3948ca02ac0c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2097,7 +2079,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2ea915df-ef64-411f-b4b8-f049ac6a8099",
+                     "jsondocId": "b843a998-f876-4f87-b58e-e0248556095c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2106,7 +2088,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0e7a78d3-df54-4fdc-b381-807bf4a6d981",
+                     "jsondocId": "231a731e-c75b-497b-954b-be9b300e0e6b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2115,7 +2097,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9fd112af-0d13-4d08-96a9-b53fe83fca06",
+                     "jsondocId": "b4352f9b-d74f-409a-86d8-d17cefb14d02",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
@@ -2127,9 +2109,9 @@
                "verb": "POST",
                "description": "Merge exons",
                "methodName": "mergeExons",
-               "jsondocId": "6b3db9e9-1dbb-4e7e-9032-ce418d10ee1e",
+               "jsondocId": "1b4514de-4f33-41fe-baa8-02ffb9b21040",
                "bodyobject": {
-                  "jsondocId": "2ba1e914-18af-4c0b-9bc3-25d432ad6a2e",
+                  "jsondocId": "34579fc1-fe71-4a87-8923-8f5aa27eae1d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2139,7 +2121,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeExons",
                "response": {
-                  "jsondocId": "25417799-15b3-4eff-b21f-8e9cda36a8fe",
+                  "jsondocId": "f5b1c5fe-b305-4dc5-9298-4d72f1a366ee",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2152,7 +2134,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a57b8e55-15d5-4e81-b28f-cb1d9eded7f6",
+                     "jsondocId": "e0a1d83c-5703-4235-90e3-b7a7b6a032e1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2161,7 +2143,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8aa39aa6-63fa-4381-8a56-2271a9b1b837",
+                     "jsondocId": "03f08ff1-9407-4905-85d7-0796552b7db9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2170,7 +2152,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84eb0272-5b8f-4af8-ba0d-8be8d1213ca2",
+                     "jsondocId": "901e576a-2b48-4761-a58d-825b68a04a70",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2179,7 +2161,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b831b95-7628-4f41-863f-2aced187c604",
+                     "jsondocId": "598a4393-336c-4883-b6bb-bd7359f6f168",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2188,7 +2170,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "86cc1152-a8aa-4c64-a46e-c28acdeb4fb5",
+                     "jsondocId": "6d5dcdef-5875-4c8c-ac20-a1efa1f82275",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -2200,9 +2182,9 @@
                "verb": "POST",
                "description": "Split exons",
                "methodName": "splitExon",
-               "jsondocId": "56dfac40-1f20-4cd2-9e6e-b886bb7bdf1a",
+               "jsondocId": "c422c707-b3f1-43f5-9820-513ed4bf8f35",
                "bodyobject": {
-                  "jsondocId": "ecf70f74-203d-49b0-8905-7131c6efb3de",
+                  "jsondocId": "c9db05fc-e8e7-4fc3-98c6-5e751bf29695",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2212,7 +2194,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitExon",
                "response": {
-                  "jsondocId": "aeb0466c-b7b2-419c-a1d6-08dfa58c6b1b",
+                  "jsondocId": "5d217959-8fa0-4fe0-afee-675be2802d15",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2225,7 +2207,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "bbb5cdbd-1317-4e71-b353-56f6f01adf72",
+                     "jsondocId": "76f29fa2-bd15-4e11-981b-e73435822f08",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2234,7 +2216,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9a6b9d14-a399-4951-ab2d-7b4940f6b3fe",
+                     "jsondocId": "d4e4bf75-d914-4905-ae11-48f44dca7fef",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2243,7 +2225,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "509d2dc7-baea-444d-b5c4-54e697cfb63d",
+                     "jsondocId": "b79a1fa0-f67a-4771-94c6-67af33d6e505",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2252,7 +2234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "38c47813-728f-452b-9325-6e776bf7b0da",
+                     "jsondocId": "eeeb7750-86d0-4488-9b56-9b71e619000c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2261,7 +2243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ea562aca-ba47-4a0b-a8ff-ecafc3325da5",
+                     "jsondocId": "9492e939-beb3-4675-a716-fbb93b5ab35f",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
@@ -2273,9 +2255,9 @@
                "verb": "POST",
                "description": "Delete feature",
                "methodName": "deleteFeature",
-               "jsondocId": "46bb4779-2aca-4319-adda-c67398a93730",
+               "jsondocId": "186ca1d9-c203-4355-b9f5-f12b5de42578",
                "bodyobject": {
-                  "jsondocId": "24354dac-097d-4204-81e3-c76e850054d0",
+                  "jsondocId": "257f2f12-a910-4a9b-a91e-b2ffe4692cb6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2285,7 +2267,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeature",
                "response": {
-                  "jsondocId": "99961b57-6a57-43cf-a5f0-336f0f696777",
+                  "jsondocId": "3f8f086d-e11c-4837-b318-3cb55743952c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2298,7 +2280,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c7f24f45-cf41-41bf-8ae3-ca361d558ab5",
+                     "jsondocId": "6adcc4bb-9ce5-4222-a91e-1c231fcd1856",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2307,7 +2289,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b4b14dc2-1242-4110-adb1-3e1966b81c04",
+                     "jsondocId": "3b970b2b-0fc8-4c88-ac09-50ebad5f1bb9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2316,7 +2298,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f5267a57-f431-45b0-88b5-0d48501b8af7",
+                     "jsondocId": "e375bc23-a04b-4dc0-81fe-39d8e3d03a4b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2325,7 +2307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7cc0cdc8-c18b-4a61-9926-652cca62c1af",
+                     "jsondocId": "8ec942fd-37e2-4030-bad7-c8bc381d13cc",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2334,7 +2316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "29b65854-3b54-43f1-9120-3609261d6e12",
+                     "jsondocId": "a1062175-f39b-4240-868d-e0a050c9620d",
                      "name": "sequence",
                      "format": "",
                      "description": "JSONArray of sequence id object to delete defined by {id:<sequence.id>} ",
@@ -2346,9 +2328,9 @@
                "verb": "POST",
                "description": "Delete variant effects for sequences",
                "methodName": "deleteVariantEffectsForSequences",
-               "jsondocId": "cdd1c0eb-4f28-4935-a77a-1a37d13fe963",
+               "jsondocId": "81e21f21-8374-4257-b2e4-10560342828d",
                "bodyobject": {
-                  "jsondocId": "f2d3465b-336a-4807-a03c-8776ef72322f",
+                  "jsondocId": "be3d1e02-0456-4cde-99cb-00857a0d3583",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2358,7 +2340,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteVariantEffectsForSequences",
                "response": {
-                  "jsondocId": "a40b7607-6bb0-4468-9153-30ed6f604bf5",
+                  "jsondocId": "321d288b-42a6-4515-a1c9-55457bd4fee2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2371,7 +2353,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "aefee867-b649-452d-ac47-ec9ab8edeace",
+                     "jsondocId": "c190053b-83ed-42ef-8804-da80f5537e6a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2380,7 +2362,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ac058c31-898e-4076-a727-df7a821d9a7a",
+                     "jsondocId": "d1abeb1a-f522-4573-8041-365d48ecb51d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2389,7 +2371,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "065f8e6a-b512-4139-9aa9-3649b55c3e29",
+                     "jsondocId": "a0e2716a-7802-464f-a119-68af0642e930",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2398,7 +2380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bd598b05-077c-4709-bbbf-a3f0478c3a41",
+                     "jsondocId": "b50cc240-d792-4b04-8d97-d9ff79bd7fae",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2407,7 +2389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ba8d981-a075-435e-9210-1ded26f71046",
+                     "jsondocId": "22dc21ef-d51e-44bf-8674-11a271ab632e",
                      "name": "sequence",
                      "format": "",
                      "description": "JSONArray of sequence id object to delete defined by {id:<sequence.id>} ",
@@ -2419,9 +2401,9 @@
                "verb": "POST",
                "description": "Delete features for sequences",
                "methodName": "deleteFeaturesForSequences",
-               "jsondocId": "37eed9ad-0990-4b96-9bf8-857e417908c6",
+               "jsondocId": "bd5f3661-1477-40a8-b32d-bfc18c4df8ff",
                "bodyobject": {
-                  "jsondocId": "c1833b10-796b-4ced-9c04-3f3caf694ff6",
+                  "jsondocId": "5a9516fa-04b5-402b-b22d-ad0157f233c6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2431,7 +2413,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeaturesForSequences",
                "response": {
-                  "jsondocId": "270d3d93-a88d-4abd-a9a3-a24006ca2840",
+                  "jsondocId": "db1b3fb1-bc23-44b1-a907-b58e8b3bf5c9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2444,7 +2426,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fe0949b3-ed7d-49e1-a599-a82e0755d6ca",
+                     "jsondocId": "b826589e-2963-4421-80e8-526195c85f26",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2453,7 +2435,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "128fc1d5-62fc-4d2a-a54c-6559be369f2f",
+                     "jsondocId": "416ac1aa-71ef-44bd-8d05-44816d5949ca",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2462,7 +2444,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "60f67d4d-9938-447e-9b75-18260b8e19a9",
+                     "jsondocId": "c645a43f-f52e-41fa-b790-8f632898bb85",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2471,7 +2453,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1b63fee9-b4d9-4a57-a5ef-3c513b175fdd",
+                     "jsondocId": "2271c400-f951-42d3-9d2b-5aedebd4e882",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2480,7 +2462,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b46b0a13-fa91-48db-ae91-1c87fdfd53a5",
+                     "jsondocId": "dcdb91cf-c242-4191-9436-5f2cc58d55a3",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
@@ -2492,9 +2474,9 @@
                "verb": "POST",
                "description": "Delete exons",
                "methodName": "deleteExon",
-               "jsondocId": "e0e0b92c-8809-4fb9-89b1-0b75ea94f866",
+               "jsondocId": "9115d71b-73da-4aca-a0b1-81eccdf997a0",
                "bodyobject": {
-                  "jsondocId": "5df96d11-565e-432a-b9ab-5b38c2097834",
+                  "jsondocId": "dbe591f1-f030-4435-a320-9116311784f2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2504,7 +2486,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteExon",
                "response": {
-                  "jsondocId": "c7b64aab-9714-48c3-ae26-ddab350ec0b4",
+                  "jsondocId": "1f72cd0f-3adc-44fe-b867-c889523ede21",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2517,7 +2499,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b217db3e-eb81-48fb-8997-e3521d9aed32",
+                     "jsondocId": "a2e97bb7-8c6f-4d91-b8d9-029871d1b1d8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2526,7 +2508,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4b77f85f-c0aa-4afe-b080-3345bb44368b",
+                     "jsondocId": "1cb9f91e-f76a-4019-9872-3bab5342a297",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2535,7 +2517,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49d46698-9b19-469a-b779-1922cc415a88",
+                     "jsondocId": "f1b7c0b3-4340-444d-ab38-20b7fca32d2d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2544,7 +2526,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1590f877-4b23-4792-bae1-f5327e5e066e",
+                     "jsondocId": "50a47c65-5998-4e6a-a1d2-8af99e447fc2",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2553,7 +2535,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3b4a50e5-e401-4e2d-8f94-10e28db93968",
+                     "jsondocId": "edf8fe9a-f69c-4b3b-aef4-1accc8731f79",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -2565,9 +2547,9 @@
                "verb": "POST",
                "description": "Make intron",
                "methodName": "makeIntron",
-               "jsondocId": "095258e1-11a5-4764-bda7-05d9048d1813",
+               "jsondocId": "4ff2e83c-56bf-4844-9ddf-b9932ea6ae70",
                "bodyobject": {
-                  "jsondocId": "c240c2b2-802e-4b94-b15a-48785cec15ca",
+                  "jsondocId": "9a49a3da-4103-4706-952c-328ce6f26b04",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2577,7 +2559,7 @@
                "apierrors": [],
                "path": "/annotationEditor/makeIntron",
                "response": {
-                  "jsondocId": "353f787d-1177-46b7-8c31-a867f7161403",
+                  "jsondocId": "26631011-f3ab-4c92-95f0-dd2c6c6d6b3f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2590,7 +2572,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "bb94be95-e0fc-4da9-bd97-c5601b478e54",
+                     "jsondocId": "d215d2e2-dcb4-4d6b-9ee7-9b8ab6ed9375",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2599,7 +2581,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5a97d056-e604-4023-b784-fc7d47ca8b40",
+                     "jsondocId": "b85cb67b-35f3-4e95-803e-df8b77cbf082",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2608,7 +2590,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9815b708-3557-4092-866e-3098b02f64ab",
+                     "jsondocId": "4e4b53b0-bc42-44a9-a6e1-f039d85e5273",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2617,7 +2599,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "be9109c0-0760-4c86-9925-b1942e15be9b",
+                     "jsondocId": "790a1a3f-bb97-4302-82fb-407d79d379d8",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2626,7 +2608,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a009749c-3e54-4d9b-bfa2-a1d4dac5f5e7",
+                     "jsondocId": "9cae4425-4ee9-48a2-85e0-88452036cb6d",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2638,9 +2620,9 @@
                "verb": "POST",
                "description": "Split transcript",
                "methodName": "splitTranscript",
-               "jsondocId": "3a677c0f-29f1-4bf1-83a4-a1952eeaeef8",
+               "jsondocId": "04a34500-2b29-45b2-a6ce-c770cef43207",
                "bodyobject": {
-                  "jsondocId": "f0f1c00f-6321-4ff3-8063-dbf20270be51",
+                  "jsondocId": "aa820154-ad1b-4039-b028-bb829b0281d7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2650,7 +2632,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitTranscript",
                "response": {
-                  "jsondocId": "e34be68c-4648-4ab9-be92-9d184c69b64a",
+                  "jsondocId": "d442363a-9c10-4e3b-a843-3632c655e3b9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2663,7 +2645,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f391042c-9cf0-457a-8e11-f2262453d5fc",
+                     "jsondocId": "76b94539-f43f-478d-905d-ef521b0af5eb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2672,7 +2654,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4cbdd449-75e6-4a34-8183-c26b72b5646c",
+                     "jsondocId": "495c75b2-2323-4c08-a0a7-aeb92513306f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2681,7 +2663,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "534df222-6a1c-4b89-a730-4be9d0440300",
+                     "jsondocId": "20d663c7-3487-4ff6-b5ec-1200e66ddb95",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2690,7 +2672,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b0474458-d598-4c41-8bb0-30217e05843b",
+                     "jsondocId": "35288125-557f-420e-9c4a-3b6f8e7e6f67",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2699,7 +2681,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7867d4b9-6c21-4813-9c7d-c0fc04bd0271",
+                     "jsondocId": "90ba2336-bedb-4167-8205-ab2f4f07dc97",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2711,9 +2693,9 @@
                "verb": "POST",
                "description": "Merge transcripts",
                "methodName": "mergeTranscripts",
-               "jsondocId": "cd90ba94-0a0f-48ca-93d2-e86054cf20bd",
+               "jsondocId": "58889267-3101-4a17-81ad-7756162e9cac",
                "bodyobject": {
-                  "jsondocId": "d281de40-8427-4835-bb8d-2316af57fa09",
+                  "jsondocId": "9772eb1c-abcc-429f-857a-c80251a6b1af",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2723,7 +2705,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeTranscripts",
                "response": {
-                  "jsondocId": "8139f54d-ad62-4883-9236-92d575388070",
+                  "jsondocId": "50848d70-20c0-480b-9e4b-61053853f5b7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2736,7 +2718,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "13864461-bade-4933-b982-9bc96c7fe859",
+                     "jsondocId": "ec8c4542-5228-4baa-8b20-d924ca9cb2dc",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2745,7 +2727,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84bd16eb-e60f-46e5-ac7b-6b2369cf772c",
+                     "jsondocId": "af19f55c-bdd2-450d-ae21-2669c7e55df3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2754,7 +2736,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "806ab628-4ea6-4c14-b256-6806074045c2",
+                     "jsondocId": "00550776-30b5-4b32-bfd3-77911eb38ee6",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2763,7 +2745,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49c63b72-6e25-4b4c-ba2f-0e0c5816ba05",
+                     "jsondocId": "120d23f2-8db2-4384-9321-4b7987b578df",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2772,7 +2754,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "54d34f63-6075-4d40-b380-69db113d9e0c",
+                     "jsondocId": "9ad94df4-c561-4dff-9637-bbd4a772c760",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2784,9 +2766,9 @@
                "verb": "POST",
                "description": "Get sequences for features",
                "methodName": "getSequence",
-               "jsondocId": "5ac20766-7a61-4ff1-8a1f-6061886b1056",
+               "jsondocId": "b2b22d4a-e9ec-45fa-b4b2-c2fdc608e52e",
                "bodyobject": {
-                  "jsondocId": "c628a013-dc82-44e7-8a74-c8a09a6df480",
+                  "jsondocId": "398e64b0-8ffb-489d-ae5e-69c81b2bba56",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2796,7 +2778,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequences",
                "response": {
-                  "jsondocId": "9888e0d0-a6a2-4cd6-a93a-ac3106f504ed",
+                  "jsondocId": "6cc9f9ae-3aa3-45e8-9e8d-ecbd26c98c33",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2805,7 +2787,7 @@
                "consumes": ["application/json"]
             },
             {
-               "jsondocId": "49a3499e-158b-4ace-a20f-44e9410bd362",
+               "jsondocId": "f5097ad1-a1bf-48c2-a791-89942cdb123f",
                "bodyobject": null,
                "apierrors": [],
                "path": "/annotationEditor/getSequenceSearchTools",
@@ -2813,7 +2795,7 @@
                "pathparameters": [],
                "queryparameters": [],
                "response": {
-                  "jsondocId": "c61978e4-c279-49ad-b1bd-2e3e202f0c69",
+                  "jsondocId": "cf36164b-0bb5-40af-9100-55acc11d01c7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2828,7 +2810,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e8970c12-2373-47a6-9f33-6ff5df202f8f",
+                     "jsondocId": "e766769e-174a-4bf1-8362-824571c14646",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2837,7 +2819,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0c7c55b3-965f-47c9-9042-9d2a3113f903",
+                     "jsondocId": "27647007-bd04-445e-8d9c-136abf0a34f0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2849,9 +2831,9 @@
                "verb": "POST",
                "description": "Get canned comments",
                "methodName": "getCannedComments",
-               "jsondocId": "264dc912-9bfb-4224-86d5-fc864448fe44",
+               "jsondocId": "3903797c-a3fd-4b4e-be67-fc4155476fda",
                "bodyobject": {
-                  "jsondocId": "2d8db743-09be-43fc-9b1c-083f0d2a0d5c",
+                  "jsondocId": "335abf7e-af9f-4141-b94d-804bb667f88a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2861,7 +2843,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getCannedComments",
                "response": {
-                  "jsondocId": "62f0e3e3-8840-45f1-a91f-0dcfc7df3f34",
+                  "jsondocId": "1a1aea7e-0578-4793-80b6-e2d862383054",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2874,7 +2856,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "be83e14b-ae43-43b3-ab3d-63b2e8a9d000",
+                     "jsondocId": "b241c74c-08e9-4fff-8d2e-a8f96e8adb6f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2883,7 +2865,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3639c0b1-288c-4b69-b473-abd1d6a40f20",
+                     "jsondocId": "414fd805-3276-416a-92c4-6931989895ce",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2892,7 +2874,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63a55c05-a4f7-4d5b-ac0d-ad755ef23787",
+                     "jsondocId": "6a8c7068-bca5-4d33-836b-855dd5b88d60",
                      "name": "client_token",
                      "format": "",
                      "description": "Organism ID/Name or Client-generated ",
@@ -2901,7 +2883,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8d48d824-d4d3-43c7-9478-e6a05dcd7559",
+                     "jsondocId": "ff9acad0-9215-4095-ace5-d28524c3c062",
                      "name": "search",
                      "format": "",
                      "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
@@ -2913,9 +2895,9 @@
                "verb": "POST",
                "description": "Search sequences",
                "methodName": "searchSequence",
-               "jsondocId": "777f71db-1922-4bfc-9bfd-70c1f8ec9679",
+               "jsondocId": "ccf9b1a8-6dfc-47ef-b647-456be4c58e81",
                "bodyobject": {
-                  "jsondocId": "900c4e19-d819-4927-a90d-e22ef7155e39",
+                  "jsondocId": "9f249121-a9f4-44e5-804c-944337726202",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2925,7 +2907,7 @@
                "apierrors": [],
                "path": "/annotationEditor/searchSequences",
                "response": {
-                  "jsondocId": "e0152ee1-9591-48d4-8af8-94d75443e2b7",
+                  "jsondocId": "6e7e5924-1918-48c0-9ecd-cee67b95409d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2938,7 +2920,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1857de63-dcbe-485a-8097-15bd568d083a",
+                     "jsondocId": "7ce0975e-57d0-4840-bc1f-62e5f01f6df1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2947,7 +2929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "94829d99-b356-4dc9-84ef-d2979573a178",
+                     "jsondocId": "9f48baa7-c4ba-411d-830b-066239ebd628",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2956,7 +2938,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "656db0cb-5116-47b5-ba8a-c47daa0179f0",
+                     "jsondocId": "89128eb8-af12-4ead-b5d8-44b8f5752a5a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2968,9 +2950,9 @@
                "verb": "POST",
                "description": "Get gff3",
                "methodName": "getGff3",
-               "jsondocId": "2a1317df-c9a9-4bc2-aa41-b1c34a658bd0",
+               "jsondocId": "c6b430ae-451e-47fd-b2ca-ba72906363dc",
                "bodyobject": {
-                  "jsondocId": "c1e99f28-62e9-4a38-892c-3a9ecc3a0d3a",
+                  "jsondocId": "3e85058c-e5f6-4142-8ad9-df0e388ce1e2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2980,7 +2962,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getGff3",
                "response": {
-                  "jsondocId": "6bfc6ec7-fdd6-4613-8b1e-2111d9316bab",
+                  "jsondocId": "73f1fd6f-3774-481f-86f0-c4aa8b4ae08d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2993,7 +2975,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a99c3b12-2f61-4fec-b5a1-773f703f0bd7",
+                     "jsondocId": "9d183fa1-6bee-4fa6-8cd9-79cfcaa16fb1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3002,7 +2984,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ec4a9eb6-1d05-46d7-9c71-7e402bab02a7",
+                     "jsondocId": "7d80ad1c-1a8b-4238-ab38-35f49256bbc4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3011,7 +2993,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4f8384b0-63a3-4a99-9232-d4b25236bdc6",
+                     "jsondocId": "eed51745-cc1a-453f-a595-17d8edd815a9",
                      "name": "days",
                      "format": "",
                      "description": "Number of past days to retrieve annotations from.",
@@ -3023,9 +3005,9 @@
                "verb": "POST",
                "description": "Get genes created or updated in the past, Returns JSON hash gene_name:organism",
                "methodName": "getRecentAnnotations",
-               "jsondocId": "5e02318b-267b-4e4b-bf9c-9ae3ab9a0734",
+               "jsondocId": "8039a276-b1e4-47d2-9fe2-0efb07174fb4",
                "bodyobject": {
-                  "jsondocId": "e77bf41c-d108-4521-bcee-68cf0cf0b5e2",
+                  "jsondocId": "37d8e40c-6d2d-4907-bc61-a426cfb81d42",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3035,7 +3017,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getRecentAnnotations",
                "response": {
-                  "jsondocId": "652dfc89-e455-477f-9302-c3d0fb36db0a",
+                  "jsondocId": "7ac4f460-945d-4a52-b72e-a999c12e88d7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3048,7 +3030,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e33e145a-bc05-4e95-bc10-4d54f2a5f633",
+                     "jsondocId": "ef839117-93e6-4f36-8276-369bd145342a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3057,7 +3039,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ac90c81-99ac-46f7-92c4-ef733fcf65ad",
+                     "jsondocId": "cade7975-0b88-420b-befb-d5017e82159b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3066,16 +3048,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2b61bfc3-60f5-4fd3-9646-5b19ea624f92",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d24de985-3ebc-46a9-bfff-e6a35359cc37",
+                     "jsondocId": "6718470e-2c6c-45f9-9551-f91542416fc0",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -3084,21 +3057,48 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02c68d82-aa18-45be-99b0-3723a27e3ce6",
+                     "jsondocId": "080be5d9-1ab4-4a58-8a45-338ed90e3724",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "27460751-698a-4ea8-b027-0bc6d7a37f6e",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f30fcea3-29a6-4fda-91b6-324aad5763d8",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "903292e1-88ef-4019-9cd6-9ca6cdaa6e31",
                      "name": "features",
                      "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
                      "type": "JSONArray",
                      "required": "true",
                      "allowedvalues": []
                   }
                ],
                "verb": "POST",
-               "description": "Set symbol of a feature",
-               "methodName": "setSymbol",
-               "jsondocId": "a7f83ba5-a208-45ca-9dae-1f125365fdbf",
+               "description": "Set exon feature boundaries",
+               "methodName": "setExonBoundaries",
+               "jsondocId": "10e934be-16d5-469f-80b4-906a261eb712",
                "bodyobject": {
-                  "jsondocId": "358959ed-323c-4d7d-9805-ee6acc13945b",
+                  "jsondocId": "1ce5a4ef-5e47-41a9-9385-ad8c1541633c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3106,9 +3106,9 @@
                   "object": "annotation editor"
                },
                "apierrors": [],
-               "path": "/annotationEditor/setSymbol",
+               "path": "/annotationEditor/setExonBoundaries",
                "response": {
-                  "jsondocId": "8081154e-281f-484a-bded-29e897a3c84f",
+                  "jsondocId": "49a65c44-a3d0-450a-9155-44408633e1c5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3121,7 +3121,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b69053b5-f9c0-449d-9074-6596744f5b04",
+                     "jsondocId": "99760157-b03e-4677-901b-7331b7cc94e9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3130,7 +3130,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8a06add8-f0b8-4f46-91fc-8b08bc22827f",
+                     "jsondocId": "70e0e020-c1d7-4099-89f1-9eae49131fc7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3139,7 +3139,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26becf75-6c02-4038-9a4e-4691f00dbf3e",
+                     "jsondocId": "4decf94e-8f45-4583-9428-4462397ae627",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -3148,7 +3148,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1546d9a2-bf51-46de-8426-382f528ab488",
+                     "jsondocId": "32466faf-e366-4e6a-a979-062543076308",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -3157,7 +3157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0825beb9-7b4f-4262-a084-5f9ad67dcded",
+                     "jsondocId": "77ade116-fe82-4f3b-af07-7796c8595c13",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -3169,9 +3169,9 @@
                "verb": "POST",
                "description": "Add attribute (key,value pair) to feature",
                "methodName": "addAttribute",
-               "jsondocId": "9ac95fb2-8d75-4508-80aa-afe8a480ca99",
+               "jsondocId": "6e339d3a-d2cc-40f7-b859-9387aaa83af6",
                "bodyobject": {
-                  "jsondocId": "f2be58e6-de41-43b7-9c3d-b81a45a31f3b",
+                  "jsondocId": "69a3f120-7506-4299-b5a6-1b184c06fb48",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3181,7 +3181,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addAttribute",
                "response": {
-                  "jsondocId": "e1f7af49-9393-4c10-a7b2-bd17750a2e07",
+                  "jsondocId": "1380f20e-c07d-412f-9fea-bfd3ec750a77",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3194,14 +3194,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "ccfa51a7-727f-4fed-a238-c8a522afa6d1",
+         "jsondocId": "75ea5724-6e06-4cfc-8219-b7e43fb2e742",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "18ac6bab-748e-41e1-ab29-f95b4b891d8c",
+                     "jsondocId": "22a407bd-b680-413c-a23c-f10a7c701e6b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3210,7 +3210,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b92d91be-ea85-4d06-90c6-555a90ff83d7",
+                     "jsondocId": "086d7c9f-305f-4825-8078-455f57bb9a5b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3219,7 +3219,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "111b9fe8-9d89-4327-9dc9-ffb80303d08a",
+                     "jsondocId": "fb17c9c9-4e29-4a8b-bd5a-c269c490e18f",
                      "name": "uniquename",
                      "format": "",
                      "description": "Uniquename (UUID) of the feature we are editing",
@@ -3228,7 +3228,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "951c1a7d-3342-43d3-9d5d-376de550cf20",
+                     "jsondocId": "842eb178-d318-450e-8abc-dd975b71b12b",
                      "name": "name",
                      "format": "",
                      "description": "Updated feature name",
@@ -3237,7 +3237,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "82b5f3e7-a534-4f40-be44-901e4035ee50",
+                     "jsondocId": "c4d60715-7c1b-4d9e-964a-51e72cda49b1",
                      "name": "symbol",
                      "format": "",
                      "description": "Updated feature symbol",
@@ -3246,7 +3246,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "056f9caf-2e9e-469f-baa7-faf47556798f",
+                     "jsondocId": "7db843d1-905d-4ef2-b773-8340e32648c2",
                      "name": "description",
                      "format": "",
                      "description": "Updated feature description",
@@ -3258,9 +3258,9 @@
                "verb": "POST",
                "description": "Update shallow feature properties",
                "methodName": "updateFeature",
-               "jsondocId": "0898d1e9-f7be-4fba-89b1-7e4148ccc2af",
+               "jsondocId": "20cf5728-0a3c-419c-b988-1a3936c89bad",
                "bodyobject": {
-                  "jsondocId": "e7b7c0cc-50c2-4b37-9274-358c6306a6ce",
+                  "jsondocId": "c87d3611-5d65-4f39-b798-8e9c9035b24b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3270,7 +3270,7 @@
                "apierrors": [],
                "path": "/annotator/updateFeature",
                "response": {
-                  "jsondocId": "37691af0-fb33-4262-b1d4-c83c24f59ef4",
+                  "jsondocId": "43d57257-0057-4d8f-90c7-4f0e47daf567",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3283,7 +3283,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2dbadae3-d765-4fb5-82cf-02c7c255349e",
+                     "jsondocId": "8217ee1d-0d99-44d4-be5c-6a496d207b88",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3292,7 +3292,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fdf0cdd0-a803-4d20-97b2-c905dcdc2949",
+                     "jsondocId": "154c98de-4354-453e-856e-acc481776c18",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3301,7 +3301,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e9f9104-6cf0-4fb5-bbaf-f9c912d022c8",
+                     "jsondocId": "687d7e94-7e0a-43e5-a4c9-0d4d1c40a11a",
                      "name": "uniquename",
                      "format": "",
                      "description": "Uniquename (UUID) of the exon we are editing",
@@ -3310,7 +3310,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cf8229d1-90e3-4b00-8fd1-ad352216311e",
+                     "jsondocId": "ac35f337-35b3-4bac-98e9-745cc0b3df9c",
                      "name": "fmin",
                      "format": "",
                      "description": "fmin for Exon Location",
@@ -3319,7 +3319,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b76deec2-0565-4fca-944b-7a6c129efe5d",
+                     "jsondocId": "be49030d-ce58-44aa-9cbb-cbfc26510055",
                      "name": "fmax",
                      "format": "",
                      "description": "fmax for Exon Location",
@@ -3328,7 +3328,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2048cd90-72a6-4074-b62e-ea8a5a84792b",
+                     "jsondocId": "2be0d692-1dbb-4160-becd-71d1c3c5ef7b",
                      "name": "strand",
                      "format": "",
                      "description": "strand for Feature Location 1 or -1",
@@ -3340,9 +3340,9 @@
                "verb": "POST",
                "description": "Update exon boundaries",
                "methodName": "setExonBoundaries",
-               "jsondocId": "f0efbbe5-eac1-4f56-9231-81d2db01e164",
+               "jsondocId": "82b10993-97e5-45b8-abca-ef1278c169df",
                "bodyobject": {
-                  "jsondocId": "6ca08a6b-b859-49d5-be26-33e08e89b2c6",
+                  "jsondocId": "d7e9325f-5c0c-4778-a3b3-7052e4339709",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3352,7 +3352,7 @@
                "apierrors": [],
                "path": "/annotator/setExonBoundaries",
                "response": {
-                  "jsondocId": "6596a3e9-ae50-476b-b2aa-14b40991fb6e",
+                  "jsondocId": "7bd4fe67-5cc8-4e6e-a719-a1ec6fde97d6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3365,7 +3365,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f5a7fade-bb0c-4249-b2a7-28d5ee04f7a2",
+                     "jsondocId": "66bb5afd-7dab-4d24-93aa-6fdb410ad8b6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3374,7 +3374,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d823c29b-ca90-41b5-a58f-6afa82b5bcd7",
+                     "jsondocId": "7d2ef5e2-f863-48b3-a6f9-06ecca57bc22",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3383,7 +3383,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "851aeefd-7ff4-4192-a27f-4cb6fdadf1e6",
+                     "jsondocId": "656388bb-b787-471d-b4ee-e43fd815e5a8",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -3392,7 +3392,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d50178ce-5532-4b87-b0fa-9f9f23a87382",
+                     "jsondocId": "04d5200d-13a2-489b-8baf-fd5fd070d108",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -3404,9 +3404,9 @@
                "verb": "POST",
                "description": "Get annotators report for group",
                "methodName": "getAnnotatorsReportForGroup",
-               "jsondocId": "59356dc6-79e2-438e-b45a-346ec260042d",
+               "jsondocId": "6ce8912b-562f-4a66-a44f-fecb71e60249",
                "bodyobject": {
-                  "jsondocId": "1b973efd-d0d1-4b24-b034-2f08daccd6ea",
+                  "jsondocId": "58249a7c-3525-4a1a-8a86-2f800f66f943",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3416,7 +3416,7 @@
                "apierrors": [],
                "path": "/group/getAnnotatorsReportForGroup",
                "response": {
-                  "jsondocId": "bb1fa94d-7f3e-4227-9549-f9e79c9672c6",
+                  "jsondocId": "e9bb3404-6330-4568-afc4-b474381d519b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3429,14 +3429,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "c3d559f6-612f-4155-a694-dd8602868154",
+         "jsondocId": "2651ea80-9ea2-4811-a662-2a17095dc4a9",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8b553756-e87d-43a0-b900-43ac89df2665",
+                     "jsondocId": "82f28e80-d97c-4573-a6d6-3fc543ad2b43",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3445,7 +3445,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8eb8f704-d135-4e9c-a036-290072341418",
+                     "jsondocId": "56299cb8-1043-478e-ac54-d9f04b0269a3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3454,7 +3454,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "42b472a5-37f6-4af4-a603-10e7910dc033",
+                     "jsondocId": "96e0d464-8acb-48f8-ad73-2cbab1b8cf40",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to update (or specify the old_value)",
@@ -3463,7 +3463,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b20d6898-90d2-4d9f-aa1d-49bdda502b99",
+                     "jsondocId": "8a673a3d-b6e5-410e-8be6-11ef5b6fef5a",
                      "name": "old_value",
                      "format": "",
                      "description": "Status name to update",
@@ -3472,7 +3472,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2fa2a36b-77b3-4a0a-9d92-6773d41ddebf",
+                     "jsondocId": "3df83dce-77d2-4f5b-8179-b03f45988e3c",
                      "name": "new_value",
                      "format": "",
                      "description": "Status name to change to (the only editable option)",
@@ -3484,9 +3484,9 @@
                "verb": "POST",
                "description": "Update status",
                "methodName": "updateStatus",
-               "jsondocId": "6d5abd6c-3a9f-4b3a-a87c-ae41964bc44e",
+               "jsondocId": "e99e24a8-7206-4400-8317-c499012d4211",
                "bodyobject": {
-                  "jsondocId": "bb8c0135-4f34-442a-9290-238e6b64d63f",
+                  "jsondocId": "baec0479-13c3-47e2-a143-f89e1d76d69a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3496,7 +3496,7 @@
                "apierrors": [],
                "path": "/availableStatus/updateStatus",
                "response": {
-                  "jsondocId": "940942b8-f2db-4a81-a401-363c0bb4c173",
+                  "jsondocId": "45a81b3d-f546-4e2d-976d-eb5492c74428",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3509,7 +3509,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1cc4a28f-484f-423d-b0bd-240710caf206",
+                     "jsondocId": "75e06df3-8cbe-461b-b2ff-37beb5365fd4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3518,7 +3518,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "650c456f-6bcb-428d-847d-b6d43ef180d7",
+                     "jsondocId": "8b9a9a0a-aeef-43ed-abfe-3e02a3536fbd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3527,7 +3527,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4294c971-c6e1-473e-abab-aeb347a5c7c3",
+                     "jsondocId": "4c874381-37ca-4e77-a947-6189b5cdaa22",
                      "name": "value",
                      "format": "",
                      "description": "Status name to add",
@@ -3539,9 +3539,9 @@
                "verb": "POST",
                "description": "Create status",
                "methodName": "createStatus",
-               "jsondocId": "e6022848-f233-424b-bf8c-e3c7892dc860",
+               "jsondocId": "b2e2e23a-bc12-4588-9e22-53bdd49a533c",
                "bodyobject": {
-                  "jsondocId": "89b9db57-007b-40b2-831d-0746795ef3a7",
+                  "jsondocId": "0e1cfb13-b721-4ec5-bd55-51f08465a57c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3551,7 +3551,7 @@
                "apierrors": [],
                "path": "/availableStatus/createStatus",
                "response": {
-                  "jsondocId": "38c0ec59-bdd8-49d1-87ab-9b5ab2892049",
+                  "jsondocId": "ec760c1a-2e83-40bc-a84c-432f995f6eb4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3564,7 +3564,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "22035437-7727-4801-a1fc-8e66dfafa2cf",
+                     "jsondocId": "14b39b27-cbe8-42fc-90ae-6a0cfa9b7bc6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3573,7 +3573,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "60c37008-074e-4d49-a398-9a75b2916e26",
+                     "jsondocId": "b0d15730-956b-4a89-9b8e-1c2ec4ed96d2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3582,7 +3582,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9d24cc28-ddec-4cd4-9491-d99cd4d22af9",
+                     "jsondocId": "1c77fa63-f835-4b22-8ee3-9f9f9e65fd2b",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to remove (or specify the name)",
@@ -3591,7 +3591,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7165271b-6d6f-4a8d-93fb-921be939e1b9",
+                     "jsondocId": "47f49270-12cf-4ced-9f07-810fdad8e7ff",
                      "name": "value",
                      "format": "",
                      "description": "Status name to delete",
@@ -3603,9 +3603,9 @@
                "verb": "POST",
                "description": "Remove a status",
                "methodName": "deleteStatus",
-               "jsondocId": "874b22f0-2ab4-43fe-a101-8379679c81e5",
+               "jsondocId": "fcf5d737-ebc9-4787-bb4a-617aed206798",
                "bodyobject": {
-                  "jsondocId": "8e0d93de-07ec-4731-a543-ea4853cc5208",
+                  "jsondocId": "e9ceb01a-2819-4113-90bf-461d0c2d8764",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3615,7 +3615,7 @@
                "apierrors": [],
                "path": "/availableStatus/deleteStatus",
                "response": {
-                  "jsondocId": "819c7295-815e-4ec0-b5e7-c3581f08e80c",
+                  "jsondocId": "e3180620-e44d-40bd-a268-c5c3ecdd485e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3628,7 +3628,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f78ba9d1-8aec-4ac2-8aa4-e1201a7555aa",
+                     "jsondocId": "de5c6246-87c5-4499-862a-93c9f3d33ec5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3637,7 +3637,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "32a7c9a8-93cd-4ab8-9214-e9f19d04cfba",
+                     "jsondocId": "16c6a372-54dd-4d89-be40-88b027e0fd5d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3646,7 +3646,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c36b9d40-16ee-4ccf-a56f-7f1d27f8a333",
+                     "jsondocId": "d5e0da38-020a-461d-940b-6b645a071f18",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to show (or specify a name)",
@@ -3655,7 +3655,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d44dbc8f-12e1-44e1-8101-5139e48bb17a",
+                     "jsondocId": "fdbaa148-38d9-465d-b947-98cc1d044060",
                      "name": "name",
                      "format": "",
                      "description": "Status name to show",
@@ -3667,9 +3667,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all statuses, or optionally, gets information about a specific status",
                "methodName": "showStatus",
-               "jsondocId": "8e4bf58b-f5f0-4d58-aa05-9da3fefd805a",
+               "jsondocId": "c9566ea3-7df2-4b16-9606-c254290816ba",
                "bodyobject": {
-                  "jsondocId": "bbe34f37-5794-4fab-a332-3b38bc08249a",
+                  "jsondocId": "31a644bd-dcbc-44bf-b2d1-5af745489c49",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3679,7 +3679,7 @@
                "apierrors": [],
                "path": "/availableStatus/showStatus",
                "response": {
-                  "jsondocId": "66cc5d6d-b33e-40be-9a80-ac8eeca66e78",
+                  "jsondocId": "18832bff-4f30-45d2-9fbf-8775ce6ddd26",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3692,14 +3692,14 @@
          "description": "Methods for managing available statuses"
       },
       {
-         "jsondocId": "c0c442eb-9817-48e3-a6c4-00acd878ba16",
+         "jsondocId": "21fb993b-8441-4cda-88f3-eb807c56a0e4",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "838375fb-1b03-4971-9ad3-6a75440fbc9a",
+                     "jsondocId": "32dc3a9c-d1f6-4901-a83c-4a13b7913a35",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3708,7 +3708,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f531bf58-978d-4e04-b284-b264df3aaa89",
+                     "jsondocId": "7d56bb69-4eda-4513-b0be-4216f5a977d0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3717,7 +3717,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0b5bea9d-8e85-45e6-ad92-e08aa71ed4ab",
+                     "jsondocId": "d7e24e28-6710-4e2e-8337-7a09d8d86212",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to add",
@@ -3726,7 +3726,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "947f41fa-3333-4600-a9ae-767852a0f09a",
+                     "jsondocId": "145243b2-8888-460d-b0fd-b809f6f3f05c",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3738,9 +3738,9 @@
                "verb": "POST",
                "description": "Create canned comment",
                "methodName": "createComment",
-               "jsondocId": "1c76547b-f83f-41c7-a5b5-ba182ff63167",
+               "jsondocId": "ddf3c418-763f-4536-a7eb-cb0287264ea9",
                "bodyobject": {
-                  "jsondocId": "22bb6a48-5850-4d14-9490-ddc533d61c8f",
+                  "jsondocId": "9ab901d3-29e5-45ee-b648-01f706b89d39",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3750,7 +3750,7 @@
                "apierrors": [],
                "path": "/cannedComment/createComment",
                "response": {
-                  "jsondocId": "ea96aca3-0fde-4a9e-8ecd-2c4cd0bd4504",
+                  "jsondocId": "400ec9d6-da14-488b-a1a8-f5a5b6c6cd14",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3763,7 +3763,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b5f2c463-634d-4097-b333-405bc30f4941",
+                     "jsondocId": "c7358b12-fe03-446a-8a39-d04d963f54c1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3772,7 +3772,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c0c0bbbb-ca22-4ff2-aa8b-ee0e05b12d42",
+                     "jsondocId": "dbff2120-f47e-455d-8c33-eb8a7d68cc2f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3781,7 +3781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6bddc04b-8ce2-4442-8752-9b4da352f7d9",
+                     "jsondocId": "eed9242d-605f-4f8f-9e6f-9d3b76fd2074",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to update (or specify the old_comment)",
@@ -3790,7 +3790,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3ecd848c-2951-4eb0-aba6-5a5b4ed73f60",
+                     "jsondocId": "19448512-6813-4266-a417-5b087857ba6a",
                      "name": "old_comment",
                      "format": "",
                      "description": "Canned comment to update",
@@ -3799,7 +3799,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a223db9b-55f7-4975-9c86-7e7f0f328049",
+                     "jsondocId": "ebde6bd2-aad8-4fef-a5fe-a25d3b74fa7c",
                      "name": "new_comment",
                      "format": "",
                      "description": "Canned comment to change to (the only editable option)",
@@ -3808,7 +3808,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5eca73b8-1686-45b7-a4a5-cf28e8e477b6",
+                     "jsondocId": "9bea5bd6-6928-4d32-a164-d519c3af2e75",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3820,9 +3820,9 @@
                "verb": "POST",
                "description": "Update canned comment",
                "methodName": "updateComment",
-               "jsondocId": "66d4810c-139f-4933-be7b-d106746da87b",
+               "jsondocId": "796e0e8e-5245-41a7-abca-9a970eb0987d",
                "bodyobject": {
-                  "jsondocId": "bc6a88e8-b3c6-43f9-9f63-ac2cc9f328b4",
+                  "jsondocId": "7787328f-da0a-420d-8f8f-4854a0478ce6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3832,7 +3832,7 @@
                "apierrors": [],
                "path": "/cannedComment/updateComment",
                "response": {
-                  "jsondocId": "3881193a-708d-45cf-967d-3ff983c58f3c",
+                  "jsondocId": "2d8a3869-b03b-4166-ab2f-790f0ea5c126",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3845,7 +3845,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3b74b402-e58c-4ef5-97d0-f1b24ed2120e",
+                     "jsondocId": "1aa8739d-132a-4930-81b8-0f4f63b69b7a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3854,7 +3854,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "51275ace-9c88-416f-8ad6-335b44ab3880",
+                     "jsondocId": "c4fd0537-4098-4d1a-b91e-9c504f930baa",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3863,7 +3863,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fa73f7c7-9456-4297-93b6-2790974612b9",
+                     "jsondocId": "94df4049-4b55-45f5-af6f-2702c8aef0eb",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to remove (or specify the name)",
@@ -3872,7 +3872,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ecbe9e1c-8ea4-456a-931f-947f6e959635",
+                     "jsondocId": "975a01e9-dccb-448e-a21a-4befffd15cac",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to delete",
@@ -3884,9 +3884,9 @@
                "verb": "POST",
                "description": "Remove a canned comment",
                "methodName": "deleteComment",
-               "jsondocId": "a2f8697c-e9f8-46d7-a172-a690e28b969a",
+               "jsondocId": "8f708c19-52d7-43b2-8c75-6d59fcbd1ac7",
                "bodyobject": {
-                  "jsondocId": "259da01f-6060-424f-98ae-067f00dd7f80",
+                  "jsondocId": "019739f4-4e2a-45e0-9409-bf27a1dbf69c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3896,7 +3896,7 @@
                "apierrors": [],
                "path": "/cannedComment/deleteComment",
                "response": {
-                  "jsondocId": "2eadc64a-5ca6-460f-906d-ca09f0eed31d",
+                  "jsondocId": "4185aaf7-0edf-4390-a61a-9c23d2e1382e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3909,7 +3909,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6da6b277-9b4f-44c4-bda0-75f3562769ee",
+                     "jsondocId": "fc9bc197-34ca-4b2e-bd91-6fd8dcbccf62",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3918,7 +3918,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "346da80b-be18-43ce-a505-1e3462734e1e",
+                     "jsondocId": "6b31f947-3f1b-4b78-b382-940dfed93980",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3927,7 +3927,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "01188de2-e221-45a8-b982-014d78d33eed",
+                     "jsondocId": "672c1476-7ca0-4c2c-be45-3390fd2676de",
                      "name": "id",
                      "format": "",
                      "description": "Comment ID to show (or specify a comment)",
@@ -3936,7 +3936,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b53ae16f-2182-4aab-af8e-39ae6f5ca3f9",
+                     "jsondocId": "9e567af2-90e2-4fde-a879-2fcae26d64d6",
                      "name": "comment",
                      "format": "",
                      "description": "Comment to show",
@@ -3948,9 +3948,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned comments, or optionally, gets information about a specific canned comment",
                "methodName": "showComment",
-               "jsondocId": "2c24b1ee-0bc0-4fec-b611-73f4d107c767",
+               "jsondocId": "bdd0ee15-58ec-4c00-a034-358c2a60110f",
                "bodyobject": {
-                  "jsondocId": "ea65458b-1f9a-4951-8dfe-0f717396b7ce",
+                  "jsondocId": "d3f21a2e-e3a8-4b57-9e80-b72e1dca121d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3960,7 +3960,7 @@
                "apierrors": [],
                "path": "/cannedComment/showComment",
                "response": {
-                  "jsondocId": "191f5645-950f-4dd1-9bb4-d6e906f24c58",
+                  "jsondocId": "6c4f5743-caae-47c4-b849-037fedf04ee7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3973,14 +3973,14 @@
          "description": "Methods for managing canned comments"
       },
       {
-         "jsondocId": "dd3f81ef-7521-41b4-a107-5d4997d68aae",
+         "jsondocId": "41a5c328-8e59-4cd6-8a28-5b9803a830dc",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "79b53a39-0267-42a6-a32b-8b8eedb36823",
+                     "jsondocId": "79a8417b-d0c2-4867-b70f-e296c3f0ef80",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3989,7 +3989,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1921eb2-9554-47ff-83d1-9478795a95bc",
+                     "jsondocId": "bdf3a0b4-abf5-40b2-9945-6816c4f778b0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3998,7 +3998,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c0642975-72a5-4d22-9ae2-d8be90fa02c5",
+                     "jsondocId": "8412cf7c-01d0-4833-acf2-927a68bc19ba",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to update (or specify the old_key)",
@@ -4007,7 +4007,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8018c1ee-487e-4f9c-ac9a-23cff59096ed",
+                     "jsondocId": "376ee48d-1b19-4af7-ac49-7f237730c21c",
                      "name": "old_key",
                      "format": "",
                      "description": "Canned key to update",
@@ -4016,7 +4016,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e473c8bd-c758-40f4-85c2-8c56392e9a69",
+                     "jsondocId": "e18e63da-7a8e-401b-bbb2-e33c6abdbb83",
                      "name": "new_key",
                      "format": "",
                      "description": "Canned key to change to (the only editable option)",
@@ -4025,7 +4025,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5055fbd0-0519-42c8-9cde-88e38bd6df3e",
+                     "jsondocId": "a39cba40-306c-497f-94ff-006af705c907",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4037,9 +4037,9 @@
                "verb": "POST",
                "description": "Update canned key",
                "methodName": "updateKey",
-               "jsondocId": "bda609c3-ca89-4fe3-a62d-a47a66ece5d1",
+               "jsondocId": "27efbe6d-4f4c-4746-9379-f1304d29eaf6",
                "bodyobject": {
-                  "jsondocId": "16e8717d-e3b1-4f19-ae4f-5c3cf44a829d",
+                  "jsondocId": "72bd4f83-a0e1-45df-9745-b26271df9fc9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4049,7 +4049,7 @@
                "apierrors": [],
                "path": "/cannedKey/updateKey",
                "response": {
-                  "jsondocId": "cdd218e5-7c52-4891-9e5a-fda3b197bbe4",
+                  "jsondocId": "30882e60-bb0f-49c5-8697-95e257db19a8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4062,7 +4062,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "25b7955e-da31-4055-b347-223b49da9345",
+                     "jsondocId": "e1026ceb-0f0a-4cea-97d3-47ec83a3303a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4071,7 +4071,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97aad909-5e6e-422d-a91e-919169a9fd39",
+                     "jsondocId": "1895294a-7429-465d-9c72-2589ab74ad3a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4080,135 +4080,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f2fa15f4-c5e6-4fef-be09-fd1cfb18b815",
-                     "name": "key",
-                     "format": "",
-                     "description": "Canned key to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "eabaeeb8-73df-4417-8ae4-30dfc1b3acf8",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "Optional additional information",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create canned key",
-               "methodName": "createKey",
-               "jsondocId": "d5426b47-4c5e-4778-ae45-3b00b243ebd9",
-               "bodyobject": {
-                  "jsondocId": "2a53f2fb-64e8-48e0-b463-626dc5489521",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned key"
-               },
-               "apierrors": [],
-               "path": "/cannedKey/createKey",
-               "response": {
-                  "jsondocId": "a57877af-f884-471c-a847-85ac98ba9564",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned key"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "8c784e04-c92d-4c0d-be39-618965a7cdff",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c582d384-29ec-47c9-8ec7-86af68d2418d",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e4efc8a5-4848-47f8-b7da-74b5163a4216",
-                     "name": "id",
-                     "format": "",
-                     "description": "Canned key ID to remove (or specify the name)",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c6277bf4-7aae-4cdb-a9b6-c2810b7499c5",
-                     "name": "key",
-                     "format": "",
-                     "description": "Canned key to delete",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Remove a canned key",
-               "methodName": "deleteKey",
-               "jsondocId": "b3fa2c04-59ce-4bcc-8dd8-69ff309f86d1",
-               "bodyobject": {
-                  "jsondocId": "264505a0-707d-49bd-924c-67419d54df85",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned key"
-               },
-               "apierrors": [],
-               "path": "/cannedKey/deleteKey",
-               "response": {
-                  "jsondocId": "c3b65793-e626-4cd3-95c6-b45d6ada7049",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned key"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "3452e810-085b-475c-bd68-ae03a34fe024",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7ff3b7e0-10f1-4faa-81cf-5fc200bbedf9",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "043c9568-5622-4958-bb9b-d67491e5ca6d",
+                     "jsondocId": "ac62412c-fe14-465e-8951-d5f7bd828720",
                      "name": "id",
                      "format": "",
                      "description": "Key ID to show (or specify a key)",
@@ -4217,7 +4089,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a94c2acd-f0d4-413d-a319-252867e383b2",
+                     "jsondocId": "3c883e7b-717d-4d7a-b437-33968733786c",
                      "name": "key",
                      "format": "",
                      "description": "Key to show",
@@ -4229,9 +4101,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned keys, or optionally, gets information about a specific canned key",
                "methodName": "showKey",
-               "jsondocId": "dbd5fc14-0a36-4504-a88e-fc1f78ae8857",
+               "jsondocId": "419aa3aa-3136-4ceb-a302-a9a9707f77a6",
                "bodyobject": {
-                  "jsondocId": "efeb8ae7-7771-4df0-b590-6f1bd97990d4",
+                  "jsondocId": "8e3635d8-24ee-401a-be4a-c13610f925b6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4241,7 +4113,135 @@
                "apierrors": [],
                "path": "/cannedKey/showKey",
                "response": {
-                  "jsondocId": "62298f69-a887-47a1-853c-1a2c6e79f241",
+                  "jsondocId": "5b8bd3b6-f5a4-479b-90e7-1221c36436ff",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned key"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "214692fa-f5a6-41d5-a3c9-f91906140d30",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0ae963c5-9a07-4d7a-b918-0f37f27a02dc",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b7b35d3e-7e6b-425f-a61a-331fc6354adf",
+                     "name": "key",
+                     "format": "",
+                     "description": "Canned key to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e619e7a4-1807-4b68-bd24-f40142ec584c",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create canned key",
+               "methodName": "createKey",
+               "jsondocId": "26cda4b7-380b-43e8-a38b-49ed6696a76e",
+               "bodyobject": {
+                  "jsondocId": "33a5082e-edb1-44c2-a65a-11e4b3d37bbc",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned key"
+               },
+               "apierrors": [],
+               "path": "/cannedKey/createKey",
+               "response": {
+                  "jsondocId": "eb72ef47-1921-401a-9bf4-67f1be12ff05",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned key"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "7f563e8a-b4b1-4237-ba8f-5ab8065988fb",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2c2d4d2f-43a6-4003-b705-43ee88a5a342",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2f328bb1-c70f-4c47-9f58-7c41eef69c8a",
+                     "name": "id",
+                     "format": "",
+                     "description": "Canned key ID to remove (or specify the name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "175a2587-9e24-42e9-ab42-e7978d720960",
+                     "name": "key",
+                     "format": "",
+                     "description": "Canned key to delete",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Remove a canned key",
+               "methodName": "deleteKey",
+               "jsondocId": "d52205f9-30cc-4367-874c-99f0c5ca752c",
+               "bodyobject": {
+                  "jsondocId": "f53b74fe-67ed-4d66-856e-8404b076ff0f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned key"
+               },
+               "apierrors": [],
+               "path": "/cannedKey/deleteKey",
+               "response": {
+                  "jsondocId": "21a38c63-b973-4356-9b88-4a88b9c88de6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4254,14 +4254,14 @@
          "description": "Methods for managing canned keys"
       },
       {
-         "jsondocId": "b6b4097f-0ea4-4de7-b08d-475fe4a8d5b7",
+         "jsondocId": "2dbc43ee-735c-4044-991c-0088531134d5",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "19bb6c26-c6ce-40ae-9116-6586df2cdb13",
+                     "jsondocId": "6a7f9165-391c-48ff-aed4-d36556d409e2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4270,7 +4270,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1e4e1bda-235a-4b21-9cb2-36d587fff8bd",
+                     "jsondocId": "501dc1a0-2846-4299-acac-6508f267a91e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4279,71 +4279,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6751e54f-5003-49de-85d8-2714debdd73c",
-                     "name": "value",
-                     "format": "",
-                     "description": "Canned value to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a9644349-d4da-4a38-9bde-7426cd8d1b39",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "Optional additional information",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create canned value",
-               "methodName": "createValue",
-               "jsondocId": "b37776a6-35dc-4295-9238-9e628ae257ab",
-               "bodyobject": {
-                  "jsondocId": "fbebd57f-59fa-40f9-ae9c-a2b29d566efb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned value"
-               },
-               "apierrors": [],
-               "path": "/cannedValue/createValue",
-               "response": {
-                  "jsondocId": "42f7d2d2-f507-4e5a-b2f9-aecabeef5600",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned value"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "3ace9ae3-c574-4d9c-aa65-da3e5a2f8a1e",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9f895852-dd00-4ab6-b6ff-51c054783ab6",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "34213096-9ed7-4c36-986c-acb3969f4732",
+                     "jsondocId": "f82fd600-f89e-4726-b4e6-d8776cd913c1",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to update (or specify the old_value)",
@@ -4352,7 +4288,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "886c7f25-2b3d-4d7c-97fe-7106c62b0db6",
+                     "jsondocId": "cb00f74a-6243-4bed-a585-023ba889b602",
                      "name": "old_value",
                      "format": "",
                      "description": "Canned value to update",
@@ -4361,7 +4297,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1ee1202a-4bb7-4f2c-aa81-95d654934a2b",
+                     "jsondocId": "ee57c289-4b49-4738-ab0c-afceb92fee69",
                      "name": "new_value",
                      "format": "",
                      "description": "Canned value to change to (the only editable option)",
@@ -4370,7 +4306,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f6fd2160-f431-4d68-8164-3b5a3a486da9",
+                     "jsondocId": "e306e75d-3211-4c7b-a215-b854a671e1fd",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4382,9 +4318,9 @@
                "verb": "POST",
                "description": "Update canned value",
                "methodName": "updateValue",
-               "jsondocId": "6b4bd69b-be9c-4823-b7dd-8614fbc2069f",
+               "jsondocId": "b9ee9445-f537-4c73-bde0-95a361c0fea9",
                "bodyobject": {
-                  "jsondocId": "590a00a9-599c-4380-a3bf-4fb3ceb9a2a7",
+                  "jsondocId": "850245bd-4be2-4202-98e7-16166b42a17d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4394,7 +4330,7 @@
                "apierrors": [],
                "path": "/cannedValue/updateValue",
                "response": {
-                  "jsondocId": "ab973175-864a-4069-9a82-0bfdfbd2c78b",
+                  "jsondocId": "a1186ef8-3ee5-413f-9386-60fc729429ed",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4407,7 +4343,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e4c04d25-7c8f-41a4-90af-143262023df8",
+                     "jsondocId": "08a4ab46-44e0-48df-8843-f54e484675df",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4416,7 +4352,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d3934e7-883c-43a1-8164-2d0f82bf4dbe",
+                     "jsondocId": "d8ae4338-ca29-494b-a392-1748bc75b8f6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4425,7 +4361,71 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "53d7a3b9-28b4-44b0-981d-2923bf2ec147",
+                     "jsondocId": "c3c1de15-38b4-4f31-9637-3d34d9b2c8cf",
+                     "name": "value",
+                     "format": "",
+                     "description": "Canned value to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8f21741f-4f0d-404e-9db2-b67b5daa0aee",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create canned value",
+               "methodName": "createValue",
+               "jsondocId": "d14b79b7-8431-452b-8feb-98ce93d0347e",
+               "bodyobject": {
+                  "jsondocId": "54e4ab14-4337-495e-9a66-5b559866a472",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned value"
+               },
+               "apierrors": [],
+               "path": "/cannedValue/createValue",
+               "response": {
+                  "jsondocId": "497b37e3-346c-45ed-a002-f945f86ba6ca",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned value"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "cf424a16-3fe1-4316-9539-8e6c341068e7",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ce8faf48-c12a-46ea-89d7-0354a111ab8b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0597eeda-c1c2-4c33-8842-3e493735d9a8",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to remove (or specify the name)",
@@ -4434,7 +4434,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "64d056df-b7a8-4dcc-adb9-1ae95e41dd66",
+                     "jsondocId": "d8d5076f-8a9d-4fc0-9ef1-b225fc93edfb",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to delete",
@@ -4446,9 +4446,9 @@
                "verb": "POST",
                "description": "Remove a canned value",
                "methodName": "deleteValue",
-               "jsondocId": "ec8a1bb7-88f5-4755-871c-9e7844612448",
+               "jsondocId": "47babec5-66c9-4f64-805a-9b93127f6317",
                "bodyobject": {
-                  "jsondocId": "c7aed8ad-22fb-4415-90fe-187e740ef1a1",
+                  "jsondocId": "fe2b6e1b-ff31-4554-8658-a4fc72f7f161",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4458,7 +4458,7 @@
                "apierrors": [],
                "path": "/cannedValue/deleteValue",
                "response": {
-                  "jsondocId": "b25c92be-05a4-4e17-8e6f-2890efa0bc3c",
+                  "jsondocId": "97530dd7-f493-4e45-a0a3-a7275a7a85f2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4471,7 +4471,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8df53935-6506-4ff9-bbfc-b713f1d3e049",
+                     "jsondocId": "d95ba3ca-e0bc-4cb2-bd92-f9f5177b0a39",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4480,7 +4480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f148226a-834c-4a2e-a551-2ed0eea2c3a2",
+                     "jsondocId": "840e47ed-a89b-496d-92c9-320228c18f85",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4489,7 +4489,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "27a93cdd-d3af-443e-8c49-0723fde3480d",
+                     "jsondocId": "1ded2ac4-500b-4757-b1ff-2c5a29fa75c3",
                      "name": "id",
                      "format": "",
                      "description": "Value ID to show (or specify a value)",
@@ -4498,7 +4498,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8bc4cf85-7d09-4c4a-a651-372d8e891bd3",
+                     "jsondocId": "7544aada-c9d5-47cb-aa84-e97a5f72d7bf",
                      "name": "value",
                      "format": "",
                      "description": "Value to show",
@@ -4510,9 +4510,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned values, or optionally, gets information about a specific canned value",
                "methodName": "showValue",
-               "jsondocId": "14047275-2988-4c26-b3dd-06ea6750de59",
+               "jsondocId": "8f5c364a-f992-4eea-91ce-f70e7f3260a9",
                "bodyobject": {
-                  "jsondocId": "bdc4d3ce-c2ae-459d-9e3f-7cda83c06785",
+                  "jsondocId": "bc703358-3795-430f-8681-9c32f96f53f5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4522,7 +4522,7 @@
                "apierrors": [],
                "path": "/cannedValue/showValue",
                "response": {
-                  "jsondocId": "d1ed0c30-a98b-4b3d-81e3-6f6ee0738298",
+                  "jsondocId": "fce52275-378b-443b-9831-e71a32827950",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4535,14 +4535,14 @@
          "description": "Methods for managing canned values"
       },
       {
-         "jsondocId": "c23b093b-f13a-4019-8181-064b49f99950",
+         "jsondocId": "af7556f9-8d4e-4c9e-9e3d-0c6cf625b24c",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e4d498da-11ca-4010-90b5-4a228e5809a6",
+                     "jsondocId": "e13c5db4-4764-47d4-be25-340267c2983c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4551,7 +4551,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f0efe8fc-906f-4798-a9cd-9ae87d402717",
+                     "jsondocId": "d53089c1-691b-4840-8ff9-f0c00d471c0c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4560,610 +4560,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "30191c10-1e93-42b6-ba67-09755221406a",
-                     "name": "id",
-                     "format": "",
-                     "description": "Group ID (or specify the name)",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9ed10bb8-78fc-4f1c-bf19-273b8b8258c2",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get organism permissions for group",
-               "methodName": "getOrganismPermissionsForGroup",
-               "jsondocId": "5774a4a0-2d22-48f4-b029-66d8d395f1a7",
-               "bodyobject": {
-                  "jsondocId": "3f7bedf4-040c-41d5-bf00-e7413c4a52d7",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/getOrganismPermissionsForGroup",
-               "response": {
-                  "jsondocId": "b8072e56-2bfd-489f-94c3-bebac547eeb7",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "9d989f8d-9faf-4b1d-aec5-bb7ca909ca3d",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cbac8a74-7955-406c-a1bc-b6c0ad076a92",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c248f605-5f45-49d8-89e0-d7c8bfdd4621",
-                     "name": "groupId",
-                     "format": "",
-                     "description": "Optional only load a specific groupId",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Load all groups",
-               "methodName": "loadGroups",
-               "jsondocId": "1a76fcea-a2b3-4cd2-852d-b49d09df7b42",
-               "bodyobject": {
-                  "jsondocId": "7eaded0a-38ac-4ae4-a8b6-8d496ca274b0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/loadGroups",
-               "response": {
-                  "jsondocId": "6f909910-01d7-4568-b9c5-6e9c275ddfc4",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "98957980-b409-4d13-931b-31741cecc88a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e8852c3e-b99c-4452-9c2e-ef7ae402d303",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "efacfab9-f792-45a1-838d-be3279f4eef5",
-                     "name": "id",
-                     "format": "",
-                     "description": "Group ID to remove (or specify the name)",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "97d98764-b637-49b2-9c1d-98f56e73159b",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name or comma-delimited list of names to remove",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete a group",
-               "methodName": "deleteGroup",
-               "jsondocId": "d2bcf7b7-3844-475b-bbb0-9b6da6be1aae",
-               "bodyobject": {
-                  "jsondocId": "6a6e7e66-3392-40de-849b-5167feab65c0",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/deleteGroup",
-               "response": {
-                  "jsondocId": "7283007f-d381-48df-92db-f6c85d1afd98",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "2ebd8f7f-db43-4a84-8734-600ab5f0ce3e",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "61117e6c-d09f-4d0c-ae86-13520b1bd562",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0b355f03-fd14-4c2e-a69f-150b5d1f5566",
-                     "name": "id",
-                     "format": "",
-                     "description": "Group ID to update",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e8e08527-e265-40f1-9d56-86d4875276b8",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name to change to (the only editable optoin)",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update group",
-               "methodName": "updateGroup",
-               "jsondocId": "e587b63b-2d52-4575-9646-ddaccd80011b",
-               "bodyobject": {
-                  "jsondocId": "e2c9b4d6-a1cf-4bf7-bdbe-578d5482596a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/updateGroup",
-               "response": {
-                  "jsondocId": "095b12ea-a4a0-4279-9d1c-7d8fb5ea8feb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "fa982e09-9b88-4b76-9e24-642f35c4557c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "76baa474-06ed-4250-b763-0e38f4b03e98",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bfd64fec-6da9-4121-9bda-df81e3bd1136",
-                     "name": "groupId",
-                     "format": "",
-                     "description": "Group ID to modify permissions for (must provide this or 'name')",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "92b0a4ad-c4bf-438d-a0f7-437502ab22a6",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name to modify permissions for (must provide this or 'groupId')",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "91173926-8632-4134-a6e5-79108f02e0d0",
-                     "name": "organism",
-                     "format": "",
-                     "description": "Organism common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c1cc89ce-18f3-4fd0-ad7d-cfe2473e37e8",
-                     "name": "ADMINISTRATE",
-                     "format": "",
-                     "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1ac16336-759f-45bb-a075-18ef9bc57711",
-                     "name": "WRITE",
-                     "format": "",
-                     "description": "Indicate if user has write and all lesser privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ffedbfde-a762-45b6-8680-50e668269300",
-                     "name": "EXPORT",
-                     "format": "",
-                     "description": "Indicate if user has export and all lesser privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2cf40177-aa5c-4d70-b0d0-72456440c3ee",
-                     "name": "READ",
-                     "format": "",
-                     "description": "Indicate if user has read and all lesser privileges for the organism",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update organism permission",
-               "methodName": "updateOrganismPermission",
-               "jsondocId": "eb9abf29-8502-42c4-be80-dce1b74ab99d",
-               "bodyobject": {
-                  "jsondocId": "103154ee-bcb8-4359-abdb-3929b2145600",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/updateOrganismPermission",
-               "response": {
-                  "jsondocId": "8e4bb2e8-43bf-4444-8472-4bdc4cdaedcc",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "0030f81e-fdf0-4e50-aaf1-66ae98f46180",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ec4bbc05-2514-4789-aa9c-dd793651340e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1ec15b0d-7c85-4e87-b912-172c80107558",
-                     "name": "groupId",
-                     "format": "",
-                     "description": "Group ID to alter membership of",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e6371606-7fd2-47bc-9e16-426f06943e8f",
-                     "name": "users",
-                     "format": "",
-                     "description": "A JSON array of strings of emails of users the now belong to the group",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "381a0b7a-a925-4e5d-a0f1-868662fa7f38",
-                     "name": "memberships",
-                     "format": "",
-                     "description": "Bulk memberships (instead of users and groupId) to update of the form: [ {groupId: <groupId>,users: [\"user1\", \"user2\", \"user3\"]}, {groupId:<another-groupId>, users: [\"user2\", \"user8\"]}]",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update group membership",
-               "methodName": "updateMembership",
-               "jsondocId": "83ca0009-4449-458a-87d6-7787bbd64154",
-               "bodyobject": {
-                  "jsondocId": "16d0a2e4-a20a-4940-bddb-919624e360da",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/updateMembership",
-               "response": {
-                  "jsondocId": "7722b9bd-49e6-4635-b173-ba584c6f013d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "a1bbb510-5577-4b7a-9ed6-ea941fc72396",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "622c259b-f813-4256-8c73-3a92a9b4b274",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "df7904ce-8829-43a3-a5a0-ed4ed4605420",
-                     "name": "groupId",
-                     "format": "",
-                     "description": "Group ID to alter membership of",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0a09c524-8f37-4937-a512-2d8d92cd27b9",
-                     "name": "users",
-                     "format": "",
-                     "description": "A JSON array of strings of emails of users the now belong to the group",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update group admin",
-               "methodName": "updateGroupAdmin",
-               "jsondocId": "c19628cd-1a52-4340-af84-2234d1c62f58",
-               "bodyobject": {
-                  "jsondocId": "2717b90e-226d-4526-840a-30d66693b59a",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/updateGroupAdmin",
-               "response": {
-                  "jsondocId": "74c06c63-923d-4ca0-b8c0-44cefad5a562",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "3d302d53-71f1-4811-b778-9133bd02b00a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e0701e3c-9606-4f2a-be79-a0eaec9eb553",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7efbe45d-8874-4bda-b99a-5fcdd506ce2b",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get group admins, returns group admins as JSONArray",
-               "methodName": "getGroupAdmin",
-               "jsondocId": "57e8adb4-a76d-4109-8510-f0e176f5809e",
-               "bodyobject": {
-                  "jsondocId": "941b5eda-34dc-4e99-8edf-ab3ef557b80d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/getGroupAdmin",
-               "response": {
-                  "jsondocId": "03eee0b9-c350-48f2-abfa-21d4135329f2",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "8bac777f-cf3c-4564-afca-507ab71c6dac",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a6b26769-8d6e-42a5-9396-765b2acd3dae",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1e18b552-7a98-4973-a137-5e28d47900de",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get creator metadata for group, returns userId as JSONObject",
-               "methodName": "getGroupCreator",
-               "jsondocId": "c433ff0a-1ea4-48a6-a5ff-e46987db4f97",
-               "bodyobject": {
-                  "jsondocId": "78ffdb99-03d6-4810-8bef-f52a7b9d15e9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/getGroupCreator",
-               "response": {
-                  "jsondocId": "f0228d60-9571-4ff4-986a-70273792768b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "925f41ee-1f98-43c3-8f89-4112431e046e",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "35a2a34e-ada3-4d12-b660-1bfd7e7e4dac",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "833c4890-52f8-41fa-a10e-4404d36d75c8",
+                     "jsondocId": "49a8bbad-8333-43e3-bb2e-2300d78f00f4",
                      "name": "name",
                      "format": "",
                      "description": "Group name to add, or a comma-delimited list of names",
@@ -5175,9 +4572,9 @@
                "verb": "POST",
                "description": "Create group",
                "methodName": "createGroup",
-               "jsondocId": "2b79020d-9c6c-4ef0-a889-87fb0a262f66",
+               "jsondocId": "f6a0dce2-ef6d-49a3-acaa-03864754d4b4",
                "bodyobject": {
-                  "jsondocId": "f7471067-590d-4d95-a416-798fdc939729",
+                  "jsondocId": "c8b296bb-f6a4-465c-b6b9-a9e92403fb30",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5187,7 +4584,610 @@
                "apierrors": [],
                "path": "/group/createGroup",
                "response": {
-                  "jsondocId": "95ef17c2-a1cc-49b2-ac83-4eed2c64e0ca",
+                  "jsondocId": "fb4b4ce8-9264-4c71-bca7-baea9a098677",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "1b0b9938-75de-4f41-a07c-9de9ad63507f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8eb295ef-4836-4af7-89fa-ea09e1d72007",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "2b05c2f7-7aa9-43bb-8ec8-80fa23d304dc",
+                     "name": "id",
+                     "format": "",
+                     "description": "Group ID (or specify the name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "21b27ba0-bffe-4b55-9902-6eb85f833635",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for group",
+               "methodName": "getOrganismPermissionsForGroup",
+               "jsondocId": "53cf25a0-5806-454d-bbfb-cf71874d20c3",
+               "bodyobject": {
+                  "jsondocId": "d8d117b7-31e4-45b0-b479-927eae1f50cb",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/getOrganismPermissionsForGroup",
+               "response": {
+                  "jsondocId": "fd943923-c81b-487b-ab78-4e376724d35f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "3fd509f0-3f0d-440d-bdcd-9ed325b30e47",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ec8d9d6a-c4ef-4a92-9dda-14729c27c7fd",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cdfe8f5f-cb54-4f44-a97a-4dc8983be816",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Optional only load a specific groupId",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Load all groups",
+               "methodName": "loadGroups",
+               "jsondocId": "80a2bebe-b04c-45f6-b0ea-42c565f7d8f3",
+               "bodyobject": {
+                  "jsondocId": "9229d95c-3050-4c43-b950-4fde8c69f3c9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/loadGroups",
+               "response": {
+                  "jsondocId": "fda527d9-74f7-4b6e-bb75-96554e15a83f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "dd64e296-d44b-457a-8547-9066f1e03aae",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b77b7a37-1f56-4355-af6c-7e70bf709aa6",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d4904cd2-abe3-4821-b319-048df0e183d5",
+                     "name": "id",
+                     "format": "",
+                     "description": "Group ID to remove (or specify the name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b225541b-fb5e-44b7-9b65-6517d55e9b6b",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name or comma-delimited list of names to remove",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete a group",
+               "methodName": "deleteGroup",
+               "jsondocId": "68486588-57d7-4991-95d5-e6b2ed6aff89",
+               "bodyobject": {
+                  "jsondocId": "d6bf6106-c071-4a2c-ae87-aa9d637e29bf",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/deleteGroup",
+               "response": {
+                  "jsondocId": "c0cca622-c59b-4265-b3db-e75aa7741f13",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "0fdd7d48-fb18-4136-8815-deecf698c7c9",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "27b763c3-881b-48c4-8c7b-1539755de7eb",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "21e3a4f0-aff0-4715-9634-4704561885f3",
+                     "name": "id",
+                     "format": "",
+                     "description": "Group ID to update",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5abe2488-44a9-49be-8474-96ef377c1d46",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to change to (the only editable optoin)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update group",
+               "methodName": "updateGroup",
+               "jsondocId": "6120bbd3-0cb8-4f0c-b249-6cb154785983",
+               "bodyobject": {
+                  "jsondocId": "355a10fb-ef5f-4d0e-9d39-23bb9fc9b787",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/updateGroup",
+               "response": {
+                  "jsondocId": "9ff2c1ca-09fa-444f-b329-0208b0fca3ca",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "4d5930f4-e2f0-4af7-8d87-cbeac5250613",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dbc05c5a-8c3f-4b9b-a198-73595c70f575",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b807bff5-0a1f-4d33-ac58-dbd1ea10f13b",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Group ID to modify permissions for (must provide this or 'name')",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6b4b15b4-3abd-4795-a542-a36b9c4753c6",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to modify permissions for (must provide this or 'groupId')",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "10810b82-7bcf-455a-8faf-0834f6c3a5dc",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Organism common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "57e81c72-389b-4601-8272-27f0076ec3d9",
+                     "name": "ADMINISTRATE",
+                     "format": "",
+                     "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6b286c86-d5bb-4405-bf68-9929c5245fb0",
+                     "name": "WRITE",
+                     "format": "",
+                     "description": "Indicate if user has write and all lesser privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "39fc08c5-366b-4a17-881d-eaee3bf285df",
+                     "name": "EXPORT",
+                     "format": "",
+                     "description": "Indicate if user has export and all lesser privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "730df792-9223-49a3-b5ca-010b58478402",
+                     "name": "READ",
+                     "format": "",
+                     "description": "Indicate if user has read and all lesser privileges for the organism",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update organism permission",
+               "methodName": "updateOrganismPermission",
+               "jsondocId": "2587cec1-1247-4fba-b011-5ef4e33cc735",
+               "bodyobject": {
+                  "jsondocId": "bc2ee70d-842b-47a9-8838-286eb6b52656",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/updateOrganismPermission",
+               "response": {
+                  "jsondocId": "ea608130-56a1-4104-90e7-4246bc6682e7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6267f6a2-670f-4ff2-a195-05d69b5b0827",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d01991a7-cfcd-4cfe-8096-7279083ec7d6",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c5ac9263-32c0-4b53-893d-aa2b79e77d9c",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Group ID to alter membership of",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "10e1bc58-9348-457c-889e-fed8f7dcd3f7",
+                     "name": "users",
+                     "format": "",
+                     "description": "A JSON array of strings of emails of users the now belong to the group",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1dcc4b3e-a3cc-4637-8306-7bce427a7ea5",
+                     "name": "memberships",
+                     "format": "",
+                     "description": "Bulk memberships (instead of users and groupId) to update of the form: [ {groupId: <groupId>,users: [\"user1\", \"user2\", \"user3\"]}, {groupId:<another-groupId>, users: [\"user2\", \"user8\"]}]",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update group membership",
+               "methodName": "updateMembership",
+               "jsondocId": "2969e3bc-5d5a-4994-b383-a9e461617485",
+               "bodyobject": {
+                  "jsondocId": "b5ecd809-952a-460f-bd77-1a76141e1fb1",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/updateMembership",
+               "response": {
+                  "jsondocId": "c4bf4a3e-3e8f-4b6c-b96d-50cf8c5674de",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "90d9b993-eab7-4fbe-a537-7e559c789ef8",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b3b035db-816d-4784-ad83-99f202ecc1db",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "888459e1-5a44-4114-a753-39c3155b689e",
+                     "name": "groupId",
+                     "format": "",
+                     "description": "Group ID to alter membership of",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d20328fe-5701-4f67-ba04-b9446bf50e8f",
+                     "name": "users",
+                     "format": "",
+                     "description": "A JSON array of strings of emails of users the now belong to the group",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update group admin",
+               "methodName": "updateGroupAdmin",
+               "jsondocId": "beec421a-aba7-47ad-8f75-8fe5f84f4e4a",
+               "bodyobject": {
+                  "jsondocId": "50573a37-6f96-419f-830b-d53c8382597a",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/updateGroupAdmin",
+               "response": {
+                  "jsondocId": "4eb4507a-a55a-4dfb-8764-f86805459e60",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "241003e0-3bba-4555-a73a-b67022921818",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "93f694fc-7ecd-42a4-b15b-54d8d694e73e",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "37d2ca49-91f3-4a9d-91d0-54fc42ec443e",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get group admins, returns group admins as JSONArray",
+               "methodName": "getGroupAdmin",
+               "jsondocId": "34136d68-0734-4607-8fc0-091f9337ee02",
+               "bodyobject": {
+                  "jsondocId": "7e420741-c36b-4514-b838-63d02b36bffa",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/getGroupAdmin",
+               "response": {
+                  "jsondocId": "afb68599-9b75-4bd8-b75b-2ed83f52f9db",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "f76c3729-eace-4c4b-8c34-50b9b9ca518f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d8e7cdbe-25fd-4426-93b6-7a2cd037f25b",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "29d1ff01-fcb2-4ee3-9630-4cf0b7c3efc5",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get creator metadata for group, returns userId as JSONObject",
+               "methodName": "getGroupCreator",
+               "jsondocId": "5a328f9b-9280-4163-a36c-0995e0dfbcfe",
+               "bodyobject": {
+                  "jsondocId": "8399a567-b3d0-495c-8597-08da3057119f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/getGroupCreator",
+               "response": {
+                  "jsondocId": "ca54824e-5f6f-4330-8d7e-a4ee70902a86",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5200,13 +5200,13 @@
          "description": "Methods for managing groups"
       },
       {
-         "jsondocId": "75b09861-7d0d-460b-9b36-dcd50c6bac03",
+         "jsondocId": "7be806aa-02f6-49fc-8c4a-a5b6eec3ba72",
          "methods": [{
             "headers": [],
             "pathparameters": [],
             "queryparameters": [
                {
-                  "jsondocId": "7ab6392a-83fa-489c-b985-fac6a52073f0",
+                  "jsondocId": "4d2fe744-dbd5-45c7-a91e-b206387303d7",
                   "name": "username",
                   "format": "",
                   "description": "",
@@ -5215,7 +5215,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "16bb4376-3529-4a62-bce1-44deae391eb2",
+                  "jsondocId": "e2f0a130-2ecb-4ec0-9799-47a0a1e1fb19",
                   "name": "password",
                   "format": "",
                   "description": "",
@@ -5224,7 +5224,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "7d2313c8-5e0f-4152-a282-9e29fcebf6ac",
+                  "jsondocId": "44ac921a-4080-4c21-ba99-885f4453a5ef",
                   "name": "date",
                   "format": "",
                   "description": "Date to query yyyy-MM-dd:HH:mm:ss or yyyy-MM-dd",
@@ -5233,7 +5233,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "e4d7468c-7f0e-4921-b1a3-b99413922dc4",
+                  "jsondocId": "ac027c35-ee22-4360-9f6b-fa4ce1f6f92b",
                   "name": "afterDate",
                   "format": "",
                   "description": "Search after or on the given date.",
@@ -5242,7 +5242,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "8f5eb590-5b38-4525-b20c-0c804e3ba6b8",
+                  "jsondocId": "1ff0d386-cfb4-45bf-951a-cb785fdcd815",
                   "name": "beforeDate",
                   "format": "",
                   "description": "Search before or on the given date.",
@@ -5251,7 +5251,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "a6fc42d4-0441-4dc0-855a-c123fb21fd75",
+                  "jsondocId": "377de601-fe3f-4dac-95de-df19143c6eb9",
                   "name": "max",
                   "format": "",
                   "description": "Max to return",
@@ -5260,7 +5260,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "df66267e-0490-486a-8848-699a0d02102f",
+                  "jsondocId": "aca714dd-116f-4cd5-85ed-c1d65ec9dd30",
                   "name": "sort",
                   "format": "",
                   "description": "Sort parameter (lastUpdated).  See FeatureEvent object/table.",
@@ -5269,7 +5269,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "0021a26f-a7a6-4ba4-9cad-cda8172899ba",
+                  "jsondocId": "c973e737-a72e-4f11-b00b-15d9c9384594",
                   "name": "order",
                   "format": "",
                   "description": "desc/asc sort order by sort param",
@@ -5281,9 +5281,9 @@
             "verb": "POST",
             "description": "Returns a JSON representation of all current Annotations before or after a given date.",
             "methodName": "findChanges",
-            "jsondocId": "d3d61fa0-3630-4640-9617-9971076918ba",
+            "jsondocId": "a2216024-8fa1-492a-ad92-1cc7b7b036b5",
             "bodyobject": {
-               "jsondocId": "021c1b90-407e-4a0e-8c92-e32e89172014",
+               "jsondocId": "cdf4d6af-e230-4783-9273-66205938963a",
                "mapValueObject": "",
                "mapKeyObject": "",
                "multiple": "Unknow",
@@ -5293,7 +5293,7 @@
             "apierrors": [],
             "path": "/featureEvent/findChanges",
             "response": {
-               "jsondocId": "dd60a0f5-9983-4238-a100-3c10e881c3b8",
+               "jsondocId": "90b625d1-b8b4-49b3-aee9-483547ac2f7c",
                "mapValueObject": "",
                "mapKeyObject": "",
                "object": "feature event"
@@ -5305,14 +5305,14 @@
          "description": "Methods for querying history"
       },
       {
-         "jsondocId": "cba1e2ff-8901-44b0-90cc-e916f7a03031",
+         "jsondocId": "5ed1f12b-e92b-4a78-a5d8-26bd3891886a",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "61af6429-c399-48e2-a8e7-995c70cf6ad4",
+                     "jsondocId": "87bd6b28-d387-4267-bd8a-bb32e05cf6a4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5321,7 +5321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9754016d-eceb-4529-aa60-ff320dc8e1b0",
+                     "jsondocId": "44df4f9e-bf6d-4a5c-bac9-06d1b9d7f01b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5330,7 +5330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "35e9162b-3ae3-43b6-aa87-5c9824c90905",
+                     "jsondocId": "89925920-2e03-4289-944c-d0d0f236ec6f",
                      "name": "type",
                      "format": "",
                      "description": "Type of annotated genomic features to export 'FASTA','GFF3','CHADO'.",
@@ -5339,7 +5339,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a2f574a1-c937-469d-9e36-cde6a9733330",
+                     "jsondocId": "8a88c96f-df83-402c-bd5a-52871fc5d53f",
                      "name": "seqType",
                      "format": "",
                      "description": "Type of output sequence 'peptide','cds','cdna','genomic'.",
@@ -5348,7 +5348,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "85a7dbdf-efb1-4492-9c12-fecfc510136a",
+                     "jsondocId": "a9976a42-e033-4cb0-8ff4-a4f107957c6a",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -5357,7 +5357,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3bb840cc-ef47-4a26-b4fc-f1be991cdf26",
+                     "jsondocId": "50cedc7e-9b0d-44f5-b883-e58400c82167",
                      "name": "sequences",
                      "format": "",
                      "description": "Names of references sequences to add (default is all).",
@@ -5366,7 +5366,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "88b2c78c-21c1-478d-ac93-c45303e0a49b",
+                     "jsondocId": "7307fc14-e0f9-47be-99b6-df84ac6f4d1a",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism that sequences belong to (will default to last organism).",
@@ -5375,7 +5375,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9a6df35c-e377-42ca-bdbe-a2be51c27709",
+                     "jsondocId": "4e973d61-5151-46bd-8646-62c658a28980",
                      "name": "output",
                      "format": "",
                      "description": "Output method 'file','text'",
@@ -5384,7 +5384,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "92f5c747-e917-4e4f-af61-a7daf185ec38",
+                     "jsondocId": "ff80923a-7aba-40e4-b7e4-c1cf0e044300",
                      "name": "exportAllSequences",
                      "format": "",
                      "description": "Export all reference sequences for an organism (over-rides 'sequences')",
@@ -5393,7 +5393,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5c631690-64f6-4d9a-a32f-483fea846785",
+                     "jsondocId": "598b7bbf-30f9-4628-9444-9b76349288f4",
                      "name": "region",
                      "format": "",
                      "description": "Highlighted genomic region to export in form sequence:min..max  e.g., chr3:1001..1034",
@@ -5405,9 +5405,9 @@
                "verb": "POST",
                "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "methodName": "write",
-               "jsondocId": "803b4665-fb59-4a22-9894-7ef8ce53f417",
+               "jsondocId": "27f78825-3d6d-4242-a33d-563f67886d7a",
                "bodyobject": {
-                  "jsondocId": "a307729e-b7cc-42fc-acac-81bd77b44886",
+                  "jsondocId": "036e4078-8dc4-4164-8c6d-91154ae1ef05",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5417,7 +5417,7 @@
                "apierrors": [],
                "path": "/IOService/write",
                "response": {
-                  "jsondocId": "84526aad-6e8e-4981-b03f-07797d56eed6",
+                  "jsondocId": "065b4aa1-2945-4f9b-9cfb-11ca9290422d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -5430,7 +5430,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e51716a3-91f5-4280-a828-77454084b69d",
+                     "jsondocId": "7f82ea26-5ebe-4eb9-8f3c-c92e07b039fe",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5439,7 +5439,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a233c06b-3ef0-4fd2-91ee-8a99301fad54",
+                     "jsondocId": "c80164aa-2873-4f83-88b7-a810d02e5fcc",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5448,7 +5448,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "903ac06d-769f-4cc4-9e2b-b863acf15312",
+                     "jsondocId": "e089d509-d86c-4e3f-a28e-234be46db785",
                      "name": "uuid",
                      "format": "",
                      "description": "UUID that holds the key to the stored download.",
@@ -5457,7 +5457,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "992b3da0-a2d5-4a31-825a-1f5f6cbc06b5",
+                     "jsondocId": "2804a98f-1cc6-4bc4-9b8e-468e5c2abd62",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -5469,9 +5469,9 @@
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
                "methodName": "download",
-               "jsondocId": "4c123d89-caf8-4d10-be3a-4cd316f810c5",
+               "jsondocId": "c97c04ae-029d-4da6-98fd-7ef850575b95",
                "bodyobject": {
-                  "jsondocId": "c6b67205-c9ec-412e-a562-d89b159bd904",
+                  "jsondocId": "c2757ee3-db42-4be6-ad61-0b4f965997db",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5481,7 +5481,7 @@
                "apierrors": [],
                "path": "/IOService/download",
                "response": {
-                  "jsondocId": "2218adcd-7af6-4040-b593-4c289c12c84c",
+                  "jsondocId": "158ebe55-11c0-4edd-ad2b-b9f1a6ce041d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -5494,14 +5494,14 @@
          "description": "Methods for bulk importing and exporting sequence data"
       },
       {
-         "jsondocId": "3fe07b9a-ed75-4238-b7e4-ba497c6c8094",
+         "jsondocId": "c75f8546-065a-4470-9112-ae35ad6815ac",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "05132e4d-55a3-44c3-b44a-c6a9db7e9190",
+                     "jsondocId": "7bb42f3e-7dda-42ae-ba0b-abb496f04b36",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5510,7 +5510,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e8aba61b-0578-464e-ac3e-3015201ae89f",
+                     "jsondocId": "73173ca5-4c91-44bb-baa3-51174f1b6a6c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5519,7 +5519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "50746721-c9a2-42ad-b9fc-4a58c0a091f9",
+                     "jsondocId": "e11cb910-0af2-4d14-a5a8-8b41f1f5154e",
                      "name": "organism",
                      "format": "",
                      "description": "Pass an Organism JSON object with an 'id' that corresponds to the organism to be removed",
@@ -5531,9 +5531,9 @@
                "verb": "POST",
                "description": "Remove an organism",
                "methodName": "deleteOrganism",
-               "jsondocId": "8c69e5a4-9ba7-460f-87f0-1ebf87c504b5",
+               "jsondocId": "59263b5c-4bc8-490f-880b-ba6a6ed9f147",
                "bodyobject": {
-                  "jsondocId": "c9a2343d-9886-4e7b-8b35-672d5d7b17e4",
+                  "jsondocId": "a0f96ae2-c5fb-4be9-9578-bfcaa0e1a4b9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5543,7 +5543,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganism",
                "response": {
-                  "jsondocId": "3ec4c16a-f8e2-4dc2-95b8-803f842e97f2",
+                  "jsondocId": "6dfa545b-262f-455c-ad54-5e07d8e847d1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5556,7 +5556,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c8649f3a-211f-4316-889b-be4c688074e6",
+                     "jsondocId": "65434e0d-0dc3-4ed2-9b23-351458134d67",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5565,7 +5565,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6c3dab1a-288b-4e3d-a36e-931c976a1cef",
+                     "jsondocId": "3cd3214e-fc22-42fd-af02-975e90f33710",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5574,7 +5574,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "08ada022-a497-4a44-85cd-d18e28351041",
+                     "jsondocId": "2dd82fd9-3605-451f-b5a8-24bc32bd6d51",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5586,9 +5586,9 @@
                "verb": "POST",
                "description": "Delete an organism along with its data directory and returns a JSON object containing properties of the deleted organism",
                "methodName": "deleteOrganismWithSequence",
-               "jsondocId": "7f365a5e-322a-4fdf-8248-e35f41def122",
+               "jsondocId": "78b55d72-a312-47b4-b9a3-cb6ab8976af6",
                "bodyobject": {
-                  "jsondocId": "b4302b58-9724-47c2-9a80-113a5fc2bb50",
+                  "jsondocId": "46ef2890-c6a0-43b7-9f71-6f48532e8269",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5598,7 +5598,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismWithSequence",
                "response": {
-                  "jsondocId": "611a9185-ddcb-4fcc-a285-74105174cf8e",
+                  "jsondocId": "88e604cf-bb86-442f-9713-f75d637d4539",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5611,7 +5611,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "963da902-084f-4269-8ae8-70d4f6e13640",
+                     "jsondocId": "f8452968-f88e-4e44-83a4-61a5b32586b0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5620,7 +5620,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "21a35eec-4a91-4250-b589-c8536079aecd",
+                     "jsondocId": "6acec412-9073-4985-82df-5f7295b77b1b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5629,7 +5629,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "70466657-6b06-4008-9cbc-1558b1f828e9",
+                     "jsondocId": "a8aefdce-fcc6-46e2-ba69-ebc7e49ab897",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism.",
@@ -5638,7 +5638,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "04a878a3-4d71-4926-9d57-c9e9686072fa",
+                     "jsondocId": "88f26d87-c8c6-4c5e-9e00-5eeb9620d540",
                      "name": "sequences",
                      "format": "",
                      "description": "(optional) Comma-delimited sequence names on that organism if only certain sequences should be deleted.",
@@ -5650,9 +5650,9 @@
                "verb": "POST",
                "description": "Remove features from an organism",
                "methodName": "deleteOrganismFeatures",
-               "jsondocId": "9923d414-5914-4433-9ee3-e49b0adde903",
+               "jsondocId": "e87d12bc-d987-4a09-8586-0568fccdb93a",
                "bodyobject": {
-                  "jsondocId": "9d71c686-0b4f-4d30-bd5b-be1b205ac8e4",
+                  "jsondocId": "2e65e21a-1c92-4531-8027-95d838afc7af",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5662,7 +5662,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
                "response": {
-                  "jsondocId": "8ee82bc2-7da8-4d17-814d-9b8a27a675b6",
+                  "jsondocId": "959877f7-2b4b-4b7e-b99c-0773a94e12cf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5675,7 +5675,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "692cee09-1e5b-4147-a978-cae7d7353fea",
+                     "jsondocId": "51b86ba1-98d6-4b98-bb57-86759333b0f9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5684,7 +5684,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "06f560ca-ffd6-4e61-a131-f349150dd992",
+                     "jsondocId": "f320c5e2-689d-48bc-9a89-d5dd86b1d688",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5693,7 +5693,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bbb94478-90ab-413b-8937-d347897c39ae",
+                     "jsondocId": "caa95997-dfd6-4e62-a8cf-68e9e06529af",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -5702,7 +5702,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "87ffb8fe-57b1-4467-b7b1-513d6719b035",
+                     "jsondocId": "428b14f0-1d87-43a6-881c-356d4959ed96",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -5711,7 +5711,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fadff300-cddb-4e4f-9fa3-2924d7881855",
+                     "jsondocId": "4bfc6f3e-4702-44d7-801c-8adc9cd42367",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -5720,7 +5720,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d7d00c5d-a1b2-4c00-b934-bcd901a1c6e1",
+                     "jsondocId": "295e49c6-953a-464d-b69f-870fe3b03db8",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5729,7 +5729,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6ba968bf-a847-4a84-8dee-1cc936ab3acf",
+                     "jsondocId": "6fce6ec8-962c-40fb-a94c-b92e62cd7d43",
                      "name": "commonName",
                      "format": "",
                      "description": "commonName for an organism",
@@ -5738,7 +5738,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "019572b1-95e0-49d4-b6b5-368bbd4e9072",
+                     "jsondocId": "2c127642-250e-48be-8c36-aae77dfc36b0",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -5747,7 +5747,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ba786b4f-da44-4bae-982a-f5b1cd248883",
+                     "jsondocId": "40bee8ab-02d9-4436-b003-75eef339138e",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5756,7 +5756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "779bd906-c861-46d9-b4ae-c37a68584b96",
+                     "jsondocId": "2427e255-e3ad-4f88-9630-eac9be47c299",
                      "name": "organismData",
                      "format": "",
                      "description": "zip or tar.gz compressed data directory",
@@ -5765,7 +5765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f689197f-2095-4f10-94c0-f189e9c4c643",
+                     "jsondocId": "b018666c-f166-4e3a-adb8-2083aab80864",
                      "name": "sequenceData",
                      "format": "",
                      "description": "FASTA file (optionally compressed) to automatically upload with",
@@ -5777,9 +5777,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganismWithSequence",
-               "jsondocId": "1c1daf1b-547f-4afe-a510-06994efd2703",
+               "jsondocId": "6b9a3636-2a4e-4742-ad2a-2faa116ee2bd",
                "bodyobject": {
-                  "jsondocId": "8dac718d-dcf1-4b23-9fa6-1cd192440943",
+                  "jsondocId": "60d9f75c-e337-4648-8435-0811faeec0d4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5789,7 +5789,7 @@
                "apierrors": [],
                "path": "/organism/addOrganismWithSequence",
                "response": {
-                  "jsondocId": "b0bac1fa-04d8-4807-b9f3-4f546f105331",
+                  "jsondocId": "de9eae21-f51b-4be1-ac4b-60bcb59d9a30",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5802,7 +5802,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "80f2c47e-fe6f-48af-9ee3-52d2575c49c1",
+                     "jsondocId": "7e245dfe-ec79-4fcd-a4ad-bcbee8aacd42",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5811,7 +5811,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8d589cfb-ac48-4e27-a913-9a0cc6ffb317",
+                     "jsondocId": "327d0d6f-8030-4421-962a-f729060a9c6d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5820,7 +5820,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cfbb9644-a99b-476f-9d6c-b069b4e18689",
+                     "jsondocId": "c0153222-b3c0-4379-bf8a-036b1da44740",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5829,7 +5829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9bcdea98-2eb1-4215-9dc3-2f940617201d",
+                     "jsondocId": "18965110-ab8e-41ef-a9cc-ef33e32ff785",
                      "name": "trackLabel",
                      "format": "",
                      "description": "Name of track",
@@ -5841,9 +5841,9 @@
                "verb": "POST",
                "description": "Removes an added track from an existing organism returning a JSON object containing all tracks for the current organism.",
                "methodName": "removeTrackFromOrganism",
-               "jsondocId": "902ea81e-3b5a-436a-944e-f29c24511de7",
+               "jsondocId": "15996f94-512d-4c94-9bbe-c43a7f6cad0a",
                "bodyobject": {
-                  "jsondocId": "069e93fa-b0f4-44e5-9903-06ab84a95e49",
+                  "jsondocId": "cc5a7f35-2d5b-4383-afb5-c570796361b0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5853,7 +5853,7 @@
                "apierrors": [],
                "path": "/organism/removeTrackFromOrganism",
                "response": {
-                  "jsondocId": "00d681e7-792f-446f-9c5c-59e3dc1eb86a",
+                  "jsondocId": "7c0e7bf2-bf58-4b40-927c-0dbd48ad7f13",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5866,7 +5866,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a7bff0e6-3f6d-4cfc-8616-f39a6bfd887a",
+                     "jsondocId": "9ab47c5e-1be2-4736-bd43-de62df67c591",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5875,7 +5875,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "978f5076-d125-44d2-be50-f4716bb5ee2b",
+                     "jsondocId": "5f3e3e8e-97f9-4b58-944b-109a358c6cdf",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5884,7 +5884,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9ee9130a-5e80-4c45-bb57-01b8346bde39",
+                     "jsondocId": "1a4b627b-b21e-48f9-99d2-590da87c8835",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5893,7 +5893,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d769e348-676f-43cd-bfac-fb8faafc6fe2",
+                     "jsondocId": "377344ff-c45b-4c36-bae1-ada2114e612d",
                      "name": "trackData",
                      "format": "",
                      "description": "zip or tar.gz compressed track data",
@@ -5902,7 +5902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f574c30a-353f-4ec2-9ee3-4ab3af58fc04",
+                     "jsondocId": "784bec2d-c3e3-4f1f-a9a0-21d8a65a6d03",
                      "name": "trackFile",
                      "format": "",
                      "description": "track file (*.bam, *.vcf, *.bw, *gff)",
@@ -5911,7 +5911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "54521d16-ff05-403c-af3c-00065d464deb",
+                     "jsondocId": "e13df6a6-d6dc-40e6-a45f-e87ce194cb7c",
                      "name": "trackFileIndex",
                      "format": "",
                      "description": "index (*.bai, *.tbi)",
@@ -5920,7 +5920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "491408c3-d501-4bb5-84a7-ea53147d6f92",
+                     "jsondocId": "b638cc9c-897b-4bb9-bbcb-72828176acdf",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -5932,9 +5932,9 @@
                "verb": "POST",
                "description": "Adds a track to an existing organism returning a JSON object containing all tracks for the current organism.",
                "methodName": "addTrackToOrganism",
-               "jsondocId": "8556a305-82f9-4acd-a9fd-d1859065a4ef",
+               "jsondocId": "984306b5-0d5f-482c-b3bd-e748e28618a7",
                "bodyobject": {
-                  "jsondocId": "c3ab0dc7-7f8e-445b-9954-42d52ebfa856",
+                  "jsondocId": "2b98201a-30ce-4448-87d9-b3e818871bc7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5944,7 +5944,7 @@
                "apierrors": [],
                "path": "/organism/addTrackToOrganism",
                "response": {
-                  "jsondocId": "09e88c0a-a166-4e32-b113-c57e3272c958",
+                  "jsondocId": "c9396a16-5694-4444-8d00-178e5043796a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5957,7 +5957,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "bc4dff3d-3ec3-4f3c-83da-a61dcadbc5ec",
+                     "jsondocId": "523a607d-e6de-4a5c-8fce-24744ac2e3f4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5966,7 +5966,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7f8bef7-cc0e-42d0-8ea6-f199d7fda496",
+                     "jsondocId": "c6248ebf-ae86-46ae-8b19-c363c105fe2a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5975,7 +5975,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02ef157d-8269-48e4-a616-3d045495bcbd",
+                     "jsondocId": "ee54b2bb-9916-463d-bb86-81fa1a76c49d",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5984,7 +5984,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7c1cbc13-f8c6-4682-9675-e2bf4f51b28e",
+                     "jsondocId": "46998733-27eb-44a3-bb8b-a6d92cb371db",
                      "name": "trackLabel",
                      "format": "",
                      "description": "Track label corresponding to the track that is to be deleted",
@@ -5996,9 +5996,9 @@
                "verb": "POST",
                "description": "Deletes a track from an existing organism and returns a JSON object of the deleted track's configuration",
                "methodName": "deleteTrackFromOrganism",
-               "jsondocId": "eb04aad9-8077-4784-8482-56dd7cda982e",
+               "jsondocId": "bcf4110b-6472-4ba2-80d9-f9235b534489",
                "bodyobject": {
-                  "jsondocId": "284bc8e2-9466-492a-87b2-448b925c9eef",
+                  "jsondocId": "0e70078f-61f1-4944-8213-41724518c142",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6008,7 +6008,7 @@
                "apierrors": [],
                "path": "/organism/deleteTrackFromOrganism",
                "response": {
-                  "jsondocId": "677f0d5b-8f3f-456c-a00c-8501513b2afc",
+                  "jsondocId": "08ddab28-56d5-4e63-84e8-eea6da212b6e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6021,7 +6021,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "741f87d1-37a8-494c-a926-fabf7780f6a3",
+                     "jsondocId": "404b9fbf-01ba-437a-954b-9918d5fb3bb6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6030,7 +6030,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4201a142-6cf4-4a92-9cec-21d97dc54997",
+                     "jsondocId": "6d1a7357-b87d-4948-b01b-f0e23cd98151",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6039,7 +6039,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f709e73c-2eb4-4ff3-89c7-6e7748e5f03d",
+                     "jsondocId": "a508aed5-1a18-4d3b-9e5f-c7bb1e7f142f",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -6048,7 +6048,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff97390f-0ad6-4810-81c3-7755abaf053b",
+                     "jsondocId": "b52c264b-0af6-4bd9-abde-728a86631bfa",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -6060,9 +6060,9 @@
                "verb": "POST",
                "description": "Update a track in an existing organism returning a JSON object containing old and new track configurations",
                "methodName": "updateTrackForOrganism",
-               "jsondocId": "e5937207-6b4a-4a07-9372-348d549dec0d",
+               "jsondocId": "a58c7975-eecc-4c13-9489-016babc0628a",
                "bodyobject": {
-                  "jsondocId": "147b5a16-1732-4db2-9c6e-56ced740dabc",
+                  "jsondocId": "5305caba-ba1c-447d-952b-359030f3f00f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6072,7 +6072,7 @@
                "apierrors": [],
                "path": "/organism/updateTrackForOrganism",
                "response": {
-                  "jsondocId": "d37fa439-32d7-4039-9973-457d4a535c14",
+                  "jsondocId": "407a4474-31a7-43b9-83bb-414173494c56",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6085,7 +6085,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5445dca0-1d59-4ffd-b886-ef28866603b1",
+                     "jsondocId": "698a58cd-5e41-485e-b2fe-a1958efb7692",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6094,7 +6094,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cf27b5ea-9f15-4a8b-a281-076563b27b6f",
+                     "jsondocId": "1546153c-d59b-4317-8173-db38ae0472fb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6103,7 +6103,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "38c30669-4bf4-434a-b4af-9197b955f7b2",
+                     "jsondocId": "5f7624c4-d4cb-4714-a097-f46ca59d282b",
                      "name": "directory",
                      "format": "",
                      "description": "Filesystem path for the organisms data directory (required)",
@@ -6112,7 +6112,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d055c6e-6d24-4e43-9838-f7f311f52490",
+                     "jsondocId": "66be9df7-e1bf-486f-9b50-910d456961ec",
                      "name": "commonName",
                      "format": "",
                      "description": "A name used for the organism",
@@ -6121,7 +6121,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "245c2824-6a5e-4798-9a7e-e7667797f692",
+                     "jsondocId": "63612831-09a7-4de3-b24b-003e6b46701f",
                      "name": "species",
                      "format": "",
                      "description": "(optional) Species name",
@@ -6130,7 +6130,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "229e9e25-210f-494e-ac6e-adda5ad1b4e2",
+                     "jsondocId": "a2b378d7-6c19-4432-869d-649f3d8c5f5c",
                      "name": "genus",
                      "format": "",
                      "description": "(optional) Species genus",
@@ -6139,7 +6139,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7a4d654f-c46f-48b1-9100-698920e5c2b6",
+                     "jsondocId": "eafcc23c-95f6-42b9-9674-d1d681d42376",
                      "name": "blatdb",
                      "format": "",
                      "description": "(optional) Filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -6148,7 +6148,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "da410682-4969-46c9-bc2b-bf8909493bdb",
+                     "jsondocId": "8fb3b8bd-c5ac-45ec-acf2-aacd0c8abffd",
                      "name": "publicMode",
                      "format": "",
                      "description": "(optional) A flag for whether the organism appears as in the public genomes list (default false)",
@@ -6157,7 +6157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "01898fab-1385-4103-b077-e4b6af3d7bfd",
+                     "jsondocId": "b9348bda-56d5-46ba-80df-575bb98ce7cc",
                      "name": "metadata",
                      "format": "",
                      "description": "(optional) Organism metadata",
@@ -6166,7 +6166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "06337288-a37e-4762-9863-1cdfb4dc504d",
+                     "jsondocId": "50c9ae5b-2a98-49cf-9b22-b610630b17f5",
                      "name": "returnAllOrganisms",
                      "format": "",
                      "description": "(optional) Return all organisms (true / false) (default true)",
@@ -6178,9 +6178,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganism",
-               "jsondocId": "85212b3c-138c-4a47-8866-107f3e72be61",
+               "jsondocId": "dd221780-9b3c-43b1-9f75-29b6176b7df6",
                "bodyobject": {
-                  "jsondocId": "6bc246a9-465d-41ea-81f4-e0cdef2f9c2b",
+                  "jsondocId": "c77d7440-6e90-4125-877a-851a8d024747",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6190,7 +6190,7 @@
                "apierrors": [],
                "path": "/organism/addOrganism",
                "response": {
-                  "jsondocId": "4e3ab3b9-e6eb-4d12-8ead-ce35d9bfd297",
+                  "jsondocId": "6a3ae6f1-e4e4-4961-a216-976f39e6ad38",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6203,7 +6203,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "24d4dc0c-8019-4e01-bbfb-94d32f2f5e08",
+                     "jsondocId": "a137fa9e-204a-4633-bcee-2e5f5b7cabfb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6212,7 +6212,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1e7b705-1f3d-47ce-b32e-7f45eb6c3ad6",
+                     "jsondocId": "77e3ef71-078e-44ba-bb41-e521ab7a2061",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6221,7 +6221,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "627ddde9-2aac-4394-9f4a-3781da48900b",
+                     "jsondocId": "84626da7-2069-4d95-949f-069ee8eaba0e",
                      "name": "organism",
                      "format": "",
                      "description": "Common name or ID for the organism",
@@ -6233,9 +6233,9 @@
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
                "methodName": "getSequencesForOrganism",
-               "jsondocId": "6cde6b8a-6d22-4c0d-94a1-7610951e8059",
+               "jsondocId": "585d612c-b68e-482c-b24b-f5702fa940b5",
                "bodyobject": {
-                  "jsondocId": "9219508c-405d-4e05-b899-8c32784664ff",
+                  "jsondocId": "83d95621-18dc-4cf9-b333-1dc80913fda0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6245,7 +6245,7 @@
                "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
                "response": {
-                  "jsondocId": "c9db7d06-beb1-4daf-94b4-39815997ac0c",
+                  "jsondocId": "134e93aa-7860-476e-b26c-7e2e29b5363a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6258,7 +6258,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "291ef211-a4b4-4d93-ad96-7b61b9df8f88",
+                     "jsondocId": "b057e3a1-8254-405a-87df-af7a14668939",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6267,7 +6267,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b39a5cae-799e-4615-84ef-faeeb72e197b",
+                     "jsondocId": "6853b867-c329-4940-b084-83a7642be06a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6276,7 +6276,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1513d56-1ab6-4ad8-b1ff-729b61ce1967",
+                     "jsondocId": "6d32bcf4-8a73-4750-b714-73066d2d9a9f",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -6285,7 +6285,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5683fc9b-3966-48d4-931f-c1563736a136",
+                     "jsondocId": "5a83145f-1f5c-404b-a4f3-a3e0247bb80c",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -6294,7 +6294,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "262c8a77-0e5d-43b1-81d4-60036309ddc4",
+                     "jsondocId": "cb77a481-a939-4770-8c89-b080cd944995",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -6303,7 +6303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3bc0f09d-0372-4bbd-bc70-8ec1133099cd",
+                     "jsondocId": "79068445-7f0d-49d7-8680-1ef459aad76d",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -6312,7 +6312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1a0cdd86-a8d7-4609-89d1-3ab3887db7df",
+                     "jsondocId": "bd4d35b1-bc36-43ac-834a-9a1df7919e44",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -6321,7 +6321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "37ecb654-019d-44de-a6ef-37ac642dc0fa",
+                     "jsondocId": "685a345d-8cc0-40fa-b153-c7ecaac7413e",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -6330,7 +6330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8c61673f-17bf-4fde-b402-943cb95a6198",
+                     "jsondocId": "a279cc11-c8dc-4391-a5e2-034870e60400",
                      "name": "name",
                      "format": "",
                      "description": "a common name used for the organism",
@@ -6339,7 +6339,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4ed7432-aa03-42ac-8907-4c163678e78e",
+                     "jsondocId": "20b7a362-c94a-4efe-9ad3-a8e466eeb4e4",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -6348,7 +6348,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a9753c79-27ff-4a56-b1bb-c58678dc0502",
+                     "jsondocId": "851a7e8c-e883-4a51-9e5d-3bee32057b47",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -6360,9 +6360,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "updateOrganismInfo",
-               "jsondocId": "5351d10a-dd14-4ab4-8266-2b843c918dae",
+               "jsondocId": "cd2ac2ff-b70f-45f1-9288-54525ba4b2fa",
                "bodyobject": {
-                  "jsondocId": "4fb75cc3-c0c6-42af-9403-6a6d6bccfffa",
+                  "jsondocId": "3688b174-db80-4b35-81a5-94afceca8236",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6372,7 +6372,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismInfo",
                "response": {
-                  "jsondocId": "1275186a-798b-4288-baff-a498c7972dbe",
+                  "jsondocId": "36b23628-ab08-4f6d-9bff-faeff6f75152",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6385,7 +6385,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b4002b9d-9825-4f58-b956-8316c60a39e3",
+                     "jsondocId": "0f5d0293-9b82-4574-9f10-3c7066953498",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6394,7 +6394,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "778d032d-6f99-4b58-9dec-bd84f0b1ad87",
+                     "jsondocId": "017cfd0b-5757-48f7-9d19-6d35928b39b6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6403,7 +6403,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26638686-6f67-44f2-88b5-90e7e07f2592",
+                     "jsondocId": "c2b54aa3-4627-4c2c-ae18-96d0e80c4fac",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -6412,7 +6412,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eb6ef41d-64ed-42fe-8e83-f3fc1084eda8",
+                     "jsondocId": "0880f417-63ce-4ad8-85e1-f2a3802cd2d8",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -6424,9 +6424,9 @@
                "verb": "POST",
                "description": "Update organism metadata",
                "methodName": "updateOrganismMetadata",
-               "jsondocId": "c7cfeed3-2110-46b6-89b6-8c32b64f0e6d",
+               "jsondocId": "2040b0f3-e19e-4a64-b6b4-000e345132b3",
                "bodyobject": {
-                  "jsondocId": "56d34589-54f3-418b-bbad-875dff929de6",
+                  "jsondocId": "9b1e15ae-a8e7-491e-9616-c66e8ad8cb7f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6436,7 +6436,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismMetadata",
                "response": {
-                  "jsondocId": "cd1a15c7-5dd3-405e-bdca-b961be4dfda6",
+                  "jsondocId": "63b3ab13-860c-47e8-b7df-f9d0389d9859",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6449,7 +6449,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f5b1095b-81bd-4ec5-afaf-2ff54d228416",
+                     "jsondocId": "56dd9204-201b-4f85-b462-343c2c1d0134",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6458,7 +6458,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49ec3f5d-fffd-4ad8-8c63-27cdebeabc41",
+                     "jsondocId": "0e7661b3-b357-47e9-af78-73c5d55c7740",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6467,7 +6467,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "960d5f89-9a21-4143-b4d5-b8a910a03e87",
+                     "jsondocId": "cb0ee7cb-c857-4e6e-806e-a7b7ebf99479",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -6479,9 +6479,9 @@
                "verb": "POST",
                "description": "Get creator metadata for organism, returns userId as String",
                "methodName": "getOrganismCreator",
-               "jsondocId": "2735e110-f2f2-450f-a059-6f0ae48bf9e8",
+               "jsondocId": "c53102e8-d2ae-4148-b06d-9fb5b152ffc6",
                "bodyobject": {
-                  "jsondocId": "98697bae-f8ee-4e10-8da4-cce05ba9e7cf",
+                  "jsondocId": "8e6a1884-1cf2-4b03-82ce-309d392499ef",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6491,7 +6491,7 @@
                "apierrors": [],
                "path": "/organism/getOrganismCreator",
                "response": {
-                  "jsondocId": "b27ee1b2-f758-4ee6-a0ed-5ba62a60524e",
+                  "jsondocId": "f02b0044-d5aa-44ee-a515-d8624897e794",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6504,7 +6504,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d7cb5282-0435-4940-af38-c53dbe72e5a5",
+                     "jsondocId": "5dc24574-1acd-4370-a27d-1aad8ea94307",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6513,7 +6513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d340ab7-55c1-4b2a-9855-e099173b06c5",
+                     "jsondocId": "c519b081-50c7-4e65-b773-561dd41d87c3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6522,7 +6522,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8f8ede1b-8793-4cc3-b8db-0887763903e1",
+                     "jsondocId": "f8e853bd-d4f5-4c0e-aab5-1ba8abcd5125",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) ID or commonName that can be used to uniquely identify an organism",
@@ -6534,9 +6534,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "methodName": "findAllOrganisms",
-               "jsondocId": "cbba6138-b3e2-4a02-9aad-f3300ec7874b",
+               "jsondocId": "a8055db5-171e-44e3-95f3-1fb9a4c75942",
                "bodyobject": {
-                  "jsondocId": "eac0785b-d783-409a-aa2a-47205e3ea003",
+                  "jsondocId": "e2d88881-794e-467d-91bd-57e13ede0579",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6546,7 +6546,7 @@
                "apierrors": [],
                "path": "/organism/findAllOrganisms",
                "response": {
-                  "jsondocId": "386284e5-f27c-4c78-80d8-a6540733bddd",
+                  "jsondocId": "1c20d3af-788b-47b6-bcfb-45d0e86cc017",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6559,14 +6559,14 @@
          "description": "Methods for managing organisms"
       },
       {
-         "jsondocId": "f537310f-e57a-496d-b8ac-5717110a2c51",
+         "jsondocId": "4474c93d-09ce-4b6e-800f-0614b6089d1e",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4c49390b-e2fb-40a9-a50e-5824495d7958",
+                     "jsondocId": "95993579-5054-499c-9743-4b93bfb8eafe",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -6575,7 +6575,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c97e0c24-bd5d-4e97-bb21-5ac2b32e26f9",
+                     "jsondocId": "25a827c0-99af-4e95-9b43-2ad5a62ec47c",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -6584,7 +6584,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "516b3dad-aa63-441c-9c4a-89d504ca1221",
+                     "jsondocId": "9a51c833-2216-4577-83aa-375122693d0f",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -6593,7 +6593,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "edc58f5d-bee9-47a0-b158-1b8af5245d64",
+                     "jsondocId": "c07ebf27-a0b1-43d9-9290-362ce02d6875",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -6602,7 +6602,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c602830b-3898-4961-b586-52b70f88c2e5",
+                     "jsondocId": "eaa8f8df-5688-446a-9039-01d096816242",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6614,12 +6614,12 @@
                "verb": "GET",
                "description": "Get sequence data within a range",
                "methodName": "sequenceByLocation",
-               "jsondocId": "0b92dfc7-a2fb-4425-965b-f43ecc9765fe",
+               "jsondocId": "3728752f-1481-4a06-b8ec-9506e5cd3a83",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/<organism name>/<sequence name>:<fmin>..<fmax>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "a22d5a9f-8d24-4253-b728-7d293ddd54bd",
+                  "jsondocId": "2cf73e8e-8f01-44c7-906a-d27185838000",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6632,7 +6632,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7639e2c8-3f4e-45f3-b208-11c7846295ce",
+                     "jsondocId": "5ecd77a0-c20b-4510-9eb3-1b16f0abba6b",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID (required)",
@@ -6641,7 +6641,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4a299a60-7ff4-428c-8b26-aea2d7cbaa1e",
+                     "jsondocId": "e8fa5a47-10b5-4794-8d72-08429b958d70",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name (required)",
@@ -6650,7 +6650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44e220f6-320b-4992-b651-05e4b1090f28",
+                     "jsondocId": "90da774e-ffdd-42c7-8887-1528a15ab7e2",
                      "name": "featureName",
                      "format": "",
                      "description": "The uniqueName (UUID) or given name of the feature (typically transcript) of the element to retrieve sequence from",
@@ -6659,7 +6659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "93e1e9f7-cbdd-4a70-8173-7921d76c2ea3",
+                     "jsondocId": "b43b4526-f472-4fe5-9a48-232e6942c086",
                      "name": "type",
                      "format": "",
                      "description": "(default genomic) Return type: genomic, cds, cdna, peptide",
@@ -6668,7 +6668,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b2de367d-a29d-4591-956d-985eb2a51841",
+                     "jsondocId": "004ddc08-743e-4f04-bfa9-3def7bed3978",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6680,12 +6680,12 @@
                "verb": "GET",
                "description": "Get sequence data as for a selected name",
                "methodName": "sequenceByName",
-               "jsondocId": "b5702ed3-214f-4499-92f6-0b7c0fd8465f",
+               "jsondocId": "9da35a9d-f882-4b23-bd14-f67a0848a680",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/<organism name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "37f3366f-e9e7-488f-8531-26ce2760af74",
+                  "jsondocId": "19b1bca3-8a7c-4575-a322-ece90d4fcbb7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6698,7 +6698,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c28fb997-b600-478a-a846-b55defeff326",
+                     "jsondocId": "cf2e93e5-4977-4014-881b-5b71cb5ebbd9",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -6707,7 +6707,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "82f33755-ec22-45b2-8d29-3858fab07d07",
+                     "jsondocId": "a0fc1793-5ba4-4c8d-98ac-8ea0b98099ad",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name (required)",
@@ -6719,12 +6719,12 @@
                "verb": "GET",
                "description": "Remove sequence cache for an organism and sequence",
                "methodName": "clearSequenceCache",
-               "jsondocId": "b39764ee-6326-4810-8468-7f0c0f8aab9a",
+               "jsondocId": "b79ccdfa-6aba-46c6-9a99-49f38db3f556",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/cache/clear/<organism name>/<sequence name>",
                "response": {
-                  "jsondocId": "395cda4c-7c4f-4673-9130-d98d4961ef1e",
+                  "jsondocId": "3e62e645-76b9-4d95-b2ca-43e42e70f0a6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6736,7 +6736,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "f91387f4-4a30-4cf6-928f-7b6e2b815cc1",
+                  "jsondocId": "f0ccfcaa-1d67-4cef-a2a2-4cce2b4f5d92",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required) or 'ALL' if admin",
@@ -6747,12 +6747,12 @@
                "verb": "GET",
                "description": "Remove sequence cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "950f8e0b-2ff5-4666-92a3-e918c48dc9e9",
+               "jsondocId": "8025efc5-66a1-4517-94d8-e1f85908e200",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "abd3f9d3-f144-4033-a4fe-30264439522d",
+                  "jsondocId": "f4fbbe5d-778a-4994-924c-df80f8eaeae5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6765,14 +6765,14 @@
          "description": "Methods for retrieving sequence data"
       },
       {
-         "jsondocId": "fcb9a3b4-2321-4dc7-b43c-0609d8e4a48b",
+         "jsondocId": "4e4cfdb7-feca-4ad5-9e4c-e2755efe4aa9",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3b7b0ec2-133c-4b09-8f54-04822c271a56",
+                     "jsondocId": "c41e4303-402b-4154-81b4-7cfc2407f193",
                      "name": "featureType",
                      "format": "",
                      "description": "Feature type",
@@ -6781,7 +6781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "620531e3-ccc3-4fad-9a6d-e5461c9b8ec4",
+                     "jsondocId": "322d773e-6145-4b75-8f53-127c1da3ede2",
                      "name": "organism",
                      "format": "",
                      "description": "Organism name",
@@ -6790,7 +6790,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ee613b7a-912c-4c70-8a6c-54a4d85e5b5b",
+                     "jsondocId": "2bea1a50-1f5c-4282-a0ea-c650d71e4379",
                      "name": "query",
                      "format": "",
                      "description": "Query value",
@@ -6802,12 +6802,12 @@
                "verb": "GET",
                "description": "Returns a JSON array of all suggested names, or optionally, gets information about a specific suggested name",
                "methodName": "search",
-               "jsondocId": "d318b814-0ba1-4b9f-ba75-fa8f471850b9",
+               "jsondocId": "89a6726e-4e95-49b6-b119-b403d7e979f7",
                "bodyobject": null,
                "apierrors": [],
                "path": "/suggestedName/search",
                "response": {
-                  "jsondocId": "2a11cf22-8415-41a6-9871-57dd0d81977c",
+                  "jsondocId": "44ae55d2-b651-4dad-969d-91fcaaf25173",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "suggested name"
@@ -6820,7 +6820,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e641c158-b630-4ef0-ab48-8791c9db7b04",
+                     "jsondocId": "53f942de-f372-4d23-a680-4c4934aebb49",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6829,7 +6829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f8a865cc-f960-4ba5-826a-6c513abd0c51",
+                     "jsondocId": "d8d4ff95-ba0a-4b5f-a7a4-4d4a36cda832",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6838,7 +6838,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "52d70f5a-22ae-4319-8335-1159195b42b2",
+                     "jsondocId": "00ce227a-f354-4cc0-89ca-f5e1ff123389",
                      "name": "name",
                      "format": "",
                      "description": "Suggested name to add",
@@ -6847,7 +6847,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "731fe8b4-7822-427f-be19-d9c13026ed5f",
+                     "jsondocId": "44a0c4c2-94fc-43ee-9eae-d6ed856e9202",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -6859,9 +6859,9 @@
                "verb": "POST",
                "description": "Create suggested name",
                "methodName": "createName",
-               "jsondocId": "20d1537c-3e50-40e4-88f9-501d12c1580b",
+               "jsondocId": "556dd4e0-5f32-49cf-8d6e-7c579486bd30",
                "bodyobject": {
-                  "jsondocId": "6d993b45-2891-42c0-87c8-59c9aeda414b",
+                  "jsondocId": "5f98b27e-073a-4f18-8efa-80249c302ad6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6871,7 +6871,7 @@
                "apierrors": [],
                "path": "/suggestedName/createName",
                "response": {
-                  "jsondocId": "39cd8d03-6bbe-40ef-a31e-4a998641d733",
+                  "jsondocId": "25fb2f05-4afa-4d2f-9aea-a7d1916d65a6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "suggested name"
@@ -6884,7 +6884,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "aab5e1cd-df02-491a-af19-902216756448",
+                     "jsondocId": "b5810c81-1cac-419b-82c9-0af3c7d3cac8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6893,7 +6893,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d63df5e-1233-4ff5-acb9-0b41e5461bad",
+                     "jsondocId": "bc7f072b-ac70-4813-a9fb-f793cb77deba",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6902,7 +6902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26a3262a-4360-4438-ac54-eb875c4cfceb",
+                     "jsondocId": "5245b8bb-cd7b-456e-b5e5-9056ffbd9e1f",
                      "name": "id",
                      "format": "",
                      "description": "Suggested name ID to update (or specify the old_name)",
@@ -6911,7 +6911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "27d1f30c-6999-4b36-8991-bb12777416d1",
+                     "jsondocId": "2b46b069-0778-4880-8eab-e2775e4f16c4",
                      "name": "old_name",
                      "format": "",
                      "description": "Suggested name to update",
@@ -6920,7 +6920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65d620e8-c04d-4bab-ab51-fcadf9d61ddf",
+                     "jsondocId": "93994499-d224-4fdb-9517-6745080aa11e",
                      "name": "new_name",
                      "format": "",
                      "description": "Suggested name to change to (the only editable option)",
@@ -6929,7 +6929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6663403b-c9e9-4f7d-aa97-51b162ed4e94",
+                     "jsondocId": "08b8cbde-71dd-4636-97fc-1cf1fae08273",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -6941,9 +6941,9 @@
                "verb": "POST",
                "description": "Update suggested name",
                "methodName": "updateName",
-               "jsondocId": "ed328dbc-7fa7-46eb-84f0-915e0a3bcd99",
+               "jsondocId": "581035c9-bfcc-41a2-a981-c1fe89ec9b2e",
                "bodyobject": {
-                  "jsondocId": "c1a65cff-1a80-415c-8fa9-b5c5d29153b4",
+                  "jsondocId": "dcc17582-585e-4e4b-a295-350eec13831d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6953,7 +6953,7 @@
                "apierrors": [],
                "path": "/suggestedName/updateName",
                "response": {
-                  "jsondocId": "06d6c71d-1dc6-41c0-8263-df25aec18636",
+                  "jsondocId": "1b4d2874-43b5-4aea-a174-146e1d32c5cf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "suggested name"
@@ -6966,7 +6966,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4e635ce6-e84c-4cdd-852a-13228b31919c",
+                     "jsondocId": "185668eb-807d-47ec-91df-2645e028a328",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6975,7 +6975,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c5455689-60d9-401a-950d-c2c99ba19ad3",
+                     "jsondocId": "ad3c8591-2e5f-42b1-840d-b4379bec7d3a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6984,7 +6984,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b1180c12-68ce-44b1-b784-582a3edd9d0a",
+                     "jsondocId": "ac518a37-a77d-4b64-8bb9-ea0b715d71f9",
                      "name": "id",
                      "format": "",
                      "description": "Suggested name ID to remove (or specify the name)",
@@ -6993,7 +6993,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ea0ad5d-d538-44b3-ae1d-81635d193eb2",
+                     "jsondocId": "df3e4e82-56a9-4348-98e0-9218310957d5",
                      "name": "name",
                      "format": "",
                      "description": "Suggested name to delete",
@@ -7005,9 +7005,9 @@
                "verb": "POST",
                "description": "Remove a suggested name",
                "methodName": "deleteName",
-               "jsondocId": "48e584e2-df07-4abe-b348-8239930954db",
+               "jsondocId": "7f74d6c0-108b-4ec7-832d-27b9073534a0",
                "bodyobject": {
-                  "jsondocId": "f637c000-058d-4456-a1af-c2a79844b1f9",
+                  "jsondocId": "324d1ea4-2866-4a7a-95eb-0d3faa86c145",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7017,7 +7017,7 @@
                "apierrors": [],
                "path": "/suggestedName/deleteName",
                "response": {
-                  "jsondocId": "2e36697c-adea-451f-9637-67cc57b2fa8a",
+                  "jsondocId": "c1f92c70-1391-4dc2-9d07-0ecf829a3065",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "suggested name"
@@ -7030,7 +7030,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "215e7f52-ab37-4ec8-952e-ba4929b65b22",
+                     "jsondocId": "2dbb6c3a-d747-44af-a642-d270e37fac94",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7039,7 +7039,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3340acd4-0643-4f7c-a26f-e2b5b64791ff",
+                     "jsondocId": "33cdec9c-8cf1-4a9e-80b9-63eaeefbeeda",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7048,7 +7048,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3f38f296-d644-4868-95a3-252a6add0ba3",
+                     "jsondocId": "fd18ab8d-5690-4841-8f55-0bea6bcdd849",
                      "name": "id",
                      "format": "",
                      "description": "Name ID to show (or specify a name)",
@@ -7057,7 +7057,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9923b50-45bf-4fcc-84a1-67f090941d00",
+                     "jsondocId": "6be09ed1-7a48-4eb0-b4d4-21859ab5bf15",
                      "name": "name",
                      "format": "",
                      "description": "Name to show",
@@ -7069,9 +7069,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all suggested names, or optionally, gets information about a specific suggested name",
                "methodName": "showName",
-               "jsondocId": "8fe58007-9cac-4af4-a40a-e17ddc2c1254",
+               "jsondocId": "51a9cce1-1193-4267-9229-988289decf7f",
                "bodyobject": {
-                  "jsondocId": "f20a0a36-18a1-46af-b3e6-f5284cb3a098",
+                  "jsondocId": "315a3f4d-9bf1-4984-8097-e10ac0f40b9a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7081,7 +7081,62 @@
                "apierrors": [],
                "path": "/suggestedName/showName",
                "response": {
-                  "jsondocId": "e77ac2a4-bd3d-490d-a944-34366d8bbe4a",
+                  "jsondocId": "340ab355-67d4-45d9-a869-421653bb8015",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "suggested name"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "15d62c6f-e10f-4812-aade-b9d2f0963ac6",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "27cb269a-769e-477f-a74d-4d7a1417b9fb",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cf6a450a-9bef-4271-a131-3d8d77635d53",
+                     "name": "names",
+                     "format": "",
+                     "description": "A comma-delimited list of names to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "A comma-delimited list of names",
+               "methodName": "addNames",
+               "jsondocId": "7901b625-5758-4fbd-ab91-c07359c4e86e",
+               "bodyobject": {
+                  "jsondocId": "8ec940f3-e048-4e3e-a967-7081865c0ea8",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "suggested name"
+               },
+               "apierrors": [],
+               "path": "/suggestedName/addNames",
+               "response": {
+                  "jsondocId": "bf57d326-d475-4cbe-a76b-3aa1d155081c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "suggested name"
@@ -7094,14 +7149,42 @@
          "description": "Methods for managing suggested names"
       },
       {
-         "jsondocId": "1172e7d3-990c-424a-87ad-158d630f7959",
+         "jsondocId": "aab1f74b-eeea-4c74-b7b4-83f4e9ab94c5",
          "methods": [
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [{
+                  "jsondocId": "bee6005a-6fac-4c5f-aa99-4e7d4b8cb983",
+                  "name": "organismName",
+                  "format": "",
+                  "description": "Organism common name (required) or 'ALL' if admin",
+                  "type": "string",
+                  "required": "true",
+                  "allowedvalues": []
+               }],
+               "verb": "GET",
+               "description": "Remove track cache for an organism",
+               "methodName": "clearOrganismCache",
+               "jsondocId": "84266740-58ba-4218-b8b9-18f2bd546af6",
+               "bodyobject": null,
+               "apierrors": [],
+               "path": "/track/cache/clear/<organism name>",
+               "response": {
+                  "jsondocId": "5f6c2245-8dcc-4671-97f6-96ea4cbee58f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "track"
+               },
+               "produces": ["application/json"],
+               "consumes": []
+            },
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e1fd79d8-249e-47c4-b285-e90197c41fb7",
+                     "jsondocId": "a805a5b5-7890-4a97-af03-1e4d22fef525",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -7110,7 +7193,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9ab7a20a-6144-4926-9242-2790129745c3",
+                     "jsondocId": "b91203d0-0424-478b-9e94-33f5d47df913",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name (required)",
@@ -7122,12 +7205,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism and track",
                "methodName": "clearTrackCache",
-               "jsondocId": "99545868-016a-4671-808f-ee4821dcc249",
+               "jsondocId": "6d795b04-75e3-403f-9b7a-c7309b74cd24",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>/<track name>",
                "response": {
-                  "jsondocId": "d9c7f7b8-20f1-482f-bcef-8638be63652f",
+                  "jsondocId": "14a48523-5daf-43c0-a04f-7aac67edde10",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7139,7 +7222,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "2f6c9865-82a5-488c-a239-90baeb9a05d7",
+                  "jsondocId": "ac74a399-75a7-493d-b387-90177f808ab9",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required)",
@@ -7150,12 +7233,12 @@
                "verb": "GET",
                "description": "List all tracks for an organism",
                "methodName": "getTracks",
-               "jsondocId": "b6be8a60-2c04-4c43-b42e-5bcb80a82d95",
+               "jsondocId": "65368df8-559d-429c-9161-331abf8dbd91",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/list/<organism name>",
                "response": {
-                  "jsondocId": "e6304d3a-6393-4907-b03e-4df9f9cdfb02",
+                  "jsondocId": "91e2071f-c36e-42da-860b-3f8a2ddc8731",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7168,7 +7251,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a6090eff-2eb9-4ba7-8d53-0ebcdbaf17d5",
+                     "jsondocId": "e7e24121-ef04-420e-8fb7-3940abb7fe42",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -7177,7 +7260,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "226cbe79-ff12-442f-8f67-3cd915dba2f9",
+                     "jsondocId": "2636231d-8454-4129-a016-59c3df9bd9ab",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -7186,7 +7269,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "67543c54-b78e-4c61-8437-e5a5e976d48a",
+                     "jsondocId": "d3dca3d4-2d7a-4236-b17d-07632af29de2",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -7195,7 +7278,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dbb2eebb-34d5-42d5-b0f2-1f04f4553a21",
+                     "jsondocId": "426a60eb-0604-466b-a5c4-f1d3b94950ad",
                      "name": "featureName",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -7204,7 +7287,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "be088147-b4a2-4110-a78d-4491dbc110c3",
+                     "jsondocId": "732a92bb-b0d8-4c61-a6d2-4ad6adddbb4e",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -7213,7 +7296,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eaa3e91e-a106-4056-a154-157bd9ddd15c",
+                     "jsondocId": "4ed7a5a3-abe0-4507-b451-ebf596599a0e",
                      "name": "flatten",
                      "format": "",
                      "description": "Brings nested top-level components to the root level.  If not provided or 'false' it will not flatten.  Default is 'gene'.",
@@ -7222,7 +7305,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "283425e2-2460-431f-88d8-8153cca57040",
+                     "jsondocId": "4acf325e-29f5-423a-96ab-ba1142c0cd5b",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -7234,12 +7317,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within but only for the selected name",
                "methodName": "featuresByName",
-               "jsondocId": "db5e5a05-8937-46e4-8998-a1e4714d9329",
+               "jsondocId": "fa15d012-d816-47dc-b9d6-b97654b73447",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "6f96006f-717e-4bc0-84f6-9a87320a2606",
+                  "jsondocId": "836e2a2d-2420-4357-996f-0a9bbbfc6441",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7252,7 +7335,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4eb1919e-d6c4-4ebd-aa16-7cc5a0c2cf82",
+                     "jsondocId": "b1d833ef-e6da-4d0c-88b0-adcb46948557",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -7261,7 +7344,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "760194f6-bec7-48ec-9f3b-52878a86378c",
+                     "jsondocId": "fe6f19b0-774d-4bd7-a2c0-0781c8664a86",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -7270,7 +7353,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7332baeb-e563-41f8-a55d-79598d8e30ae",
+                     "jsondocId": "104c60aa-b580-43f3-88a7-df011a09cff1",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -7279,7 +7362,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8ae223ed-3597-4c60-81a7-43a06cd2b3c6",
+                     "jsondocId": "72a828ff-af2f-4edf-b3e3-e04f1aaa1596",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -7288,7 +7371,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b517220e-5111-479a-a047-3209a17340fe",
+                     "jsondocId": "d6781bcc-fe4c-4c6d-811e-5622ea5a8296",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -7297,7 +7380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e584c8e6-c052-4f9d-b5fd-563ec767fa49",
+                     "jsondocId": "883876ce-bd51-4809-aa9d-947e7d5efe21",
                      "name": "name",
                      "format": "",
                      "description": "If top-level feature 'name' matches, then annotate with 'selected'=true.  Multiple names can be passed in.",
@@ -7306,7 +7389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d68192e0-d9f4-4f70-8de3-47966c7a5617",
+                     "jsondocId": "79ca8d7b-6ac9-42cc-a3c2-12aa9e9f3c68",
                      "name": "onlySelected",
                      "format": "",
                      "description": "(default false).  If 'selected'!=1 one, then exclude.",
@@ -7315,7 +7398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0fe42c1e-ab97-4c3a-b14a-8926f5211e1e",
+                     "jsondocId": "91463210-8f48-4ac1-a057-a3f8a52d618c",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -7324,7 +7407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6712a9fb-0a26-4373-adca-ec90ed4acc3c",
+                     "jsondocId": "b9bc003e-ad3a-4040-ab58-6c053cad3a9e",
                      "name": "flatten",
                      "format": "",
                      "description": "Brings nested top-level components to the root level.  If not provided or 'false' it will not flatten.  Default is 'gene'.",
@@ -7333,7 +7416,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "08a8c326-f449-4a4d-a271-9ddd13883e84",
+                     "jsondocId": "928a9e5c-d610-468f-9f5d-b08b32ecbb31",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -7345,40 +7428,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within an range",
                "methodName": "featuresByLocation",
-               "jsondocId": "b78e6f72-8072-4916-a8e2-5d673f39ea07",
+               "jsondocId": "ec034911-39f6-4c50-8d4a-66841d111e81",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>:<fmin>..<fmax>.<type>?name=<name>&onlySelected=<onlySelected>&ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "af8f466d-ed4b-45c5-a8b4-a0668a74d09e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "track"
-               },
-               "produces": ["application/json"],
-               "consumes": []
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [{
-                  "jsondocId": "e3d1a50c-4e67-4d8b-a44c-723df7853b66",
-                  "name": "organismName",
-                  "format": "",
-                  "description": "Organism common name (required) or 'ALL' if admin",
-                  "type": "string",
-                  "required": "true",
-                  "allowedvalues": []
-               }],
-               "verb": "GET",
-               "description": "Remove track cache for an organism",
-               "methodName": "clearOrganismCache",
-               "jsondocId": "8efe7c70-19fd-4650-9c21-c9fb0f49217a",
-               "bodyobject": null,
-               "apierrors": [],
-               "path": "/track/cache/clear/<organism name>",
-               "response": {
-                  "jsondocId": "4fc32f58-2c1c-4654-8649-070cb42e9a52",
+                  "jsondocId": "2a59096a-c260-4e12-9d2e-766b0c485d43",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7391,14 +7446,14 @@
          "description": "Methods for retrieving track data"
       },
       {
-         "jsondocId": "892be8fe-65d8-4776-ad9b-60d6ae424eef",
+         "jsondocId": "b5bda72a-f9d7-4eb1-bbe8-3305782753d6",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d25d24e0-ffc0-4501-ae11-6985a633c484",
+                     "jsondocId": "ac1030aa-4721-48a4-b36a-7a8e755a45a3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7407,7 +7462,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9c20b02-7e6f-4aa1-adb9-69e8f68108a8",
+                     "jsondocId": "5b109ec3-4b3e-41a1-bfb4-42acff42a20f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7416,62 +7471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1c47b79-ab87-4144-9a44-250830211e2d",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to fetch",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get organism permissions for user, returns an array of permission objects",
-               "methodName": "getOrganismPermissionsForUser",
-               "jsondocId": "546b823d-0267-4107-8e24-da6cd509548e",
-               "bodyobject": {
-                  "jsondocId": "0a7d6b3e-59b7-48c1-ae60-c3e3cb139e8e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/getOrganismPermissionsForUser",
-               "response": {
-                  "jsondocId": "423a3083-3f78-442d-abc5-06e5d04ccf27",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "33515572-4998-40d1-b4ee-c71c93e9aa30",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bb57843e-bb43-45f0-8e01-6120389327aa",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cb484b25-648c-4b2f-8fc3-b8fc79f38838",
+                     "jsondocId": "7c7ce58a-b74e-4055-800c-24f01edad21c",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to modify permissions for",
@@ -7480,7 +7480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "27e8b040-4e3d-49fe-a985-ee6fcfdd7cb5",
+                     "jsondocId": "391accdf-ac52-44d8-b179-d7a58833d016",
                      "name": "user",
                      "format": "",
                      "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
@@ -7489,7 +7489,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1b09e0a1-0529-496d-bc4f-29fa50eac1af",
+                     "jsondocId": "906d0e35-5009-448d-84d4-766d74f57a04",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism to update",
@@ -7498,7 +7498,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c0f77454-6985-475e-9a4b-d5177613c10e",
+                     "jsondocId": "7f8f3eef-8ee8-4be2-9071-e98ce10266ba",
                      "name": "id",
                      "format": "",
                      "description": "Permission ID to update (can get from userId/organism instead)",
@@ -7507,7 +7507,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "752e86a9-9314-4f36-a1b7-a22b3a157843",
+                     "jsondocId": "238aecd2-0195-49b2-8fd1-d89587f6136e",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -7516,7 +7516,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0881db89-54a4-4203-8920-0c2489a7b3ee",
+                     "jsondocId": "65714725-b9f7-4f82-ac2c-067eb570fe66",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -7525,7 +7525,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1150756-89e4-42dd-915c-5d490b4ca3a3",
+                     "jsondocId": "3cb8e022-1019-44d8-adb4-6e0dbe5d149e",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -7534,7 +7534,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63156dff-86da-48f9-ba99-a0c1a29a5e23",
+                     "jsondocId": "21ef5e78-852d-4b9a-963b-294cde4059b6",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -7546,9 +7546,9 @@
                "verb": "POST",
                "description": "Update organism permissions",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "c28ea0ea-0615-4c9a-8f97-2fc8f14b94e8",
+               "jsondocId": "6b142508-2597-4060-9f58-dcd5f03dcd22",
                "bodyobject": {
-                  "jsondocId": "8d156195-bab0-4b08-b405-3cf41e40fb2a",
+                  "jsondocId": "24a26995-9be8-4ced-8a6c-a739874d3cef",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7558,7 +7558,7 @@
                "apierrors": [],
                "path": "/user/updateOrganismPermission",
                "response": {
-                  "jsondocId": "6c61fe0e-d906-4d1f-923d-f18cbce43745",
+                  "jsondocId": "40ec2687-cf25-4422-84a6-908418a15ce3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7571,7 +7571,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7af86760-e409-4eb9-9d2c-f168aa547d8f",
+                     "jsondocId": "ba2cc8b9-70e1-41dd-acf8-cfb8e25eb341",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7580,7 +7580,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ec2f324-c0a1-46a0-926f-c5827863fb6f",
+                     "jsondocId": "5b5bae6c-ddcf-40e8-8483-93aeed82ade0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7589,7 +7589,62 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8f982935-fa04-4179-bc8c-d816a10c6cf6",
+                     "jsondocId": "585242c2-751e-4d45-8007-ce5b512527d8",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to fetch",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for user, returns an array of permission objects",
+               "methodName": "getOrganismPermissionsForUser",
+               "jsondocId": "2acfb008-adde-4a2d-8454-a84895168745",
+               "bodyobject": {
+                  "jsondocId": "7ba19ca1-b2c3-46aa-8254-33bc74804b80",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/getOrganismPermissionsForUser",
+               "response": {
+                  "jsondocId": "7ac8aa0e-0751-4f13-9866-36acd43c3896",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5bdcab9c-2db9-4707-b62c-0e41a205e06e",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cc874298-d990-479a-8e57-0fbd2a840661",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "31126d1b-f870-4fb9-92b9-9016f34ce42c",
                      "name": "userId",
                      "format": "",
                      "description": "Optionally only user a specific userId as an integer database id or a username string",
@@ -7598,7 +7653,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7b1dc3a2-5b48-482c-8e13-dc18489b4828",
+                     "jsondocId": "868b5b0b-88f3-44b8-9ced-f2e9024df4c0",
                      "name": "start",
                      "format": "",
                      "description": "(optional) Result start / offset",
@@ -7607,7 +7662,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "30b3dfc0-eee1-4da7-a54a-63171c9a1420",
+                     "jsondocId": "488229c8-bbd5-4c37-9e5c-da708e92fb96",
                      "name": "length",
                      "format": "",
                      "description": "(optional) Result length",
@@ -7616,7 +7671,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db2aa993-1ea5-42e1-aca6-28c4d0e6d111",
+                     "jsondocId": "f41c53cf-1614-4ff1-8f68-0824be6dfe6b",
                      "name": "name",
                      "format": "",
                      "description": "(optional) Search name",
@@ -7625,7 +7680,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ad71cca2-7594-415f-a22a-a54034d25849",
+                     "jsondocId": "41172196-71be-4b59-8614-bab1af3c0591",
                      "name": "sortColumn",
                      "format": "",
                      "description": "(optional) Sort column, default 'name'",
@@ -7634,7 +7689,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4f6bd9ba-0f0c-4290-8321-e1477618bae2",
+                     "jsondocId": "00eb5b49-13be-4e99-9340-720f31d73c6c",
                      "name": "sortAscending",
                      "format": "",
                      "description": "(optional) Sort column is ascending if true (default false)",
@@ -7643,7 +7698,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a7100609-515f-4c24-a9bf-3bc1a7b2dd75",
+                     "jsondocId": "e9c936c4-4fc1-4d71-b581-9f6174b64897",
                      "name": "omitEmptyOrganisms",
                      "format": "",
                      "description": "(optional) Omits empty organism permissions from return (default false)",
@@ -7652,7 +7707,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f08a283e-db2e-4c5c-861a-a19475124084",
+                     "jsondocId": "0ce56614-cdd6-4ceb-9a10-23a631c81adc",
                      "name": "showInactiveUsers",
                      "format": "",
                      "description": "(optional) Shows inactive users without permissions (default false)",
@@ -7664,9 +7719,9 @@
                "verb": "POST",
                "description": "Load all users and their permissions",
                "methodName": "loadUsers",
-               "jsondocId": "b688d6f6-bbe7-4f53-b70e-a252da00edb5",
+               "jsondocId": "ae233bdd-baf6-43f6-8e96-8a0616090a57",
                "bodyobject": {
-                  "jsondocId": "16a5e6d5-e0ad-4fb3-b369-c3972a671d47",
+                  "jsondocId": "55f6317d-d409-44e6-a832-76c3ad6c0362",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7676,7 +7731,7 @@
                "apierrors": [],
                "path": "/user/loadUsers",
                "response": {
-                  "jsondocId": "4a9c8c33-e4d2-4814-9fa0-935c66797271",
+                  "jsondocId": "7d3c72e4-9826-45e1-9041-1efab77541ea",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7689,7 +7744,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3f03cbb2-9892-4869-88ac-bf90e7059560",
+                     "jsondocId": "2f0e4fc8-0bbd-4113-bcab-b65eda8e8544",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7698,7 +7753,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "138c12c6-2698-46a7-b02e-f7af262fc210",
+                     "jsondocId": "5bb8b3c9-4fed-46a8-953a-788d0a4ac66d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7707,7 +7762,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bdd4bbc2-b93b-42cd-910f-bb8f7dcaf037",
+                     "jsondocId": "c6fa38ae-0068-4233-9e6d-f7be30104187",
                      "name": "group",
                      "format": "",
                      "description": "Group name",
@@ -7716,7 +7771,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b41809f9-d39a-41cf-9812-0ed9ce451902",
+                     "jsondocId": "a0f5c589-7c83-436f-a94c-bbf45a2d3fb3",
                      "name": "userId",
                      "format": "",
                      "description": "User id",
@@ -7725,7 +7780,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44cf637a-5cc2-41e0-acb5-2bf74bbd971b",
+                     "jsondocId": "eb46e950-4271-4450-9230-107083388306",
                      "name": "user",
                      "format": "",
                      "description": "User email/username (supplied if user id unknown)",
@@ -7737,9 +7792,9 @@
                "verb": "POST",
                "description": "Add user to group",
                "methodName": "addUserToGroup",
-               "jsondocId": "7e31221b-64d6-46a8-8d57-f63391a54699",
+               "jsondocId": "cd5e1d26-a449-44f3-aec0-98475c542d5e",
                "bodyobject": {
-                  "jsondocId": "f6fd7809-f8cf-4d5e-ab94-feba52fc8e68",
+                  "jsondocId": "8acddd2f-9050-481d-b143-9aff675a952f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7749,7 +7804,7 @@
                "apierrors": [],
                "path": "/user/addUserToGroup",
                "response": {
-                  "jsondocId": "9da52ef5-3921-4d9c-af7b-a5fa2e3d0d6c",
+                  "jsondocId": "8ed63dd0-8fa7-4607-bb06-7845236f9585",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7762,7 +7817,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "639bdefc-bf63-47bb-9c4a-aa8166724b52",
+                     "jsondocId": "2c8cc647-987a-48d4-befe-ea251d85922f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7771,7 +7826,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97057873-3a0e-4831-8300-0c94f9325446",
+                     "jsondocId": "a06db520-140e-4dcf-b7f3-087f1ca45cae",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7780,7 +7835,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f5c9e4cf-b5b2-44f4-a53b-8effda778a98",
+                     "jsondocId": "172d9331-d63a-4d09-b7df-850153d5c2da",
                      "name": "group",
                      "format": "",
                      "description": "Group name",
@@ -7789,7 +7844,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "da7c62e2-1e91-40d4-992b-e6e9ec8f541e",
+                     "jsondocId": "34488e35-a3f8-45f6-9f1f-570d669340cb",
                      "name": "userId",
                      "format": "",
                      "description": "User id",
@@ -7798,7 +7853,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9df6c775-2db4-455f-b400-245079754fb3",
+                     "jsondocId": "8bf8403c-255f-495d-9eab-85b2d017f540",
                      "name": "user",
                      "format": "",
                      "description": "User email/username (supplied if user id unknown)",
@@ -7810,9 +7865,9 @@
                "verb": "POST",
                "description": "Remove user from group",
                "methodName": "removeUserFromGroup",
-               "jsondocId": "0ee9a396-2b23-42df-96f6-adc0d3d24002",
+               "jsondocId": "4da61e1d-f525-46b3-8d31-feef3705600e",
                "bodyobject": {
-                  "jsondocId": "298c4975-1f70-49cf-898e-c5794f6ceef8",
+                  "jsondocId": "4aaf741b-ce46-429b-8b8f-de19de4b96cb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7822,7 +7877,7 @@
                "apierrors": [],
                "path": "/user/removeUserFromGroup",
                "response": {
-                  "jsondocId": "56738b8b-8716-4975-a9b4-7ba431eeb3c8",
+                  "jsondocId": "5d4c40b0-9212-4814-bcb7-15afb0ff7e32",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7835,7 +7890,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "009a437e-c89d-469d-9044-667d082b95f0",
+                     "jsondocId": "9853811d-a11d-4622-8d92-73cce502f11f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7844,7 +7899,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f8c0d89a-58ac-45bf-a307-ee57c117c7c6",
+                     "jsondocId": "a15944b4-6c3a-413c-a50a-f139204a1d43",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7853,7 +7908,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b4bd4d73-519d-497d-a6a8-b9461438063c",
+                     "jsondocId": "55f36d62-9ea2-466d-ac8c-3786acdb1af4",
                      "name": "email",
                      "format": "",
                      "description": "Email of the user to add",
@@ -7862,7 +7917,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d453bf29-8b33-4d6b-bf6d-6ef556281840",
+                     "jsondocId": "1af391f3-3f4e-4c0a-ab14-4db71ad636e6",
                      "name": "firstName",
                      "format": "",
                      "description": "First name of user to add",
@@ -7871,7 +7926,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d7e566d8-ac94-41f5-b8aa-0a7aa7d8894d",
+                     "jsondocId": "a4eba4e5-68d7-4eac-b1b3-ce446edc836e",
                      "name": "lastName",
                      "format": "",
                      "description": "Last name of user to add",
@@ -7880,7 +7935,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bb7b1dcb-cf6b-46d6-9c33-c65edcf89c4d",
+                     "jsondocId": "ee222584-3f86-410c-8d67-7391ce19ef10",
                      "name": "metadata",
                      "format": "",
                      "description": "User metadata (optional)",
@@ -7889,7 +7944,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d04da893-38b7-41a5-ba2c-26444b72e2f5",
+                     "jsondocId": "27af192d-e1cc-41ab-ba5e-0c0e059ac67e",
                      "name": "role",
                      "format": "",
                      "description": "User role USER / ADMIN (optional: default USER) ",
@@ -7898,7 +7953,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "23c831d8-ab62-4e25-9cd9-0eee9bbde0fb",
+                     "jsondocId": "01ca5e15-7d58-466f-b7fb-7064238b8dfa",
                      "name": "newPassword",
                      "format": "",
                      "description": "Password of user to add",
@@ -7910,9 +7965,9 @@
                "verb": "POST",
                "description": "Create user",
                "methodName": "createUser",
-               "jsondocId": "477ac7ef-800d-4eb5-bccc-105bf65871f5",
+               "jsondocId": "921f821c-a76c-4946-abfc-46b7f716cbfa",
                "bodyobject": {
-                  "jsondocId": "b385567c-b7b3-45fb-84ef-6a57690aabb2",
+                  "jsondocId": "863c30af-6c30-4e82-9da8-acabd8dc3e9a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7922,7 +7977,7 @@
                "apierrors": [],
                "path": "/user/createUser",
                "response": {
-                  "jsondocId": "3031fa64-cd6b-4f21-a5fd-d3ba48a13e1f",
+                  "jsondocId": "5ad63a39-6582-4591-a66f-3c03a14feb81",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7935,7 +7990,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5690929d-a699-4ce4-8622-a97d939ebe7c",
+                     "jsondocId": "ef92dffa-067d-4bc5-bd3f-3b63bd210df9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7944,7 +7999,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b1edcede-b98f-486a-8a90-14db4e77d2b9",
+                     "jsondocId": "ca044973-dde0-469c-8e67-6a66b18326c0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7953,7 +8008,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63e235d1-372a-4fe8-9cf3-1f0ef9f8bfff",
+                     "jsondocId": "00b83b85-1130-435b-b118-b717b1d6e737",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to delete",
@@ -7962,7 +8017,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d870e132-cc9c-4209-8cb4-83fdc58ebe49",
+                     "jsondocId": "388567fe-536a-4d4b-a62b-1996ffc8886a",
                      "name": "userToDelete",
                      "format": "",
                      "description": "Username (email) to inactivate",
@@ -7974,9 +8029,9 @@
                "verb": "POST",
                "description": "Inactivate user, removing all permsissions and setting flag",
                "methodName": "inactivateUser",
-               "jsondocId": "b71a1e60-8047-45e0-a86f-b61b6f59ca7b",
+               "jsondocId": "de388f4e-f4e1-45a8-a252-a04fb127a9cb",
                "bodyobject": {
-                  "jsondocId": "ed5b938d-e0e1-43df-9864-41858b62f5dd",
+                  "jsondocId": "08d82dac-5d74-4472-a90a-337a956d9128",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7986,7 +8041,7 @@
                "apierrors": [],
                "path": "/user/inactivateUser",
                "response": {
-                  "jsondocId": "62fc3405-004a-44c7-8c9c-87c2c8bd5102",
+                  "jsondocId": "adc87128-5a48-4a0f-83b7-9c8968e89e90",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7999,7 +8054,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "45953330-50a3-47cc-9e74-0ede3b514278",
+                     "jsondocId": "94b0dd4a-6fa6-46d7-9ea8-cb244ac41538",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -8008,7 +8063,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "31166ac4-1532-4886-a53a-0b495d7510e9",
+                     "jsondocId": "beb5854a-c6f6-4c64-b703-4fe44c7a5050",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -8017,7 +8072,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e5c7e263-377d-49b4-9111-9d900bb42e5d",
+                     "jsondocId": "f617be56-41f9-414b-b421-7fc16a7957d3",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to delete",
@@ -8026,7 +8081,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "52882379-e8c9-4da1-81ef-942bea610dea",
+                     "jsondocId": "f163be6c-5359-4210-9c0f-0cbec0988f61",
                      "name": "userToActivate",
                      "format": "",
                      "description": "Username (email) to inactivate",
@@ -8038,9 +8093,9 @@
                "verb": "POST",
                "description": "Activate user",
                "methodName": "activateUser",
-               "jsondocId": "003fb7b0-d987-44c8-afd2-4de1bc8237e0",
+               "jsondocId": "f19e21fc-6735-4a7c-bd61-e33bae487cbb",
                "bodyobject": {
-                  "jsondocId": "29a6fa4a-6d1d-4919-8fe9-b84fac9196c5",
+                  "jsondocId": "0c6ad4bf-913e-4781-b126-5facfdaa1d4d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -8050,7 +8105,7 @@
                "apierrors": [],
                "path": "/user/activateUser",
                "response": {
-                  "jsondocId": "50895e27-8e93-454c-8028-9c4d29dade4c",
+                  "jsondocId": "80ef73fa-fb6f-4f82-99a6-d7a9e91fc897",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -8063,7 +8118,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "77a08cf5-10a5-45fa-a343-9a32d45e4c6c",
+                     "jsondocId": "b9ddb352-5b22-4424-8c7b-726b85fa4421",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -8072,7 +8127,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6deedcbe-a334-42ad-a47f-10e23f155ce0",
+                     "jsondocId": "d5a649d5-5804-419b-b9da-e5fe729cc945",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -8081,7 +8136,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ca2a657c-b457-454f-bde9-4ff3ade9b1f5",
+                     "jsondocId": "ba02dfcf-697b-44ab-97c9-4784179ee2ad",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to delete",
@@ -8090,7 +8145,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dffc30b0-899f-4649-ace3-ae5759056f8f",
+                     "jsondocId": "25a46721-e258-4d1a-9f14-2f3585992a75",
                      "name": "userToDelete",
                      "format": "",
                      "description": "Username (email) to delete",
@@ -8102,9 +8157,9 @@
                "verb": "POST",
                "description": "Delete user",
                "methodName": "deleteUser",
-               "jsondocId": "95a1b95a-bc20-4c1b-8a1f-94469d1e1431",
+               "jsondocId": "5486be2e-e283-4433-b2c1-a147e32cd76f",
                "bodyobject": {
-                  "jsondocId": "83e5c4dc-1fa7-441e-899a-f1985b61031d",
+                  "jsondocId": "2c7109c6-0c18-4a9a-bd0d-a7dc2543a156",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -8114,7 +8169,7 @@
                "apierrors": [],
                "path": "/user/deleteUser",
                "response": {
-                  "jsondocId": "42a6a4d8-ae4b-425d-938f-6dc3a72590d7",
+                  "jsondocId": "15282ea1-1331-4138-8a70-5ea59fe50a4f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -8127,7 +8182,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "514e8826-ebc7-4414-adf0-ca0373c58923",
+                     "jsondocId": "e2875c15-1df3-4ef5-baf1-488f0f9314f5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -8136,7 +8191,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f63e443f-cd09-480d-9d93-c4b66e29ae24",
+                     "jsondocId": "5a13d64b-275c-4272-a39f-61360581bc33",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -8145,7 +8200,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e9ff5ab0-111a-492a-8e34-ef85ccb17f85",
+                     "jsondocId": "4d480f5b-73b4-40e4-a3a9-9f2ee5d0ae78",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to update",
@@ -8154,7 +8209,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db5e20b8-f8ad-42e5-99f8-791bb136046e",
+                     "jsondocId": "656d03a8-5fcb-48ee-a536-6d9605354b2e",
                      "name": "email",
                      "format": "",
                      "description": "Email of the user to update",
@@ -8163,7 +8218,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e73361df-756c-4fd1-926b-48e4d3eae950",
+                     "jsondocId": "71846109-3249-416c-a6f7-50a599e1ea57",
                      "name": "firstName",
                      "format": "",
                      "description": "First name of user to update",
@@ -8172,7 +8227,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5384027e-36ac-4862-a04a-0c30c0a537d5",
+                     "jsondocId": "13c3b7f7-9d3b-4226-bb39-eaec6cd7aeed",
                      "name": "lastName",
                      "format": "",
                      "description": "Last name of user to update",
@@ -8181,7 +8236,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b7fe427f-777e-4a64-81c5-efbb9444e710",
+                     "jsondocId": "30a8f775-5dd7-4785-8859-d4b78fa2d76b",
                      "name": "metadata",
                      "format": "",
                      "description": "User metadata (optional)",
@@ -8190,7 +8245,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f22ab3c0-1d7a-4394-ba30-d727c78aa8ca",
+                     "jsondocId": "888efef7-0aa7-45ed-a1ec-a854bb933a71",
                      "name": "newPassword",
                      "format": "",
                      "description": "Password of user to update",
@@ -8202,9 +8257,9 @@
                "verb": "POST",
                "description": "Update user",
                "methodName": "updateUser",
-               "jsondocId": "41a99048-a653-4722-acfb-038472f61078",
+               "jsondocId": "12fd4aaa-5e34-41b0-bb0d-f40737b42caa",
                "bodyobject": {
-                  "jsondocId": "3365d43a-6f26-40da-bc78-c926b8a6f795",
+                  "jsondocId": "fba429dc-fa15-4c86-a919-3cbe7b79f952",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -8214,7 +8269,7 @@
                "apierrors": [],
                "path": "/user/updateUser",
                "response": {
-                  "jsondocId": "c08ef057-242c-4101-94d0-f81f18135335",
+                  "jsondocId": "5b85d409-7307-4104-8898-d4279bcd3d63",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -8227,7 +8282,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c9b145bc-e766-42da-86a7-ce31b8b65b4f",
+                     "jsondocId": "a2c5cd71-a0bc-4492-b06e-eda51903d9d3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -8236,7 +8291,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7e20878c-f0f1-4c45-b3a7-9e8725de57c0",
+                     "jsondocId": "a09c394f-e0d2-470c-830d-3b87a7fe3113",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -8245,7 +8300,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "43db4bd2-a227-42a0-bcad-e41021698672",
+                     "jsondocId": "b86a5da1-77a2-416e-9bc1-e3ce21c11800",
                      "name": "email",
                      "format": "",
                      "description": "Email of the user",
@@ -8257,9 +8312,9 @@
                "verb": "POST",
                "description": "Get creator metadata for user, returns creator userId as JSONObject",
                "methodName": "getUserCreator",
-               "jsondocId": "b0bae7fc-7edc-48ce-9259-b9e88e28a301",
+               "jsondocId": "cf0f6057-07c0-4674-bcb2-28c7776f936e",
                "bodyobject": {
-                  "jsondocId": "a329d094-2cf5-4924-b461-dfc85ddaa7f4",
+                  "jsondocId": "0bbff3f7-9385-42c4-b05a-23b6658bf459",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -8269,7 +8324,7 @@
                "apierrors": [],
                "path": "/user/getUserCreator",
                "response": {
-                  "jsondocId": "6a1401b8-4831-4921-a7bf-595f317bc9ad",
+                  "jsondocId": "34c4d9e7-d597-40e5-a935-dc91dcc27ef7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -8282,13 +8337,13 @@
          "description": "Methods for managing users"
       },
       {
-         "jsondocId": "fcb4cdae-0504-45fa-a58c-d2833b5b81e2",
+         "jsondocId": "40060e27-5df3-430e-89b1-8d0faf2072e5",
          "methods": [{
             "headers": [],
             "pathparameters": [],
             "queryparameters": [
                {
-                  "jsondocId": "29b32fc2-3ce5-4515-87d4-96b68c8e1f4b",
+                  "jsondocId": "5da5ef58-cc5b-4e4b-a329-2ac39190d603",
                   "name": "organismString",
                   "format": "",
                   "description": "Organism common name or ID (required)",
@@ -8297,7 +8352,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "42257fd6-22a2-4619-9b9a-60e65d080c70",
+                  "jsondocId": "671b234b-431d-4012-834d-14fd77f93f7c",
                   "name": "trackName",
                   "format": "",
                   "description": "Track name by label in trackList.json (required)",
@@ -8306,7 +8361,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "a1d8343c-ed28-4945-a354-fe7ce8545edd",
+                  "jsondocId": "ba57c654-1331-4583-8ed8-03d2cd4ee515",
                   "name": "sequence",
                   "format": "",
                   "description": "Sequence name (required)",
@@ -8315,7 +8370,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "3d821811-259c-4747-8def-2493c36ccbb7",
+                  "jsondocId": "ba8b43df-08ed-494c-bb4d-ba68cab7c33e",
                   "name": "fmin",
                   "format": "",
                   "description": "Minimum range (required)",
@@ -8324,7 +8379,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "84670751-d57b-4bb9-ab88-a4037257d35c",
+                  "jsondocId": "3b2838d8-9563-445a-97fc-15b961df13fd",
                   "name": "fmax",
                   "format": "",
                   "description": "Maximum range (required)",
@@ -8333,7 +8388,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "0413498f-ed19-4eac-bfe2-b85bfdea601d",
+                  "jsondocId": "7db8b005-28eb-4e6c-b061-b317d32878be",
                   "name": "type",
                   "format": "",
                   "description": ".json (required)",
@@ -8342,7 +8397,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "7b8f01bd-8403-43a7-b8e0-e058ac26544e",
+                  "jsondocId": "fa65626d-56f1-4f44-9c66-15b83d525d4f",
                   "name": "includeGenotypes",
                   "format": "",
                   "description": "(default: false).  If true, will include genotypes associated with variants from VCF.",
@@ -8351,7 +8406,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "9cf1523f-bc2b-489f-9399-6f2791cee124",
+                  "jsondocId": "1910ef36-c845-42b9-84aa-b3da67790896",
                   "name": "ignoreCache",
                   "format": "",
                   "description": "(default: false).  Use cache for request, if available.",
@@ -8363,12 +8418,12 @@
             "verb": "GET",
             "description": "Get VCF track data for a given range as JSON",
             "methodName": "featuresByLocation",
-            "jsondocId": "6a88ece1-03a0-4785-bac8-21f716a140ce",
+            "jsondocId": "1fc9ae73-c9d4-417c-909b-6afdd4e0f97c",
             "bodyobject": null,
             "apierrors": [],
             "path": "/vcf/<organism_name>/<track_name>/<sequence_name>:<fmin>..<fmax>.<type>?includeGenotypes=<includeGenotypes>&ignoreCache=<ignoreCache>",
             "response": {
-               "jsondocId": "1e0c7dc6-c2b2-4de1-ae9b-b860e8d3285c",
+               "jsondocId": "807b20a9-594a-483d-94ed-2065d1c8a982",
                "mapValueObject": "",
                "mapKeyObject": "",
                "object": "vcf"

--- a/web-app/js/restapidoc/restapidoc.json
+++ b/web-app/js/restapidoc/restapidoc.json
@@ -2,14 +2,14 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
-         "jsondocId": "d2e7e66f-b116-4fdc-a8e1-b64483a0d17a",
+         "jsondocId": "bb26a95b-8fe5-45eb-a373-85d21bbfe003",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "420d9bd5-c30b-434a-98b4-22d42196fbc5",
+                     "jsondocId": "1cd6c7c4-abdb-431d-a4b7-16b1eddf9313",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -18,7 +18,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14aed3fd-0215-44af-be94-924a08e03c02",
+                     "jsondocId": "38750304-82ec-41da-b134-51c5f3a5623b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -27,7 +27,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "243aee5a-19e7-4a75-993d-8b7e1afcbb68",
+                     "jsondocId": "ef51f793-c5fe-405c-8550-ff6108dfaa03",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -36,7 +36,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5d1fee93-b6ab-44db-862c-e8269fd5dbab",
+                     "jsondocId": "b40ec31b-2cb4-4d6e-9625-05c743c7dbc0",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -45,7 +45,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eee383bb-a1ed-4949-bb80-1f9a37e7fd61",
+                     "jsondocId": "c74f9260-4f18-4f6d-a9ba-2b44c3366e6c",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
@@ -57,9 +57,9 @@
                "verb": "POST",
                "description": "Set name of a feature",
                "methodName": "setName",
-               "jsondocId": "5902a7bc-fb8c-42e2-ae99-7ab226e55a35",
+               "jsondocId": "3b39f179-60f3-4115-b825-98bb9470106e",
                "bodyobject": {
-                  "jsondocId": "9efd4fd2-e583-49e3-8fdd-4e5e137e10b6",
+                  "jsondocId": "f5b78316-9f1b-47b4-96a4-da201dac0432",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -69,7 +69,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setName",
                "response": {
-                  "jsondocId": "433020de-ed96-4747-9430-42806e0f86d8",
+                  "jsondocId": "e3eceffc-2b92-4136-81e5-94b02fe56a0d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -82,7 +82,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e88a6295-af07-48a5-9026-d5615c287e00",
+                     "jsondocId": "922dad26-fad3-451a-a067-99c24e3de8e1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -91,7 +91,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "abd607ae-3ca1-40c1-bc29-32830ed1921f",
+                     "jsondocId": "3f0147a1-aee4-480a-96d8-e8fe6994be5e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -100,7 +100,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "77a1a03a-a287-48f2-b870-1c1680128e32",
+                     "jsondocId": "99a356e7-45aa-4a73-a336-fd7b12618879",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -109,7 +109,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "56fc40b8-1523-4a4b-b88a-a440d014e221",
+                     "jsondocId": "5c99bc68-1a3d-4559-bd37-2c4668821c65",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -118,299 +118,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5c635da7-ae24-43f0-b21b-5c59c2d90e92",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set status of a feature",
-               "methodName": "setStatus",
-               "jsondocId": "80450ae3-f081-4943-abc8-e25f396f55de",
-               "bodyobject": {
-                  "jsondocId": "de377ae0-b36d-4c1f-b5f5-ad8775a100f7",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setStatus",
-               "response": {
-                  "jsondocId": "e12e91b7-d361-40a0-b536-c59fcca5c276",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "49009356-c651-488d-b1d5-a97b9f687011",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c9a1ec82-2c61-4b57-ba63-cbe60bf5bdce",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d618d430-d4b6-4392-998d-5596aff2f034",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d2a8f23c-75fb-4044-80fa-82cc9c5ade5d",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4178bb09-01c0-4c21-96ec-b67812f993b5",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get comments",
-               "methodName": "getComments",
-               "jsondocId": "35466539-7ca8-4256-8037-7c31c1a73c18",
-               "bodyobject": {
-                  "jsondocId": "2a76393b-3203-4495-8945-0077a530aa97",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getComments",
-               "response": {
-                  "jsondocId": "5aa4e92b-8cbc-428e-9847-ac42fcba9930",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "a17027f9-bbc5-491c-9aff-aa94969bd651",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ea1b6357-3815-4986-ba4d-7da905e9d0d0",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2ea66bc2-4bb1-49c6-8adc-0f679bd70584",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "efca5b9c-05fd-49af-aa38-a3257969e15a",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "eb819c41-2318-4cc3-bd59-4a62756a98b4",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set symbol of a feature",
-               "methodName": "setSymbol",
-               "jsondocId": "54fea7d6-2e07-4f3c-94a6-06b1fd26c47d",
-               "bodyobject": {
-                  "jsondocId": "8407da68-0082-42ff-947b-6c8fe9f69642",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setSymbol",
-               "response": {
-                  "jsondocId": "8236b757-7f96-482a-8020-078e5a536940",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "33669fd5-18fd-44be-91ae-49e0219adff5",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2d02ee01-c8e5-46c8-8ac0-6942bd5a9691",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e14e0e51-84f0-43b4-8621-36a8345ebe5b",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6b96147b-447a-4c58-ae5b-42c645f37a73",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7c460182-bc8f-477f-95a3-867da39c7f80",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add attribute (key,value pair) to feature",
-               "methodName": "addAttribute",
-               "jsondocId": "f56db8ef-25aa-44f3-8cd7-50b3ac4410fa",
-               "bodyobject": {
-                  "jsondocId": "ffaf001a-45d1-400d-b89c-cdcebab13cb9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addAttribute",
-               "response": {
-                  "jsondocId": "37255d27-b5b4-444c-8da9-49d8e7be8d3f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "98b137af-a678-431f-b3d0-0464a6bfc2bb",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b7d329ef-ec9a-425e-97ee-635e27709c38",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "058fbc4f-88d2-4c72-affa-371874cea583",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0d187fb0-3d69-4f85-bd4e-b82a6b729875",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2a7d6f0e-d4a1-4bc4-a4ef-76fd1b966143",
+                     "jsondocId": "500efc36-3287-489a-822c-f4cbe26748fe",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
@@ -422,9 +130,9 @@
                "verb": "POST",
                "description": "Set description for a feature",
                "methodName": "setDescription",
-               "jsondocId": "6d479000-c6b5-4fb4-a51f-8658e14aaa53",
+               "jsondocId": "4afac5da-ee76-40ca-a7af-c7ba4ac36be6",
                "bodyobject": {
-                  "jsondocId": "53544aa4-87cd-413a-938d-3cedfdbf2a6f",
+                  "jsondocId": "6caba347-cdfb-4763-8d98-27c027730819",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -434,7 +142,390 @@
                "apierrors": [],
                "path": "/annotationEditor/setDescription",
                "response": {
-                  "jsondocId": "42577366-4aae-4222-aebd-fea7ffc88704",
+                  "jsondocId": "8dfed81f-0f25-4fe2-9afe-a86a67cad67c",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "43d07a73-2c02-4ac1-bc4d-948f35a269b7",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "816b3d12-bc38-45c8-89d2-93db0670ce0a",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "19d0da4d-b708-4c5b-b34b-f94ec037d282",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "beee68b2-739a-4a8b-a46e-687c1f305f99",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a5011c17-6aa7-42cc-a173-c6ece21e64d1",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set status of a feature",
+               "methodName": "setStatus",
+               "jsondocId": "7c2702bc-2603-4c28-879b-51000c2fd2e1",
+               "bodyobject": {
+                  "jsondocId": "99a94959-e9df-425d-b1f1-a5a2ae70f202",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setStatus",
+               "response": {
+                  "jsondocId": "782083fe-65b4-4693-b531-8dbe9324ffc2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "b61f2417-0e5f-4e35-b292-523f29914866",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d666e9cc-310c-4afd-8e56-a11160538882",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "67db5f2c-77df-4cdf-a40a-d29a4c8b2446",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9bba66ff-5829-40cd-a956-530e51a4cfad",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b498ec3c-0938-49f9-a22b-a43dd3ce1827",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get comments",
+               "methodName": "getComments",
+               "jsondocId": "903bbdc9-69c1-4569-bd92-41fc1babd126",
+               "bodyobject": {
+                  "jsondocId": "f18276ee-3ff4-4112-b58c-73aa6682a176",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getComments",
+               "response": {
+                  "jsondocId": "890bcd84-5cd5-4823-8978-2802daeb93d6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "daf398e4-1aef-4f48-928f-444367698821",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dd8c6351-a212-4629-ad72-9f7edb287226",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "11d24b96-7813-4a78-b357-3a657a6488ff",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "459f0693-2aed-4de8-9fc6-1694cd7d95e9",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "71244540-63ad-494d-8594-126c954f0153",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add attribute (key,value pair) to feature",
+               "methodName": "addAttribute",
+               "jsondocId": "2799c67d-6071-4d13-9ff2-f188297f4c45",
+               "bodyobject": {
+                  "jsondocId": "dce25a62-f374-4242-a42b-8c337bbfef6b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addAttribute",
+               "response": {
+                  "jsondocId": "78dc94a5-3d9c-4626-8bd2-869ae9c43b6e",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "83e2439e-faf7-4297-841f-ee3792dd9b56",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "ca6239c3-53a3-4733-9bbf-1c594c5a67e6",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c13d7de0-4820-4f19-b95c-666cd1fbf002",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "eafdae02-3385-4bdb-ab99-2c816a6d98df",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "132dee5f-eacd-462d-954a-2798dc7d9a43",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set symbol of a feature",
+               "methodName": "setSymbol",
+               "jsondocId": "17d12630-f933-4485-87e0-85caf089ca85",
+               "bodyobject": {
+                  "jsondocId": "e70a35fa-897d-466c-9e5b-ddb81e5d70ad",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setSymbol",
+               "response": {
+                  "jsondocId": "7563b82d-7a2c-4644-9039-e49b4c53a82d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "c4215ce9-bd04-478b-b739-36029afe75b1",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "44f9e6d0-ce14-4192-9398-38ecfa01d783",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f0ca88a4-d2e3-4efb-8fdc-7a2f301ec610",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "20988d69-ff92-4e3c-b604-a502d97282af",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "84bd19c0-1055-4910-8066-6bc5b6175b3a",
+                     "name": "suppressHistory",
+                     "format": "",
+                     "description": "Suppress the history of this operation",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "44441a5f-78bc-4639-829e-c397f63cfc77",
+                     "name": "suppressEvents",
+                     "format": "",
+                     "description": "Suppress instant update of the user interface",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f23c013d-1a9c-4575-a4d3-bfbf9e370838",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set exon feature boundaries",
+               "methodName": "setExonBoundaries",
+               "jsondocId": "7872cafd-f348-4c89-919a-db21e5064e57",
+               "bodyobject": {
+                  "jsondocId": "a700e277-2e53-4899-8361-0bbb0b78cd14",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setExonBoundaries",
+               "response": {
+                  "jsondocId": "99839ae0-cefc-45b4-ad58-43ea3d9a5a8e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -449,9 +540,9 @@
                "verb": "POST",
                "description": "Returns a translation table as JSON",
                "methodName": "getTranslationTable",
-               "jsondocId": "44373bfd-c8ba-41c0-b62b-7c81117b9849",
+               "jsondocId": "5ac2ba45-a6af-48bb-a121-8b18b0a688ba",
                "bodyobject": {
-                  "jsondocId": "2fb684ec-6282-4a2e-a5d9-2b02d4e9de6a",
+                  "jsondocId": "1cfdc94a-c4c1-4916-a935-7141cbee834f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -461,7 +552,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getTranslationTable",
                "response": {
-                  "jsondocId": "a280e9be-c6e9-499e-be6a-522ed194a244",
+                  "jsondocId": "4c205182-ba59-45d4-af1a-2b7e65184e17",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -474,7 +565,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "da5f1f66-157c-4ca9-8047-13e080275fea",
+                     "jsondocId": "04aaedb7-7838-4951-83a0-76e7815173a3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -483,7 +574,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7d74fe7a-e0dc-49dd-ac3f-77c93001eb42",
+                     "jsondocId": "a1667687-b374-440e-9d23-b15cea236454",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -492,7 +583,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "889c415e-c231-45fc-a6cf-03904822b014",
+                     "jsondocId": "3c189884-557a-48f6-9df6-929b83c6e02f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -501,7 +592,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8f6ab958-82f0-4620-b52e-09cebc7b093e",
+                     "jsondocId": "dd973b0e-a8bc-44b0-952a-2af86d95474e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -510,7 +601,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5bfe6922-5a91-4968-8d6f-0f9a42ce7015",
+                     "jsondocId": "4c199981-25da-4635-938f-02a8ca9f5d3b",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -519,7 +610,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "acd6562b-4823-480d-89f0-ffb33226ce27",
+                     "jsondocId": "93de3a43-f1c9-4051-974f-e868190acaef",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -528,7 +619,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a6325522-dd32-49d8-b5dc-9d3a2495c70c",
+                     "jsondocId": "7a7336a4-e76f-4675-9c2a-aef9463a313a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -540,9 +631,9 @@
                "verb": "POST",
                "description": "Add non-coding genomic feature",
                "methodName": "addFeature",
-               "jsondocId": "5c1d5030-1ae2-4c21-9535-d02d779f6ce3",
+               "jsondocId": "18d112cc-989a-4f0f-a11b-2901c8ba87e7",
                "bodyobject": {
-                  "jsondocId": "ce7c4fd3-5f89-42ba-befa-080b84c081c8",
+                  "jsondocId": "8080bc72-1712-4d6b-bf04-9e66a2e6a1ca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -552,7 +643,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addFeature",
                "response": {
-                  "jsondocId": "ecc95e33-479d-466c-ae1f-b2313407b1a2",
+                  "jsondocId": "aec459d6-ace5-4eee-9ea7-c1a66d7c721c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -565,7 +656,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "62c891b8-696a-4367-9c3c-15c9dfe6b650",
+                     "jsondocId": "0a447491-83b2-433a-b80e-1ffb30b3fce5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -574,7 +665,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e930ee02-2240-4513-8269-0ce45d66b381",
+                     "jsondocId": "58cd00da-ea99-493b-8c32-3219b82451a0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -583,7 +674,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c86dcea3-276e-48bd-af20-86b051bba553",
+                     "jsondocId": "886e684f-5c33-475f-8d49-bc6fcfbdc643",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -592,7 +683,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4c0af33a-5d83-4f87-a4bd-13e007011dd3",
+                     "jsondocId": "431f5e2a-f48f-46d5-8420-fda92b98fc1c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -601,7 +692,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bf4d8c6a-5912-4d77-8ab7-e383a4f0f132",
+                     "jsondocId": "16d95a16-480d-4099-9e4d-a9c0dc6e2f8d",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -610,7 +701,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bb0e7246-e69d-4e47-90b9-1dd5db315203",
+                     "jsondocId": "d20459bf-547f-4971-8560-e4b59e7993aa",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -619,7 +710,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ad543aed-d1ca-47a1-adda-bf365903f602",
+                     "jsondocId": "c09e14d2-335e-4f59-ad88-7226354a56b9",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -631,9 +722,9 @@
                "verb": "POST",
                "description": "Add an exon",
                "methodName": "addExon",
-               "jsondocId": "61456aa0-1120-476b-a7ad-4231a9fe869f",
+               "jsondocId": "79fe8b2f-07e0-4fe7-9a4d-5af98a9d5d84",
                "bodyobject": {
-                  "jsondocId": "cf676df1-f649-4d04-978f-4d702e59ca66",
+                  "jsondocId": "f321898b-bfe5-4669-ac2a-d02a891f82c4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -643,7 +734,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addExon",
                "response": {
-                  "jsondocId": "7711c7fa-138c-482c-b69a-ba1824ad7f07",
+                  "jsondocId": "efb90e3c-32ed-4887-ab50-68ecd4e2be9c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -656,7 +747,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3c898d11-ff50-4754-93db-b73221215f20",
+                     "jsondocId": "c5f38b04-3999-486a-b81f-0c39bc915b87",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -665,7 +756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c291c7be-d38a-4f57-b00a-92932c652bd2",
+                     "jsondocId": "98efd0b8-1bb4-4d40-8e3a-dcbeca96762a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -674,7 +765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dd7e2fbd-85aa-445a-ac47-3b57b1753dd8",
+                     "jsondocId": "66132731-4d5b-44e3-9d7c-a2248623fd77",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -683,7 +774,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "865f9384-33ce-4c9b-81c8-8318869adc2f",
+                     "jsondocId": "988deaea-aeb9-4917-a83d-89c425b64a1e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -692,7 +783,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ba9ba90-8155-440e-b552-0b3ae616e514",
+                     "jsondocId": "740c568f-f880-47ba-9183-6dea5609b3a2",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -704,9 +795,9 @@
                "verb": "POST",
                "description": "Add comments",
                "methodName": "addComments",
-               "jsondocId": "b660fbb5-6b55-4207-8b78-03e0df83e1f5",
+               "jsondocId": "13bb5a48-d069-4750-a2f4-8d5ae3c92135",
                "bodyobject": {
-                  "jsondocId": "bc6a78b5-f3ca-469e-a7d4-d6d368a5fa8c",
+                  "jsondocId": "f4934243-c4a3-4a98-b691-6d3daaee6749",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -716,7 +807,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addComments",
                "response": {
-                  "jsondocId": "b95244d4-573b-4d46-8ec6-8954b43eec9d",
+                  "jsondocId": "87d19d4e-d3c6-428c-8222-93fba744d09e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -729,7 +820,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ca4ef648-f584-43b5-aaa1-dfa696f2a17e",
+                     "jsondocId": "6a586cf2-d1a6-4103-a5f5-ab8e252805c0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -738,7 +829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "95eaa71d-45f8-4870-a4bc-762ad5b6ffbb",
+                     "jsondocId": "b7885650-d3c6-4b7b-bf21-2af057c3ff41",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -747,7 +838,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bb4bbe96-b9fd-4b61-878a-c8f243146402",
+                     "jsondocId": "ee499479-7bc7-4b75-b956-60003edfaf67",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -756,7 +847,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3a4d084a-06a3-480c-99a4-8c21596b595b",
+                     "jsondocId": "15530172-0e79-43b3-81ba-12cefc07f321",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -765,7 +856,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8bf85707-a5cd-4dcb-a33f-3cbd99d4b4b1",
+                     "jsondocId": "99e909cc-4c51-4e71-818a-dbb6e2388228",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -777,9 +868,9 @@
                "verb": "POST",
                "description": "Delete comments",
                "methodName": "deleteComments",
-               "jsondocId": "7c37ca0b-14ff-40e1-8652-9101c75ec007",
+               "jsondocId": "ab982aaa-f169-4d8c-a3e4-f2db3b0e82b9",
                "bodyobject": {
-                  "jsondocId": "19c71f44-e2ea-48ea-b0e2-ec3b5becc94f",
+                  "jsondocId": "579e3f5c-1231-4126-ba23-15dee429769a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -789,7 +880,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteComments",
                "response": {
-                  "jsondocId": "cf74550c-cdf5-4f8d-9394-87a95eda217c",
+                  "jsondocId": "532b8631-83f6-469e-a726-1e85ab5a312f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -802,7 +893,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fa7df018-1121-42cd-919b-485ced41f2f3",
+                     "jsondocId": "2a21ea9e-9621-43d7-a1eb-55f1ec6bc5e6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -811,7 +902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b706260a-3c1d-4b46-8222-9239f6f1e0ac",
+                     "jsondocId": "71ecafc3-0b19-4b9f-96bd-8c87da8ede94",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -820,7 +911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ce259cc5-2614-461f-9206-f99c2cccceb1",
+                     "jsondocId": "d8230508-e6c3-4139-8aea-3119af8e2315",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -829,7 +920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d18581f9-04ac-4153-9d2c-6b1f28837bb8",
+                     "jsondocId": "5b152316-2e9b-4a99-a041-c78d0cd199d9",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -838,7 +929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e1e7f616-74c4-49ec-9ff3-2d12c931933b",
+                     "jsondocId": "2ad18f9f-52bd-46fe-b6ff-45e844cb762e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -850,9 +941,9 @@
                "verb": "POST",
                "description": "Update comments",
                "methodName": "updateComments",
-               "jsondocId": "29ec5b0c-b3f9-4b30-9631-620744316ca1",
+               "jsondocId": "56fafd66-e124-4458-8704-59ec0601774a",
                "bodyobject": {
-                  "jsondocId": "faca1e71-3e1e-4642-8dcb-f9129248b02c",
+                  "jsondocId": "a64a70fc-06b8-4e3a-b942-03b287ed5ac4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -862,7 +953,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateComments",
                "response": {
-                  "jsondocId": "cb6a4465-fe9e-489d-b1d9-c7d672c78fad",
+                  "jsondocId": "31566b47-d276-4918-8542-95617e6ae102",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -875,7 +966,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1c20a444-9717-4617-85b7-2090416a39a2",
+                     "jsondocId": "bc35f48f-6b57-460b-92c6-56831929e1a8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -884,7 +975,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7d9876ac-0f53-4f26-b853-745b48bdb863",
+                     "jsondocId": "3811ecd6-bf3d-4701-bcd0-0f72b6a51a23",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -893,7 +984,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "842c86a0-500c-4f22-8966-1ab45dc017e6",
+                     "jsondocId": "b106d612-62dd-4b47-b516-10d0ce260468",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -902,7 +993,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1b2baa1a-2158-4f58-9afc-aa8656dbf664",
+                     "jsondocId": "d82f88f6-a5b5-4bf3-b36c-f73db3299e27",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -911,7 +1002,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "31772023-926e-4aaa-a060-ed77e3dfc415",
+                     "jsondocId": "e821c59f-0758-4633-9f0d-ca382ca04df6",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -920,7 +1011,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0f2f6d10-4324-4e77-b2c3-13dc765e613a",
+                     "jsondocId": "a0bd7ea3-08f7-4d45-9eba-f8e9510fb0c4",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -929,7 +1020,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7d58286-d6f0-4fd8-ae5c-db37a7e3c12a",
+                     "jsondocId": "15b0d442-7eb7-4e6d-824a-7dbf1e6bd118",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -941,9 +1032,9 @@
                "verb": "POST",
                "description": "Add transcript",
                "methodName": "addTranscript",
-               "jsondocId": "012d07a6-4cf9-445c-8fc6-1c8bf239cc4d",
+               "jsondocId": "9496f07a-67ba-48a7-bc8d-5401f102171d",
                "bodyobject": {
-                  "jsondocId": "4f3de025-2763-45d1-904a-546db49feb6e",
+                  "jsondocId": "a90b2d9f-2b47-4408-9f86-95ca8c7939ec",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -953,7 +1044,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addTranscript",
                "response": {
-                  "jsondocId": "032b1bb2-2566-43f1-9c5a-8dfd4ea3bf65",
+                  "jsondocId": "d3718775-20bf-40c6-ae54-06ba9960d81d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -966,7 +1057,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b39ffb0d-a2ea-4cbf-97c8-4a0365c3390c",
+                     "jsondocId": "e5d83e9f-3a11-42b0-b4a6-ff6a5289d7fa",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -975,7 +1066,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1dc847b-2d42-4656-8d52-c818342446b4",
+                     "jsondocId": "765cc721-ec42-4dae-aa88-4085df2bea2e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -984,7 +1075,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d843c0bb-ff9c-45aa-a1b6-f1b69682f88f",
+                     "jsondocId": "ee51782d-1374-4003-a482-c63a67ebe45e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -993,7 +1084,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1f746b22-aab2-4cad-8e29-a9c234711524",
+                     "jsondocId": "3dbeb24f-6e0e-40fd-b91d-28f103bc9e0c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1002,7 +1093,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "777574f8-9102-4a0f-8820-f0e7376ecb41",
+                     "jsondocId": "704acf19-5389-431d-b5c8-cb35e3346e59",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1011,7 +1102,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7e2b594e-c028-4053-af4c-ca41cdb19b38",
+                     "jsondocId": "f1aa2a72-1f08-42ee-8c76-ce53153deb28",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1020,7 +1111,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f9a70398-dcb5-408f-9e36-9e744d4af38e",
+                     "jsondocId": "04809c0f-4670-49a5-aad0-8a72c1983e95",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
@@ -1032,9 +1123,9 @@
                "verb": "POST",
                "description": "Duplicate transcript",
                "methodName": "duplicateTranscript",
-               "jsondocId": "f62b79c5-a5ca-4c2d-b319-ef1a85d03541",
+               "jsondocId": "cd05c71a-31aa-4fa3-9152-e78e5c095a8a",
                "bodyobject": {
-                  "jsondocId": "a9f57258-d4dc-4d1d-8455-9d33c4a52992",
+                  "jsondocId": "a9e255aa-3616-4248-944f-652ff4483305",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1044,7 +1135,7 @@
                "apierrors": [],
                "path": "/annotationEditor/duplicateTranscript",
                "response": {
-                  "jsondocId": "50abfdca-30e9-41ac-9e34-d375e7bafe91",
+                  "jsondocId": "430bb8e6-e792-47d2-a11e-c1974c94276a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1057,7 +1148,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "65149d3b-f3eb-4d28-b40b-e4d66302af4d",
+                     "jsondocId": "dc68d300-9d01-493d-86ab-3d50d017f907",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1066,7 +1157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c43e3c4-717e-45a4-b259-28bc4a5cb732",
+                     "jsondocId": "2a50132e-4f3a-4c40-9cb4-70dda2f475c1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1075,7 +1166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4c1d185f-2a49-4ff1-a307-ad1fc24daf15",
+                     "jsondocId": "1cc15bc9-aa89-4831-8d56-b7e33e957f73",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1084,7 +1175,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14f85e0e-888d-4faa-8282-3fd7e3a90608",
+                     "jsondocId": "de88e7f8-6547-4862-a42c-ff47a81f7572",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1093,7 +1184,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a9238d99-cc04-4123-9028-c2cf935cc2a3",
+                     "jsondocId": "2b354db9-8757-4bf4-94cc-cd8ef062c3b4",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -1105,9 +1196,9 @@
                "verb": "POST",
                "description": "Set translation start",
                "methodName": "setTranslationStart",
-               "jsondocId": "9bd76795-8313-4558-b282-a7cbf4cae25f",
+               "jsondocId": "1beb83d7-6b5c-4314-9828-511b25dade73",
                "bodyobject": {
-                  "jsondocId": "b27faf77-90eb-4863-9282-4747f5f8f044",
+                  "jsondocId": "bc1710dc-70cd-46f0-b5e7-0455c775d10a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1117,7 +1208,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationStart",
                "response": {
-                  "jsondocId": "1fc91592-a9ed-464f-a182-83eebba6ae36",
+                  "jsondocId": "d118e279-617a-4063-82a1-2c98ff3902a3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1130,7 +1221,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6f6bc260-07a3-4593-99a5-68b19db19a2f",
+                     "jsondocId": "ec4a653a-194d-4023-8d12-48d50e39f04b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1139,7 +1230,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "181a3537-bd80-4be2-a7ec-2356bba4aec4",
+                     "jsondocId": "9d23f01c-080e-412f-8fc9-e250da01e506",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1148,7 +1239,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "16f56f54-b1b0-4c54-a1e2-3438cdc50a46",
+                     "jsondocId": "a6e877bb-647b-4451-8e81-3f6304304419",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1157,7 +1248,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "33419aba-2321-4e7f-8efc-7ae18232392d",
+                     "jsondocId": "9e47806f-4d1d-4b39-b9c1-257ccb984557",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1166,7 +1257,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3052ae2f-b2d7-44e5-b09b-ded8b389ef09",
+                     "jsondocId": "8e50f3a4-8186-4ba9-bfa7-0c3fadb77bed",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
@@ -1178,9 +1269,9 @@
                "verb": "POST",
                "description": "Set translation end",
                "methodName": "setTranslationEnd",
-               "jsondocId": "1d1d7c25-9a72-444c-a0bd-c24595edaf49",
+               "jsondocId": "1f45e823-bf65-4456-9d44-92595f232d8f",
                "bodyobject": {
-                  "jsondocId": "c849de54-8960-4102-8d26-aa90c8990fa1",
+                  "jsondocId": "b4684145-d75b-4d95-aec1-b9f829da75d8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1190,7 +1281,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationEnd",
                "response": {
-                  "jsondocId": "e8828847-defd-411f-816c-7ace077e8643",
+                  "jsondocId": "87307c5d-4d9c-4ee8-a301-d3ae299cee86",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1203,7 +1294,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f39cd48b-520f-439d-843e-6db1f5cc5676",
+                     "jsondocId": "760bc1d5-3cb9-4871-9589-c4d48796f42a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1212,7 +1303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "272748b6-4394-4ce0-b9f8-c0365f0ba58c",
+                     "jsondocId": "e183a865-9556-4888-9489-04a5c201abc8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1221,7 +1312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9e81879-f345-4cdd-9018-d41971bff001",
+                     "jsondocId": "471d6c7b-d914-4d4a-97b1-105ca5be3612",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1230,7 +1321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a7c48703-8cab-4d42-b649-9d60f69467f1",
+                     "jsondocId": "c1f4ef7a-adfc-430e-808e-72a61ed776c1",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1239,7 +1330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ad8241d7-8f2b-4e16-92d8-4051846e1923",
+                     "jsondocId": "160661f9-9386-4e41-bed4-63049975c74c",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
@@ -1251,9 +1342,9 @@
                "verb": "POST",
                "description": "Set longest ORF",
                "methodName": "setLongestOrf",
-               "jsondocId": "7a94f272-0233-4dca-838a-0207d51de296",
+               "jsondocId": "b8a0ed5d-540f-4602-a601-b1ba02b24b0d",
                "bodyobject": {
-                  "jsondocId": "6da52481-aa9d-49d4-ba5b-4c2e9b75fad1",
+                  "jsondocId": "a7a84fb2-716b-4342-8a31-1745fa72d584",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1263,7 +1354,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setLongestOrf",
                "response": {
-                  "jsondocId": "99e11722-6217-421b-bc59-2ff237c67fd1",
+                  "jsondocId": "46032e68-2452-4d67-8c93-d90475f79936",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1276,7 +1367,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c7cc6643-5a78-46a9-9f54-03a70613899e",
+                     "jsondocId": "284092e2-0cca-4e73-ad29-52067f0c2016",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1285,7 +1376,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4c7d888-c008-417f-96cb-a87f5ab1f2ae",
+                     "jsondocId": "de1b5756-a29b-44f6-91ce-2ed028f00c05",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1294,7 +1385,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e889b7c4-f1f6-412d-bcfb-3a88008f037d",
+                     "jsondocId": "29d0d9cb-b895-4aa4-aae8-509d384e3c46",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1303,7 +1394,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "34dca390-dc4f-43aa-81d7-04c672cf03d0",
+                     "jsondocId": "31d2d028-01ab-4d1a-b069-6b5212ad1c09",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1312,7 +1403,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1748192b-05f1-40e7-bce3-9ee8f6783ca2",
+                     "jsondocId": "dd4b1b1c-66cb-443a-b7e0-f6c1bb86b960",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -1324,9 +1415,9 @@
                "verb": "POST",
                "description": "Set boundaries of genomic feature",
                "methodName": "setBoundaries",
-               "jsondocId": "e07439af-264a-4c75-9fc1-84edfe94e84b",
+               "jsondocId": "4d8c2582-2831-47e5-88c7-b75057dcf904",
                "bodyobject": {
-                  "jsondocId": "abd71cbb-b10f-46dc-82f4-6db21f0b3f36",
+                  "jsondocId": "60fae109-ff28-453c-b92d-65484a000377",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1336,7 +1427,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setBoundaries",
                "response": {
-                  "jsondocId": "67e77f2c-d735-454a-84a3-3c511196e3e5",
+                  "jsondocId": "f76df3b2-f012-4b13-90a8-3fd6266b731a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1349,7 +1440,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1e716e54-69ee-4749-9c9b-0da003c3875a",
+                     "jsondocId": "616a5f3b-2077-47da-a1fe-5ce8a29f54b9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1358,7 +1449,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ee2965f9-c638-4587-930b-a16ac15c2ca7",
+                     "jsondocId": "1ee79784-06c8-48df-aa2d-cc8aeecfce3d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1367,7 +1458,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "27f95b4a-14fe-4bcf-92a2-cd9811192862",
+                     "jsondocId": "3e34f31b-ecda-4c98-accf-d2ff0d88eae9",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1376,7 +1467,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "054c7b93-3b4f-4456-b35b-cf4bd89e7adc",
+                     "jsondocId": "f6697488-24bb-4eaf-83c2-1cc7b435468b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1388,9 +1479,9 @@
                "verb": "POST",
                "description": "Get all annotated features for a sequence",
                "methodName": "getFeatures",
-               "jsondocId": "0a950127-74ba-4d92-8b93-af0248312913",
+               "jsondocId": "0d48d260-45c3-4794-a323-ad42442c1754",
                "bodyobject": {
-                  "jsondocId": "5ae59b0c-18cf-4e12-bed3-cbed9c85493a",
+                  "jsondocId": "09ba64eb-65be-4891-9c27-5a7516eac0f7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1400,7 +1491,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getFeatures",
                "response": {
-                  "jsondocId": "7e0e5382-25ca-4cf3-bb6b-e6825aef75cb",
+                  "jsondocId": "1ff17344-2752-4c20-8b04-2d92ab844976",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1413,7 +1504,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3a2eaa74-0db9-4188-9d45-fd40eb4ef7eb",
+                     "jsondocId": "64395266-1c37-496d-ab55-f570e20f8753",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1422,7 +1513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ed83f0bf-7e78-42fc-9aff-5c5a8d6db957",
+                     "jsondocId": "ed506f5d-119a-4a09-9a6e-03ceb575ae09",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1431,7 +1522,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "38fbe71d-ed3a-4948-a644-123425f7ac50",
+                     "jsondocId": "eb7caaf6-f780-4e77-a7af-ece204cecc79",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1440,7 +1531,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "99f24e08-a120-43c5-9e2c-0de4d7392f8b",
+                     "jsondocId": "f845ff68-73f4-482a-8963-b15cd0e69384",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1452,9 +1543,9 @@
                "verb": "POST",
                "description": "Get sequence alterations for a given sequence",
                "methodName": "getSequenceAlterations",
-               "jsondocId": "2a2d9f75-49b9-4386-8714-a60e25fc5f4f",
+               "jsondocId": "3be33901-ebb9-493b-aee1-438083523037",
                "bodyobject": {
-                  "jsondocId": "392795e0-16a1-4859-8b6d-5cdd68a744e6",
+                  "jsondocId": "2a1d11ee-124e-4a0b-b7f4-e98d51cba316",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1464,7 +1555,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequenceAlterations",
                "response": {
-                  "jsondocId": "3c2e4c23-8142-447c-b77c-07319ca02deb",
+                  "jsondocId": "dc397063-d38b-4ca3-882a-15ece5849552",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1477,7 +1568,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3ad442f2-d605-493b-997e-80f179d49480",
+                     "jsondocId": "9cdadc52-bee1-4eb7-ae5c-b3073fedfa1e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1486,7 +1577,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1bad3882-3598-488b-b24c-b4c7efaad6ce",
+                     "jsondocId": "c6e37afc-dff0-4c38-980c-8c4ce7e6d4c9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1495,7 +1586,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8ff0ece0-495c-4fea-beac-f054ee808d45",
+                     "jsondocId": "e1b71c0a-048d-47e8-a4e0-03b269b4e5aa",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1504,7 +1595,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "96527feb-b658-49d5-94fe-65012c84ca1d",
+                     "jsondocId": "43bad522-2b45-4505-868c-46fdfcb7d024",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1513,7 +1604,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "74e1538d-a7ce-4852-86b3-6bc95dcc61ca",
+                     "jsondocId": "96728336-88c8-42fe-90ae-58f6c358cc53",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -1525,9 +1616,9 @@
                "verb": "POST",
                "description": "Delete attribute (key,value pair) for feature",
                "methodName": "deleteAttribute",
-               "jsondocId": "ce040723-ab26-43cf-9b63-e07fd06477fb",
+               "jsondocId": "0edfd95a-8ee9-4745-b99f-2ff9e85a6a31",
                "bodyobject": {
-                  "jsondocId": "04af35bb-2c93-4a5c-b443-c62174710733",
+                  "jsondocId": "060ee372-318f-4539-9376-a9f8ae41ae6e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1537,7 +1628,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteAttribute",
                "response": {
-                  "jsondocId": "de1681a6-591f-453d-b53f-87d055106d43",
+                  "jsondocId": "8290482d-3cc6-4a27-a7ca-c017c8745c1c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1550,7 +1641,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0533b364-4ac7-4e62-8542-0496c5d86d42",
+                     "jsondocId": "13e38e82-6a2c-42b1-ac87-2d538ab2a1f0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1559,7 +1650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cc9f97fa-f7c2-4caa-8f00-29d278a85ec6",
+                     "jsondocId": "87715077-8fd0-47c2-a718-16af41471006",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1568,7 +1659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d89a15c-1674-4f7d-8113-7050652ca082",
+                     "jsondocId": "ebd5ae8f-0f6f-441a-931c-d4b155b11e3d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1577,7 +1668,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fd294f14-81f9-47c1-8838-b0dc62a03539",
+                     "jsondocId": "8008c665-112e-402c-bdeb-3504eb858b19",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1586,7 +1677,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e83cd028-e550-46d9-b572-b14c37e93701",
+                     "jsondocId": "c67e34cd-8ba4-4cd5-b1e0-ea6e9a5abc7f",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.",
@@ -1598,9 +1689,9 @@
                "verb": "POST",
                "description": "Update attribute (key,value pair) for feature",
                "methodName": "updateAttribute",
-               "jsondocId": "4da09004-4be1-44fd-be7c-42789bde9abe",
+               "jsondocId": "983b168e-e729-4a0b-ba94-461a95eaf10d",
                "bodyobject": {
-                  "jsondocId": "f055cb33-202c-47d6-ad8a-f7c9fde66d92",
+                  "jsondocId": "0c7827ac-6a9e-438d-9e3c-77a7fdf210ee",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1610,7 +1701,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateAttribute",
                "response": {
-                  "jsondocId": "f77396da-5df5-4c55-af42-e0421ca5f867",
+                  "jsondocId": "38b1a699-d389-48bb-ac5d-742c1a206250",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1623,7 +1714,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f07bda86-1876-45b1-8c5b-6627736fff24",
+                     "jsondocId": "d62d7943-d811-45f1-86db-463907592336",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1632,7 +1723,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7b70ed79-3176-4440-b205-62ee3593da8d",
+                     "jsondocId": "b936949d-68c3-427c-9430-40d8dbf04d09",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1641,7 +1732,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "afa9bc7e-8072-4563-bbd7-ede65722b1bf",
+                     "jsondocId": "0581ea27-3553-45e9-93a3-69e0c57b30c2",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1650,7 +1741,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1806ce0-c8e6-4bea-b04c-7a0076677405",
+                     "jsondocId": "5426e75c-e4be-4b85-9c92-1457b2099b8b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1659,7 +1750,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a9fba830-d67e-4087-a959-a37ecb6d3128",
+                     "jsondocId": "e1744734-f01b-4f40-ad9c-3f41f9f68eb3",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1671,9 +1762,9 @@
                "verb": "POST",
                "description": "Add dbxref (db,id pair) to feature",
                "methodName": "addDbxref",
-               "jsondocId": "a0bce3a2-4f1f-4dc4-bb79-946bbd34c29e",
+               "jsondocId": "2c4cdde3-9df6-4a93-bd23-6934e431ecc9",
                "bodyobject": {
-                  "jsondocId": "e12659a7-fe7c-44da-8246-71e2edd004ad",
+                  "jsondocId": "5d72aaa8-a21c-46aa-a0c6-b03d58f33d4d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1683,7 +1774,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addDbxref",
                "response": {
-                  "jsondocId": "3a0ae9c2-15c6-4d14-96ee-fc8f234509f5",
+                  "jsondocId": "31792db0-9f4e-4d5d-b7ec-e5bd34ecda55",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1696,7 +1787,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "cbd44cb4-8b1f-4f55-ad67-e84ef6c53aed",
+                     "jsondocId": "404f493c-1a05-45e1-a32a-37f4b833192e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1705,7 +1796,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c5ab16b7-3e17-4769-879e-8c5d7dda88a4",
+                     "jsondocId": "e858eea4-d318-47ec-9b10-2e9eaebbab7a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1714,7 +1805,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "22ee6be4-d8d1-494f-bd59-d6f39b028784",
+                     "jsondocId": "bb83c864-c58f-4de7-83bf-ecd15fdaf284",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1723,7 +1814,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fa2d6f48-0177-42cb-a345-9ad545a81c9c",
+                     "jsondocId": "675febd9-6a80-4272-acb2-b71b783e3596",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1732,7 +1823,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1ee1340-9722-4969-bc90-2350a4148bb2",
+                     "jsondocId": "c5ab28a8-1041-43c1-a8f9-d165dc990b50",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.",
@@ -1744,9 +1835,9 @@
                "verb": "POST",
                "description": "Update dbxrefs (db,id pairs) for a feature",
                "methodName": "updateDbxref",
-               "jsondocId": "dc24f181-bc21-4e2b-81df-234ba5fe4b38",
+               "jsondocId": "b9ba0054-a3d9-46a7-8aae-40ac5696d5f1",
                "bodyobject": {
-                  "jsondocId": "61ca64df-81bb-450d-84a1-1a80d9bf1f9e",
+                  "jsondocId": "64536fc7-e1e6-41bb-982a-1f9e27e35f06",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1756,7 +1847,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateDbxref",
                "response": {
-                  "jsondocId": "f79d9945-0b71-40c2-a844-6486f1044c69",
+                  "jsondocId": "b6682c35-555f-48e2-b272-9a842da09539",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1769,7 +1860,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3b114d39-8b8e-41b2-8f71-e1ddf53e9a8c",
+                     "jsondocId": "9520ba53-8d91-4a67-8b7a-a8d6ea082b56",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1778,7 +1869,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1fa82231-76c5-46a3-91d4-53b666afe891",
+                     "jsondocId": "4f566b5e-86f8-4d4d-83e4-2eaf76cd4cda",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1787,7 +1878,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "268206d8-f488-45a0-af9e-88dda299418b",
+                     "jsondocId": "0b36a97f-5811-4eb4-9dce-f1db663bf90d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1796,7 +1887,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "58e412e9-30a8-4c3d-9855-5aabafb5eb7d",
+                     "jsondocId": "46adc0d8-d558-4668-a102-67ec3a5a0e66",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1805,7 +1896,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ef4fdee8-deba-459b-92bc-a34e70c8e4af",
+                     "jsondocId": "ebaab076-6977-46c8-8553-9c0953c376fa",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1817,9 +1908,9 @@
                "verb": "POST",
                "description": "Delete dbxrefs (db,id pairs) for a feature",
                "methodName": "deleteDbxref",
-               "jsondocId": "7b7536e3-f178-4f34-aa49-abed2c9a8f6d",
+               "jsondocId": "5a13602b-d3bc-4115-833f-551fa7616180",
                "bodyobject": {
-                  "jsondocId": "9b97d330-8901-4482-a2df-89636b7b9cca",
+                  "jsondocId": "207900a9-86af-4e03-a0a7-e778f38d225b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1829,7 +1920,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteDbxref",
                "response": {
-                  "jsondocId": "d45cbe9a-5002-4ff3-a84c-9f2501d532fc",
+                  "jsondocId": "1ab084b3-7640-4334-8321-7f031d855097",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1842,7 +1933,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e2e84118-7876-48f2-879f-13625d921011",
+                     "jsondocId": "b6d537a0-8873-42a2-927b-2ce03fd01a09",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1851,7 +1942,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "315e1c59-8058-4e48-88e4-bb85bf0e30fd",
+                     "jsondocId": "cc7c942f-c33e-4613-8e22-047992adcb6c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1860,7 +1951,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b401881d-0842-407b-8ab3-f203b4601df9",
+                     "jsondocId": "755176de-52bb-4b2c-ae36-1645cc08b733",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1869,7 +1960,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "59450da9-bc47-4668-98f1-0da72b786e73",
+                     "jsondocId": "2e2e2314-d3b0-4c26-b831-9a0245e074a3",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1878,7 +1969,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02847467-8621-4b1a-935d-5e94cb808282",
+                     "jsondocId": "1423084a-53a3-4a18-8da0-37cb56e6451f",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
@@ -1890,9 +1981,9 @@
                "verb": "POST",
                "description": "Set readthrough stop codon",
                "methodName": "setReadthroughStopCodon",
-               "jsondocId": "44b8c3ec-60e5-44d3-8372-f8bfbee6e58c",
+               "jsondocId": "8829ce3e-0fc8-4b6c-b8fe-91191eb7af87",
                "bodyobject": {
-                  "jsondocId": "85b59697-37eb-4eaf-85f2-28a148679df3",
+                  "jsondocId": "130dfab1-b919-4a65-9ccb-2e4164992314",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1902,7 +1993,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setReadthroughStopCodon",
                "response": {
-                  "jsondocId": "7d261301-719f-4001-9677-fc7399fcc236",
+                  "jsondocId": "4ab01e72-2638-479e-ae3b-28cff12c81e9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1915,7 +2006,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9d8b5f10-5f33-4a46-a6e8-0208e732c3a7",
+                     "jsondocId": "2e10f04a-64b4-4486-a476-1dbc9744aa04",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1924,7 +2015,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f9a42051-ffb2-4eed-bc87-ebc33a7a535e",
+                     "jsondocId": "a5a63df7-b408-4942-acf2-5e924ded2d03",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1933,7 +2024,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3921232c-6652-4c50-973c-161f82434b5e",
+                     "jsondocId": "dd5a261d-1086-43a9-a948-dc6e6b5f66a9",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1942,7 +2033,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f57b570f-e3f4-4781-abb9-dfbc2571f58e",
+                     "jsondocId": "e6d7ff43-0aec-4e83-a6f7-e032de9018cc",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1951,7 +2042,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "10cd5d51-e293-4cce-a26a-59a8c26f5c71",
+                     "jsondocId": "b017b4b6-52bf-4d69-9dd0-f1206f42c7c9",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
@@ -1963,9 +2054,9 @@
                "verb": "POST",
                "description": "Add sequence alteration",
                "methodName": "addSequenceAlteration",
-               "jsondocId": "f24ef9af-a275-45f3-9249-bc3f9c2394fa",
+               "jsondocId": "a4f3fe51-0c86-41f7-b16e-55b2dcbe023a",
                "bodyobject": {
-                  "jsondocId": "ec273547-9d38-4d2b-926a-8467729c0b0a",
+                  "jsondocId": "4e153921-9edc-4f1e-93ab-b45170c64227",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1975,7 +2066,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addSequenceAlteration",
                "response": {
-                  "jsondocId": "424c322f-12a9-4e3e-bc73-4a417d45d5fb",
+                  "jsondocId": "47b36fa8-549b-4b4b-9dc7-4101b242d53a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1988,7 +2079,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c2f132a5-4e19-4c92-a77f-fcc8d8d811dd",
+                     "jsondocId": "602296ee-222e-4878-95e3-c6d55f3a65f6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1997,7 +2088,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b017f55d-c0f0-44ee-8b82-812c5a1887b1",
+                     "jsondocId": "9945e5fe-6917-449f-85ce-63fa34df33e1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2006,7 +2097,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55039104-235c-474c-b348-ee3e2b33b57f",
+                     "jsondocId": "501d017d-20fc-4526-8fcd-61bef75b5be3",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2015,7 +2106,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97e646de-6efd-47d2-9b6f-099c1484a135",
+                     "jsondocId": "8957e962-54aa-4c29-8879-b2bcc540a20c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2024,7 +2115,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "75119974-1039-4a82-a0e7-37c64c876c78",
+                     "jsondocId": "a45da32e-fadb-454e-9e2d-91a0005fe1bd",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
@@ -2036,9 +2127,9 @@
                "verb": "POST",
                "description": "Delete sequence alteration",
                "methodName": "deleteSequenceAlteration",
-               "jsondocId": "34a8c86e-956b-4d21-8f80-6e07e6cee064",
+               "jsondocId": "05dd9dee-8c0e-49d1-8c1a-ec8ca049a67b",
                "bodyobject": {
-                  "jsondocId": "7e5826e3-031e-4d91-b5f7-5962eef77d8b",
+                  "jsondocId": "1dbb61a0-46b7-42d4-9be8-312dd0309f8d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2048,7 +2139,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteSequenceAlteration",
                "response": {
-                  "jsondocId": "2105b710-aaa4-4a6d-9a9a-d4818e6da3cd",
+                  "jsondocId": "bddd3bf7-a448-4a5a-a38e-3cb6f53f5913",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2061,7 +2152,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "586f6aa7-498b-43d7-b077-7ee56188a68d",
+                     "jsondocId": "e8a6abf6-8e78-478e-9afe-098629ee0118",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2070,7 +2161,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "57b8b6de-f507-4aa5-819d-c4b95cb18c26",
+                     "jsondocId": "6dfec6d0-0972-48aa-9dd1-2f5a16dd53bb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2079,7 +2170,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "514f819c-c42b-472c-852e-a524573ac537",
+                     "jsondocId": "ad6b1c6b-bff7-4d16-8419-4c46047122f9",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2088,7 +2179,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ffe7b3a-ff7b-4e00-8911-decadec46bea",
+                     "jsondocId": "3473b101-9c59-403c-b09e-c172ddffdb3c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2097,7 +2188,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7b57cde6-cb2f-4356-aa8f-ba23358a0f71",
+                     "jsondocId": "d5f80f4b-01b6-41e6-9a88-be25c4b960b7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
@@ -2109,9 +2200,9 @@
                "verb": "POST",
                "description": "Flip strand",
                "methodName": "flipStrand",
-               "jsondocId": "ae79622b-c5a6-44f5-9005-13e717b41162",
+               "jsondocId": "e3991218-640d-4753-a151-dd2fece644e1",
                "bodyobject": {
-                  "jsondocId": "4f64f453-03a8-4d5a-8d9c-d205f4f381af",
+                  "jsondocId": "11e42fcd-ec3f-409f-9913-ab4e628c897e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2121,7 +2212,7 @@
                "apierrors": [],
                "path": "/annotationEditor/flipStrand",
                "response": {
-                  "jsondocId": "38ce23a9-b98e-4fc8-98e4-4c0bb3c96ec8",
+                  "jsondocId": "3b1eed0c-1184-4692-8530-845fe231ff2e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2134,7 +2225,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "16926c64-08b7-4881-b2c1-f77da49e026a",
+                     "jsondocId": "d1ec2c8c-b455-47e1-b797-ab45f3aff4ea",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2143,7 +2234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0f462daf-9f5a-42dd-bc5d-d91ad7b9f9a3",
+                     "jsondocId": "46deb667-b827-487e-9784-a53147ca20ef",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2152,7 +2243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cd821e77-136f-40b4-91ed-4c2477a120d4",
+                     "jsondocId": "cc6292b3-1eda-4179-885b-e46643197d0e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2161,7 +2252,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "20624b6e-8e1d-495e-af01-d47d9c97021e",
+                     "jsondocId": "918d11e8-9ddd-400d-b879-44e3f6b540fd",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2170,7 +2261,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f9a261ba-7745-4e4e-a3e2-46b91dcb56b5",
+                     "jsondocId": "ce00cd0b-4a4e-448a-b301-199950bd4d11",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
@@ -2182,9 +2273,9 @@
                "verb": "POST",
                "description": "Merge exons",
                "methodName": "mergeExons",
-               "jsondocId": "bf4a5ac8-008d-44f8-b908-5ba40a7dddc8",
+               "jsondocId": "4d4f1c4a-9f59-4e23-bd7a-0c46fd642442",
                "bodyobject": {
-                  "jsondocId": "4f52900a-182d-4b09-ad59-f998ab9cab89",
+                  "jsondocId": "bf81312f-5ba4-4985-8505-c0655eedb174",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2194,7 +2285,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeExons",
                "response": {
-                  "jsondocId": "20964f1a-247e-42a3-badd-465479b3ac90",
+                  "jsondocId": "5a3ca03d-728f-4b0f-a68f-44c071a0eae4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2207,7 +2298,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "305f3ff6-b0ad-4726-bd79-a4967709a89a",
+                     "jsondocId": "160ce5ff-3501-4746-9f26-c2fd5c7ff1d4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2216,7 +2307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8eec350d-5948-4cad-9531-b741a544fef0",
+                     "jsondocId": "338818a2-8774-4153-bfbf-d74ea8e3658b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2225,7 +2316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "85ebf266-9144-4f0b-9c8e-66ec33709a6c",
+                     "jsondocId": "d7a425cb-df28-4631-b8de-eefb5fde306e",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2234,7 +2325,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bfffbc38-9a4a-4263-b9c5-72e7d94b185b",
+                     "jsondocId": "5ba45f6b-38f2-4282-a335-559b7acf26e6",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2243,7 +2334,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "10d4c83b-bd10-4749-a720-ba7b43a1f30d",
+                     "jsondocId": "b465d175-2380-4e65-905d-ea73683ca58d",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -2255,9 +2346,9 @@
                "verb": "POST",
                "description": "Split exons",
                "methodName": "splitExon",
-               "jsondocId": "efc8f2a7-9c81-4896-ae2f-0c9b939df419",
+               "jsondocId": "4b04efb0-2625-437d-a157-6ffb45ab893b",
                "bodyobject": {
-                  "jsondocId": "6859ec1e-e062-4755-9ded-b5b5f65bda8c",
+                  "jsondocId": "e9916f3a-34c6-4e3d-b609-c6713e226bd6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2267,7 +2358,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitExon",
                "response": {
-                  "jsondocId": "1e851a34-30c0-4bb0-8b30-6607c6814955",
+                  "jsondocId": "aed509ab-c389-4c7f-83a0-fc15758ddb0f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2280,7 +2371,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4d20ff17-9391-442a-8a57-d54498e69ed3",
+                     "jsondocId": "e60ec2bd-487e-40ae-aa18-0dc7dc6f2a42",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2289,7 +2380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1fc2941-687f-4af5-9c2d-0a267c1701ab",
+                     "jsondocId": "0678eceb-83d0-483e-8d4f-6c4b99db31c8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2298,7 +2389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f850636-75a5-4130-b5df-3e254aa088f6",
+                     "jsondocId": "8cdd9316-8006-428b-9027-304b23b7aa34",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2307,7 +2398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "666879cc-85ca-47a6-839d-96c3e8176ccd",
+                     "jsondocId": "99152ce9-a53c-4c58-b41b-ea2e300e7f01",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2316,7 +2407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2be42e45-9f69-450b-8895-8dbaad15ed21",
+                     "jsondocId": "2f23a9a4-909d-45d0-a1eb-c83cbe25baa8",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
@@ -2328,9 +2419,9 @@
                "verb": "POST",
                "description": "Delete feature",
                "methodName": "deleteFeature",
-               "jsondocId": "cf6e2afc-2938-48b2-9cd4-c785aa07f027",
+               "jsondocId": "d9ddfff2-7cd7-47c0-bcc6-a4d13c121a4f",
                "bodyobject": {
-                  "jsondocId": "38df42fd-da91-49b0-94d3-cbee543090a0",
+                  "jsondocId": "11cc0879-b482-4f2d-ba07-8b67a68247b6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2340,7 +2431,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeature",
                "response": {
-                  "jsondocId": "96356cd1-5723-479c-bef3-0250a94315fe",
+                  "jsondocId": "66b3f661-f5a1-4861-bfed-632d3f48949c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2353,7 +2444,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "16e4b0c3-2a89-4368-b5c3-735a7d8406c1",
+                     "jsondocId": "92a0bc05-099d-43ca-b5ee-6a1dbfb7fbab",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2362,7 +2453,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6c25c3cc-7e7e-482d-9079-be8340218706",
+                     "jsondocId": "925c6e33-6c19-4bc5-9d3a-746ccca5a969",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2371,7 +2462,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "22996e52-ded7-401e-8c0b-58078d5823a3",
+                     "jsondocId": "87d447ce-5c5e-41b4-a7aa-9940e17923bf",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2380,7 +2471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "225f5269-990b-4ef9-9147-a48cdc6957c9",
+                     "jsondocId": "5a4c27a4-d408-435a-9b8e-d8c5cb2c3c14",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2389,7 +2480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f0959613-4b11-4806-b0f6-9334a71c2e54",
+                     "jsondocId": "595ca2af-4bbe-4fef-a107-0692776d40b7",
                      "name": "sequence",
                      "format": "",
                      "description": "JSONArray of sequence id object to delete defined by {id:<sequence.id>} ",
@@ -2401,9 +2492,9 @@
                "verb": "POST",
                "description": "Delete variant effects for sequences",
                "methodName": "deleteVariantEffectsForSequences",
-               "jsondocId": "09dd8a19-3177-4a4c-adda-c42c3bd69aee",
+               "jsondocId": "12a74edf-da7c-43a4-8bc6-642336c2465d",
                "bodyobject": {
-                  "jsondocId": "176aef41-d4b4-4a28-9e8c-a8337414f761",
+                  "jsondocId": "afcb9442-f4ab-4749-9d6f-972185367149",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2413,7 +2504,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteVariantEffectsForSequences",
                "response": {
-                  "jsondocId": "645a5422-dc9e-4433-a12e-cef498431473",
+                  "jsondocId": "18e6c11a-8177-4744-acc7-0494d49f76fc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2426,7 +2517,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a5742244-d0c5-4718-9c3a-9ce0896106a9",
+                     "jsondocId": "a115ce76-e417-4348-a211-aeb016d216a7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2435,7 +2526,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f83d9f23-daaa-40fd-845f-16d0c61f151a",
+                     "jsondocId": "a4d1db81-da02-4efa-8566-e236fe37027e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2444,7 +2535,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7e93afa6-a1c5-40be-a4c8-fd2f602d114d",
+                     "jsondocId": "ac134a60-2939-44cc-b39e-7a0b9640dfa5",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2453,7 +2544,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b477a74f-33f0-431e-aa46-635000ed3741",
+                     "jsondocId": "e745616a-c97c-4421-b1f4-a15096ddfce8",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2462,7 +2553,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c5908962-efdf-4659-bc45-1656e066c9de",
+                     "jsondocId": "e7c57073-5d3a-49d7-b4ae-8083fbb21b53",
                      "name": "sequence",
                      "format": "",
                      "description": "JSONArray of sequence id object to delete defined by {id:<sequence.id>} ",
@@ -2474,9 +2565,9 @@
                "verb": "POST",
                "description": "Delete features for sequences",
                "methodName": "deleteFeaturesForSequences",
-               "jsondocId": "0ac8d791-d4e7-437d-ba0a-599985f0875d",
+               "jsondocId": "3eb341c6-f9b5-4423-ae26-239ee52f8f72",
                "bodyobject": {
-                  "jsondocId": "b26f0f1a-e400-439d-b5d2-879c94488737",
+                  "jsondocId": "d867a0b5-dbcc-4248-acff-5f5b02da6307",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2486,7 +2577,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeaturesForSequences",
                "response": {
-                  "jsondocId": "99e4975c-0965-4ce4-adf3-f3b03bc58807",
+                  "jsondocId": "cb120d8d-9765-4ec5-b205-3b5fe7aa6a0e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2499,7 +2590,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "448f36ca-f180-47f7-9223-367a170e6eb4",
+                     "jsondocId": "ca3bdc2f-61f1-4b6a-badb-9ecaade3edc7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2508,7 +2599,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b7812c82-1538-4c29-9f9e-3bd150c6ff0b",
+                     "jsondocId": "fbd15ad9-be36-4852-b5ef-c6cd93ca6f62",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2517,7 +2608,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ae235a11-def9-4ef6-94b8-ecc28d1da18a",
+                     "jsondocId": "280cfb42-c74a-4fe1-ba9f-e3de77a5fddc",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2526,7 +2617,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "201e07fd-e0ad-445e-bc27-8f92c8f8bc7c",
+                     "jsondocId": "4e252f9d-f501-46f8-ad25-be35dcd4d210",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2535,7 +2626,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6ce598f6-0b38-48ac-aa9c-f59e7415f2b5",
+                     "jsondocId": "d6341f3a-f066-4d12-8bb1-659b2d2bd8fa",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
@@ -2547,9 +2638,9 @@
                "verb": "POST",
                "description": "Delete exons",
                "methodName": "deleteExon",
-               "jsondocId": "efbbff65-1e98-4eaf-8ae3-7f51071e6fe7",
+               "jsondocId": "8a451dac-22b8-4bd0-b716-d497a2836269",
                "bodyobject": {
-                  "jsondocId": "52161f55-a4de-46f2-beda-4463606a3bac",
+                  "jsondocId": "d87a8298-dc9b-4f9d-9106-88b46e079b7f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2559,7 +2650,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteExon",
                "response": {
-                  "jsondocId": "796426e3-11fe-4ab2-b2a7-0a6f6506c960",
+                  "jsondocId": "86cbf599-ef1b-4a3b-9695-db85025fd0fd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2572,7 +2663,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "41b56f4b-e60f-42c5-9e08-d0a3bbcf0cfa",
+                     "jsondocId": "3be545e5-e247-43e7-9611-b5fc02e83e26",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2581,7 +2672,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff68e3f4-f209-41fe-a636-65def7ce918f",
+                     "jsondocId": "fa3081d8-af94-45d8-a88e-8d197bf41991",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2590,7 +2681,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e281ab3c-b341-4428-aa3c-e2a79d8d8729",
+                     "jsondocId": "12254d40-c21d-44a8-a105-d85d564ad61d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2599,7 +2690,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "08993855-996e-4303-a693-cdd042aee4ec",
+                     "jsondocId": "a27923e1-5862-4136-bae3-a6e2799b12c9",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2608,7 +2699,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "efb616c1-99d8-42ec-ad5b-3b17bd580496",
+                     "jsondocId": "dfdcc54b-32c5-4360-aa56-c86b5c876675",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -2620,9 +2711,9 @@
                "verb": "POST",
                "description": "Make intron",
                "methodName": "makeIntron",
-               "jsondocId": "dffeaaf2-5c50-4fa4-b5b4-38cc9c60dc0f",
+               "jsondocId": "84c6d407-fd83-4c74-8f10-983bca4d4a52",
                "bodyobject": {
-                  "jsondocId": "a82ac8d2-a7a9-4c0d-9aa3-ddd304d093dd",
+                  "jsondocId": "87c33ddc-daff-4616-ac24-96abe4f98ebd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2632,7 +2723,7 @@
                "apierrors": [],
                "path": "/annotationEditor/makeIntron",
                "response": {
-                  "jsondocId": "5b219ecb-5a13-497d-9215-4dcd68f5a52d",
+                  "jsondocId": "7e48ee9f-746c-41e0-9877-f1da45e9fd04",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2645,7 +2736,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3ebbc076-0789-4be1-9109-33f57a9c8d2d",
+                     "jsondocId": "65a7e8d0-93de-4f31-8e1f-65a0c631ff8f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2654,7 +2745,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5a95616a-4629-4b6b-a905-ad128cee4bc9",
+                     "jsondocId": "323b38b3-6b55-4505-81a9-bc3bb7040475",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2663,7 +2754,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0a676103-3c28-4498-9fe0-a00070168d0c",
+                     "jsondocId": "93aeda17-4652-4877-acd1-19543574ae3c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2672,7 +2763,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "22517ce9-a3b3-4292-b9bd-edef1948e171",
+                     "jsondocId": "68df7f04-31c4-4099-a991-ea8d9c9eebf7",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2681,7 +2772,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "503bc59a-0abe-4409-a8f2-e98059c06131",
+                     "jsondocId": "684c07f9-55ae-4721-b74f-679134a0dee7",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2693,9 +2784,9 @@
                "verb": "POST",
                "description": "Split transcript",
                "methodName": "splitTranscript",
-               "jsondocId": "8e1ca587-edad-4c90-b1b0-7f1ca9828bc4",
+               "jsondocId": "62a42e21-9cc7-49a5-8d78-bbe6f266fa46",
                "bodyobject": {
-                  "jsondocId": "b51804ad-3cd1-41a5-9f04-8204f862e75b",
+                  "jsondocId": "84715b01-92ee-4a97-976f-92069a24b0e1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2705,7 +2796,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitTranscript",
                "response": {
-                  "jsondocId": "263176de-58d5-45d2-830c-5a9415c7e338",
+                  "jsondocId": "86b80a83-6d19-4c86-a40d-a510b8da960c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2718,7 +2809,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b8ebd238-83a5-461c-aa63-abd597754a54",
+                     "jsondocId": "ae0ee8d4-771e-460f-b7dd-70849beb46aa",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2727,7 +2818,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "caf2603c-d9cd-4341-993c-4c64e88728d5",
+                     "jsondocId": "427bd5a1-c533-40e7-9e14-b87ae489d564",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2736,7 +2827,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "76fa58c5-d344-4604-9e41-483f66ce1b56",
+                     "jsondocId": "416108bd-91f3-4e6e-81bf-17d621041a6a",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2745,7 +2836,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "763d422a-747a-46bf-b795-e1c9e62810e0",
+                     "jsondocId": "aa1f589a-d1f8-45ea-9bfe-7439c4d555e6",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2754,7 +2845,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7fa6aab3-c801-427f-946c-f4d206364def",
+                     "jsondocId": "91bb4f62-6abb-4dd3-acb3-c137a8de409e",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2766,9 +2857,9 @@
                "verb": "POST",
                "description": "Merge transcripts",
                "methodName": "mergeTranscripts",
-               "jsondocId": "3d8491d7-4d0c-4aa1-a371-af6dfc1d97a3",
+               "jsondocId": "4d07ef0b-b898-4c35-8a43-2e4129a0d7ac",
                "bodyobject": {
-                  "jsondocId": "319ccbc5-d59d-4d62-8d56-549bd3cb508a",
+                  "jsondocId": "bf77524f-7241-4558-84d9-2c03da6a2fc7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2778,7 +2869,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeTranscripts",
                "response": {
-                  "jsondocId": "c75063be-0de7-4b2f-8a77-cd19a976e7fd",
+                  "jsondocId": "4ec75984-8f93-473b-8afc-4fa7ee71ba55",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2791,7 +2882,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ee47bc10-6342-4950-9c21-9653b41d7259",
+                     "jsondocId": "2c62c966-7fbf-4f65-a3ef-f88b3cb54292",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2800,7 +2891,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9a7f04dd-4eea-4ba8-8687-b64271dab943",
+                     "jsondocId": "e73717c3-e3a4-49e1-96dc-c9c2e3141bf9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2809,7 +2900,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "521dd847-60d9-4c33-ba93-a99d77ce2920",
+                     "jsondocId": "29c7bdc4-0dc2-429c-bcbd-0f6624285c8d",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2818,7 +2909,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f9b35838-8524-433c-8db2-85eaa08d1d3c",
+                     "jsondocId": "f2b5f540-94d6-42bf-a344-741adb0da09e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2827,7 +2918,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3de37e77-eb8d-476c-a904-90b2ecaff068",
+                     "jsondocId": "6aa5b4b3-8696-4160-a2c8-0dc7ddfcd362",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2839,9 +2930,9 @@
                "verb": "POST",
                "description": "Get sequences for features",
                "methodName": "getSequence",
-               "jsondocId": "87b02bc5-ce51-4347-804d-66cc6ebd5b02",
+               "jsondocId": "de837734-3798-468b-b2c8-7a0a0c5238d9",
                "bodyobject": {
-                  "jsondocId": "890c956d-ec62-46db-9845-d91885c2fedf",
+                  "jsondocId": "364a2afd-6dfc-41b3-ab73-911ad506bc18",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2851,7 +2942,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequences",
                "response": {
-                  "jsondocId": "ebdec96b-09da-47df-9197-a72482365b3c",
+                  "jsondocId": "88fcead1-9f43-4f02-8371-8d84951a386d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2860,7 +2951,7 @@
                "consumes": ["application/json"]
             },
             {
-               "jsondocId": "f3f2de3f-a4e6-4ef2-ab0f-17108b37997a",
+               "jsondocId": "f69b0051-b899-40c8-8a1e-821790096cbb",
                "bodyobject": null,
                "apierrors": [],
                "path": "/annotationEditor/getSequenceSearchTools",
@@ -2868,7 +2959,7 @@
                "pathparameters": [],
                "queryparameters": [],
                "response": {
-                  "jsondocId": "1374a595-54bc-4f9a-91ad-1f40aee10471",
+                  "jsondocId": "204e7b35-6e1b-4ce8-911a-4c070780638a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2883,7 +2974,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ab9f75d6-ffeb-4a6a-a135-18beb108df0c",
+                     "jsondocId": "da65e922-97f7-44be-8bff-8420c5c379b6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2892,7 +2983,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bcc6d448-5546-4167-8e53-99f1b1a94ced",
+                     "jsondocId": "f89e1e1c-b227-4b0d-a3c3-50e22c6f4d1d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2904,9 +2995,9 @@
                "verb": "POST",
                "description": "Get canned comments",
                "methodName": "getCannedComments",
-               "jsondocId": "f14aac84-17d6-45de-8bf5-c7ed280faf90",
+               "jsondocId": "e5ce4128-334a-4ada-8394-58d35bc2e01a",
                "bodyobject": {
-                  "jsondocId": "e0e648d0-6aaf-4045-83e3-f3dd2153c40a",
+                  "jsondocId": "75e6765a-2dd8-442f-a46a-755da128562b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2916,7 +3007,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getCannedComments",
                "response": {
-                  "jsondocId": "0950b86d-8f6d-4005-b8b6-f7c72bb37dae",
+                  "jsondocId": "b7870201-4f50-4323-a102-717631de6d52",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2929,7 +3020,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c63e4bd6-473a-4dd4-8a3a-3780d8b837cc",
+                     "jsondocId": "5c9ea016-9d09-48d6-9848-7a7bb74a35ce",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2938,7 +3029,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5e4308b3-fdd7-49ea-961b-1cd15acab4bd",
+                     "jsondocId": "db3eeb89-9714-412c-980f-c688f46cae7f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2947,7 +3038,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "24400999-28ea-46a9-86a2-e509f2bb37d6",
+                     "jsondocId": "18a2b5fc-bd8a-4f64-9347-1a50bc0ffd90",
                      "name": "client_token",
                      "format": "",
                      "description": "Organism ID/Name or Client-generated ",
@@ -2956,7 +3047,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e9319d31-b258-4aa6-96ff-a324b4c65142",
+                     "jsondocId": "59feab85-804d-40b8-a06f-c672c11279b2",
                      "name": "search",
                      "format": "",
                      "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
@@ -2968,9 +3059,9 @@
                "verb": "POST",
                "description": "Search sequences",
                "methodName": "searchSequence",
-               "jsondocId": "a6b5eb66-1b95-4a4a-9a1a-ffea8a0940fa",
+               "jsondocId": "2555de64-7df1-4b94-bcd6-d3a9ec5e214b",
                "bodyobject": {
-                  "jsondocId": "cff8424e-5883-4ef7-92f8-464e5d11e044",
+                  "jsondocId": "f03737c2-ab25-4d06-8946-e3e580611941",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2980,7 +3071,7 @@
                "apierrors": [],
                "path": "/annotationEditor/searchSequences",
                "response": {
-                  "jsondocId": "ac6ee475-8328-41ad-9216-7cf3b4070d9b",
+                  "jsondocId": "834e9e56-959a-4cbd-a123-99633cc05b23",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2993,7 +3084,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c0f119ac-2d16-4d9a-837a-c3ad5422f7a1",
+                     "jsondocId": "4e657e4d-d0aa-4ae2-bed5-8ebf9d1cca3c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3002,7 +3093,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "09b1884e-ee21-4c82-8fd1-20456f594938",
+                     "jsondocId": "4f639df4-a8ab-4fd5-b2c4-db7618b15cbc",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3011,7 +3102,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "be704645-ebea-4f03-9113-4476aeba9f6e",
+                     "jsondocId": "3fc820fd-75c8-489a-95d9-b372c1d436b4",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -3023,9 +3114,9 @@
                "verb": "POST",
                "description": "Get gff3",
                "methodName": "getGff3",
-               "jsondocId": "6ba58013-19e5-4ac9-bf5b-f981b8213adf",
+               "jsondocId": "190fc32d-db02-4731-b76b-54fbca8bd147",
                "bodyobject": {
-                  "jsondocId": "c52151a1-75b9-416b-8838-d0e58ec1538c",
+                  "jsondocId": "f549077e-8cbd-4f71-8d3b-8c808be9916b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3035,7 +3126,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getGff3",
                "response": {
-                  "jsondocId": "a565d714-3072-430e-b799-78af36240cec",
+                  "jsondocId": "3c16e127-a8c6-4155-beb6-554c0cbaaf2d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3048,7 +3139,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0bd39c1e-67eb-4a78-bcfc-929b31d34bb4",
+                     "jsondocId": "d68b3bfd-0294-47e3-bbc2-97f9af87fd5f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3057,7 +3148,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "89db7bdf-e6e4-4e0f-9e8d-284051e9ad4d",
+                     "jsondocId": "0c6ab948-0b8e-4301-99cd-ce54e659aec2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3066,7 +3157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "18546711-5f5a-4d7e-92a3-43229b63cd67",
+                     "jsondocId": "5a1e518e-a582-4be4-9fed-16ff7b57e186",
                      "name": "days",
                      "format": "",
                      "description": "Number of past days to retrieve annotations from.",
@@ -3078,9 +3169,9 @@
                "verb": "POST",
                "description": "Get genes created or updated in the past, Returns JSON hash gene_name:organism",
                "methodName": "getRecentAnnotations",
-               "jsondocId": "92ec0845-91aa-48c6-9cbc-e5925006a5ea",
+               "jsondocId": "ba36a1ac-cb9f-46bd-ae8c-eb3cc76d9b98",
                "bodyobject": {
-                  "jsondocId": "848cf144-f532-4ff6-ad62-ff036dfeed18",
+                  "jsondocId": "ccacef78-4fde-45f5-8f3c-8647dbb589ae",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3090,98 +3181,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getRecentAnnotations",
                "response": {
-                  "jsondocId": "3b6de79d-b4b6-460b-8c89-a0114fbcc17e",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "56a764c8-aab1-44a9-93ac-eef2ac956080",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6f7f0149-d0e2-4f75-8c73-949401dedade",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3fbe27f7-44b5-4c15-b341-d9ecfbbdfec3",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c3f0deaf-d9c9-4fd3-8733-3c26f0c1c8a8",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d3c941d3-de96-483d-8a7a-1f00b53aa1d9",
-                     "name": "suppressHistory",
-                     "format": "",
-                     "description": "Suppress the history of this operation",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "75fad5b4-18f0-40ee-8e65-adaba61c211b",
-                     "name": "suppressEvents",
-                     "format": "",
-                     "description": "Suppress instant update of the user interface",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5a0be5b7-fd21-441f-a2b7-09aa6543506e",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set exon feature boundaries",
-               "methodName": "setExonBoundaries",
-               "jsondocId": "b6f511d1-0b3b-4173-bbc7-53e16fc0a084",
-               "bodyobject": {
-                  "jsondocId": "605aa38f-196c-406d-affa-745cb827a356",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setExonBoundaries",
-               "response": {
-                  "jsondocId": "05d48fe7-258b-4cb3-9cc5-46368d126743",
+                  "jsondocId": "974845ff-c9be-4a58-bde0-8f7d56495826",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3194,14 +3194,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "179995d6-966a-4047-a00e-400dac9defb6",
+         "jsondocId": "116cd1e7-576c-48a7-b1ef-e16e25ff458b",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "801b073e-e5e6-4f65-8779-0fd49d40187e",
+                     "jsondocId": "54c1a0e3-03c1-4f8c-b955-330a4b611c13",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3210,7 +3210,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d06e9b7d-1e09-4dab-98c4-9f87805e6186",
+                     "jsondocId": "ed811906-2a81-440e-8fb1-507cde3aa71c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3219,7 +3219,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "337ed74d-7945-4c9d-a160-1fc54e46bae6",
+                     "jsondocId": "d687e893-eeaa-4d42-98b9-8130756ed305",
                      "name": "uniquename",
                      "format": "",
                      "description": "Uniquename (UUID) of the feature we are editing",
@@ -3228,7 +3228,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "71db1ebd-82f9-4b31-95e0-c1dcb234c6be",
+                     "jsondocId": "a3ed8d2d-e689-4e6a-a245-2e4599c7383f",
                      "name": "name",
                      "format": "",
                      "description": "Updated feature name",
@@ -3237,7 +3237,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63718346-389e-4858-99e1-5a16b78b4324",
+                     "jsondocId": "aef18c6a-99a4-48a7-bc09-d2eb3ad9b625",
                      "name": "symbol",
                      "format": "",
                      "description": "Updated feature symbol",
@@ -3246,7 +3246,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "699c9a6f-5e68-4b0e-9a73-7d33da27a92a",
+                     "jsondocId": "53cf1791-1d31-414f-b97d-5044f4a2691e",
                      "name": "description",
                      "format": "",
                      "description": "Updated feature description",
@@ -3258,9 +3258,9 @@
                "verb": "POST",
                "description": "Update shallow feature properties",
                "methodName": "updateFeature",
-               "jsondocId": "782e2e82-bcbb-404e-a3a3-60b8bfae11f6",
+               "jsondocId": "8a67aae9-0aa8-4388-8d49-39c5520d1149",
                "bodyobject": {
-                  "jsondocId": "857872b0-c7dc-4078-9f4a-c8cd02b3ab4f",
+                  "jsondocId": "c839b2b3-85d6-4617-a0ed-f595ebac073e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3270,7 +3270,7 @@
                "apierrors": [],
                "path": "/annotator/updateFeature",
                "response": {
-                  "jsondocId": "7a482bbf-7859-4995-acde-1e8f96155887",
+                  "jsondocId": "4ceceb6b-ceec-4721-a229-8dcc388abed4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3283,7 +3283,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6863a278-9aa5-4413-b720-0ca3a758c3f8",
+                     "jsondocId": "8958cd59-f0c8-4a7c-9b2b-ab698a417b8c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3292,7 +3292,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45762636-1c0e-4317-aae4-aeb0531a2350",
+                     "jsondocId": "f59483c9-d136-4597-94a9-a2d358005b60",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3301,7 +3301,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ef04aa86-3cf4-4cc6-8aca-0538a7a5ba35",
+                     "jsondocId": "20be0243-2ce1-4b06-bca9-8d96cb5236ab",
                      "name": "uniquename",
                      "format": "",
                      "description": "Uniquename (UUID) of the exon we are editing",
@@ -3310,7 +3310,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f8cbdd57-433d-44ec-8a64-9e7efcb6fa2b",
+                     "jsondocId": "09eeca26-be46-4403-bb62-15a6bae586c1",
                      "name": "fmin",
                      "format": "",
                      "description": "fmin for Exon Location",
@@ -3319,7 +3319,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "05da3548-8b86-4d44-8709-5cab1ac4f71c",
+                     "jsondocId": "47212b6b-9f58-4dd3-b36e-1c1049b538b5",
                      "name": "fmax",
                      "format": "",
                      "description": "fmax for Exon Location",
@@ -3328,7 +3328,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c6c1c99c-0d9d-462c-b86f-4fe9c9461aed",
+                     "jsondocId": "b13b1858-1a5c-4fb9-aeff-4694e7bdcace",
                      "name": "strand",
                      "format": "",
                      "description": "strand for Feature Location 1 or -1",
@@ -3340,9 +3340,9 @@
                "verb": "POST",
                "description": "Update exon boundaries",
                "methodName": "setExonBoundaries",
-               "jsondocId": "06fd36d0-1d9b-459d-a255-29131e33c6e7",
+               "jsondocId": "184177b5-de54-4dd5-8f93-e3a1d1dab499",
                "bodyobject": {
-                  "jsondocId": "3138779e-4e28-40d5-93b6-fa28692588b3",
+                  "jsondocId": "3d7dacf2-f4dd-4142-b5d1-5200523dbe8a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3352,7 +3352,7 @@
                "apierrors": [],
                "path": "/annotator/setExonBoundaries",
                "response": {
-                  "jsondocId": "366c842a-6437-4bf8-918c-0e0a0fa56adc",
+                  "jsondocId": "5dfdd58c-579b-497a-ac31-fb0acf398f71",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3365,7 +3365,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f727158c-03eb-4f1d-baa9-68e8a77244dd",
+                     "jsondocId": "928957f2-d2f4-401c-beca-0035790e28c8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3374,7 +3374,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5c6f0b67-3333-460d-a7ca-7cf2d0b6cdbf",
+                     "jsondocId": "abcf97b5-e5c5-459e-b312-0be3b7d92903",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3383,7 +3383,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c05a35e5-2d03-4d4c-8b1e-6623102d0114",
+                     "jsondocId": "e98f3a09-07c2-497e-91ba-17a2e40b2fbb",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -3392,7 +3392,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "865c1692-93dd-40f7-a834-99d37de0efcf",
+                     "jsondocId": "64f867aa-60a1-433d-bd06-6fdab4089b51",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -3404,9 +3404,9 @@
                "verb": "POST",
                "description": "Get annotators report for group",
                "methodName": "getAnnotatorsReportForGroup",
-               "jsondocId": "10cac025-dca7-408d-b8f1-158c80711189",
+               "jsondocId": "5002a087-5354-4a5c-8c01-16b283c1c06d",
                "bodyobject": {
-                  "jsondocId": "29af9ad9-8362-4c78-a28d-49539ace3ede",
+                  "jsondocId": "8cacd3cb-d347-4944-820e-3eeea06205f3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3416,7 +3416,7 @@
                "apierrors": [],
                "path": "/group/getAnnotatorsReportForGroup",
                "response": {
-                  "jsondocId": "2ecdaec6-a13b-40d7-affd-9390990eecce",
+                  "jsondocId": "4702cf31-4e57-487f-8458-c28a6b73971f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3429,14 +3429,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "cd1464b0-6dd6-4c99-838f-cd8610546097",
+         "jsondocId": "2d537f43-b70a-4ca8-ad60-3bc37c2b3912",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4523694c-8252-4127-b8b6-f9c289213c62",
+                     "jsondocId": "60250f6c-77bd-45c3-96d7-67bed7885d5d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3445,7 +3445,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8666a4ca-213c-46d5-b5ad-47a9fe36f3b1",
+                     "jsondocId": "e10258e3-743d-4c2a-af09-86937fd1d660",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3454,7 +3454,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "23b31997-392d-4eae-9083-242b560ec154",
+                     "jsondocId": "b578ad39-87da-4182-a2a4-37df2ea68e5e",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to update (or specify the old_value)",
@@ -3463,7 +3463,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "afd5e9e6-63d6-47c9-bf6b-bae81137e06b",
+                     "jsondocId": "7c5e6cfd-5623-48f6-8412-a3cc2d0891e2",
                      "name": "old_value",
                      "format": "",
                      "description": "Status name to update",
@@ -3472,7 +3472,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5aa1d5ab-8f79-48e4-94c7-7ce23eba5713",
+                     "jsondocId": "beb82c5a-a027-4cff-9b36-48b08c6498b9",
                      "name": "new_value",
                      "format": "",
                      "description": "Status name to change to (the only editable option)",
@@ -3484,9 +3484,9 @@
                "verb": "POST",
                "description": "Update status",
                "methodName": "updateStatus",
-               "jsondocId": "3a4fab6d-50c1-4ba7-abcc-00c5142ec7e3",
+               "jsondocId": "dd07f07c-7f28-4c9c-89b8-be85675aa24e",
                "bodyobject": {
-                  "jsondocId": "b5283ac1-e7a2-4b6c-8fdd-05c4379dca97",
+                  "jsondocId": "c5b111f9-dca3-49c1-986c-66a7dd1e60a0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3496,7 +3496,7 @@
                "apierrors": [],
                "path": "/availableStatus/updateStatus",
                "response": {
-                  "jsondocId": "ecf70577-6f8c-4ebd-b6b7-e84db762e5be",
+                  "jsondocId": "df3f647e-360e-4cd0-ba48-59ba9a68b0f8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3509,7 +3509,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "611993b0-4ce7-4dae-b1c5-02ec58cae726",
+                     "jsondocId": "87e0f4f8-8082-440b-9df5-45eb813371da",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3518,7 +3518,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e4688e2-ef8c-4e76-b5d5-0c023dce12d6",
+                     "jsondocId": "c41318b1-1494-4618-8cbc-d46a80e2f224",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3527,7 +3527,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5083f3d1-70e0-4289-b637-3fce74f6a796",
+                     "jsondocId": "e05c8903-b5c1-4ef5-b9b2-a0db1eb66e79",
                      "name": "value",
                      "format": "",
                      "description": "Status name to add",
@@ -3539,9 +3539,9 @@
                "verb": "POST",
                "description": "Create status",
                "methodName": "createStatus",
-               "jsondocId": "e8e24e4f-99e9-45e5-a799-d503f0fa41be",
+               "jsondocId": "c85e6380-b744-4094-9e00-e85972794f6f",
                "bodyobject": {
-                  "jsondocId": "d8dec70b-f022-4e2f-ac74-c6e1629bc36b",
+                  "jsondocId": "f7d4dc6b-e03d-42e4-a706-4560b1c3b122",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3551,7 +3551,7 @@
                "apierrors": [],
                "path": "/availableStatus/createStatus",
                "response": {
-                  "jsondocId": "b8855bc9-faf9-4fb9-9547-bbb7809fa24e",
+                  "jsondocId": "18964884-308e-46c8-9b6b-15a22f374a3b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3564,7 +3564,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6169677b-12dc-42d8-a683-e0582dd2c8ed",
+                     "jsondocId": "b6e6eacb-f44b-4b96-9594-6fdc828b5adb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3573,7 +3573,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "980214b2-0c07-4e9c-8862-c26a94b6ee17",
+                     "jsondocId": "2855c6e3-8700-43c1-9047-f91c3cc5d7cb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3582,7 +3582,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "522da91a-d7b2-49e2-a4b6-0ba97cf62976",
+                     "jsondocId": "b0b30c0f-223e-4eac-9aaf-87d65e2018d9",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to remove (or specify the name)",
@@ -3591,7 +3591,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "959ebc23-a5d0-4dd6-8f5d-1b6909b79b73",
+                     "jsondocId": "7ce9d0b3-d882-487e-94d2-2299ffdae6e6",
                      "name": "value",
                      "format": "",
                      "description": "Status name to delete",
@@ -3603,9 +3603,9 @@
                "verb": "POST",
                "description": "Remove a status",
                "methodName": "deleteStatus",
-               "jsondocId": "4079cf03-45c1-41de-befc-12a58ab9ca14",
+               "jsondocId": "a0bbf466-4f3b-45df-bb77-5003b40cf629",
                "bodyobject": {
-                  "jsondocId": "e4950a76-ddd4-47e1-bd95-1cffefff3c9d",
+                  "jsondocId": "615db8d7-d58c-4747-8dbb-934d4bba4381",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3615,7 +3615,7 @@
                "apierrors": [],
                "path": "/availableStatus/deleteStatus",
                "response": {
-                  "jsondocId": "b0964fbf-2fec-4cba-8fdc-82ebf3bae817",
+                  "jsondocId": "252291d3-ad12-4043-9851-7d6e92e4cae6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3628,7 +3628,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "54b9b077-3e8e-4dbf-a0a8-4abf35b6cf56",
+                     "jsondocId": "5cc602f6-bb3a-4ab2-bd70-cc82424dfad1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3637,7 +3637,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "839065b3-4dd6-423e-85f5-998c48561b02",
+                     "jsondocId": "b5eb5a49-796f-4c79-ae0c-40e56d522e27",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3646,7 +3646,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6ba3843f-5966-464d-8f8d-291455916fcc",
+                     "jsondocId": "3ee89d17-7787-4831-a41b-5ef8db26090a",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to show (or specify a name)",
@@ -3655,7 +3655,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "93a66d9f-4f2e-4bdd-ac1b-c0190d1eadef",
+                     "jsondocId": "28d59659-e67f-4817-a209-9c65912ce3f5",
                      "name": "name",
                      "format": "",
                      "description": "Status name to show",
@@ -3667,9 +3667,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all statuses, or optionally, gets information about a specific status",
                "methodName": "showStatus",
-               "jsondocId": "b17ab8aa-4326-46bf-a586-ce4816f58fe6",
+               "jsondocId": "ec1131d7-d463-471e-916d-46ecced1629a",
                "bodyobject": {
-                  "jsondocId": "62f3a697-6487-4bf0-8d4f-8a3f37952abe",
+                  "jsondocId": "d56f8dbc-a89d-41ad-8615-adaad00fb05a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3679,7 +3679,7 @@
                "apierrors": [],
                "path": "/availableStatus/showStatus",
                "response": {
-                  "jsondocId": "8ce886ac-cc43-46ed-b955-d50c8e5b2c78",
+                  "jsondocId": "0ef160a3-7ec0-4939-a156-f5c3056058d5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3692,14 +3692,14 @@
          "description": "Methods for managing available statuses"
       },
       {
-         "jsondocId": "ce2d3375-6ecc-4eed-abac-9e30758c34d8",
+         "jsondocId": "307a68f5-6378-4fa8-8434-4f3f75925084",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6025607c-d43e-4ad8-90ee-41330056fbe5",
+                     "jsondocId": "545d7d33-d939-4ad8-a04c-70ed89b633f9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3708,7 +3708,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f408981-5440-47bb-aa00-b8d52c34f6dc",
+                     "jsondocId": "81670599-5c2b-4335-a1ae-cdebd1f5439a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3717,7 +3717,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "810d05d9-8955-4ced-8966-8da7d23779c0",
+                     "jsondocId": "8b84f4fc-95c1-4ff7-addc-ffdaaee0c422",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to add",
@@ -3726,7 +3726,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3cb92d25-5fc1-491e-a7eb-32443af85739",
+                     "jsondocId": "fd7a9cde-18d6-4325-8881-3e867c17587d",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3738,9 +3738,9 @@
                "verb": "POST",
                "description": "Create canned comment",
                "methodName": "createComment",
-               "jsondocId": "4a1517e5-69e3-42bb-b90a-3827f3a7ef77",
+               "jsondocId": "3346ab8c-089e-43e8-ad07-7089f4f20d1d",
                "bodyobject": {
-                  "jsondocId": "379ec40c-033e-4597-8d25-2777ac1e7c51",
+                  "jsondocId": "290b0e4b-f80e-45a5-ae36-4d7af7bc4757",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3750,7 +3750,7 @@
                "apierrors": [],
                "path": "/cannedComment/createComment",
                "response": {
-                  "jsondocId": "cfd8c94a-6375-4f6c-bc7a-bdedf6bfebf4",
+                  "jsondocId": "d3ee7c24-7b46-47d4-84e2-ebc9ddcfce95",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3763,7 +3763,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5b881586-3595-4823-9c1a-010bd23a90b2",
+                     "jsondocId": "d9520382-6fce-491d-977a-9343a2e4ac86",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3772,7 +3772,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6a6ef634-27c2-48f6-9000-ccec90fcd16b",
+                     "jsondocId": "4b363187-098d-4b97-b0de-7401e3cb2b41",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3781,7 +3781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ef25af42-0c12-4e80-80e8-5b11c21226e0",
+                     "jsondocId": "668ac2b5-c9fa-4175-9b62-187577d28ee6",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to update (or specify the old_comment)",
@@ -3790,7 +3790,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "eba812e2-a627-4176-ac17-bd4e9facdc1e",
+                     "jsondocId": "85c1e12c-17a3-4d05-8da8-ac04c55d8e13",
                      "name": "old_comment",
                      "format": "",
                      "description": "Canned comment to update",
@@ -3799,7 +3799,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b9317203-7bc1-4f89-9ec1-c225c50b99fe",
+                     "jsondocId": "27c1c7dd-889a-4906-a163-d99b4fa2f7b1",
                      "name": "new_comment",
                      "format": "",
                      "description": "Canned comment to change to (the only editable option)",
@@ -3808,7 +3808,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "25ec6ae9-510e-4a3f-b789-ad899e0bfe4e",
+                     "jsondocId": "bb6cf01f-fc8d-4d2d-9c4f-ae6df7bec099",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3820,9 +3820,9 @@
                "verb": "POST",
                "description": "Update canned comment",
                "methodName": "updateComment",
-               "jsondocId": "dc149696-3097-4e51-93ee-cf5dafead786",
+               "jsondocId": "98317855-36d4-4dbf-8c68-a56f53c8d8a0",
                "bodyobject": {
-                  "jsondocId": "bc6d642c-9abc-4b8c-b183-ade7d360f74c",
+                  "jsondocId": "2cebb75c-46f1-4a91-a3f0-efecc5d37440",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3832,7 +3832,7 @@
                "apierrors": [],
                "path": "/cannedComment/updateComment",
                "response": {
-                  "jsondocId": "3032e5c8-e5da-47e5-9842-cb9ae1f4445c",
+                  "jsondocId": "709729a4-e093-42b7-88f2-e60670f3d2dd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3845,7 +3845,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0fbbd87b-7b7c-4ec0-a0ba-bd8b0c24e784",
+                     "jsondocId": "b386d732-abba-4d36-b29c-07755da21026",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3854,7 +3854,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "96e0367d-093c-4d92-a732-da33cf1136cb",
+                     "jsondocId": "8ba7b061-acf2-4359-924a-5d61f951c4d7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3863,7 +3863,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5928f9ff-c3c9-497a-b495-1ba9da90c491",
+                     "jsondocId": "77c3f996-2f0d-4dd1-8697-5c68eadf0e40",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to remove (or specify the name)",
@@ -3872,7 +3872,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "34959cc0-7e03-437f-b4f1-2d4d343ea9bf",
+                     "jsondocId": "2c3afa7a-3d40-49d6-b7f1-7552385e9f90",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to delete",
@@ -3884,9 +3884,9 @@
                "verb": "POST",
                "description": "Remove a canned comment",
                "methodName": "deleteComment",
-               "jsondocId": "2992181d-7eb8-4ee7-9860-d47133a14c7c",
+               "jsondocId": "27203ec4-d747-4d7c-979c-8e748d480839",
                "bodyobject": {
-                  "jsondocId": "0d2d0f18-8119-4310-8e60-8cbf613f8a7d",
+                  "jsondocId": "d61cf815-7986-4a8f-8aa8-d1bec240ed42",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3896,7 +3896,7 @@
                "apierrors": [],
                "path": "/cannedComment/deleteComment",
                "response": {
-                  "jsondocId": "496c01fd-d834-4b12-b354-96de33d07f95",
+                  "jsondocId": "7b6f245b-4313-49cc-93ce-14fb0d22f8e0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3909,7 +3909,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9d617ed5-ab12-4904-8f42-19be7b4b5112",
+                     "jsondocId": "8c9ec4dd-485b-4fd1-9d20-b373d688ebef",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3918,7 +3918,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0838027b-783c-4ede-9a56-cc3fd7a0e90d",
+                     "jsondocId": "990e1dca-d355-4a65-9dfe-b7c344e56950",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3927,7 +3927,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d252f2fc-c969-4ded-84d9-35e0dc26b06c",
+                     "jsondocId": "96e686e4-391e-4f41-ab03-81800573d69f",
                      "name": "id",
                      "format": "",
                      "description": "Comment ID to show (or specify a comment)",
@@ -3936,7 +3936,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f0b7a0ab-06cf-4fca-a3dd-a3a7ad87333b",
+                     "jsondocId": "f862ce80-1b98-4c97-9cb4-4dcc1307dd2d",
                      "name": "comment",
                      "format": "",
                      "description": "Comment to show",
@@ -3948,9 +3948,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned comments, or optionally, gets information about a specific canned comment",
                "methodName": "showComment",
-               "jsondocId": "9e9c7f96-ee5e-451e-a7ec-934ac8ec5841",
+               "jsondocId": "c049c469-948d-4af9-80ab-87465f5e3e86",
                "bodyobject": {
-                  "jsondocId": "343fe327-8605-4470-9e0a-e4692114d70f",
+                  "jsondocId": "aa1eb7e0-51cb-4a37-aef1-f5b0ad846328",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3960,7 +3960,7 @@
                "apierrors": [],
                "path": "/cannedComment/showComment",
                "response": {
-                  "jsondocId": "7cfebb24-c83a-4c49-a083-c5c0833bf6d4",
+                  "jsondocId": "eaff7575-16bc-4a7c-9505-acbe310bac94",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3973,14 +3973,14 @@
          "description": "Methods for managing canned comments"
       },
       {
-         "jsondocId": "6ed7d912-e737-4c4a-a400-394ecb427bb3",
+         "jsondocId": "8ab07553-c187-42bf-8a16-0f143a371469",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c72084a6-b769-48b0-814e-12e623dbc9ff",
+                     "jsondocId": "2966f1a5-5c5a-4fd1-84e6-e915e0eb122c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3989,7 +3989,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6f126cbd-fa62-4ab6-b466-7445bf497bad",
+                     "jsondocId": "e330cdae-2f1e-4e17-947d-8d8a6873140c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3998,7 +3998,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7e2bfb01-609f-4ab6-8137-fe2685da4a17",
+                     "jsondocId": "3279ce9b-229f-427d-8399-db1d75b4f58e",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to update (or specify the old_key)",
@@ -4007,7 +4007,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1c818d0-d1d7-4130-8dfb-9c88f83aed40",
+                     "jsondocId": "1727dd41-96ac-44e1-a359-eaf6c7206f2d",
                      "name": "old_key",
                      "format": "",
                      "description": "Canned key to update",
@@ -4016,7 +4016,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ea71b98-b895-4179-893f-1f42df666987",
+                     "jsondocId": "aa18f7bd-bc90-44c2-8459-bd01d1d4b7e1",
                      "name": "new_key",
                      "format": "",
                      "description": "Canned key to change to (the only editable option)",
@@ -4025,7 +4025,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cc58e5eb-a407-4440-97e0-f4e606ad2aba",
+                     "jsondocId": "0266edbd-d114-4de1-992a-5c0776e5916a",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4037,9 +4037,9 @@
                "verb": "POST",
                "description": "Update canned key",
                "methodName": "updateKey",
-               "jsondocId": "39bd4a2b-d74d-42ce-b734-53991514958a",
+               "jsondocId": "7a5a03c4-c586-4f11-81a3-4730dd3ab5d6",
                "bodyobject": {
-                  "jsondocId": "83884057-7791-4ba6-9483-ac79e76b28b5",
+                  "jsondocId": "b2eb3ec3-4cbd-44fb-a7eb-b3f3d9850d9d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4049,7 +4049,7 @@
                "apierrors": [],
                "path": "/cannedKey/updateKey",
                "response": {
-                  "jsondocId": "ce8f5b3c-e612-4cad-aa0d-f15164b8b6cc",
+                  "jsondocId": "25dc341e-faae-4fb9-b77f-a257d225466e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4062,7 +4062,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8df69412-2b20-4d44-b90a-17d2ebc1565d",
+                     "jsondocId": "97fb94a6-92be-4005-9f05-6c2f5fbebc54",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4071,7 +4071,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "af80cb2b-1bef-493d-be29-f350621568ef",
+                     "jsondocId": "de858f8e-a09d-4253-abf4-a4852cbd7882",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4080,135 +4080,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db25aafb-7a7d-420d-aadb-da9a75a5fc76",
-                     "name": "key",
-                     "format": "",
-                     "description": "Canned key to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c4fa4c8b-ad51-45e2-8201-cdc288beb974",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "Optional additional information",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create canned key",
-               "methodName": "createKey",
-               "jsondocId": "4012649e-8256-4180-acd4-76023061adda",
-               "bodyobject": {
-                  "jsondocId": "ce59925d-b9af-4ee7-970b-aa8b33ae17db",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned key"
-               },
-               "apierrors": [],
-               "path": "/cannedKey/createKey",
-               "response": {
-                  "jsondocId": "ddabdc8d-912d-4fb7-92d0-e274ee476353",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned key"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "c5255753-3315-4956-9b0d-4b0f37554f6c",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "3c128470-15d6-423b-bc21-a14e14b636fa",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2c07947a-423b-4ca1-a6c1-3bc9a6b6bc46",
-                     "name": "id",
-                     "format": "",
-                     "description": "Canned key ID to remove (or specify the name)",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ad9442b5-7660-4e01-88ea-a5f83e33660d",
-                     "name": "key",
-                     "format": "",
-                     "description": "Canned key to delete",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Remove a canned key",
-               "methodName": "deleteKey",
-               "jsondocId": "0bf01791-d4e4-4660-9c84-0132174a4a3f",
-               "bodyobject": {
-                  "jsondocId": "0f82244d-8d38-46cb-a3c0-07bd2616cc96",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned key"
-               },
-               "apierrors": [],
-               "path": "/cannedKey/deleteKey",
-               "response": {
-                  "jsondocId": "13c7e43d-f84a-48d0-b864-064b966d8b28",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned key"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "f7832400-6660-45dd-b0cc-242654f4311e",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ae4a9f6c-2128-49a8-bd0f-15d51091c6f7",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "534a5b0f-0103-41a7-a8f7-d1909fffbe20",
+                     "jsondocId": "74c5b17e-17b6-4f16-aa6d-f5d9026bb3ef",
                      "name": "id",
                      "format": "",
                      "description": "Key ID to show (or specify a key)",
@@ -4217,7 +4089,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "58da0c15-4e34-4724-b368-da9358461214",
+                     "jsondocId": "c4187e86-ec81-4846-89d6-e87b9f6d00e9",
                      "name": "key",
                      "format": "",
                      "description": "Key to show",
@@ -4229,9 +4101,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned keys, or optionally, gets information about a specific canned key",
                "methodName": "showKey",
-               "jsondocId": "881b39c5-4e66-48cd-b8fd-e96bf75e11b5",
+               "jsondocId": "72e1ef63-68e1-4441-a21a-93f38778b48a",
                "bodyobject": {
-                  "jsondocId": "586f07a2-4b85-4bc6-abde-dddcddb887db",
+                  "jsondocId": "60e8768f-7b46-473e-89e9-389609848ce2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4241,7 +4113,135 @@
                "apierrors": [],
                "path": "/cannedKey/showKey",
                "response": {
-                  "jsondocId": "98269122-f2ef-4ea1-a2d5-fa8accb236ca",
+                  "jsondocId": "b634a653-a628-4a32-b9dd-3ddcd9f140ee",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned key"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "bf638e59-60f6-44c3-ac33-a4d696ac2a3c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "15e2149d-080a-4fee-b4d5-7e17e43cf5e5",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "09d56993-90ca-42eb-8837-252f34aca4e0",
+                     "name": "key",
+                     "format": "",
+                     "description": "Canned key to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6cd544a9-7bb5-4e91-932c-e5843ba5ac2f",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create canned key",
+               "methodName": "createKey",
+               "jsondocId": "3d523703-dd2e-416e-868d-75dabe7ade01",
+               "bodyobject": {
+                  "jsondocId": "0563a880-ab3a-41a6-af95-bf8029b69dc3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned key"
+               },
+               "apierrors": [],
+               "path": "/cannedKey/createKey",
+               "response": {
+                  "jsondocId": "c5a26022-0aba-4140-91f8-6caf150dea29",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned key"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "41bcaf0c-65a3-4ba9-a802-460a4f96d331",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "269c59bd-33b5-490e-829f-20a741eefa56",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "080b1281-3432-40e1-b63c-26e2257fe5ed",
+                     "name": "id",
+                     "format": "",
+                     "description": "Canned key ID to remove (or specify the name)",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f1a23945-ca81-4a75-a06a-86cbfa0d1c8d",
+                     "name": "key",
+                     "format": "",
+                     "description": "Canned key to delete",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Remove a canned key",
+               "methodName": "deleteKey",
+               "jsondocId": "ba4ddc6b-d5a1-4e17-85f9-278507cef5a9",
+               "bodyobject": {
+                  "jsondocId": "15cdede1-d9f8-40bb-af4c-a317d219b206",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned key"
+               },
+               "apierrors": [],
+               "path": "/cannedKey/deleteKey",
+               "response": {
+                  "jsondocId": "0edfcd23-db5b-4b59-9448-9dd1467404e6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4254,14 +4254,14 @@
          "description": "Methods for managing canned keys"
       },
       {
-         "jsondocId": "8e9aa8ea-eebf-4689-b8aa-8f81292124ff",
+         "jsondocId": "968a96e4-1adb-4a30-bbd6-0027dfa638d2",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "914e931d-1325-4236-924b-c9ad33501bf0",
+                     "jsondocId": "539275b2-6008-411e-bec6-1970ef8dbc6d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4270,7 +4270,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2a91e33e-e7fa-4c06-af32-2d818ee8c565",
+                     "jsondocId": "225e1f1e-7427-4631-b8e4-8ae686bc0860",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4279,71 +4279,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3096e3de-2207-4011-8e08-f35f32e5b3ec",
-                     "name": "value",
-                     "format": "",
-                     "description": "Canned value to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "6c9834ac-65ac-475f-9361-c1110263f9dc",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "Optional additional information",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create canned value",
-               "methodName": "createValue",
-               "jsondocId": "3445f1e1-49cf-4644-a030-20d2c3cfdbdf",
-               "bodyobject": {
-                  "jsondocId": "3523d617-da87-4386-9b70-bcc623861e20",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned value"
-               },
-               "apierrors": [],
-               "path": "/cannedValue/createValue",
-               "response": {
-                  "jsondocId": "15e7c9c5-82e5-44f4-b4d5-f638146acb14",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned value"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "e2e8748a-14f2-4c01-8463-aea6c704f73d",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "bd745ba9-3cad-4c08-872f-e5dbc2868778",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b37e0ab9-ce74-4b84-b45a-f55fbd7a0cfe",
+                     "jsondocId": "3d607602-fa08-47f8-9785-a65f16db01b1",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to update (or specify the old_value)",
@@ -4352,7 +4288,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c143fe13-3e71-4361-9b9a-e2dbf4e0a006",
+                     "jsondocId": "cbab941f-67e1-43e7-9b83-d187513e3579",
                      "name": "old_value",
                      "format": "",
                      "description": "Canned value to update",
@@ -4361,7 +4297,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e2684402-8bc3-46e9-96aa-9488585ded02",
+                     "jsondocId": "a7eccf4e-76bf-4d13-8c60-b4f628f69eda",
                      "name": "new_value",
                      "format": "",
                      "description": "Canned value to change to (the only editable option)",
@@ -4370,7 +4306,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dc601f67-bde3-496f-9e30-71323dac7ee6",
+                     "jsondocId": "75f03792-1d6f-49f7-a814-cb9be0504c43",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4382,9 +4318,9 @@
                "verb": "POST",
                "description": "Update canned value",
                "methodName": "updateValue",
-               "jsondocId": "e398eff8-4761-4664-921e-96d2a4b506c9",
+               "jsondocId": "63c671d2-cd24-449c-92b1-172e0cf6d685",
                "bodyobject": {
-                  "jsondocId": "6e5c30f8-898c-45c2-a29e-7a42aa9ea7f3",
+                  "jsondocId": "7e643ed5-1da2-41e1-b5cc-9ffc3ad3b557",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4394,7 +4330,7 @@
                "apierrors": [],
                "path": "/cannedValue/updateValue",
                "response": {
-                  "jsondocId": "92f85fe7-e707-43a0-b330-2cfdf42e851b",
+                  "jsondocId": "b5f98510-7643-48e0-94c1-220959756257",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4407,7 +4343,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "05c665b8-f616-4ab4-9a01-6a15bcadf8f8",
+                     "jsondocId": "b2a95658-23e6-42e2-9702-5029db15627b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4416,7 +4352,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "285e4f70-b06d-43f6-a722-b1899446f90e",
+                     "jsondocId": "693c0319-6448-4077-8d3d-608026bb31bc",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4425,7 +4361,71 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7a9bd1fb-7b58-47db-aa25-f1e8ec8fe0d9",
+                     "jsondocId": "02a757b3-fca3-4491-8849-7d2dff2836f2",
+                     "name": "value",
+                     "format": "",
+                     "description": "Canned value to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "74e30342-1328-40ed-8b4e-19d8339f88df",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create canned value",
+               "methodName": "createValue",
+               "jsondocId": "6a6f1424-b6d6-478a-9fb9-52721bcf471a",
+               "bodyobject": {
+                  "jsondocId": "92114e02-6342-4dfd-8a22-c14689085ce3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned value"
+               },
+               "apierrors": [],
+               "path": "/cannedValue/createValue",
+               "response": {
+                  "jsondocId": "5ba2c9fc-8417-4d4d-9967-104086611cae",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned value"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "37c4bd0c-e773-4ef8-a474-30cb250efea9",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5eb856f4-0046-4ac9-a1ea-74a3d511a179",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e63fab81-1510-40a7-b8d2-e878707b2cec",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to remove (or specify the name)",
@@ -4434,7 +4434,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3cc18989-a48f-426c-b412-312559d4cd38",
+                     "jsondocId": "3e9cde9d-1a0d-43a1-a562-7d9326ea864b",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to delete",
@@ -4446,9 +4446,9 @@
                "verb": "POST",
                "description": "Remove a canned value",
                "methodName": "deleteValue",
-               "jsondocId": "a8bc3679-1674-4cc1-ac83-0c656b29f81a",
+               "jsondocId": "66834c29-d14a-4c65-b411-b7037a29bc9e",
                "bodyobject": {
-                  "jsondocId": "7ed646cc-b99f-46c9-be30-99f0cc658e26",
+                  "jsondocId": "4d2e7b2f-c316-459d-8dbf-9fe9eaacd22f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4458,7 +4458,7 @@
                "apierrors": [],
                "path": "/cannedValue/deleteValue",
                "response": {
-                  "jsondocId": "c6272dc0-1598-4c1f-ba85-380cc1bc9ebe",
+                  "jsondocId": "3ab64d29-ef33-4ba0-9d89-35337da8e957",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4471,7 +4471,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fcd22dea-8ee0-4ae6-9527-cb9434b0e705",
+                     "jsondocId": "874aa38c-f0a9-43ba-9e36-f3c86d94e5b1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4480,7 +4480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "121d5ad3-adc6-49be-aecb-97dcc5e5fe14",
+                     "jsondocId": "26cf166a-f426-4c32-847d-a414e422bb30",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4489,7 +4489,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "510f2c06-b97e-4789-bccb-4f955d7cb30e",
+                     "jsondocId": "952cf330-0bca-4ce2-9557-526b712776eb",
                      "name": "id",
                      "format": "",
                      "description": "Value ID to show (or specify a value)",
@@ -4498,7 +4498,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b0b372b6-d608-40f7-a9c8-02c9ee155417",
+                     "jsondocId": "1aa8b6d1-1d48-4a0f-b95e-fced6262f025",
                      "name": "value",
                      "format": "",
                      "description": "Value to show",
@@ -4510,9 +4510,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned values, or optionally, gets information about a specific canned value",
                "methodName": "showValue",
-               "jsondocId": "42f32808-5f5f-4e7f-8d0c-617174384551",
+               "jsondocId": "9a200061-30c5-42e3-8ba6-5234f75a3405",
                "bodyobject": {
-                  "jsondocId": "33c7549b-ccdb-4cd5-bdd9-1d4ba54ab896",
+                  "jsondocId": "3ed72041-3601-4157-bb00-d6d9cbbf43b5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4522,7 +4522,7 @@
                "apierrors": [],
                "path": "/cannedValue/showValue",
                "response": {
-                  "jsondocId": "3dc77f5f-6f26-4dbf-92fd-9d3144ce1f4e",
+                  "jsondocId": "a4507728-4085-49ef-87ad-e773043cbbba",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4535,14 +4535,14 @@
          "description": "Methods for managing canned values"
       },
       {
-         "jsondocId": "90df3a74-8ca7-4ca0-b5ca-c14832c68aff",
+         "jsondocId": "121cb650-ff2c-4555-bb0d-4e3f73977c37",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "aa2d03b3-1b9d-4d9b-a207-1a66a2365043",
+                     "jsondocId": "7e8999ec-b844-4b36-9117-f1a8a65b0225",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4551,7 +4551,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26178af4-1770-4909-a66a-8288398c7df6",
+                     "jsondocId": "f73165c3-2e12-4df4-92de-ba1c7cf70ac8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4560,7 +4560,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7f07a85c-9904-4232-8586-d4809efd4c10",
+                     "jsondocId": "ab1d55df-f293-4c63-a668-079449209a84",
                      "name": "name",
                      "format": "",
                      "description": "Group name to add, or a comma-delimited list of names",
@@ -4572,9 +4572,9 @@
                "verb": "POST",
                "description": "Create group",
                "methodName": "createGroup",
-               "jsondocId": "53ceb2f0-59d5-4790-a94b-aa20ceea6a40",
+               "jsondocId": "bc8f8b7a-30b3-4ad2-9473-0036c5050620",
                "bodyobject": {
-                  "jsondocId": "5f5932a9-a491-4d38-9463-92b1d2340938",
+                  "jsondocId": "eebf3bfe-51d6-4be6-8cd8-694a9aefd6ba",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4584,7 +4584,7 @@
                "apierrors": [],
                "path": "/group/createGroup",
                "response": {
-                  "jsondocId": "85b204e6-2715-4eda-bd64-2caaa46d6d91",
+                  "jsondocId": "f97c0754-97e5-4aec-b3de-9ce427819d52",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4597,7 +4597,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "896e6fbb-cded-4a29-b423-a7a0ba851100",
+                     "jsondocId": "0eb11e52-f507-4ca6-912e-1dc229f098d7",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4606,7 +4606,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "45886dc3-93a2-4b3a-a168-35c9b32afd2a",
+                     "jsondocId": "9ed71f67-5acc-42de-8438-6689f9255f88",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4615,7 +4615,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c368c224-1169-46e7-bc30-d984f43311c5",
+                     "jsondocId": "79a71962-5d35-4510-b689-89e9c814cec5",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -4624,7 +4624,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cc87f872-ed21-4183-b0e3-95bdece9ddd7",
+                     "jsondocId": "644b060d-fe08-4866-abcc-c6e16b77b087",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -4636,9 +4636,9 @@
                "verb": "POST",
                "description": "Get organism permissions for group",
                "methodName": "getOrganismPermissionsForGroup",
-               "jsondocId": "ebfbeae5-2b70-43e0-8c2a-b3c786bf63b1",
+               "jsondocId": "dedc231d-7f87-4789-8a51-ed5edcd16294",
                "bodyobject": {
-                  "jsondocId": "108dd9c2-b1ed-4532-85e0-06e0ec469e6a",
+                  "jsondocId": "614b8394-0e7d-4c69-92dd-6a2918b73336",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4648,7 +4648,7 @@
                "apierrors": [],
                "path": "/group/getOrganismPermissionsForGroup",
                "response": {
-                  "jsondocId": "d35540af-4512-4c39-b29e-3231727f4f91",
+                  "jsondocId": "025b931f-a2bc-4ced-9ceb-9a7b3998b8d2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4661,7 +4661,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "be8976a7-dcf8-4ca4-b1ae-f382cf666ff5",
+                     "jsondocId": "db16b809-215d-4c14-aeed-0700096312b5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4670,7 +4670,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0f7e17da-77f7-4440-8ccf-f6c12f450717",
+                     "jsondocId": "4ad76642-1fc4-4f6e-9772-61a34d0bec25",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4679,7 +4679,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e5134325-42b6-4f5a-82d7-bb75675df83b",
+                     "jsondocId": "f6b89561-7352-443e-9998-920b8327b1a6",
                      "name": "groupId",
                      "format": "",
                      "description": "Optional only load a specific groupId",
@@ -4691,9 +4691,9 @@
                "verb": "POST",
                "description": "Load all groups",
                "methodName": "loadGroups",
-               "jsondocId": "bc83ae03-68a6-4681-82dd-73871bd3b556",
+               "jsondocId": "82375105-d042-4a5c-a266-f16d4d342902",
                "bodyobject": {
-                  "jsondocId": "428f9cf6-6f96-4ad7-8880-138438714796",
+                  "jsondocId": "cd795472-7d4d-4b61-8e90-256421b95d18",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4703,7 +4703,7 @@
                "apierrors": [],
                "path": "/group/loadGroups",
                "response": {
-                  "jsondocId": "9feb1486-c2a9-40d8-8349-6451fa7f8c42",
+                  "jsondocId": "adf45672-fb4b-424f-9e7a-efda86453847",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4716,7 +4716,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4cd52872-fe30-48db-b465-09a921e75008",
+                     "jsondocId": "641309f2-360a-4240-bb3e-ce7d168d4692",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4725,7 +4725,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2109a0ff-9a7d-4878-afe9-6cec8307e6eb",
+                     "jsondocId": "345a6391-ea3f-499f-b7ac-aee65d6f8767",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4734,7 +4734,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "99b0418b-7f6b-4d62-9078-014584e51d92",
+                     "jsondocId": "91021757-0bf5-469c-b54a-c2c1813ed2a4",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to remove (or specify the name)",
@@ -4743,7 +4743,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d77d062c-d76c-4eb2-9811-8fe0816b541f",
+                     "jsondocId": "ada2a84a-67ea-476c-99dc-43749ba2161e",
                      "name": "name",
                      "format": "",
                      "description": "Group name or comma-delimited list of names to remove",
@@ -4755,9 +4755,9 @@
                "verb": "POST",
                "description": "Delete a group",
                "methodName": "deleteGroup",
-               "jsondocId": "ae9cfa3b-b67d-45e5-b050-e3bf1473c664",
+               "jsondocId": "402b2589-f5b1-46bd-bc39-d820ffe64729",
                "bodyobject": {
-                  "jsondocId": "883b4084-bd73-4926-a4c5-2e92a5d72a46",
+                  "jsondocId": "1ac39a1b-ec14-4ed8-9599-c8d67e975228",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4767,7 +4767,7 @@
                "apierrors": [],
                "path": "/group/deleteGroup",
                "response": {
-                  "jsondocId": "b0868a53-3fd0-4ab5-a91d-4ea5d1753375",
+                  "jsondocId": "030059f8-4892-447c-bec7-790ce79104a0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4780,7 +4780,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c512f884-fa81-4840-89bf-1cec5f00ec4f",
+                     "jsondocId": "96af58d7-8d37-4e25-8f36-2cce92a97bbb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4789,7 +4789,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "04c72a95-d0af-4d0d-99a2-45688bac8448",
+                     "jsondocId": "e510e226-11ae-4a13-b6c9-04c2d3cebbf7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4798,7 +4798,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "33778a45-d81c-463d-96fe-01c630333f63",
+                     "jsondocId": "52ac1240-e364-491a-b048-6f781ce11c51",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to update",
@@ -4807,7 +4807,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db162fe4-a393-4c30-a344-ac778015db90",
+                     "jsondocId": "eda41c0d-fa5c-4bd6-9fa7-f39cd196bfe1",
                      "name": "name",
                      "format": "",
                      "description": "Group name to change to (the only editable optoin)",
@@ -4819,9 +4819,9 @@
                "verb": "POST",
                "description": "Update group",
                "methodName": "updateGroup",
-               "jsondocId": "79ac9fa5-c9fb-482a-b1c4-452480d644cb",
+               "jsondocId": "01c1f6de-32bb-46d3-903f-c9a7d5a9905e",
                "bodyobject": {
-                  "jsondocId": "63a81fe2-2184-42d9-9701-3a04709d5745",
+                  "jsondocId": "70255feb-0ebd-4450-8093-efafe0e300b1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4831,7 +4831,7 @@
                "apierrors": [],
                "path": "/group/updateGroup",
                "response": {
-                  "jsondocId": "db133e26-de1f-4b6a-bb45-d73139458b47",
+                  "jsondocId": "276e9d40-88b0-4cc1-847f-44c2030e0853",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4844,7 +4844,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a741330c-4d44-4fc6-8de2-0f3050b5df78",
+                     "jsondocId": "b1eaab4c-bc98-4018-b706-4ee896680452",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4853,7 +4853,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9032d523-aa1e-4de0-b8ae-8ef8bf7940da",
+                     "jsondocId": "5501af09-8c33-428e-b101-e174c7fc55a8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4862,7 +4862,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c39e4526-9d19-4188-a192-0d9c2b00c6fc",
+                     "jsondocId": "688269d7-a19f-4f60-b16c-5427e496c59c",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to modify permissions for (must provide this or 'name')",
@@ -4871,7 +4871,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c015a896-74b0-4609-907e-5c4303e27fc7",
+                     "jsondocId": "ad6bde9a-ce98-431c-898a-2ee6e59763e5",
                      "name": "name",
                      "format": "",
                      "description": "Group name to modify permissions for (must provide this or 'groupId')",
@@ -4880,7 +4880,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "daea601c-4fc7-4824-aec4-3c853f265d70",
+                     "jsondocId": "fe89b834-f769-4b58-9fc0-a5690f850de5",
                      "name": "organism",
                      "format": "",
                      "description": "Organism common name",
@@ -4889,7 +4889,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ad082b4a-649c-40a2-bcfe-c2e8b00f8d8d",
+                     "jsondocId": "9ec15fe3-e29f-4164-a460-f751b4b0bf9f",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -4898,7 +4898,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ba144e99-23da-4acd-acbe-6be37bcbced3",
+                     "jsondocId": "f8a5a06c-0f38-4b38-9814-6c47bc77d755",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -4907,7 +4907,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3d5bf8b1-f121-4b76-91fa-41231486a0d6",
+                     "jsondocId": "8573890b-2b70-46ed-a1d7-67331ce7b2a3",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -4916,7 +4916,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "94e953a3-10c3-43d9-856b-b567f0eb6d99",
+                     "jsondocId": "d6e40a8b-6357-4530-a1dd-9776c8af5a30",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -4928,9 +4928,9 @@
                "verb": "POST",
                "description": "Update organism permission",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "2a1ca422-735e-4694-ad04-21819dd6739c",
+               "jsondocId": "e54cbf7b-416d-4135-b8cb-29b96f40002a",
                "bodyobject": {
-                  "jsondocId": "3c828f9f-118a-45f8-a9d7-cdcd847a688c",
+                  "jsondocId": "70d6a72c-9826-42b0-a25e-761c23d85b64",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4940,7 +4940,7 @@
                "apierrors": [],
                "path": "/group/updateOrganismPermission",
                "response": {
-                  "jsondocId": "fbd1936e-cba8-4aad-a440-5f86145abb3b",
+                  "jsondocId": "cd5efa0e-11b6-4291-be1e-025ca9869947",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4953,7 +4953,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d073ac0f-e306-42cf-8026-6af0bb97288e",
+                     "jsondocId": "69dfa805-e63b-4eb4-a0f3-15b4be1189c3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4962,7 +4962,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "99a38d92-8f84-4bf0-b324-d04a3925f4e7",
+                     "jsondocId": "e247b856-ee4a-4891-ad4e-9270914d6f3d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4971,7 +4971,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2fc16224-2d98-403c-a55c-665e17c2b7ee",
+                     "jsondocId": "abd3acaf-4a9f-4d2b-b4eb-5f63184d676b",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -4980,7 +4980,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "225cf0bb-4101-4978-8d1a-17ad187d4764",
+                     "jsondocId": "09f52ffd-3aa4-450f-9587-355a1e2d8088",
                      "name": "users",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -4989,7 +4989,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "76864756-4743-4657-8e69-d12650ac2de5",
+                     "jsondocId": "f1bba737-6a67-47a5-a120-b58d844b4e0b",
                      "name": "memberships",
                      "format": "",
                      "description": "Bulk memberships (instead of users and groupId) to update of the form: [ {groupId: <groupId>,users: [\"user1\", \"user2\", \"user3\"]}, {groupId:<another-groupId>, users: [\"user2\", \"user8\"]}]",
@@ -5001,9 +5001,9 @@
                "verb": "POST",
                "description": "Update group membership",
                "methodName": "updateMembership",
-               "jsondocId": "68992ad3-488e-4dac-ab31-85a7153704ac",
+               "jsondocId": "142d88ce-ddb0-4744-a687-9ff029252c16",
                "bodyobject": {
-                  "jsondocId": "a84a7a49-f659-41e4-8da4-631ad5904f29",
+                  "jsondocId": "d02f57eb-4e28-42ab-89b6-bbbf38dedcf8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5013,7 +5013,7 @@
                "apierrors": [],
                "path": "/group/updateMembership",
                "response": {
-                  "jsondocId": "4086170b-cec8-4330-8f31-724ca00ca9fd",
+                  "jsondocId": "5912ad18-f515-4a55-be93-74541babad5b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5026,7 +5026,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0a125302-2542-45e0-af80-ea6710915828",
+                     "jsondocId": "a86655f3-4c8e-4c2a-a82f-7222bfb4bbbe",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5035,7 +5035,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d7449703-14f8-4f87-ba34-438640ec10dd",
+                     "jsondocId": "5f2d24fb-307b-4d31-9319-9fe5e55dc1b8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5044,7 +5044,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ddda9687-9539-4db5-b478-7bdbce3bfb06",
+                     "jsondocId": "9aa695d9-9417-429d-b76f-a7c0e2e13dd9",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -5053,7 +5053,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1d86592-536a-48a2-87f5-e7a65708729a",
+                     "jsondocId": "d2b2c5e6-03c2-4c1b-b015-e7ca532e224b",
                      "name": "users",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -5065,9 +5065,9 @@
                "verb": "POST",
                "description": "Update group admin",
                "methodName": "updateGroupAdmin",
-               "jsondocId": "f074d28c-9db9-4d52-816d-42ea49faa68a",
+               "jsondocId": "52f4cf46-7e07-4ee3-96a9-93331c989635",
                "bodyobject": {
-                  "jsondocId": "04406aa4-b280-40f4-a8dd-4afc4e612992",
+                  "jsondocId": "3f51a989-614b-4eb3-8790-f87db6b52ed9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5077,7 +5077,7 @@
                "apierrors": [],
                "path": "/group/updateGroupAdmin",
                "response": {
-                  "jsondocId": "73c569fe-923c-48f5-8d2d-184d6a135fc0",
+                  "jsondocId": "82afe39e-00f4-4da2-b284-15911565361f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5090,7 +5090,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4f5ab162-265e-4068-8381-224ee91d4116",
+                     "jsondocId": "5cb6db07-43a3-4ac5-95f8-b4707f7f9b1e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5099,7 +5099,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e3533b9c-f398-4fb7-ab6b-46adb2c0afcb",
+                     "jsondocId": "afbac910-ff06-4b6b-9803-56563d0d053c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5108,7 +5108,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "76290215-b306-4b0a-a248-ff8b16a9f0d1",
+                     "jsondocId": "ec444c2a-89bb-4a4f-aacf-5fa3bb2eff2f",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -5120,9 +5120,9 @@
                "verb": "POST",
                "description": "Get group admins, returns group admins as JSONArray",
                "methodName": "getGroupAdmin",
-               "jsondocId": "d851b3ec-5f6d-4031-b56f-d368546ecbe2",
+               "jsondocId": "a4802ef2-8d7a-4396-a175-eec7b40ae891",
                "bodyobject": {
-                  "jsondocId": "b9978f9d-71fe-49df-b359-8f81aec925f6",
+                  "jsondocId": "baba9673-df87-4bfc-a041-a750e0ff7d75",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5132,7 +5132,7 @@
                "apierrors": [],
                "path": "/group/getGroupAdmin",
                "response": {
-                  "jsondocId": "676e865b-943a-4a5c-90bf-b07c6936d026",
+                  "jsondocId": "76e1b690-de99-44d9-bad2-ff34fbd18498",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5145,7 +5145,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "08b43597-56c8-40c8-9e76-c3c45240191c",
+                     "jsondocId": "47c1163b-52c7-479d-8905-c27b9de9d12b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5154,7 +5154,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6fce1e8e-ee5f-4083-8d09-af27e5dd50d3",
+                     "jsondocId": "0b5d6cec-a35b-46c3-af69-2775241a608a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5163,7 +5163,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8d12b090-797e-47dc-8d73-62e8d5625e8d",
+                     "jsondocId": "daf58a44-eb04-43b0-a825-198401d7a9dc",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -5175,9 +5175,9 @@
                "verb": "POST",
                "description": "Get creator metadata for group, returns userId as JSONObject",
                "methodName": "getGroupCreator",
-               "jsondocId": "04878a7c-d524-4737-b9d3-d9584ddeaa5f",
+               "jsondocId": "9cf1c9f7-7f14-41c5-839b-5295dc8d5a20",
                "bodyobject": {
-                  "jsondocId": "abb6ba1d-7c60-40eb-aedc-7a92b1bfe028",
+                  "jsondocId": "aa61a554-96f0-4f63-847b-6115791f836a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5187,7 +5187,7 @@
                "apierrors": [],
                "path": "/group/getGroupCreator",
                "response": {
-                  "jsondocId": "59520a0f-cc5a-44fd-a487-6bc6e70aff0e",
+                  "jsondocId": "7bc29e0a-3309-4a45-b903-3aef0df17200",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5200,13 +5200,13 @@
          "description": "Methods for managing groups"
       },
       {
-         "jsondocId": "ae3603ef-4b22-4ac4-965d-3bae4ffb5a86",
+         "jsondocId": "cbda541a-b59a-495a-88e1-2c402ea9c458",
          "methods": [{
             "headers": [],
             "pathparameters": [],
             "queryparameters": [
                {
-                  "jsondocId": "293bbe4d-cea8-4778-83d8-728e219b59af",
+                  "jsondocId": "06220f59-c434-490c-b292-3398b6a59ae1",
                   "name": "username",
                   "format": "",
                   "description": "",
@@ -5215,7 +5215,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "832fbd96-4996-4bb4-9dad-88aa111ebe64",
+                  "jsondocId": "d7dbc73d-64dd-40b4-ad56-46dccbfec570",
                   "name": "password",
                   "format": "",
                   "description": "",
@@ -5224,7 +5224,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "4bf6fb0c-46fa-4b37-8581-59464e6890d2",
+                  "jsondocId": "6a904a14-783a-4e3f-926f-872687fe92d0",
                   "name": "date",
                   "format": "",
                   "description": "Date to query yyyy-MM-dd:HH:mm:ss or yyyy-MM-dd",
@@ -5233,7 +5233,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "dc8b52fd-0eed-4968-b6ea-3e5225ec0303",
+                  "jsondocId": "cafb840b-8577-49cc-bf9c-605bf13647d3",
                   "name": "afterDate",
                   "format": "",
                   "description": "Search after or on the given date.",
@@ -5242,7 +5242,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "3eefc0c3-058d-401d-8ff2-8d665896cde4",
+                  "jsondocId": "68409aeb-fa12-48d8-ad50-5178f9879240",
                   "name": "beforeDate",
                   "format": "",
                   "description": "Search before or on the given date.",
@@ -5251,7 +5251,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "abdce62a-91bd-406e-a58f-e40aee97b1c5",
+                  "jsondocId": "1cefbb6d-65d5-4d16-95c3-4c227685d4f2",
                   "name": "max",
                   "format": "",
                   "description": "Max to return",
@@ -5260,7 +5260,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "42c26442-8ad8-4060-9ae5-3f167a69d51c",
+                  "jsondocId": "df048b6d-d1df-4751-ac57-d210729936e9",
                   "name": "sort",
                   "format": "",
                   "description": "Sort parameter (lastUpdated).  See FeatureEvent object/table.",
@@ -5269,7 +5269,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "02ac3b13-4cc9-47cf-a7be-f1bdeafcce34",
+                  "jsondocId": "541bca8e-e47e-40a5-ad85-7d69ceaa4ca2",
                   "name": "order",
                   "format": "",
                   "description": "desc/asc sort order by sort param",
@@ -5281,9 +5281,9 @@
             "verb": "POST",
             "description": "Returns a JSON representation of all current Annotations before or after a given date.",
             "methodName": "findChanges",
-            "jsondocId": "147bbffc-e823-4c3c-b819-386b97bd50e8",
+            "jsondocId": "6d1f83df-b414-4173-adb9-ad5294d4f04f",
             "bodyobject": {
-               "jsondocId": "db7b7fd3-3210-4644-b223-443b2e18be1d",
+               "jsondocId": "739a1fd6-d637-414d-a9ad-e371be5e67ba",
                "mapValueObject": "",
                "mapKeyObject": "",
                "multiple": "Unknow",
@@ -5293,7 +5293,7 @@
             "apierrors": [],
             "path": "/featureEvent/findChanges",
             "response": {
-               "jsondocId": "d71396af-36ac-495c-becb-8af8aebd96a4",
+               "jsondocId": "93a1d154-f534-4a1c-882d-c7b7e284af72",
                "mapValueObject": "",
                "mapKeyObject": "",
                "object": "feature event"
@@ -5305,14 +5305,14 @@
          "description": "Methods for querying history"
       },
       {
-         "jsondocId": "064d89b9-9bd0-44ba-9677-3aa6974c0c90",
+         "jsondocId": "7c5a5bbe-93c6-4f79-a69a-187bbefa5cab",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "43d013b2-bf64-4467-86e1-700b2da39f7b",
+                     "jsondocId": "ab012613-4548-4eb5-8685-843cb65ece68",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5321,7 +5321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1e210aa1-704e-4894-b22b-3c7eca30d8d4",
+                     "jsondocId": "518011d9-fc85-4762-9a2c-a4acaa4459f9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5330,7 +5330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66568942-e44e-49da-aec2-ae7d8cecc2c9",
+                     "jsondocId": "070c7ed2-509d-48e5-8307-3830fcb1d25c",
                      "name": "type",
                      "format": "",
                      "description": "Type of annotated genomic features to export 'FASTA','GFF3','CHADO'.",
@@ -5339,7 +5339,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bf4b2490-d90b-43d7-80fd-113f56b6f273",
+                     "jsondocId": "3e7e0375-f08f-42ba-84ed-df205f2a36e4",
                      "name": "seqType",
                      "format": "",
                      "description": "Type of output sequence 'peptide','cds','cdna','genomic'.",
@@ -5348,7 +5348,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aa67e7a7-feab-4c28-8f48-2a38bd084462",
+                     "jsondocId": "330afafc-2151-48a0-85c4-b77b27348eff",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -5357,7 +5357,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8fe95cbe-a819-4f28-b0da-3e95edc38b54",
+                     "jsondocId": "6ef49587-af52-40f3-be41-4e99a3b0378c",
                      "name": "sequences",
                      "format": "",
                      "description": "Names of references sequences to add (default is all).",
@@ -5366,7 +5366,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0374e715-24f1-43a1-a6fc-fe646c86ac1a",
+                     "jsondocId": "afb29838-8cde-4502-8b20-ee753cde64ec",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism that sequences belong to (will default to last organism).",
@@ -5375,7 +5375,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7427e9f-74a3-44e9-809f-6e1a13a8dc01",
+                     "jsondocId": "27f68a49-05e3-411c-8a93-ff228627c172",
                      "name": "output",
                      "format": "",
                      "description": "Output method 'file','text'",
@@ -5384,7 +5384,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1d8cd35e-cc4a-492a-babd-60719d3c429c",
+                     "jsondocId": "10d0bd01-de16-4bea-b204-928acc4c4139",
                      "name": "exportAllSequences",
                      "format": "",
                      "description": "Export all reference sequences for an organism (over-rides 'sequences')",
@@ -5393,7 +5393,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "359582c6-5f22-4d46-b37d-1cb28813df97",
+                     "jsondocId": "4c523b11-deb5-420c-9a80-f6297c13b830",
                      "name": "region",
                      "format": "",
                      "description": "Highlighted genomic region to export in form sequence:min..max  e.g., chr3:1001..1034",
@@ -5405,9 +5405,9 @@
                "verb": "POST",
                "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "methodName": "write",
-               "jsondocId": "fbb184f2-02bf-446b-bd2d-14ebdaaaa754",
+               "jsondocId": "828e14b7-1d53-4b5a-864d-ffa079e8ddd0",
                "bodyobject": {
-                  "jsondocId": "90012e04-9b7b-4bb9-bd80-79d96482a50a",
+                  "jsondocId": "e6200380-e828-4da1-86b3-282adf7f3970",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5417,7 +5417,7 @@
                "apierrors": [],
                "path": "/IOService/write",
                "response": {
-                  "jsondocId": "6dce4270-7e5b-4284-ad11-b39f1fbec33f",
+                  "jsondocId": "614e11d6-d4f9-46dd-94dc-1e46724e16e8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -5430,7 +5430,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7472a142-d8d1-4482-96fb-8746bf00ca2c",
+                     "jsondocId": "a141509a-0778-4429-ac18-52c4e4cadbf2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5439,7 +5439,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1d697e10-1742-4a7c-ab09-25e603c15af3",
+                     "jsondocId": "aac46f22-d2a1-4af6-b68f-3d1c4267b7b6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5448,7 +5448,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "262d1a74-c520-4b99-8313-1ea7d61997be",
+                     "jsondocId": "7136995d-05db-4419-9584-8b972b1613b2",
                      "name": "uuid",
                      "format": "",
                      "description": "UUID that holds the key to the stored download.",
@@ -5457,7 +5457,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b24665c0-9ec4-49e9-ab15-7f99110559c2",
+                     "jsondocId": "6af3f9e7-9bbf-40de-93e9-2650e799f217",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -5469,9 +5469,9 @@
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
                "methodName": "download",
-               "jsondocId": "273019d9-b555-441c-9be5-2f39d56d7fdc",
+               "jsondocId": "180c89f2-c247-4d69-8884-5e7778ab5b13",
                "bodyobject": {
-                  "jsondocId": "d4484b36-368d-4426-8ed3-6e6624624f62",
+                  "jsondocId": "15dbebfa-ac35-40b1-8097-91c2360d496e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5481,7 +5481,7 @@
                "apierrors": [],
                "path": "/IOService/download",
                "response": {
-                  "jsondocId": "559e08d9-7727-42ee-bb38-8fa992f1b9a0",
+                  "jsondocId": "94f92088-5e18-4f07-b5e6-9d2802398d3a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -5494,14 +5494,14 @@
          "description": "Methods for bulk importing and exporting sequence data"
       },
       {
-         "jsondocId": "55f708be-ca2c-4692-afab-4ef60f0b5191",
+         "jsondocId": "b677525a-9308-4cf2-9340-26360d6813d0",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "37c72783-0c6b-4784-8ad1-41f53ac06ab2",
+                     "jsondocId": "d70ef944-3133-49ee-8d9c-1cf5dadca7c5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5510,7 +5510,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aaf4a92b-e664-4910-94cd-ebea3daa0fd2",
+                     "jsondocId": "6ebc48e3-cfd3-49b8-9c0e-68eeef1b6034",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5519,7 +5519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ee1ebc8c-2de2-49c7-a4fe-33d87262b0f3",
+                     "jsondocId": "d5e5f21a-4d15-4be4-9980-b9ac36e274ac",
                      "name": "organism",
                      "format": "",
                      "description": "Pass an Organism JSON object with an 'id' that corresponds to the organism to be removed",
@@ -5531,9 +5531,9 @@
                "verb": "POST",
                "description": "Remove an organism",
                "methodName": "deleteOrganism",
-               "jsondocId": "0069e08e-7831-4308-b8cd-d948daca9186",
+               "jsondocId": "03bd18b6-0ead-442d-b641-c75a93a7d5a1",
                "bodyobject": {
-                  "jsondocId": "5090df6e-98b8-45ff-a74c-de71875d92a9",
+                  "jsondocId": "9c371d76-bc41-4a64-afc6-32de439bc9d1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5543,7 +5543,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganism",
                "response": {
-                  "jsondocId": "6c99b15b-f977-476e-99d2-b818f87fea1f",
+                  "jsondocId": "6aec9910-3a37-440c-aa78-85a5a88f0750",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5556,7 +5556,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "cb9e8c8d-4eae-4b90-b5ee-08d58a80b2c1",
+                     "jsondocId": "6908815e-bc1d-4d6e-9c7d-8354217c0b08",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5565,7 +5565,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e00ca6e9-8406-475a-a9b4-de143c5cfd4d",
+                     "jsondocId": "f42259be-08fa-49d9-bc99-1573bd389514",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5574,7 +5574,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "54289b06-262c-4a22-a3cc-d86cde79d5c2",
+                     "jsondocId": "6b2124f6-43b2-42ef-a5bd-bc6ee7168610",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5586,9 +5586,9 @@
                "verb": "POST",
                "description": "Delete an organism along with its data directory and returns a JSON object containing properties of the deleted organism",
                "methodName": "deleteOrganismWithSequence",
-               "jsondocId": "6e3bf610-6578-4b3e-b835-7cf075cc4488",
+               "jsondocId": "cb326e94-ddb9-4df5-9be0-e99f5a9d7186",
                "bodyobject": {
-                  "jsondocId": "f95c860b-10f6-416f-81ce-82b55812236c",
+                  "jsondocId": "c745d57d-5532-4acf-8c78-51a89dc58931",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5598,7 +5598,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismWithSequence",
                "response": {
-                  "jsondocId": "b5bdf458-b1e4-4aec-a082-317f9381dd66",
+                  "jsondocId": "e7cd5689-b436-4ce8-9d2c-ae409da88715",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5611,7 +5611,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ec415a98-5013-4989-9ca6-4ebb227d4e69",
+                     "jsondocId": "d9ec0304-e48b-4b54-855a-667aa340db28",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5620,7 +5620,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "59b3eb72-7d7c-457d-819d-31f47a87ae12",
+                     "jsondocId": "843140e4-d552-4961-966c-f69451293dee",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5629,7 +5629,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f106da8e-bf3a-42d2-8d31-cce6408a6214",
+                     "jsondocId": "ce7c0e4b-99a5-4881-bd6d-aec32ce535fa",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism.",
@@ -5638,7 +5638,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "637f3051-363a-4258-8c69-306d90e9587b",
+                     "jsondocId": "10cb2805-6e68-4a39-8d0f-e5403f493a9d",
                      "name": "sequences",
                      "format": "",
                      "description": "(optional) Comma-delimited sequence names on that organism if only certain sequences should be deleted.",
@@ -5650,9 +5650,9 @@
                "verb": "POST",
                "description": "Remove features from an organism",
                "methodName": "deleteOrganismFeatures",
-               "jsondocId": "20c40549-ee18-4fa9-941c-f861dc299241",
+               "jsondocId": "08a0867e-14f4-4bc4-b188-08799b4ff82d",
                "bodyobject": {
-                  "jsondocId": "f57179f0-97c9-4268-9b9c-ac47307699cf",
+                  "jsondocId": "54659764-e015-45aa-895a-37fd1c6d268c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5662,7 +5662,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
                "response": {
-                  "jsondocId": "f074639d-6e3b-4434-a0e0-f8ea8c33884f",
+                  "jsondocId": "a7d96292-ac98-4820-8221-4b9bb60b78ab",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5675,7 +5675,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "75b1d057-313a-401a-858d-6653c005cb57",
+                     "jsondocId": "fe59058f-599d-46ad-baca-e482c015c6ed",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5684,7 +5684,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "05024152-0087-4547-a3b6-f05093c7893d",
+                     "jsondocId": "f30fd6b9-b71a-43cc-94ac-bec18a26cacc",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5693,7 +5693,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e7df1035-e4d9-430f-a790-9d4b8ea11082",
+                     "jsondocId": "7a5d4bf4-5dc9-4f50-8561-c6274f7e0674",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -5702,7 +5702,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d29f7ead-b2d3-49c2-a98c-9a41267f92d3",
+                     "jsondocId": "90333334-f120-47dd-b624-30eb91e5e610",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -5711,7 +5711,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "80a796d4-d5e2-4fae-b7eb-e173e3361e33",
+                     "jsondocId": "990564a7-99cd-4bce-8764-dd3e73526883",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -5720,7 +5720,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "136f60b8-55b9-4faf-8868-545075d137b9",
+                     "jsondocId": "b90ed8e7-e4b7-454b-adc6-d04d82c042cb",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5729,7 +5729,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "10ea6eee-4358-47ce-9bae-10f45aaed99c",
+                     "jsondocId": "acb3d0f0-0d6b-424c-87e5-a67cc99518c8",
                      "name": "commonName",
                      "format": "",
                      "description": "commonName for an organism",
@@ -5738,7 +5738,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ca80d949-7cfa-4eae-b478-c418212dbf1b",
+                     "jsondocId": "e42d8b5a-28e4-4d95-ada7-80253dd9fdc1",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -5747,7 +5747,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a679c00a-e0cc-43eb-a398-4439169ef4c4",
+                     "jsondocId": "2c9c0cd4-eb92-407a-8762-f37bfd9ec587",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5756,7 +5756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7dfd6b7b-8865-4e46-b1da-8f548215ac9f",
+                     "jsondocId": "deff980c-c605-447f-b277-9d3e84c351e7",
                      "name": "organismData",
                      "format": "",
                      "description": "zip or tar.gz compressed data directory",
@@ -5765,7 +5765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "345b5b7b-09a9-4924-9420-0c5f0cabf24b",
+                     "jsondocId": "747678da-0357-4a51-abc8-79342d1ed8e2",
                      "name": "sequenceData",
                      "format": "",
                      "description": "FASTA file (optionally compressed) to automatically upload with",
@@ -5777,9 +5777,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganismWithSequence",
-               "jsondocId": "36fe0a07-8a84-4f71-8026-eb8ac0e5410e",
+               "jsondocId": "9360f5bc-f3cc-4e69-943a-dfef421dd872",
                "bodyobject": {
-                  "jsondocId": "485f42f6-b57c-4768-921c-f5c2c2043d81",
+                  "jsondocId": "2ae948d8-5744-4d7a-ab07-d10880bb6521",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5789,7 +5789,7 @@
                "apierrors": [],
                "path": "/organism/addOrganismWithSequence",
                "response": {
-                  "jsondocId": "8062f825-8128-4869-9b99-7c4d4798e2da",
+                  "jsondocId": "4de5b61a-bede-4b04-8a28-f63b134f1b54",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5802,7 +5802,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f1ec2bcc-c6a4-484d-871c-ba918b2791c3",
+                     "jsondocId": "be86f7ad-1c8e-4958-adad-00abc539cd92",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5811,7 +5811,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "828f7a51-3469-4cee-9237-b73dad62192e",
+                     "jsondocId": "daa10223-dbcb-4a0c-a22f-7e3633999ecd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5820,7 +5820,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c891fa3a-f2f9-4df2-9a9e-ea86e4d4e89d",
+                     "jsondocId": "f22e52ba-6f5f-4b32-ad39-dc7e029ffa9c",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5829,7 +5829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a1b1bb5a-bcc1-405b-b064-606a65f71da9",
+                     "jsondocId": "73bdb178-26d7-48eb-9c49-a203ab88e0d2",
                      "name": "trackLabel",
                      "format": "",
                      "description": "Name of track",
@@ -5841,9 +5841,9 @@
                "verb": "POST",
                "description": "Removes an added track from an existing organism returning a JSON object containing all tracks for the current organism.",
                "methodName": "removeTrackFromOrganism",
-               "jsondocId": "734637af-83eb-4197-a0cd-0877f0e95e73",
+               "jsondocId": "630dbb04-8a60-4e7c-9fb0-72fde48bb324",
                "bodyobject": {
-                  "jsondocId": "0d065d80-136e-4ba5-8281-2300164d1ca0",
+                  "jsondocId": "8f825b79-46e4-4dd4-ab82-6124eb27c812",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5853,7 +5853,7 @@
                "apierrors": [],
                "path": "/organism/removeTrackFromOrganism",
                "response": {
-                  "jsondocId": "a5dbed6f-7bf5-46cb-acd7-d6f933b5fd33",
+                  "jsondocId": "b2f1e808-e738-4b32-bf6f-07f3d7dfec13",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5866,7 +5866,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "725ccca2-82c8-4c56-800c-88c1cfccd36b",
+                     "jsondocId": "20ff527a-8eca-4043-b8b7-b76b6574dbff",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5875,7 +5875,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1874286-6488-4429-9771-c8d1951b7b25",
+                     "jsondocId": "0baa7f66-8b7c-43d6-9c3f-7fd609c77909",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5884,7 +5884,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9d72641d-922e-458a-bf16-207e30a2a332",
+                     "jsondocId": "53a9c3f5-9c50-4966-809f-24f6633c1de6",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5893,7 +5893,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d71971c7-f73f-42e8-9f7a-1e31157e6975",
+                     "jsondocId": "d1c8e1a0-6e91-4c0b-ac87-b1dd67e98ab4",
                      "name": "trackData",
                      "format": "",
                      "description": "zip or tar.gz compressed track data",
@@ -5902,7 +5902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f84f3b4e-5d42-43e4-9f65-bd6ec55a5837",
+                     "jsondocId": "0cf0d997-2c8d-4f03-9da9-6dddcbfe4a85",
                      "name": "trackFile",
                      "format": "",
                      "description": "track file (*.bam, *.vcf, *.bw, *gff)",
@@ -5911,7 +5911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff0c85a4-f3bb-44be-8882-0e8f1555fff5",
+                     "jsondocId": "6958f5e0-d485-4684-ad36-74e10fce8779",
                      "name": "trackFileIndex",
                      "format": "",
                      "description": "index (*.bai, *.tbi)",
@@ -5920,7 +5920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8425203e-835a-449b-bf44-eac60087e4a7",
+                     "jsondocId": "60a66d2d-2e6e-4cd4-a30a-56adac7fd545",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -5932,9 +5932,9 @@
                "verb": "POST",
                "description": "Adds a track to an existing organism returning a JSON object containing all tracks for the current organism.",
                "methodName": "addTrackToOrganism",
-               "jsondocId": "779a7c9f-8465-4aa3-b505-d88e91a5cc02",
+               "jsondocId": "476a5542-3311-4e4d-a8b6-5671a68b9c92",
                "bodyobject": {
-                  "jsondocId": "66c58fb2-6c24-4fae-8560-82de58ab2d78",
+                  "jsondocId": "7664e0fa-6bf0-4800-aef6-db20fd6887d3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5944,7 +5944,7 @@
                "apierrors": [],
                "path": "/organism/addTrackToOrganism",
                "response": {
-                  "jsondocId": "aed1022d-7436-4777-975a-76f685704d47",
+                  "jsondocId": "d2086040-9210-4448-b482-19a7df6f6523",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5957,7 +5957,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4cb385d8-9040-4fe3-a973-ee43b1751825",
+                     "jsondocId": "d0e535b5-4b47-44c0-93e7-e17fb2457cec",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5966,7 +5966,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c4168214-523a-49e3-a684-c825e474aff4",
+                     "jsondocId": "241cdd4d-0f54-49df-9371-bbf19d72e91d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5975,7 +5975,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f9dda5d7-ba02-457f-b750-5d67a5b42c97",
+                     "jsondocId": "c8174c7b-8429-4761-ac52-4e33cbe098f2",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5984,7 +5984,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d54d8428-e55a-4619-bcd2-4db02ccf3306",
+                     "jsondocId": "c59c77fd-53de-487d-a2f1-d0baf3538b9b",
                      "name": "trackLabel",
                      "format": "",
                      "description": "Track label corresponding to the track that is to be deleted",
@@ -5996,9 +5996,9 @@
                "verb": "POST",
                "description": "Deletes a track from an existing organism and returns a JSON object of the deleted track's configuration",
                "methodName": "deleteTrackFromOrganism",
-               "jsondocId": "3472c305-7673-4324-9169-3d903d71b5d9",
+               "jsondocId": "653862af-2d35-4c3e-91fd-a3f75d5c3c1a",
                "bodyobject": {
-                  "jsondocId": "cc19eead-f6d9-4e03-975b-9015030fde10",
+                  "jsondocId": "e39cdaa1-cb37-4099-9ac1-77fcb9120096",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6008,7 +6008,7 @@
                "apierrors": [],
                "path": "/organism/deleteTrackFromOrganism",
                "response": {
-                  "jsondocId": "33b9fcd5-5b38-4f12-9f14-ee752de043c4",
+                  "jsondocId": "bf951c86-2ac6-4414-b0dc-9ce01bdd91f9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6021,7 +6021,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "76a64729-0015-4caf-aff5-42dbf280a0bf",
+                     "jsondocId": "9f70c9e5-2a8e-44d3-8f7e-70a1ba840c3b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6030,7 +6030,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6b3a3b32-0e9b-4cbc-a689-86915c772d4f",
+                     "jsondocId": "1cef6fff-36da-4c76-8293-4760409e8770",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6039,7 +6039,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d3c7d8a-2ddf-4fa0-82a4-c4cd66960399",
+                     "jsondocId": "7c17ab1c-7c12-4075-880d-afce42e5c0b9",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -6048,7 +6048,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7a56c73d-7ca0-46d8-8d93-3ad612fef063",
+                     "jsondocId": "753a4e19-ebc8-4c82-bffa-ecbc581ed03a",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -6060,9 +6060,9 @@
                "verb": "POST",
                "description": "Update a track in an existing organism returning a JSON object containing old and new track configurations",
                "methodName": "updateTrackForOrganism",
-               "jsondocId": "2bbd6d1d-17b7-46c2-aa3e-7e22cefa87c8",
+               "jsondocId": "1ad5dc82-6d79-4710-ab68-2f88387d52dc",
                "bodyobject": {
-                  "jsondocId": "1e50dc85-6bab-4a93-91e0-04cf57fa1756",
+                  "jsondocId": "6253b17f-a427-40d4-a162-6f5423c5d2ec",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6072,7 +6072,7 @@
                "apierrors": [],
                "path": "/organism/updateTrackForOrganism",
                "response": {
-                  "jsondocId": "c325c696-882d-42dc-814c-d836e91f895e",
+                  "jsondocId": "e3b206e7-99aa-48d5-a54e-e926d3d42755",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6085,7 +6085,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3089ef3c-0e70-41b7-a0c4-fc502f3f4bdc",
+                     "jsondocId": "bffd90f5-ded1-44ac-99fe-06f622dcddb9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6094,7 +6094,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "547e2ff2-6314-4b12-880f-ef424488b87c",
+                     "jsondocId": "f3ff18fe-c09f-4341-9f63-49af8f7bdc82",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6103,7 +6103,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "68794421-8a03-41ee-b3ec-2ed6ab93940d",
+                     "jsondocId": "d7f3b9bf-2da7-4108-91df-c1586c90f0f1",
                      "name": "directory",
                      "format": "",
                      "description": "Filesystem path for the organisms data directory (required)",
@@ -6112,7 +6112,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e365a1fe-32d4-4cd1-b94b-39435284adc3",
+                     "jsondocId": "df5cda96-8b5e-4135-9561-f92108289609",
                      "name": "commonName",
                      "format": "",
                      "description": "A name used for the organism",
@@ -6121,7 +6121,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bd68f777-788c-4dc4-8969-9ec09db0d40d",
+                     "jsondocId": "0302bfd4-eb49-45db-a16b-10ed4ca975df",
                      "name": "species",
                      "format": "",
                      "description": "(optional) Species name",
@@ -6130,7 +6130,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b2297b97-b4bc-4de4-9e7d-9d321b4e3092",
+                     "jsondocId": "7bf43e68-c452-4419-87a4-f8fdf2028bdd",
                      "name": "genus",
                      "format": "",
                      "description": "(optional) Species genus",
@@ -6139,7 +6139,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49bc2dec-5b3f-410b-9850-bb992ff11b79",
+                     "jsondocId": "7f9b8933-3b68-426d-85dc-5fec543f0d79",
                      "name": "blatdb",
                      "format": "",
                      "description": "(optional) Filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -6148,7 +6148,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "693d6e5d-d192-4ede-80a3-ee397c6778d3",
+                     "jsondocId": "4381e6e6-a26f-474e-99e9-506238c34abb",
                      "name": "publicMode",
                      "format": "",
                      "description": "(optional) A flag for whether the organism appears as in the public genomes list (default false)",
@@ -6157,7 +6157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "34eeffa2-02da-431c-90f4-76e5b411cf28",
+                     "jsondocId": "f594bc79-c669-4b3a-8698-5f7c5db2c57c",
                      "name": "metadata",
                      "format": "",
                      "description": "(optional) Organism metadata",
@@ -6166,7 +6166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "166f94a7-50a7-4cbf-be6a-8ba71d4065f4",
+                     "jsondocId": "779fe546-14d4-40ce-b449-ca7deacb9f84",
                      "name": "returnAllOrganisms",
                      "format": "",
                      "description": "(optional) Return all organisms (true / false) (default true)",
@@ -6178,9 +6178,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganism",
-               "jsondocId": "d8800429-8fb3-45d9-b25a-9587bb4ab005",
+               "jsondocId": "9b04d00e-d37d-4e87-bc27-e428c9967930",
                "bodyobject": {
-                  "jsondocId": "e8d36a78-7881-478e-9d52-dfc362329c88",
+                  "jsondocId": "7720b16f-a316-4ad5-9031-52dea3d02515",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6190,7 +6190,7 @@
                "apierrors": [],
                "path": "/organism/addOrganism",
                "response": {
-                  "jsondocId": "3ac9b62c-031a-423d-a41f-c8ff8273b5b0",
+                  "jsondocId": "1f7bf21a-4f16-490a-96a2-749d5e577191",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6203,7 +6203,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5ff1098b-0e5a-4d25-bebf-da1673603777",
+                     "jsondocId": "14ba588a-3728-4b25-bc1c-4f66b0e8167c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6212,7 +6212,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "41490ae1-9a45-4beb-a359-b1c2a4d32e06",
+                     "jsondocId": "1db06f70-8a12-4caf-bb1d-cde77d685879",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6221,7 +6221,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "83fae56c-011e-41db-8328-1e835f554c80",
+                     "jsondocId": "59a5a3ee-3281-4b93-a021-22f3289562a4",
                      "name": "organism",
                      "format": "",
                      "description": "Common name or ID for the organism",
@@ -6233,9 +6233,9 @@
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
                "methodName": "getSequencesForOrganism",
-               "jsondocId": "70748f2b-d766-490c-bd31-41f46dfccb28",
+               "jsondocId": "33e36512-70ec-4fcb-9850-e798981b7aa9",
                "bodyobject": {
-                  "jsondocId": "09722be3-7287-4ec5-9e4f-86c018e8ebc8",
+                  "jsondocId": "01be61d1-b946-49b2-a007-f6e227322ef9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6245,7 +6245,7 @@
                "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
                "response": {
-                  "jsondocId": "f34a0c0c-5393-4c64-8121-6eabc80c1208",
+                  "jsondocId": "09aac61c-1a22-45ce-9f85-75a4ce0cb7b1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6258,7 +6258,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "436505da-6120-48a7-b851-91787694d39a",
+                     "jsondocId": "40d7d4ab-a933-4dd5-964b-ee2a9fa5c44b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6267,7 +6267,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "582caea6-3631-4f1e-ab4b-31cf11b11962",
+                     "jsondocId": "5607498d-1b6d-47af-bffc-218f03b1ff1f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6276,7 +6276,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7ae30476-0b4b-475e-a819-b9230f0e066e",
+                     "jsondocId": "37d60017-8550-4866-b180-72a30836234c",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -6285,7 +6285,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b4818cc8-dbfe-4147-a4fe-6260f623011e",
+                     "jsondocId": "cc0bd3a2-0f2b-41a4-b7ef-a4688fc8c747",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -6294,7 +6294,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b210f137-2bc3-449c-b524-e3d24664f4c4",
+                     "jsondocId": "12feedb7-2580-422c-ba9f-5723108aed90",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -6303,7 +6303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e011ed0f-0b77-4b54-a30c-ace3dac85e3f",
+                     "jsondocId": "23db4580-7953-4db7-b37d-3d8a5b57c923",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -6312,7 +6312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0af6523a-236e-41d0-acad-01b1a9720ef3",
+                     "jsondocId": "482050b1-55a8-4bff-805d-e802d1641789",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -6321,7 +6321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5ee30453-8afc-4db7-8250-b4974c003a7d",
+                     "jsondocId": "8c8ebc32-b14f-4b65-8fcd-b0cdc368110f",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -6330,7 +6330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a391fc04-c809-4759-bcab-7cc47b567b70",
+                     "jsondocId": "e2fe7c00-9598-4ad1-96a5-bd7bb97b901c",
                      "name": "name",
                      "format": "",
                      "description": "a common name used for the organism",
@@ -6339,7 +6339,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e6b3206c-c914-4e59-86bb-d752abf77f58",
+                     "jsondocId": "54abc36b-a223-4894-ae10-538969c67faf",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -6348,7 +6348,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d3ac47b2-fd9c-49de-8ed6-123b3ebe4896",
+                     "jsondocId": "057497aa-3f32-458c-8f98-b2d415460f58",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -6360,9 +6360,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "updateOrganismInfo",
-               "jsondocId": "368b88fa-3032-4edb-9086-e89d8bec06bd",
+               "jsondocId": "ea77d7f0-bb74-43a6-90d6-1053a68a5020",
                "bodyobject": {
-                  "jsondocId": "3e3d5afd-458e-4377-abac-1e6df75f3111",
+                  "jsondocId": "b43a0beb-3bd1-4d5c-9a58-fd89c39962fb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6372,7 +6372,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismInfo",
                "response": {
-                  "jsondocId": "e2aaa7e4-d1bb-4d11-b9d1-3a61f5730c25",
+                  "jsondocId": "c369aba1-b4e5-454e-a522-5e5a554509ed",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6385,7 +6385,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "089b1a3b-1fec-4c15-b09f-a6269665d599",
+                     "jsondocId": "fd1be139-3924-464c-8568-6cf1570e2572",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6394,7 +6394,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e311d03-9e05-4b93-a458-e4eec5e50a87",
+                     "jsondocId": "efac8b85-42bb-4e16-88ca-57f61d5478f4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6403,7 +6403,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5046dd2a-c054-4deb-aa4f-35bd08d42d1f",
+                     "jsondocId": "4696a4b6-4664-4c80-8ec5-4bfb07d47104",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -6412,7 +6412,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0117931d-3a74-4e23-8f54-2bc8635196b6",
+                     "jsondocId": "079f0839-7960-494d-a0d1-018f9b7cb01f",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -6424,9 +6424,9 @@
                "verb": "POST",
                "description": "Update organism metadata",
                "methodName": "updateOrganismMetadata",
-               "jsondocId": "11f4f5cf-c363-4dfc-bd72-d9c3e65805de",
+               "jsondocId": "1e8030ef-4e5a-4d3d-ac1b-2205c72793b7",
                "bodyobject": {
-                  "jsondocId": "ca632972-8ae5-43ec-995a-99b128714de7",
+                  "jsondocId": "990d72df-daee-4e5d-9648-869461c87226",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6436,7 +6436,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismMetadata",
                "response": {
-                  "jsondocId": "8fc81f4a-d7cb-40f0-b8cb-8a91577303ea",
+                  "jsondocId": "997f8246-07f2-46d0-8654-4a60951a61f2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6449,7 +6449,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "75e529ee-5fd4-4cf1-9183-55437996382e",
+                     "jsondocId": "70466218-37fe-4ec1-9c14-52d34f52fc2a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6458,7 +6458,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "25775dfa-8949-4798-bf83-956ee3d0b2e2",
+                     "jsondocId": "ec265355-28e9-43a6-adea-595b14148ab2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6467,7 +6467,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "051c46e8-702b-47ca-b285-a8f4bba4720f",
+                     "jsondocId": "212bf845-bd13-4314-bde3-3ed437f1ecfe",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -6479,9 +6479,9 @@
                "verb": "POST",
                "description": "Get creator metadata for organism, returns userId as String",
                "methodName": "getOrganismCreator",
-               "jsondocId": "caeb2e5b-a9d2-416c-98da-d120e59bdee4",
+               "jsondocId": "0b60cac5-ae95-4a09-bc1e-b3a18a93cbea",
                "bodyobject": {
-                  "jsondocId": "7f2a7de5-e09d-4ee6-be02-ae4bc5816d5d",
+                  "jsondocId": "8862f743-95f6-49c5-a74b-32d41a15cf2e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6491,7 +6491,7 @@
                "apierrors": [],
                "path": "/organism/getOrganismCreator",
                "response": {
-                  "jsondocId": "f1320c12-0283-481a-a526-adbd3365ae76",
+                  "jsondocId": "2a5b3eca-c77b-4298-b4d3-21e3209a85ab",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6504,7 +6504,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "83f74a61-755f-4793-ae22-63c76f45c8dd",
+                     "jsondocId": "13e5aee9-fda4-47cb-b4ea-f085e274a45b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6513,7 +6513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "49fede6a-d0e0-4e4b-b91a-ac5a1ccb32cb",
+                     "jsondocId": "7cbe8664-c655-4dd7-acdd-12190003ee00",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6522,7 +6522,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "71a81572-c8f5-4d77-9a63-48fd57772d1c",
+                     "jsondocId": "4b412359-bdba-47eb-8095-2abe70c5239f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) ID or commonName that can be used to uniquely identify an organism",
@@ -6534,9 +6534,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "methodName": "findAllOrganisms",
-               "jsondocId": "0e84ad31-aa89-48c2-a89c-d0e0d96019de",
+               "jsondocId": "c7cd7f9f-2858-41e4-b5ab-8bf047a74331",
                "bodyobject": {
-                  "jsondocId": "2e81769c-fa75-4d4f-baab-6a4c71558bb1",
+                  "jsondocId": "e5c5f229-7305-4fb3-9b46-1c9273672db7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6546,7 +6546,7 @@
                "apierrors": [],
                "path": "/organism/findAllOrganisms",
                "response": {
-                  "jsondocId": "6ea2cfbd-2623-4727-b6cc-a5134dee65bb",
+                  "jsondocId": "11652fbe-3464-4b8b-a6ac-4efad01beb23",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6559,14 +6559,14 @@
          "description": "Methods for managing organisms"
       },
       {
-         "jsondocId": "321eea7c-f268-43dc-a597-1e07a84bb465",
+         "jsondocId": "b1bcc74f-e0ba-4fa5-9e65-d1cced18acc5",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e2595b08-3cfb-43d0-b4c0-05248dcc34fd",
+                     "jsondocId": "1a45ffdf-1b30-4ab3-a5cf-27eee649c009",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -6575,7 +6575,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "be1034e3-e9a3-4082-a26d-f3fadb226f9c",
+                     "jsondocId": "f4dc78c3-7a83-4de8-90a5-db0a3048c133",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -6584,7 +6584,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f6f1f054-3e7b-420d-b3d1-9f14c0eabdf9",
+                     "jsondocId": "126f73c7-269f-4063-bc00-1e6e01a166b7",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -6593,7 +6593,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "40b96b67-17d0-4a1f-aeea-e221ba21e8e1",
+                     "jsondocId": "edc323a1-ad11-47c8-ae37-46418778648a",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -6602,7 +6602,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "880a4ba9-586f-4cbc-bd0c-47c8db82ea52",
+                     "jsondocId": "01a25635-39eb-4f9a-8569-2da7d15374fb",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6614,12 +6614,12 @@
                "verb": "GET",
                "description": "Get sequence data within a range",
                "methodName": "sequenceByLocation",
-               "jsondocId": "5a0b50c4-cf30-4f94-9828-edf3da528c42",
+               "jsondocId": "21320c61-b536-4aa8-99cd-e589c97095e4",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/<organism name>/<sequence name>:<fmin>..<fmax>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "f7336b06-d146-4f78-9257-757790002801",
+                  "jsondocId": "569ae2c3-6078-4b0a-b11c-a33d5637b5e1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6632,7 +6632,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "dc002a3e-5399-45ea-8899-441d3a100f69",
+                     "jsondocId": "64c3c438-40d0-4c7c-afa2-2cf10ba6bf61",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID (required)",
@@ -6641,7 +6641,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cc951c91-4dd6-4cec-921f-38882429ea8b",
+                     "jsondocId": "07c90762-41a6-4349-af03-ad820df587d9",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name (required)",
@@ -6650,7 +6650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e74542c4-4a38-4064-b555-28bd1400abb5",
+                     "jsondocId": "01861251-dfcb-477e-9609-2972836898ab",
                      "name": "featureName",
                      "format": "",
                      "description": "The uniqueName (UUID) or given name of the feature (typically transcript) of the element to retrieve sequence from",
@@ -6659,7 +6659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "10539ea0-9418-4b12-b929-5121f26c97ac",
+                     "jsondocId": "0fdbf2f5-5a32-4f66-9952-757a888bca5f",
                      "name": "type",
                      "format": "",
                      "description": "(default genomic) Return type: genomic, cds, cdna, peptide",
@@ -6668,7 +6668,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d152be49-37ff-4d99-94be-944761dc3e11",
+                     "jsondocId": "9704475f-405e-4725-9fac-0b301dd68fc8",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6680,12 +6680,12 @@
                "verb": "GET",
                "description": "Get sequence data as for a selected name",
                "methodName": "sequenceByName",
-               "jsondocId": "42c57781-5395-4d38-8803-101c4c559825",
+               "jsondocId": "fae238de-97f4-4e09-adce-e1566cf7bb79",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/<organism name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "76a74d46-ff2d-4b79-a2ab-059db6cf0fd4",
+                  "jsondocId": "58185a19-35c6-4ad6-9366-687a33d820d3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6698,7 +6698,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "08833d8b-f523-4367-8201-8fe96b074cc0",
+                     "jsondocId": "977b7318-627a-473c-9d76-e4c16c64eef9",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -6707,7 +6707,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "04a1a904-7de7-4d8d-aca6-557894d251d2",
+                     "jsondocId": "7454bce3-86e9-4a7d-98de-8cc62c129bd7",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name (required)",
@@ -6719,12 +6719,12 @@
                "verb": "GET",
                "description": "Remove sequence cache for an organism and sequence",
                "methodName": "clearSequenceCache",
-               "jsondocId": "93f8857f-c7e1-48e9-84d5-aa9c75f5cdae",
+               "jsondocId": "8479a31f-a242-470d-b915-569fb70a71bc",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/cache/clear/<organism name>/<sequence name>",
                "response": {
-                  "jsondocId": "7f49afcc-cbdd-448d-93c3-aec6695da5c4",
+                  "jsondocId": "71e88477-7c7f-4452-9285-abf8c3bfeb0b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6736,7 +6736,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "816e0cd6-e722-403c-b764-602ccf807a78",
+                  "jsondocId": "f1991ed8-c396-434a-bb6f-da6b953f5b76",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required) or 'ALL' if admin",
@@ -6747,12 +6747,12 @@
                "verb": "GET",
                "description": "Remove sequence cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "827d5feb-a4a8-4a06-b986-2dc934c4773c",
+               "jsondocId": "8c3a6978-396e-4405-a4c9-23ed3fcf10a9",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "7042e247-61e9-4f12-8924-46fbd49a1a28",
+                  "jsondocId": "4c11f22c-d1f5-45e5-a51e-3c467a91a62e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6765,14 +6765,62 @@
          "description": "Methods for retrieving sequence data"
       },
       {
-         "jsondocId": "82da2702-ccdb-4e52-a2bf-c110e1d7210b",
+         "jsondocId": "8dca199d-78d9-4051-b338-378a5c1de063",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ca345df2-4e0a-4e68-abbe-2494d5c91a0a",
+                     "jsondocId": "c0b2ead3-d606-4da4-bb08-bbc668cd008b",
+                     "name": "featureType",
+                     "format": "",
+                     "description": "Feature type",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a5e83f7c-1c0d-4d0a-a919-0bcba9b6380c",
+                     "name": "organism",
+                     "format": "",
+                     "description": "Organism name",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c79d4f87-4579-43cb-a645-143531bc485e",
+                     "name": "query",
+                     "format": "",
+                     "description": "Query value",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "GET",
+               "description": "Returns a JSON array of all suggested names, or optionally, gets information about a specific suggested name",
+               "methodName": "search",
+               "jsondocId": "7c6ee1ad-43d2-4fab-885b-420fd5918746",
+               "bodyobject": null,
+               "apierrors": [],
+               "path": "/suggestedName/search",
+               "response": {
+                  "jsondocId": "0087e088-73f3-4aaa-a357-7aa3693e8af5",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "suggested name"
+               },
+               "produces": ["application/json"],
+               "consumes": []
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "1750d670-c593-45c0-8f9f-e2e881c5429f",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6781,7 +6829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c856fcc9-69b8-4267-84eb-5975acb85e10",
+                     "jsondocId": "c6b95277-0c14-4fbb-8c6b-804e821a89ff",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6790,7 +6838,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "573b2011-eaf4-4b19-9fec-0574f38dc66f",
+                     "jsondocId": "62a668a4-08b3-49e0-81fd-737bcd7e3254",
                      "name": "name",
                      "format": "",
                      "description": "Suggested name to add",
@@ -6799,7 +6847,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "653a93a6-c984-4a3b-88ae-fc3d2317d409",
+                     "jsondocId": "e2c74c8c-1a35-4ac2-be1b-e934bbd548b8",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -6811,9 +6859,9 @@
                "verb": "POST",
                "description": "Create suggested name",
                "methodName": "createName",
-               "jsondocId": "3eaccb4b-d8b9-4024-854c-ff779bc0eb80",
+               "jsondocId": "2f713e13-9545-48a7-bf87-08ebc14162fc",
                "bodyobject": {
-                  "jsondocId": "2dbaf933-99b4-4958-b558-2e2967be33f2",
+                  "jsondocId": "d5ad1d7e-4d69-453c-a67e-04375e8be5dc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6823,7 +6871,7 @@
                "apierrors": [],
                "path": "/suggestedName/createName",
                "response": {
-                  "jsondocId": "efeda75f-6f0a-43df-a918-23e5120b94df",
+                  "jsondocId": "284f1edf-74fd-428f-bcd6-c4e9963a5328",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "suggested name"
@@ -6836,7 +6884,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1027bceb-e9b0-400a-9f81-4ad2b48e0418",
+                     "jsondocId": "4f78ca6a-457b-4ff7-b327-2bfecbb9f870",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6845,7 +6893,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0b2992c9-2f76-435c-9f59-ab0b717befc4",
+                     "jsondocId": "3690f5f5-6be3-41a8-9fe3-689f9c9a9262",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6854,7 +6902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "90e07910-7d82-4127-bad7-698dacbb9158",
+                     "jsondocId": "7547f51a-d305-42b3-a793-09d4a80f5d24",
                      "name": "id",
                      "format": "",
                      "description": "Suggested name ID to update (or specify the old_name)",
@@ -6863,7 +6911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6bc1d8de-4d6f-4e59-933c-65bf2b99afcb",
+                     "jsondocId": "172815fc-e034-417b-8dd1-d6fe5f2e4fe9",
                      "name": "old_name",
                      "format": "",
                      "description": "Suggested name to update",
@@ -6872,7 +6920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "91e7ebd4-0123-473d-86b4-dc0414d19440",
+                     "jsondocId": "30f07b35-b9cb-4ad7-a903-fa207fe0842a",
                      "name": "new_name",
                      "format": "",
                      "description": "Suggested name to change to (the only editable option)",
@@ -6881,7 +6929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "79ec372a-13b8-4aa3-b067-acffd9beafbe",
+                     "jsondocId": "609031c3-55d8-4edc-98de-553829924115",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -6893,9 +6941,9 @@
                "verb": "POST",
                "description": "Update suggested name",
                "methodName": "updateName",
-               "jsondocId": "f6db6360-1519-4ac8-a86a-ffd0650cdd16",
+               "jsondocId": "ba8cb037-f65f-4cd3-9a4e-7d282c3b298a",
                "bodyobject": {
-                  "jsondocId": "19489b40-b259-4f17-894a-e84538aada0d",
+                  "jsondocId": "c268e39d-cfba-4a7e-b521-6e3f96533ff3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6905,7 +6953,7 @@
                "apierrors": [],
                "path": "/suggestedName/updateName",
                "response": {
-                  "jsondocId": "51095465-8089-45fc-8f42-231ae8d3cdd6",
+                  "jsondocId": "cb7c1f4f-fc67-4367-9002-d891a6b40daf",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "suggested name"
@@ -6918,7 +6966,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "777f2276-7fa4-4824-b6ab-e91a4d020a5b",
+                     "jsondocId": "b498ad37-bc6a-4f82-a709-d9aa3567d9e3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6927,7 +6975,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d68b27a-c9d0-40ed-bf3d-b991ead1a392",
+                     "jsondocId": "a748a5cc-c44b-4faf-9177-111762aec847",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6936,7 +6984,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "53b4d8a1-8212-4513-b687-09f4b655e13a",
+                     "jsondocId": "8379ffe5-0996-4458-b51f-d2cdbc83173f",
                      "name": "id",
                      "format": "",
                      "description": "Suggested name ID to remove (or specify the name)",
@@ -6945,7 +6993,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4a3e1135-b919-4384-b6f2-8b48239e21f9",
+                     "jsondocId": "2018ae1d-b8bd-40d7-a8fe-4ea87173a539",
                      "name": "name",
                      "format": "",
                      "description": "Suggested name to delete",
@@ -6957,9 +7005,9 @@
                "verb": "POST",
                "description": "Remove a suggested name",
                "methodName": "deleteName",
-               "jsondocId": "827ed84f-8f6f-41be-b266-45d15310d419",
+               "jsondocId": "42b42eab-ab85-4645-bfa9-c5157171d7bd",
                "bodyobject": {
-                  "jsondocId": "cb5c13a1-a3a6-455f-8971-6fa4d91e9cba",
+                  "jsondocId": "c4801e94-3657-47ce-a7c1-ce45bf39a590",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6969,7 +7017,7 @@
                "apierrors": [],
                "path": "/suggestedName/deleteName",
                "response": {
-                  "jsondocId": "1e92585a-ec73-439a-8174-b0ca214b1e2c",
+                  "jsondocId": "0f397f8b-47d8-4972-9d8e-a824652bd866",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "suggested name"
@@ -6982,7 +7030,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "36c42c3f-5de6-4007-92cd-a2d403e84cf8",
+                     "jsondocId": "4b1a8c3e-1bc6-46b0-9a4a-326674b8198a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6991,7 +7039,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1820033b-8aa2-453b-84d8-9c818967de18",
+                     "jsondocId": "427a3658-ea2d-4882-a264-73c6eba28a24",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7000,7 +7048,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "450a0ac3-bf56-46bf-aa4c-ab0bcb5a66ed",
+                     "jsondocId": "b3e39385-f019-4dcc-8093-8e8ea743ec3f",
                      "name": "id",
                      "format": "",
                      "description": "Name ID to show (or specify a name)",
@@ -7009,7 +7057,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "571f1611-1d01-4e50-a2c2-b8b5b464b43a",
+                     "jsondocId": "2f87e6d7-cd65-4d10-8e7b-56a7d174f669",
                      "name": "name",
                      "format": "",
                      "description": "Name to show",
@@ -7021,9 +7069,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all suggested names, or optionally, gets information about a specific suggested name",
                "methodName": "showName",
-               "jsondocId": "39a4d0b8-9db4-424a-b203-a1711a4a101d",
+               "jsondocId": "916d4cd3-046b-491f-b52d-a082b81a562f",
                "bodyobject": {
-                  "jsondocId": "a66ef085-e605-4194-b351-4580c3a066a4",
+                  "jsondocId": "76350eae-bb5a-4ac7-b278-36d855bc874e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7033,7 +7081,7 @@
                "apierrors": [],
                "path": "/suggestedName/showName",
                "response": {
-                  "jsondocId": "a5586ff3-edf2-4a8c-ad44-64af6cbe6b55",
+                  "jsondocId": "df805490-bb39-40c0-bd6e-0d2aeed498d5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "suggested name"
@@ -7046,13 +7094,13 @@
          "description": "Methods for managing suggested names"
       },
       {
-         "jsondocId": "18208c8e-e68a-409c-af4b-faa3f25a8621",
+         "jsondocId": "7d94e468-7ee3-4cfd-852b-1c14d63c0577",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "6a0552d2-888e-48fe-92ba-fae97c295c63",
+                  "jsondocId": "76c6c31c-b9d6-49fb-96a7-743dddc7fae9",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required) or 'ALL' if admin",
@@ -7063,12 +7111,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "cb11ef8b-4aaf-43c0-9725-334d581007fd",
+               "jsondocId": "d1d890ef-e758-4d83-bc71-1930a775f17e",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "8114c63e-c63b-4cbc-87fb-95b8f5fb93a6",
+                  "jsondocId": "02b01c24-6fb4-4334-a16a-a9ca670ecfa4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7081,7 +7129,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a8e00618-310e-4b74-90cf-e0f71e2cff04",
+                     "jsondocId": "c96eb136-b9f2-4958-b0c4-93f710989305",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -7090,7 +7138,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4533e7d0-17c5-493c-93ae-d492b55e6d8e",
+                     "jsondocId": "4d0d7cc7-55d7-40e2-8e07-c05fb1b76b33",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name (required)",
@@ -7102,12 +7150,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism and track",
                "methodName": "clearTrackCache",
-               "jsondocId": "49e9e611-192c-42cb-97c0-e6a9b1b200ae",
+               "jsondocId": "05884efe-d29e-4842-aff3-260e1b9e4b4c",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>/<track name>",
                "response": {
-                  "jsondocId": "4c4a0aaf-843b-4307-8f7d-afd0e9e0163e",
+                  "jsondocId": "248b7cbd-0ab0-4213-baec-55c6c6ad7d1a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7119,7 +7167,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "39c94269-2e23-4c85-a4ec-74596624c92d",
+                  "jsondocId": "e1bd8e0a-9f33-489b-ba83-7cb1c669b755",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required)",
@@ -7130,12 +7178,12 @@
                "verb": "GET",
                "description": "List all tracks for an organism",
                "methodName": "getTracks",
-               "jsondocId": "7f0d9353-c9f1-483b-bd7f-3ae789cf1cee",
+               "jsondocId": "2a58f72b-3ed2-487b-8ec8-f61301d97ec9",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/list/<organism name>",
                "response": {
-                  "jsondocId": "ae05f846-10dd-428f-abb0-446ef230d344",
+                  "jsondocId": "146ed196-3d33-4f99-b482-1dacb12fcc19",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7148,7 +7196,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3a3d6314-5668-4abd-be0b-7cb999944387",
+                     "jsondocId": "93b67099-5048-4b1b-a34c-3861e82b7022",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -7157,7 +7205,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "69fa8ea5-7928-47cb-8f2a-cf9de47e7e59",
+                     "jsondocId": "41aefb4e-9fdb-4a2a-bf65-93ba51ae4831",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -7166,7 +7214,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e66d7d42-6075-4483-a004-6c88767b2ae4",
+                     "jsondocId": "5b41fda9-ddd5-4e75-b676-91da25bb3fa8",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -7175,7 +7223,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d850670-61ba-46ea-bb7b-c961cf65fdfe",
+                     "jsondocId": "45445856-504e-459b-8112-25b17a473c2a",
                      "name": "featureName",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -7184,7 +7232,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "efab8cbe-1a09-412c-a94b-dd8231551afd",
+                     "jsondocId": "d84e6e50-01a1-4c70-a117-0b1996178a78",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -7193,7 +7241,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "471465f0-a8b6-4b13-8193-37ca6264637c",
+                     "jsondocId": "8a58c005-abbc-45bd-bc89-4a7dc9780480",
                      "name": "flatten",
                      "format": "",
                      "description": "Brings nested top-level components to the root level.  If not provided or 'false' it will not flatten.  Default is 'gene'.",
@@ -7202,7 +7250,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d96556f4-eb51-41cc-b0e1-f9f90571da92",
+                     "jsondocId": "3fbca4a3-ad59-455d-ae7c-3b39763634bf",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -7214,12 +7262,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within but only for the selected name",
                "methodName": "featuresByName",
-               "jsondocId": "af9de509-e77c-4f77-b39c-d981308d1676",
+               "jsondocId": "f08c076d-21f6-4c35-bc6f-b341cb9104bd",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "57636270-a299-4313-9602-648cd5f0989b",
+                  "jsondocId": "50bc09c5-ebff-4dd1-81b9-20398a54b295",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7232,7 +7280,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b7652fdc-3707-4947-85bb-3cbac628f9e6",
+                     "jsondocId": "8579b125-4046-4751-a697-1339e6a596ac",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -7241,7 +7289,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "25345e81-c8db-40ba-96c8-e2fc28399363",
+                     "jsondocId": "a04f28ef-e318-4668-af2f-056a29604508",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -7250,7 +7298,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f8608522-1192-430d-a49c-f29f996091da",
+                     "jsondocId": "768821d5-f511-4225-bfe3-5c40f76e5755",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -7259,7 +7307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "15c58f90-54c0-4333-98cb-281d8e210907",
+                     "jsondocId": "e95b385a-c92b-404b-933d-f80c39d9b4cf",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -7268,7 +7316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8cad546b-6c98-4ded-9141-241d436162ee",
+                     "jsondocId": "664962cc-28dc-402d-a98d-08aa6f2a4c09",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -7277,7 +7325,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6113fd91-8a02-4a4c-af2c-b97763c1531b",
+                     "jsondocId": "714d49d1-f606-493a-84ac-41e2170c969a",
                      "name": "name",
                      "format": "",
                      "description": "If top-level feature 'name' matches, then annotate with 'selected'=true.  Multiple names can be passed in.",
@@ -7286,7 +7334,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ceb3e23a-77e9-4ca9-aaa2-1337c54da3ec",
+                     "jsondocId": "5da69cc0-e2a0-4591-97f9-6f557743afab",
                      "name": "onlySelected",
                      "format": "",
                      "description": "(default false).  If 'selected'!=1 one, then exclude.",
@@ -7295,7 +7343,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5be78ccc-fe32-400d-929e-9be7525be119",
+                     "jsondocId": "dd84289d-7d4e-4a35-8c8e-d3709ffe6652",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -7304,7 +7352,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bc71e655-6bce-4535-98fa-748a4f74186d",
+                     "jsondocId": "3f8432a9-09d1-4c13-853a-536078b28032",
                      "name": "flatten",
                      "format": "",
                      "description": "Brings nested top-level components to the root level.  If not provided or 'false' it will not flatten.  Default is 'gene'.",
@@ -7313,7 +7361,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cefcf450-1ad3-4496-817e-0cbf6f2a4c70",
+                     "jsondocId": "64cfcf61-5b64-479f-b6c9-d9eb274069d5",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -7325,12 +7373,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within an range",
                "methodName": "featuresByLocation",
-               "jsondocId": "61bbd5a2-3261-4d89-8551-ad2e70b36896",
+               "jsondocId": "493fae92-0b4f-4fc6-9ffe-3357daf6fe0e",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>:<fmin>..<fmax>.<type>?name=<name>&onlySelected=<onlySelected>&ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "bb9b686e-ab23-4c14-9c98-fa6353fbc4ae",
+                  "jsondocId": "b15fbdfc-49e1-4935-853e-db8de3062c3d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7343,14 +7391,14 @@
          "description": "Methods for retrieving track data"
       },
       {
-         "jsondocId": "ef945d05-4ef0-4d66-9415-f4bdff610acd",
+         "jsondocId": "85b9cb7b-e671-46fd-97cd-ad47401eae45",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "17b10f07-0b4b-4fc3-811e-c971d868c2a9",
+                     "jsondocId": "3509b325-710e-4d76-a76c-d6ecc636bb20",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7359,7 +7407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e1396a5-e20b-430c-9852-7a03a90fdfa2",
+                     "jsondocId": "90d118da-93bb-4902-bce2-0d8e6e404a7a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7368,7 +7416,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "48b4dabd-2b76-4399-9d1e-11767b1c16f1",
+                     "jsondocId": "37ea8433-bf0f-4693-aa21-a6b26820269e",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to modify permissions for",
@@ -7377,7 +7425,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fe21d986-bb3d-4058-95f2-028b48926ec0",
+                     "jsondocId": "6fd88973-52a5-4471-8071-382ca7fd3321",
                      "name": "user",
                      "format": "",
                      "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
@@ -7386,7 +7434,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "788cbea0-8c56-4476-b550-53320927acf3",
+                     "jsondocId": "18f642d3-caca-43a1-9f96-c28dc28d6a2c",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism to update",
@@ -7395,7 +7443,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "31424aff-383c-4352-8b9a-497b146f52c0",
+                     "jsondocId": "af89276b-4891-4caa-b007-d3de7219a7e0",
                      "name": "id",
                      "format": "",
                      "description": "Permission ID to update (can get from userId/organism instead)",
@@ -7404,7 +7452,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "79351f25-64ba-49c7-b657-e66d82c5b723",
+                     "jsondocId": "12fe54d0-93f0-4271-b0d3-e62438c94a11",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -7413,7 +7461,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1b9caad-3f4c-4084-873e-5aa0a192e3ca",
+                     "jsondocId": "a6581170-a137-42d1-bcde-a64eade218c5",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -7422,7 +7470,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "988fd3b7-6e2e-4f69-80ef-e8a79a71c436",
+                     "jsondocId": "4d89ae59-a9e1-4329-8a6b-b419bed7efb0",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -7431,7 +7479,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a3f55bf9-55f0-479d-924e-d46742fb6d81",
+                     "jsondocId": "0f68ba9b-9127-44ba-b4ff-af9deaf9b3a6",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -7443,9 +7491,9 @@
                "verb": "POST",
                "description": "Update organism permissions",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "a4d80784-12f7-46a0-83bc-370048bf52a8",
+               "jsondocId": "c04518f3-5229-4618-841e-533592065981",
                "bodyobject": {
-                  "jsondocId": "641d44da-fc3d-4785-836e-28e755d72866",
+                  "jsondocId": "1078b66c-648e-4823-a761-4b8bfa336006",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7455,7 +7503,7 @@
                "apierrors": [],
                "path": "/user/updateOrganismPermission",
                "response": {
-                  "jsondocId": "c31e3f1d-b5bf-4e8f-b099-cf2c6551628c",
+                  "jsondocId": "ee4cf743-e033-4070-ab15-1e1ef1a3fc88",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7468,7 +7516,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "dad31dcd-126d-4af9-a277-cc3ed2ae1957",
+                     "jsondocId": "dd53d719-b29b-499b-add2-b1d3bbbd598b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7477,7 +7525,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8a799b78-df34-4938-a214-fc2b75fa3817",
+                     "jsondocId": "b4fe3520-9d28-42bd-8dba-e4781998954f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7486,62 +7534,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b5c8725-dc1f-4e42-ad46-ac03f4bf308d",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to fetch",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get organism permissions for user, returns an array of permission objects",
-               "methodName": "getOrganismPermissionsForUser",
-               "jsondocId": "2bda81ad-744e-4a24-9af5-9b2beb03ce80",
-               "bodyobject": {
-                  "jsondocId": "e1bd474e-a087-47f6-b4bd-0d60012f53b9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/getOrganismPermissionsForUser",
-               "response": {
-                  "jsondocId": "5a2226c5-09ee-435d-a706-cc938a7c3fa1",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "63355736-ad70-4fed-b0d0-bde9ce77ff8e",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e0a3b7f2-6c13-4820-b730-ee8d104aa357",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "97fcac50-37ca-4d0e-8aed-2c8b411c8cde",
+                     "jsondocId": "511144a9-9fab-48c2-89b3-deb813e1a3b1",
                      "name": "userId",
                      "format": "",
                      "description": "Optionally only user a specific userId as an integer database id or a username string",
@@ -7550,7 +7543,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fa70d737-0ca2-44e4-955f-d69746cc1fa6",
+                     "jsondocId": "0c68d3ea-67fe-4428-a91a-4e00c68e817d",
                      "name": "start",
                      "format": "",
                      "description": "(optional) Result start / offset",
@@ -7559,7 +7552,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1e29ea59-7e63-454b-8550-8d0dcf765c77",
+                     "jsondocId": "2a0399cb-2af3-449f-87ae-03160d45f0cd",
                      "name": "length",
                      "format": "",
                      "description": "(optional) Result length",
@@ -7568,7 +7561,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "28fdedee-5dda-4ed0-8243-45b43f3e9c1e",
+                     "jsondocId": "6e656370-4f1d-4079-be31-16cf32befa60",
                      "name": "name",
                      "format": "",
                      "description": "(optional) Search name",
@@ -7577,7 +7570,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "64eb7ca2-ebcb-4d26-97c9-6073a4666720",
+                     "jsondocId": "dbe9f3d4-d1a9-47b9-91ab-7dbec171fd17",
                      "name": "sortColumn",
                      "format": "",
                      "description": "(optional) Sort column, default 'name'",
@@ -7586,7 +7579,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "619db896-f0e7-41c1-b40f-bff1320d2c64",
+                     "jsondocId": "fb32cf21-c45a-47c2-b04f-3d8026bfd337",
                      "name": "sortAscending",
                      "format": "",
                      "description": "(optional) Sort column is ascending if true (default false)",
@@ -7595,7 +7588,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "93ce555a-120f-4fe1-92eb-758ac488893b",
+                     "jsondocId": "d92987ac-9961-465a-864e-5aae8a45e938",
                      "name": "omitEmptyOrganisms",
                      "format": "",
                      "description": "(optional) Omits empty organism permissions from return (default false)",
@@ -7604,7 +7597,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "96b2f7b4-82be-4818-867d-f65a36b3f1ee",
+                     "jsondocId": "68ff089a-b6a0-4c2a-ad41-84f8a67f2d39",
                      "name": "showInactiveUsers",
                      "format": "",
                      "description": "(optional) Shows inactive users without permissions (default false)",
@@ -7616,9 +7609,9 @@
                "verb": "POST",
                "description": "Load all users and their permissions",
                "methodName": "loadUsers",
-               "jsondocId": "098b60f7-dba9-42db-9816-bce9a7615fd8",
+               "jsondocId": "87517032-d211-4121-b257-6f85e083d56e",
                "bodyobject": {
-                  "jsondocId": "6230a52b-db66-4134-92a1-18d3d358140c",
+                  "jsondocId": "b6450ada-44be-4ce7-b149-856e3ec72381",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7628,7 +7621,7 @@
                "apierrors": [],
                "path": "/user/loadUsers",
                "response": {
-                  "jsondocId": "6286e36b-7dfb-4beb-b748-1ccd1abc19cc",
+                  "jsondocId": "fbc3e49b-b171-4654-865d-f9026fab392e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7641,7 +7634,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "46e7eb17-255b-434a-8708-c581e5beb4ed",
+                     "jsondocId": "08453f03-9a14-49a2-b9f5-f931c4f71053",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7650,7 +7643,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fe0818d1-3db6-4602-91be-3268cb626b15",
+                     "jsondocId": "2cff84aa-57eb-44e6-a0ed-f987d4bdf522",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7659,7 +7652,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f6fea25a-00a1-4a87-83fe-8137c4558cb4",
+                     "jsondocId": "2c71c532-7001-4e01-9772-86ab266bf77d",
                      "name": "group",
                      "format": "",
                      "description": "Group name",
@@ -7668,7 +7661,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8e7807ce-59ea-4e62-9f65-3a5b81cc1311",
+                     "jsondocId": "fc4d2ec4-f927-4a1c-afc7-156967ee0bd3",
                      "name": "userId",
                      "format": "",
                      "description": "User id",
@@ -7677,7 +7670,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "68fe410a-c479-4472-a99c-a42452b600fb",
+                     "jsondocId": "ad343a75-2235-4210-b0c7-972040275d3d",
                      "name": "user",
                      "format": "",
                      "description": "User email/username (supplied if user id unknown)",
@@ -7689,9 +7682,9 @@
                "verb": "POST",
                "description": "Add user to group",
                "methodName": "addUserToGroup",
-               "jsondocId": "0a61f477-a853-4fa2-8488-f32b15997bb0",
+               "jsondocId": "580ed279-08e7-4106-bd50-3ccacb594a73",
                "bodyobject": {
-                  "jsondocId": "4c977456-d6a7-4e64-9642-18ea5a2501d6",
+                  "jsondocId": "18cc1e8e-7e50-4c67-8668-1960be6de5a0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7701,7 +7694,7 @@
                "apierrors": [],
                "path": "/user/addUserToGroup",
                "response": {
-                  "jsondocId": "35da3038-449c-47a9-b51a-7bbc93e5b26c",
+                  "jsondocId": "cc22f55e-f911-41d6-beb3-8dd1870c366f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7714,7 +7707,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "af74c643-1467-4094-b8dd-f343f0e3b555",
+                     "jsondocId": "55916296-fd27-4fe7-9d8d-3213f3450ede",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7723,7 +7716,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fb8c4226-c760-4ed8-bc9c-2db7f83e9bf5",
+                     "jsondocId": "ed31c954-86eb-415a-ae60-9818eecdc7cd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7732,7 +7725,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "114bb994-9063-4467-8de2-4ce06bbcba03",
+                     "jsondocId": "f1c83995-d04d-4aef-9189-df9d22014831",
                      "name": "group",
                      "format": "",
                      "description": "Group name",
@@ -7741,7 +7734,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "782b21ba-79e9-4e54-a990-f4975bb55a0e",
+                     "jsondocId": "38aa8208-8202-4a7c-9f4d-d879331379d0",
                      "name": "userId",
                      "format": "",
                      "description": "User id",
@@ -7750,7 +7743,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "337959da-daf1-4261-b7f8-7d8c87e85aac",
+                     "jsondocId": "ada08399-9222-4995-b45f-9fca617f7869",
                      "name": "user",
                      "format": "",
                      "description": "User email/username (supplied if user id unknown)",
@@ -7762,9 +7755,9 @@
                "verb": "POST",
                "description": "Remove user from group",
                "methodName": "removeUserFromGroup",
-               "jsondocId": "70e72f49-a62f-480e-ac27-f03a32bb7c56",
+               "jsondocId": "6f8f5ca9-a1e2-4f95-8a2f-872a6d8dc24e",
                "bodyobject": {
-                  "jsondocId": "de19664d-34b4-4ec1-81f2-77ef06415218",
+                  "jsondocId": "af991b8c-a3e0-47b5-8c7c-a06a039a9476",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7774,7 +7767,7 @@
                "apierrors": [],
                "path": "/user/removeUserFromGroup",
                "response": {
-                  "jsondocId": "fd0112cb-613b-49e9-8b39-adb76f4611f4",
+                  "jsondocId": "2c87ea55-2ee8-41aa-88d2-9446838074cb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7787,7 +7780,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fd5d1fbd-2382-45d7-9c26-33dde02451f9",
+                     "jsondocId": "78fca5ef-1ddc-4169-8ad4-40c6abafb749",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7796,7 +7789,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5bc28212-5325-4833-8e80-df71425fe6c8",
+                     "jsondocId": "9faf46ab-ad80-4e46-9038-321710b57e6f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7805,7 +7798,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2e3b69d5-c76e-48d3-8adc-fe3af7d2f1fe",
+                     "jsondocId": "500d8d3e-3ef8-41d1-9034-ce080200d39b",
                      "name": "email",
                      "format": "",
                      "description": "Email of the user to add",
@@ -7814,7 +7807,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "38bc67f3-23b2-417f-a768-52bfaf062c0e",
+                     "jsondocId": "3227ca84-0984-4cdf-9e1c-583b95bb705e",
                      "name": "firstName",
                      "format": "",
                      "description": "First name of user to add",
@@ -7823,7 +7816,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "daf78c86-2995-41b9-9a5d-502d74dd1f6d",
+                     "jsondocId": "65daa8c7-75c5-4797-9d48-c494b6ef72b3",
                      "name": "lastName",
                      "format": "",
                      "description": "Last name of user to add",
@@ -7832,7 +7825,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cc477385-548e-4799-8fff-b43bc95e2382",
+                     "jsondocId": "ec7919c5-0100-4f44-aed7-83d9048bbbdc",
                      "name": "metadata",
                      "format": "",
                      "description": "User metadata (optional)",
@@ -7841,7 +7834,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6479ef43-1046-415d-baaa-5a7c820c23a8",
+                     "jsondocId": "9ad2fd12-4b2f-45b8-ab14-30a4f8308fb0",
                      "name": "role",
                      "format": "",
                      "description": "User role USER / ADMIN (optional: default USER) ",
@@ -7850,7 +7843,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "60091f05-4d52-4cad-b17a-f3e6167224ad",
+                     "jsondocId": "3f529cc9-1cfd-48da-ab79-f238a2ffea9c",
                      "name": "newPassword",
                      "format": "",
                      "description": "Password of user to add",
@@ -7862,9 +7855,9 @@
                "verb": "POST",
                "description": "Create user",
                "methodName": "createUser",
-               "jsondocId": "55c0bb88-15f0-4d94-8f17-60aed48003b6",
+               "jsondocId": "dbc4b93e-52c4-40bf-a971-cf67f23cee01",
                "bodyobject": {
-                  "jsondocId": "82fa1113-dd2e-4d16-9770-b604a3b57114",
+                  "jsondocId": "8d5b0901-239c-4a70-b6d0-c67c3a33176f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7874,7 +7867,7 @@
                "apierrors": [],
                "path": "/user/createUser",
                "response": {
-                  "jsondocId": "a68052e2-0dcd-4937-bace-f9598366339a",
+                  "jsondocId": "12510bde-4270-4ede-8180-7965f38cd51a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7887,7 +7880,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2eac8b9d-2bb3-419b-9819-543a7f90d755",
+                     "jsondocId": "ddc9fa11-3d10-4c76-b1ee-47c21495606a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7896,7 +7889,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b278111d-e4e8-42f6-b815-bdb33ec857b2",
+                     "jsondocId": "bdf1c980-cd76-404e-9284-5dbcbb486f92",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7905,7 +7898,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "80f2240c-305e-4e3c-9997-65113cf165d5",
+                     "jsondocId": "9edd7456-d71a-4b61-8b4a-172c9db37268",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to delete",
@@ -7914,7 +7907,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2b151d82-bfbd-4fcf-8ddb-1f4a4d8a5b4c",
+                     "jsondocId": "e006bbbd-7d9f-4027-907d-ffe68a63b282",
                      "name": "userToDelete",
                      "format": "",
                      "description": "Username (email) to inactivate",
@@ -7926,9 +7919,9 @@
                "verb": "POST",
                "description": "Inactivate user, removing all permsissions and setting flag",
                "methodName": "inactivateUser",
-               "jsondocId": "f32e1907-2334-491f-b44e-2d3e1c7ee77d",
+               "jsondocId": "777f3ff2-274a-493b-b540-8a2263eeff2e",
                "bodyobject": {
-                  "jsondocId": "30b18c7f-cd30-45aa-996a-89e0aa8eea37",
+                  "jsondocId": "4ae4a96f-f165-4329-ad2e-4516d8d91870",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7938,7 +7931,7 @@
                "apierrors": [],
                "path": "/user/inactivateUser",
                "response": {
-                  "jsondocId": "b6b367c3-1abf-41f7-be86-a9426627b1c1",
+                  "jsondocId": "e8f037e9-0e1f-415d-8e81-a1054e18ccf6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7951,7 +7944,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "861a81bf-af32-4f5f-9c40-9de65cd89f85",
+                     "jsondocId": "365485d9-284b-4522-8642-5f3ae9be5bd9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7960,7 +7953,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "facf8a1b-531e-423a-9d19-6958936c204b",
+                     "jsondocId": "250bcf87-2ef0-449e-be35-e7da5e6ab207",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7969,7 +7962,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ecfddb4-b5c0-48a8-a040-46b665005b4e",
+                     "jsondocId": "9ac2a6b7-6480-4312-b0f8-9abb73aa82c5",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to delete",
@@ -7978,7 +7971,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8c39f60a-2646-4e5f-b9a5-216c4d3ae674",
+                     "jsondocId": "d50cdfc7-f12c-4543-ae18-152bc5136fc0",
                      "name": "userToActivate",
                      "format": "",
                      "description": "Username (email) to inactivate",
@@ -7990,9 +7983,9 @@
                "verb": "POST",
                "description": "Activate user",
                "methodName": "activateUser",
-               "jsondocId": "97bff0e7-134f-439a-95dd-4b55358064ab",
+               "jsondocId": "496493c3-03af-4d7d-bb5d-4a78b8c44b6b",
                "bodyobject": {
-                  "jsondocId": "02638313-1dc5-42f0-a5aa-b61c68e7cf21",
+                  "jsondocId": "47cd9f96-2707-4c5a-9918-741fe45d3062",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -8002,7 +7995,7 @@
                "apierrors": [],
                "path": "/user/activateUser",
                "response": {
-                  "jsondocId": "c253eed5-5ba4-43a5-bfb2-e7067522d7cf",
+                  "jsondocId": "370c2d83-e51d-461c-9800-368ab4dbc65e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -8015,7 +8008,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "45d558ea-3cbe-4fa2-b501-633addd7a638",
+                     "jsondocId": "4b589fd9-91a1-4171-a0b2-ca148c9e609a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -8024,7 +8017,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63802d18-e033-4b1a-8bdd-dbbf78311af9",
+                     "jsondocId": "d3850163-4d22-48b0-8407-f24a624f054a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -8033,7 +8026,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e37a9bbb-fb10-47ce-821c-a138626ae7c0",
+                     "jsondocId": "6850dd17-b061-4625-b90a-f154b6f6589f",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to delete",
@@ -8042,7 +8035,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ebb800f1-4d6a-40cf-8efe-b1835a3db14a",
+                     "jsondocId": "f9aae98d-9f4f-4cc5-88ed-0fe3a706478d",
                      "name": "userToDelete",
                      "format": "",
                      "description": "Username (email) to delete",
@@ -8054,9 +8047,9 @@
                "verb": "POST",
                "description": "Delete user",
                "methodName": "deleteUser",
-               "jsondocId": "3e2e2f5b-3347-4d34-ab40-ffff963d5653",
+               "jsondocId": "dccc270d-2720-43ee-9e93-948abd16c7fa",
                "bodyobject": {
-                  "jsondocId": "1165c1e3-1871-46cd-8137-df8cb046af30",
+                  "jsondocId": "4215a310-bed3-4d6a-90fe-339208b510da",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -8066,7 +8059,7 @@
                "apierrors": [],
                "path": "/user/deleteUser",
                "response": {
-                  "jsondocId": "e9354d65-7522-44d1-8233-80859bad64c6",
+                  "jsondocId": "86c7b453-de0b-4dac-9217-8414dcab0574",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -8079,7 +8072,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "46a97e03-ee7d-4cb0-823d-16976b0c55a6",
+                     "jsondocId": "b0159766-0efa-42c8-9cf0-580e5ac850c6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -8088,7 +8081,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d0143ee6-3b79-48b4-8ebd-e7700796b3ea",
+                     "jsondocId": "ab8a5eeb-f006-4407-82fe-91d6c2d976ce",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -8097,7 +8090,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a9bea061-d37f-46dc-80bf-28432b2ad682",
+                     "jsondocId": "61a6e25b-4a8c-4eb2-b28a-d13f5a4bd682",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to update",
@@ -8106,7 +8099,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e49c2411-bfdd-46b8-b22a-9224299ebb54",
+                     "jsondocId": "207f2705-071c-48de-a3a8-e28580925c50",
                      "name": "email",
                      "format": "",
                      "description": "Email of the user to update",
@@ -8115,7 +8108,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cde0d3ce-c658-4f2d-bf39-ea328abfb814",
+                     "jsondocId": "63b3f0b7-95af-4b10-8c66-024d14db9c08",
                      "name": "firstName",
                      "format": "",
                      "description": "First name of user to update",
@@ -8124,7 +8117,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "20641c4e-c081-4094-ba3c-fd33fabf9504",
+                     "jsondocId": "eaac2646-748f-4bda-8dfa-62285b07d9a9",
                      "name": "lastName",
                      "format": "",
                      "description": "Last name of user to update",
@@ -8133,7 +8126,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9efe27dd-5f32-46e7-8b4a-d2183d92a7e5",
+                     "jsondocId": "3c0df20c-7f5c-4d66-abe6-27e21cb47e9f",
                      "name": "metadata",
                      "format": "",
                      "description": "User metadata (optional)",
@@ -8142,7 +8135,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8202cb7c-450c-4046-b2af-037c235ff5e9",
+                     "jsondocId": "4ab29a63-4be0-49e5-8ebc-a40bccde0be0",
                      "name": "newPassword",
                      "format": "",
                      "description": "Password of user to update",
@@ -8154,9 +8147,9 @@
                "verb": "POST",
                "description": "Update user",
                "methodName": "updateUser",
-               "jsondocId": "4f02f0d0-5f90-4f00-aa3d-3f77b4b16374",
+               "jsondocId": "98c1a60f-e3a7-4808-a016-c7f769e53e17",
                "bodyobject": {
-                  "jsondocId": "ad886346-b891-46c7-b606-4c4a83e726c6",
+                  "jsondocId": "6a2c387c-7c12-4bfd-8bd7-c1fd0335e6d8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -8166,7 +8159,7 @@
                "apierrors": [],
                "path": "/user/updateUser",
                "response": {
-                  "jsondocId": "4909af4b-8543-4fb1-b8be-a20e36f8da9a",
+                  "jsondocId": "12f844f8-1786-42f9-893c-d4a103ea6123",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -8179,7 +8172,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f56ed934-40eb-4067-af2b-37253c6337a9",
+                     "jsondocId": "9c5195f4-d004-4126-a82d-7a22bbead6ab",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -8188,7 +8181,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "06228df4-e216-4429-8d7e-8a5f47e811e8",
+                     "jsondocId": "74bca497-12a7-41fb-8409-03de2019c1b3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -8197,7 +8190,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d2852b6-fad6-431d-a4f4-817f8cdb6a5c",
+                     "jsondocId": "5aebb764-ee99-4f5e-be25-28723507b970",
                      "name": "email",
                      "format": "",
                      "description": "Email of the user",
@@ -8209,9 +8202,9 @@
                "verb": "POST",
                "description": "Get creator metadata for user, returns creator userId as JSONObject",
                "methodName": "getUserCreator",
-               "jsondocId": "d6692c20-4bb6-4368-a6cf-51436bac2c1d",
+               "jsondocId": "7efd0acc-1e40-4f8c-956d-9dcd6a7634d7",
                "bodyobject": {
-                  "jsondocId": "3edac37f-db82-4b33-8ee7-18a823f0ba0e",
+                  "jsondocId": "99ddcc09-28cf-4b59-bddf-a5c8dd57a82b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -8221,7 +8214,62 @@
                "apierrors": [],
                "path": "/user/getUserCreator",
                "response": {
-                  "jsondocId": "34fda8d5-1b3d-488b-8569-b0a564545c3f",
+                  "jsondocId": "2aab690c-dfd2-4b86-898b-5c930e8bd94d",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5718a6ae-6dde-4358-8ed4-168809cd7e72",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "de03e85b-f383-492f-b4ef-fe33d41d474a",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4017d9a7-79c6-4219-8f7c-75eb129bb622",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to fetch",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for user, returns an array of permission objects",
+               "methodName": "getOrganismPermissionsForUser",
+               "jsondocId": "4f2830ea-9115-4425-b198-714fce1715d0",
+               "bodyobject": {
+                  "jsondocId": "23843202-d5e5-44e1-b1f0-d4d84a67a9e3",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/getOrganismPermissionsForUser",
+               "response": {
+                  "jsondocId": "5e754958-5ef3-47ee-ac8c-b68a8031e37e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -8234,13 +8282,13 @@
          "description": "Methods for managing users"
       },
       {
-         "jsondocId": "9b9499e3-fd46-4d61-8e16-1feaec4c305a",
+         "jsondocId": "d7d8b230-0c67-4f47-8a55-33a73c3b0895",
          "methods": [{
             "headers": [],
             "pathparameters": [],
             "queryparameters": [
                {
-                  "jsondocId": "dca7c3ea-6f49-42f0-b572-b1aa47a02fcb",
+                  "jsondocId": "49318583-babd-4dae-bb68-ed122be28515",
                   "name": "organismString",
                   "format": "",
                   "description": "Organism common name or ID (required)",
@@ -8249,7 +8297,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "78012aac-5458-4288-8dee-c85cbaf259e5",
+                  "jsondocId": "e4e12867-6fd4-467d-b742-c0c6f33d2668",
                   "name": "trackName",
                   "format": "",
                   "description": "Track name by label in trackList.json (required)",
@@ -8258,7 +8306,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "2629eba9-6313-4450-aa5c-0b31e6079e74",
+                  "jsondocId": "9baa28f3-4e56-432c-b70b-653a21bde9e2",
                   "name": "sequence",
                   "format": "",
                   "description": "Sequence name (required)",
@@ -8267,7 +8315,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "84ff1f66-b739-4bb4-a469-6c3e075de49d",
+                  "jsondocId": "25196b62-23be-4bf3-95c9-ee47e0004d89",
                   "name": "fmin",
                   "format": "",
                   "description": "Minimum range (required)",
@@ -8276,7 +8324,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "3c5293b2-43e7-4e9d-bc08-6414c110ad86",
+                  "jsondocId": "f1f2faf2-5f1b-421c-809f-9dfb3f4adc1d",
                   "name": "fmax",
                   "format": "",
                   "description": "Maximum range (required)",
@@ -8285,7 +8333,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "dd2a556a-3c83-41cb-ae7c-41fa78a9690f",
+                  "jsondocId": "3a589c48-a86b-459d-9053-34cd81a4ccb5",
                   "name": "type",
                   "format": "",
                   "description": ".json (required)",
@@ -8294,7 +8342,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "e64aec20-60d7-4133-a1d7-dcb3ed6da339",
+                  "jsondocId": "a4170cd7-2146-406e-9bdf-9a652e252351",
                   "name": "includeGenotypes",
                   "format": "",
                   "description": "(default: false).  If true, will include genotypes associated with variants from VCF.",
@@ -8303,7 +8351,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "fecd5992-c672-4aba-bb89-01dc3aeecfa1",
+                  "jsondocId": "918189c8-ad2d-4b9f-860c-fec9bf5fc5c6",
                   "name": "ignoreCache",
                   "format": "",
                   "description": "(default: false).  Use cache for request, if available.",
@@ -8315,12 +8363,12 @@
             "verb": "GET",
             "description": "Get VCF track data for a given range as JSON",
             "methodName": "featuresByLocation",
-            "jsondocId": "cb0c332f-e34a-4aa3-92d5-185e3989702c",
+            "jsondocId": "b66a855a-261e-4918-9a27-7f81ebafc606",
             "bodyobject": null,
             "apierrors": [],
             "path": "/vcf/<organism_name>/<track_name>/<sequence_name>:<fmin>..<fmax>.<type>?includeGenotypes=<includeGenotypes>&ignoreCache=<ignoreCache>",
             "response": {
-               "jsondocId": "dc12cda6-2065-42ff-a842-7aa82915f208",
+               "jsondocId": "d325acd9-592a-4252-afa1-d55a28f91e37",
                "mapValueObject": "",
                "mapKeyObject": "",
                "object": "vcf"


### PR DESCRIPTION
fixes #1991 

- [ ] filter by organism name and feature type
- [ ] extend to transcript and other details screens
- [x] add to `get_annotation_info_editor`??
- [ ] add types and organisms to script (via groovy) and web-service or remove / update description 

===

- [x] add web-service and script for bulk upload of names
- [x] get views working
- [x] get feature type suggestion name controller working
- [x] add autosuggest to typeahead
- [x] if no suggestedNames, can we change the update style

=== maybe not these ===

- ~~add integration test for controller?~~
- ~~get file upload working~~ would just use a psql upload for now
