### PR TITLE
Restrict ro fix 2172

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/go/GoAnnotationController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/go/GoAnnotationController.groovy
@@ -77,6 +77,7 @@ class GoAnnotationController {
         GoAnnotation goAnnotation = new GoAnnotation()
         Feature feature = Feature.findByUniqueName(dataObject.gene)
         goAnnotation.feature = feature
+        goAnnotation.aspect = dataObject.aspect
         goAnnotation.goRef = dataObject.goTerm
         goAnnotation.geneProductRelationshipRef = dataObject.geneRelationship
         goAnnotation.evidenceRef = dataObject.evidenceCode

--- a/grails-app/controllers/org/bbop/apollo/go/GoAnnotationController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/go/GoAnnotationController.groovy
@@ -62,6 +62,7 @@ class GoAnnotationController {
             , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
             , @RestApiParam(name = "gene", type = "string", paramType = RestApiParamType.QUERY, description = "uniqueName of gene feature to query on")
             , @RestApiParam(name = "goTerm", type = "string", paramType = RestApiParamType.QUERY, description = "GO CURIE")
+            , @RestApiParam(name = "aspect", type = "string", paramType = RestApiParamType.QUERY, description = "(required) BP, MF, CC")
             , @RestApiParam(name = "geneRelationship", type = "string", paramType = RestApiParamType.QUERY, description = "Gene relationship (RO) CURIE")
             , @RestApiParam(name = "evidenceCode", type = "string", paramType = RestApiParamType.QUERY, description = "Evidence (ECO) CURIE")
             , @RestApiParam(name = "negate", type = "boolean", paramType = RestApiParamType.QUERY, description = "Negate evidence (default false)")
@@ -102,6 +103,7 @@ class GoAnnotationController {
             , @RestApiParam(name = "id", type = "string", paramType = RestApiParamType.QUERY, description = "GO Annotation ID to update (required)")
             , @RestApiParam(name = "gene", type = "string", paramType = RestApiParamType.QUERY, description = "uniqueName of gene feature to query on")
             , @RestApiParam(name = "goTerm", type = "string", paramType = RestApiParamType.QUERY, description = "GO CURIE")
+            , @RestApiParam(name = "aspect", type = "string", paramType = RestApiParamType.QUERY, description = "(required) BP, MF, CC")
             , @RestApiParam(name = "geneRelationship", type = "string", paramType = RestApiParamType.QUERY, description = "Gene relationship (RO) CURIE")
             , @RestApiParam(name = "evidenceCode", type = "string", paramType = RestApiParamType.QUERY, description = "Evidence (ECO) CURIE")
             , @RestApiParam(name = "negate", type = "boolean", paramType = RestApiParamType.QUERY, description = "Negate evidence (default false)")
@@ -115,6 +117,7 @@ class GoAnnotationController {
         permissionService.checkPermissions(dataObject, PermissionEnum.WRITE)
         User user = permissionService.getCurrentUser(dataObject)
         GoAnnotation goAnnotation = GoAnnotation.findById(dataObject.id)
+        goAnnotation.aspect = dataObject.aspect
         goAnnotation.goRef = dataObject.goTerm
         goAnnotation.geneProductRelationshipRef = dataObject.geneRelationship
         goAnnotation.evidenceRef = dataObject.evidenceCode

--- a/grails-app/domain/org/bbop/apollo/go/GoAnnotation.groovy
+++ b/grails-app/domain/org/bbop/apollo/go/GoAnnotation.groovy
@@ -7,6 +7,7 @@ import org.bbop.apollo.User
 class GoAnnotation {
 
     static constraints = {
+        aspect nullable: false,blank: false
         feature nullable: false
         goRef nullable: false, blank: false
         evidenceRef nullable: false, blank: false
@@ -23,6 +24,7 @@ class GoAnnotation {
             owners: User
     ]
 
+    String aspect
     Feature feature
     String goRef
     String evidenceRef

--- a/grails-app/services/org/bbop/apollo/go/GoAnnotationService.groovy
+++ b/grails-app/services/org/bbop/apollo/go/GoAnnotationService.groovy
@@ -30,6 +30,7 @@ class GoAnnotationService {
                 goObject.put("id",goAnnotation.getId())
             }
             goObject.put("gene",feature.uniqueName)
+            goObject.put("aspect",goAnnotation.aspect)
             goObject.put("goTerm",goAnnotation.goRef)
             goObject.put("geneRelationship",goAnnotation.geneProductRelationshipRef)
             goObject.put("evidenceCode",goAnnotation.evidenceRef)

--- a/src/gwt/org/bbop/apollo/gwt/client/AnnotatorPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/AnnotatorPanel.java
@@ -547,6 +547,8 @@ public class AnnotatorPanel extends Composite {
             default:
                 GWT.log("not sure what to do with " + type);
         }
+
+
         reselectSubTab();
 
 
@@ -697,6 +699,7 @@ public class AnnotatorPanel extends Composite {
             @Override
             public void onSelectionChange(SelectionChangeEvent event) {
                 selectedAnnotationInfo = singleSelectionModel.getSelectedObject();
+                tabPanel.setVisible(showDetails && selectedAnnotationInfo!=null);
                 if (selectedAnnotationInfo != null) {
                     exonDetailPanel.updateData(selectedAnnotationInfo);
                     goPanel.updateData(selectedAnnotationInfo);
@@ -786,7 +789,7 @@ public class AnnotatorPanel extends Composite {
             toggleAnnotation.setIcon(IconType.INFO_CIRCLE);
         }
 
-        tabPanel.setVisible(showDetails);
+        tabPanel.setVisible(showDetails && singleSelectionModel.getSelectedObject()!=null);
     }
 
     @UiHandler("toggleAnnotation")

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -132,6 +132,7 @@ public class GoPanel extends Composite {
 
         initWidget(ourUiBinder.createAndBindUi(this));
 
+        aspectField.addItem("Choose");
         for(Aspect aspect : Aspect.values()){
             aspectField.addItem(aspect.name(),aspect.getLookup());
         }
@@ -201,7 +202,7 @@ public class GoPanel extends Composite {
             @Override
             public void onChange(ChangeEvent event) {
                 String selectedItemText  = geneProductRelationshipField.getSelectedItemText();
-                geneProductRelationshipLink.setHTML(selectedItemText);
+                geneProductRelationshipLink.setHTML(selectedItemText + " ("+geneProductRelationshipField.getSelectedValue()+")");
                 geneProductRelationshipLink.setHref(RO_BASE + selectedItemText.replace(":", "_"));
             }
         });
@@ -214,22 +215,22 @@ public class GoPanel extends Composite {
         geneProductRelationshipField.clear();
         switch(aspect){
             case BP:
-                geneProductRelationshipField.addItem("RO:0002331","involved in");
-                geneProductRelationshipField.addItem("RO:0002263","acts upstream of");
-                geneProductRelationshipField.addItem("RO:0004034","acts upstream of positive effect");
-                geneProductRelationshipField.addItem("RO:0004035","acts upstream of negative effect");
-                geneProductRelationshipField.addItem("RO:0002264","acts upstream of or within");
-                geneProductRelationshipField.addItem("RO:0004032","acts upstream of or within positive effect");
-                geneProductRelationshipField.addItem("RO:0004033","acts upstream of or within negative effect");
+                geneProductRelationshipField.addItem("involved in","RO:0002331");
+                geneProductRelationshipField.addItem("acts upstream of","RO:0002263");
+                geneProductRelationshipField.addItem("acts upstream of positive effect","RO:0004034");
+                geneProductRelationshipField.addItem("acts upstream of negative effect","RO:0004035");
+                geneProductRelationshipField.addItem("acts upstream of or within","RO:0002264");
+                geneProductRelationshipField.addItem("acts upstream of or within positive effect","RO:0004032");
+                geneProductRelationshipField.addItem("acts upstream of or within negative effect","RO:0004033");
                 break;
             case MF:
-                geneProductRelationshipField.addItem("RO:0002327","enables");
-                geneProductRelationshipField.addItem("RO:0002326","contributes to");
+                geneProductRelationshipField.addItem("enables","RO:0002327");
+                geneProductRelationshipField.addItem("contributes to","RO:0002326");
                 break;
             case CC:
-                geneProductRelationshipField.addItem("BFO:0000050","part of");
-                geneProductRelationshipField.addItem("RO:0002325","colocalizes with");
-                geneProductRelationshipField.addItem("RO:0002432","is active in");
+                geneProductRelationshipField.addItem("part of","BFO:0000050");
+                geneProductRelationshipField.addItem("colocalizes with","RO:0002325");
+                geneProductRelationshipField.addItem("is active in","RO:0002432");
                 break;
             default:
                 Bootbox.alert("A problem has occurred");

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -262,17 +262,6 @@ public class GoPanel extends Composite {
     private void initLookups() {
         goTermField = new SuggestBox(goLookup);
 
-//        BiolinkOntologyOracle roLookup = new BiolinkOntologyOracle("RO");
-//        roLookup.addPreferredSuggestion("enables", "http://purl.obolibrary.org/obo/RO_0002327", "RO:0002327");
-//        roLookup.addPreferredSuggestion("involved in", "http://purl.obolibrary.org/obo/RO_0002331", "RO:0002331");
-//        roLookup.addPreferredSuggestion("part of", "http://purl.obolibrary.org/obo/BFO_0000050", "BFO:0000050");
-//        roLookup.addPreferredSuggestion("enabled by", "http://purl.obolibrary.org/obo/RO_0002333", "RO:0002333");
-//        roLookup.addPreferredSuggestion("occurs in", "http://purl.obolibrary.org/obo/BFO_0000066", "BFO:0000066");
-//        roLookup.addPreferredSuggestion("causally upstream of or within", "http://purl.obolibrary.org/obo/RO_0002418", "RO:0002418");
-//        roLookup.addPreferredSuggestion("has participant", "http://purl.obolibrary.org/obo/RO_0000057", "RO:0000057");
-//        geneProductRelationshipField = new SuggestBox(roLookup);
-
-
         // most from here: http://geneontology.org/docs/guide-go-evidence-codes/
         BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle("ECO");
         ecoLookup.addPreferredSuggestion("experimental evidence used in manual assertion (EXP)", "http://www.evidenceontology.org/term/ECO:0000269/", "ECO:0000269");
@@ -386,7 +375,7 @@ public class GoPanel extends Composite {
             for(int i = 0 ; i < aspectField.getItemCount() ; i++){
                 aspectField.setItemSelected(i,aspectField.getItemText(i).equals(selectedGoAnnotation.getAspect().name()));
             }
-            //
+
             setRelationValues(aspectField.getSelectedItemText(),aspectField.getSelectedValue());
             enableFields(aspectField.getSelectedValue().length()>0);
 
@@ -422,8 +411,6 @@ public class GoPanel extends Composite {
                 addReferenceSelection(noteString);
             }
             noteField.setText("");
-
-
         }
 
     }

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -139,14 +139,7 @@ public class GoPanel extends Composite {
         aspectField.addChangeHandler(new ChangeHandler() {
             @Override
             public void onChange(ChangeEvent event) {
-                goTermField.setText("");
-                goTermLink.setText("");
-                aspectLabel.setText(aspectField.getSelectedValue());
-                goLookup.setCategory(aspectField.getSelectedValue());
-
-                // TODO: set constrainted RO values
-                setRelationValues(aspectField.getSelectedItemText(),aspectField.getSelectedValue());
-                enableFields(aspectField.getSelectedValue().length()>0);
+                handleAspectChange();
             }
         });
 
@@ -208,6 +201,16 @@ public class GoPanel extends Composite {
         });
 
         redraw();
+    }
+
+    private void handleAspectChange(){
+        goTermField.setText("");
+        goTermLink.setText("");
+        aspectLabel.setText(aspectField.getSelectedValue());
+        goLookup.setCategory(aspectField.getSelectedValue());
+
+        setRelationValues(aspectField.getSelectedItemText(),aspectField.getSelectedValue());
+        enableFields(aspectField.getSelectedValue().length()>0);
     }
 
     private void enableFields(boolean enabled) {
@@ -352,6 +355,9 @@ public class GoPanel extends Composite {
     }
 
     private void clearModal() {
+        aspectField.setItemSelected(0,true);
+        handleAspectChange();
+        aspectLabel.setText("");
         goTermField.setText("");
         goTermLink.setText("");
 //        geneProductRelationshipField.setText("");
@@ -374,6 +380,11 @@ public class GoPanel extends Composite {
             clearModal();
         } else {
             GoAnnotation selectedGoAnnotation = selectionModel.getSelectedObject();
+
+            for(int i = 0 ; i < aspectField.getItemCount() ; i++){
+                aspectField.setItemSelected(i,aspectField.getSelectedItemText().equals(selectedGoAnnotation.getAspect().name()));
+            }
+
             goTermField.setText(selectedGoAnnotation.getGoTerm());
             goTermLink.setHref(GO_BASE + selectedGoAnnotation.getGoTerm());
             GoRestService.lookupTerm(goTermLink,selectedGoAnnotation.getGoTerm());
@@ -543,6 +554,7 @@ public class GoPanel extends Composite {
 
     private GoAnnotation getEditedGoAnnotation() {
         GoAnnotation goAnnotation = new GoAnnotation();
+        goAnnotation.setAspect(Aspect.valueOf(aspectField.getSelectedItemText()));
         goAnnotation.setGene(annotationInfo.getUniqueName());
         goAnnotation.setGoTerm(goTermField.getText());
         goAnnotation.setGeneRelationship(geneProductRelationshipField.getSelectedValue());

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -15,7 +15,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.cellview.client.DataGrid;
 import com.google.gwt.user.cellview.client.TextColumn;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwt.view.client.SelectionChangeEvent;
@@ -132,7 +131,7 @@ public class GoPanel extends Composite {
 
         initWidget(ourUiBinder.createAndBindUi(this));
 
-        aspectField.addItem("Choose");
+        aspectField.addItem("Choose","");
         for(Aspect aspect : Aspect.values()){
             aspectField.addItem(aspect.name(),aspect.getLookup());
         }
@@ -146,7 +145,8 @@ public class GoPanel extends Composite {
                 goLookup.setCategory(aspectField.getSelectedValue());
 
                 // TODO: set constrainted RO values
-                setRelationValues(aspectField.getSelectedItemText());
+                setRelationValues(aspectField.getSelectedItemText(),aspectField.getSelectedValue());
+                enableFields(aspectField.getSelectedValue().length()>0);
             }
         });
 
@@ -199,7 +199,6 @@ public class GoPanel extends Composite {
         });
 
         geneProductRelationshipField.addChangeHandler(new ChangeHandler() {
-
             @Override
             public void onChange(ChangeEvent event) {
                 String selectedItemText  = geneProductRelationshipField.getSelectedItemText();
@@ -211,9 +210,22 @@ public class GoPanel extends Composite {
         redraw();
     }
 
-    private void setRelationValues(String selectedItemText) {
-        Aspect aspect = Aspect.valueOf(selectedItemText);
+    private void enableFields(boolean enabled) {
+        saveNewGoAnnotation.setEnabled(enabled);
+        goTermField.setEnabled(enabled);
+        evidenceCodeField.setEnabled(enabled);
+        geneProductRelationshipField.setEnabled(enabled);
+        referenceFieldPrefix.setEnabled(enabled);
+        referenceFieldId.setEnabled(enabled);
+        withFieldPrefix.setEnabled(enabled);
+        withFieldId.setEnabled(enabled);
+        noteField.setEnabled(enabled);
+    }
+
+    private void setRelationValues(String selectedItemText,String selectedItemValue) {
+        Aspect aspect = selectedItemValue.length()>0 ? Aspect.valueOf(selectedItemText): null;
         geneProductRelationshipField.clear();
+        if(aspect==null ) return;
         switch(aspect){
             case BP:
                 geneProductRelationshipField.addItem("involved in","RO:0002331");
@@ -477,6 +489,8 @@ public class GoPanel extends Composite {
             Bootbox.alert(errorString);
             return;
         }
+        withFieldPrefix.clear();
+        withFieldId.clear();
         RequestCallback requestCallback = new RequestCallback() {
             @Override
             public void onResponseReceived(Request request, Response response) {
@@ -521,8 +535,7 @@ public class GoPanel extends Composite {
         if (!goAnnotation.getGeneRelationship().contains(":")) {
             validationErrors.add("You must provide a prefix and suffix for the Gene Relationship");
         }
-
-        if (goAnnotation.getReference().getReferenceString().length()==0 ) {
+        if (goAnnotation.getReference().getReferenceString().trim().length()==0 ) {
             validationErrors.add("You must provide at least one reference");
         }
         return validationErrors;
@@ -550,7 +563,6 @@ public class GoPanel extends Composite {
         String withPrefixText = withFieldPrefix.getText();
         String withIdText = withFieldId.getText();
         if (withPrefixText.length() > 0 && withIdText.length() > 0) {
-            withFieldPrefix.clear();
             withOrFromList.add(new WithOrFrom(withPrefixText, withIdText));
         }
 

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -386,6 +386,7 @@ public class GoPanel extends Composite {
             }
             //
             setRelationValues(aspectField.getSelectedItemText(),aspectField.getSelectedValue());
+            enableFields(aspectField.getSelectedValue().length()>0);
 
             goTermField.setText(selectedGoAnnotation.getGoTerm());
             goTermLink.setHref(GO_BASE + selectedGoAnnotation.getGoTerm());

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -15,6 +15,7 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.cellview.client.DataGrid;
 import com.google.gwt.user.cellview.client.TextColumn;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwt.view.client.SelectionChangeEvent;
@@ -168,6 +169,7 @@ public class GoPanel extends Composite {
             @Override
             public void onDoubleClick(DoubleClickEvent event) {
                 goAnnotationTitle.setText("Edit GO Annotation for "+AnnotatorPanel.selectedAnnotationInfo.getName());
+                handleSelection();
                 editGoModal.show();
             }
         }, DoubleClickEvent.getType());
@@ -543,8 +545,11 @@ public class GoPanel extends Composite {
         if (!goAnnotation.getGeneRelationship().contains(":")) {
             validationErrors.add("You must provide a prefix and suffix for the Gene Relationship");
         }
-        if (goAnnotation.getReference().getReferenceString().trim().length()==0 ) {
-            validationErrors.add("You must provide at least one reference");
+        if (goAnnotation.getReference().getPrefix().length()==0 ) {
+            validationErrors.add("You must provide at least a reference prefix.");
+        }
+        if (goAnnotation.getReference().getLookupId().length()==0 ) {
+            validationErrors.add("You must provide at least a reference id.");
         }
         return validationErrors;
     }
@@ -598,6 +603,7 @@ public class GoPanel extends Composite {
 
     @UiHandler("cancelNewGoAnnotation")
     public void cancelNewGoAnnotationButton(ClickEvent e) {
+        clearModal();
         editGoModal.hide();
     }
 

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -1,10 +1,7 @@
 package org.bbop.apollo.gwt.client;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.dom.client.DoubleClickEvent;
-import com.google.gwt.event.dom.client.DoubleClickHandler;
+import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.http.client.Request;
@@ -28,6 +25,7 @@ import org.bbop.apollo.gwt.client.dto.GoAnnotationConverter;
 import org.bbop.apollo.gwt.client.oracles.BiolinkOntologyOracle;
 import org.bbop.apollo.gwt.client.resources.TableResources;
 import org.bbop.apollo.gwt.client.rest.GoRestService;
+import org.bbop.apollo.gwt.shared.go.Aspect;
 import org.bbop.apollo.gwt.shared.go.GoAnnotation;
 import org.bbop.apollo.gwt.shared.go.Reference;
 import org.bbop.apollo.gwt.shared.go.WithOrFrom;
@@ -112,6 +110,11 @@ public class GoPanel extends Composite {
 //    Button referenceValidateButton;
     @UiField
     HTML goAnnotationTitle;
+    @UiField
+    org.gwtbootstrap3.client.ui.ListBox aspectField;
+    @UiField
+    HTML aspectLabel;
+
     private static ListDataProvider<GoAnnotation> dataProvider = new ListDataProvider<>();
     private static List<GoAnnotation> annotationInfoList = dataProvider.getList();
     private SingleSelectionModel<GoAnnotation> selectionModel = new SingleSelectionModel<>();
@@ -127,6 +130,22 @@ public class GoPanel extends Composite {
         dataGrid.setSelectionModel(selectionModel);
 
         initWidget(ourUiBinder.createAndBindUi(this));
+
+        for(Aspect aspect : Aspect.values()){
+            aspectField.addItem(aspect.name(),aspect.getLookup());
+        }
+
+        aspectField.addChangeHandler(new ChangeHandler() {
+            @Override
+            public void onChange(ChangeEvent event) {
+                goTermField.setText("");
+                goTermLink.setText("");
+                aspectLabel.setText(aspectField.getSelectedValue());
+
+                // TODO: set constrainted RO values
+                setRelationValues(aspectField.getSelectedItemText());
+            }
+        });
 
         selectionModel.addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
             @Override
@@ -186,6 +205,10 @@ public class GoPanel extends Composite {
         });
 
         redraw();
+    }
+
+    private void setRelationValues(String selectedItemText) {
+
     }
 
     private void initLookups() {

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -211,6 +211,7 @@ public class GoPanel extends Composite {
 
         setRelationValues(aspectField.getSelectedItemText(),aspectField.getSelectedValue());
         enableFields(aspectField.getSelectedValue().length()>0);
+        geneProductRelationshipLink.setText("");
     }
 
     private void enableFields(boolean enabled) {
@@ -360,7 +361,6 @@ public class GoPanel extends Composite {
         aspectLabel.setText("");
         goTermField.setText("");
         goTermLink.setText("");
-//        geneProductRelationshipField.setText("");
         geneProductRelationshipField.clear();
         geneProductRelationshipLink.setText("");
         evidenceCodeField.setText("");
@@ -382,22 +382,18 @@ public class GoPanel extends Composite {
             GoAnnotation selectedGoAnnotation = selectionModel.getSelectedObject();
 
             for(int i = 0 ; i < aspectField.getItemCount() ; i++){
-                aspectField.setItemSelected(i,aspectField.getSelectedItemText().equals(selectedGoAnnotation.getAspect().name()));
+                aspectField.setItemSelected(i,aspectField.getItemText(i).equals(selectedGoAnnotation.getAspect().name()));
             }
+            //
+            setRelationValues(aspectField.getSelectedItemText(),aspectField.getSelectedValue());
 
             goTermField.setText(selectedGoAnnotation.getGoTerm());
             goTermLink.setHref(GO_BASE + selectedGoAnnotation.getGoTerm());
             GoRestService.lookupTerm(goTermLink,selectedGoAnnotation.getGoTerm());
 
-
-//            geneProductRelationshipField.setText(selectedGoAnnotation.getGeneRelationship());
-//            geneProductRelationshipField.setSelectedIndex(selectedGoAnnotation.getGeneRelationship());
-
-            // TODO: set the proper one when it comes back
-//            String selectedGeneRelationship = selectedGoAnnotation.getGeneRelationship();
-//            for(int i = 0 ; i < geneProductRelationshipField.getItemCount() ; i++){
-////                if(geneProductRelationshipField.setItemSelected(i,);)
-//            }
+            for(int i = 0 ; i < geneProductRelationshipField.getItemCount() ; i++){
+                geneProductRelationshipField.setItemSelected(i,geneProductRelationshipField.getValue(i).equals(selectedGoAnnotation.getGeneRelationship()));
+            }
 
 
             geneProductRelationshipLink.setHref(RO_BASE + selectedGoAnnotation.getGeneRelationship().replaceAll(":", "_"));

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -60,7 +60,6 @@ public class GoPanel extends Composite {
     TextBox noteField;
     @UiField(provided = true)
     SuggestBox goTermField;
-//    @UiField(provided = true)
     @UiField
     org.gwtbootstrap3.client.ui.ListBox geneProductRelationshipField;
     @UiField(provided = true)
@@ -121,6 +120,7 @@ public class GoPanel extends Composite {
     private SingleSelectionModel<GoAnnotation> selectionModel = new SingleSelectionModel<>();
 
     private AnnotationInfo annotationInfo;
+    private BiolinkOntologyOracle goLookup = new BiolinkOntologyOracle("GO");
 
     public GoPanel() {
 
@@ -143,6 +143,7 @@ public class GoPanel extends Composite {
                 goTermField.setText("");
                 goTermLink.setText("");
                 aspectLabel.setText(aspectField.getSelectedValue());
+                goLookup.setCategory(aspectField.getSelectedValue());
 
                 // TODO: set constrainted RO values
                 setRelationValues(aspectField.getSelectedItemText());
@@ -241,7 +242,7 @@ public class GoPanel extends Composite {
     }
 
     private void initLookups() {
-        goTermField = new SuggestBox(new BiolinkOntologyOracle("GO"));
+        goTermField = new SuggestBox(goLookup);
 
 //        BiolinkOntologyOracle roLookup = new BiolinkOntologyOracle("RO");
 //        roLookup.addPreferredSuggestion("enables", "http://purl.obolibrary.org/obo/RO_0002327", "RO:0002327");

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -532,7 +532,7 @@ public class GoPanel extends Composite {
         GoAnnotation goAnnotation = new GoAnnotation();
         goAnnotation.setGene(annotationInfo.getUniqueName());
         goAnnotation.setGoTerm(goTermField.getText());
-        goAnnotation.setGeneRelationship(geneProductRelationshipField.getSelectedItemText());
+        goAnnotation.setGeneRelationship(geneProductRelationshipField.getSelectedValue());
         goAnnotation.setEvidenceCode(evidenceCodeField.getText());
         goAnnotation.setNegate(notQualifierCheckBox.getValue());
         goAnnotation.setWithOrFromList(getWithList());

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -212,8 +212,8 @@ public class GoPanel extends Composite {
     private void setRelationValues(String selectedItemText) {
         Aspect aspect = Aspect.valueOf(selectedItemText);
         geneProductRelationshipField.clear();
-        switch(aspect.getLookup()){
-            case Aspect.BP.getLookup():
+        switch(aspect){
+            case BP:
                 geneProductRelationshipField.addItem("RO:0002331","involved in");
                 geneProductRelationshipField.addItem("RO:0002263","acts upstream of");
                 geneProductRelationshipField.addItem("RO:0004034","acts upstream of positive effect");
@@ -222,11 +222,11 @@ public class GoPanel extends Composite {
                 geneProductRelationshipField.addItem("RO:0004032","acts upstream of or within positive effect");
                 geneProductRelationshipField.addItem("RO:0004033","acts upstream of or within negative effect");
                 break;
-            case Aspect.MF.getLookup():
+            case MF:
                 geneProductRelationshipField.addItem("RO:0002327","enables");
                 geneProductRelationshipField.addItem("RO:0002326","contributes to");
                 break;
-            case Aspect.CC.getLookup():
+            case CC:
                 geneProductRelationshipField.addItem("BFO:0000050","part of");
                 geneProductRelationshipField.addItem("RO:0002325","colocalizes with");
                 geneProductRelationshipField.addItem("RO:0002432","is active in");

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -60,8 +60,9 @@ public class GoPanel extends Composite {
     TextBox noteField;
     @UiField(provided = true)
     SuggestBox goTermField;
-    @UiField(provided = true)
-    SuggestBox geneProductRelationshipField;
+//    @UiField(provided = true)
+    @UiField
+    org.gwtbootstrap3.client.ui.ListBox geneProductRelationshipField;
     @UiField(provided = true)
     SuggestBox evidenceCodeField;
     @UiField
@@ -195,12 +196,13 @@ public class GoPanel extends Composite {
             }
         });
 
-        geneProductRelationshipField.addSelectionHandler(new SelectionHandler<SuggestOracle.Suggestion>() {
+        geneProductRelationshipField.addChangeHandler(new ChangeHandler() {
+
             @Override
-            public void onSelection(SelectionEvent<SuggestOracle.Suggestion> event) {
-                SuggestOracle.Suggestion suggestion = event.getSelectedItem();
-                geneProductRelationshipLink.setHTML(suggestion.getDisplayString());
-                geneProductRelationshipLink.setHref(RO_BASE + suggestion.getReplacementString().replace(":", "_"));
+            public void onChange(ChangeEvent event) {
+                String selectedItemText  = geneProductRelationshipField.getSelectedItemText();
+                geneProductRelationshipLink.setHTML(selectedItemText);
+                geneProductRelationshipLink.setHref(RO_BASE + selectedItemText.replace(":", "_"));
             }
         });
 
@@ -208,21 +210,47 @@ public class GoPanel extends Composite {
     }
 
     private void setRelationValues(String selectedItemText) {
+        Aspect aspect = Aspect.valueOf(selectedItemText);
+        geneProductRelationshipField.clear();
+        switch(aspect.getLookup()){
+            case Aspect.BP.getLookup():
+                geneProductRelationshipField.addItem("RO:0002331","involved in");
+                geneProductRelationshipField.addItem("RO:0002263","acts upstream of");
+                geneProductRelationshipField.addItem("RO:0004034","acts upstream of positive effect");
+                geneProductRelationshipField.addItem("RO:0004035","acts upstream of negative effect");
+                geneProductRelationshipField.addItem("RO:0002264","acts upstream of or within");
+                geneProductRelationshipField.addItem("RO:0004032","acts upstream of or within positive effect");
+                geneProductRelationshipField.addItem("RO:0004033","acts upstream of or within negative effect");
+                break;
+            case Aspect.MF.getLookup():
+                geneProductRelationshipField.addItem("RO:0002327","enables");
+                geneProductRelationshipField.addItem("RO:0002326","contributes to");
+                break;
+            case Aspect.CC.getLookup():
+                geneProductRelationshipField.addItem("BFO:0000050","part of");
+                geneProductRelationshipField.addItem("RO:0002325","colocalizes with");
+                geneProductRelationshipField.addItem("RO:0002432","is active in");
+                break;
+            default:
+                Bootbox.alert("A problem has occurred");
+
+
+        }
 
     }
 
     private void initLookups() {
         goTermField = new SuggestBox(new BiolinkOntologyOracle("GO"));
 
-        BiolinkOntologyOracle roLookup = new BiolinkOntologyOracle("RO");
-        roLookup.addPreferredSuggestion("enables", "http://purl.obolibrary.org/obo/RO_0002327", "RO:0002327");
-        roLookup.addPreferredSuggestion("involved in", "http://purl.obolibrary.org/obo/RO_0002331", "RO:0002331");
-        roLookup.addPreferredSuggestion("part of", "http://purl.obolibrary.org/obo/BFO_0000050", "BFO:0000050");
-        roLookup.addPreferredSuggestion("enabled by", "http://purl.obolibrary.org/obo/RO_0002333", "RO:0002333");
-        roLookup.addPreferredSuggestion("occurs in", "http://purl.obolibrary.org/obo/BFO_0000066", "BFO:0000066");
-        roLookup.addPreferredSuggestion("causally upstream of or within", "http://purl.obolibrary.org/obo/RO_0002418", "RO:0002418");
-        roLookup.addPreferredSuggestion("has participant", "http://purl.obolibrary.org/obo/RO_0000057", "RO:0000057");
-        geneProductRelationshipField = new SuggestBox(roLookup);
+//        BiolinkOntologyOracle roLookup = new BiolinkOntologyOracle("RO");
+//        roLookup.addPreferredSuggestion("enables", "http://purl.obolibrary.org/obo/RO_0002327", "RO:0002327");
+//        roLookup.addPreferredSuggestion("involved in", "http://purl.obolibrary.org/obo/RO_0002331", "RO:0002331");
+//        roLookup.addPreferredSuggestion("part of", "http://purl.obolibrary.org/obo/BFO_0000050", "BFO:0000050");
+//        roLookup.addPreferredSuggestion("enabled by", "http://purl.obolibrary.org/obo/RO_0002333", "RO:0002333");
+//        roLookup.addPreferredSuggestion("occurs in", "http://purl.obolibrary.org/obo/BFO_0000066", "BFO:0000066");
+//        roLookup.addPreferredSuggestion("causally upstream of or within", "http://purl.obolibrary.org/obo/RO_0002418", "RO:0002418");
+//        roLookup.addPreferredSuggestion("has participant", "http://purl.obolibrary.org/obo/RO_0000057", "RO:0000057");
+//        geneProductRelationshipField = new SuggestBox(roLookup);
 
 
         // most from here: http://geneontology.org/docs/guide-go-evidence-codes/
@@ -312,7 +340,8 @@ public class GoPanel extends Composite {
     private void clearModal() {
         goTermField.setText("");
         goTermLink.setText("");
-        geneProductRelationshipField.setText("");
+//        geneProductRelationshipField.setText("");
+        geneProductRelationshipField.clear();
         geneProductRelationshipLink.setText("");
         evidenceCodeField.setText("");
         evidenceCodeLink.setText("");
@@ -336,7 +365,16 @@ public class GoPanel extends Composite {
             GoRestService.lookupTerm(goTermLink,selectedGoAnnotation.getGoTerm());
 
 
-            geneProductRelationshipField.setText(selectedGoAnnotation.getGeneRelationship());
+//            geneProductRelationshipField.setText(selectedGoAnnotation.getGeneRelationship());
+//            geneProductRelationshipField.setSelectedIndex(selectedGoAnnotation.getGeneRelationship());
+
+            // TODO: set the proper one when it comes back
+//            String selectedGeneRelationship = selectedGoAnnotation.getGeneRelationship();
+//            for(int i = 0 ; i < geneProductRelationshipField.getItemCount() ; i++){
+////                if(geneProductRelationshipField.setItemSelected(i,);)
+//            }
+
+
             geneProductRelationshipLink.setHref(RO_BASE + selectedGoAnnotation.getGeneRelationship().replaceAll(":", "_"));
             GoRestService.lookupTerm(geneProductRelationshipLink,selectedGoAnnotation.getGeneRelationship());
 
@@ -492,7 +530,7 @@ public class GoPanel extends Composite {
         GoAnnotation goAnnotation = new GoAnnotation();
         goAnnotation.setGene(annotationInfo.getUniqueName());
         goAnnotation.setGoTerm(goTermField.getText());
-        goAnnotation.setGeneRelationship(geneProductRelationshipField.getText());
+        goAnnotation.setGeneRelationship(geneProductRelationshipField.getSelectedItemText());
         goAnnotation.setEvidenceCode(evidenceCodeField.getText());
         goAnnotation.setNegate(notQualifierCheckBox.getValue());
         goAnnotation.setWithOrFromList(getWithList());

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
@@ -48,6 +48,11 @@
                     <b:ModalBody>
                         <b:Container fluid="true" width="100%">
                             <b:Row addStyleNames="{style.row}">
+                                <b:Column size="MD_2">
+                                    <b:Label>Aspect</b:Label>
+                                    <b:ListBox ui:field="aspectField"/>
+                                    <gwt:HTML ui:field="aspectLabel" />
+                                </b:Column>
                                 <b:Column size="MD_6">
                                     <b:Label>Go Term</b:Label>
                                     <b:SuggestBox ui:field="goTermField"/>
@@ -62,6 +67,7 @@
                             <b:Row addStyleNames="{style.row}">
                                 <b:Column size="MD_8">
                                     <b:Label>Relation between Gene Product and GO Term</b:Label>
+<!--                                    <b:SuggestBox ui:field="geneProductRelationshipField"/>-->
                                     <b:SuggestBox ui:field="geneProductRelationshipField"/>
                                     <gwt:Anchor ui:field="geneProductRelationshipLink" target="_blank"/>
                                 </b:Column>

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
@@ -48,7 +48,7 @@
                     <b:ModalBody>
                         <b:Container fluid="true" width="100%">
                             <b:Row addStyleNames="{style.row}">
-                                <b:Column size="MD_2">
+                                <b:Column size="MD_3">
                                     <b:Label>Aspect</b:Label>
                                     <b:ListBox ui:field="aspectField"/>
                                     <gwt:HTML ui:field="aspectLabel" />
@@ -58,7 +58,7 @@
                                     <b:SuggestBox ui:field="goTermField"/>
                                     <gwt:Anchor ui:field="goTermLink" target="_blank"/>
                                 </b:Column>
-                                <b:Column size="MD_4">
+                                <b:Column size="MD_3">
                                     <b:Label>Evidence Code</b:Label>
                                     <b:SuggestBox ui:field="evidenceCodeField"/>
                                     <gwt:Anchor ui:field="evidenceCodeLink" target="_blank"/>

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
@@ -68,7 +68,7 @@
                                 <b:Column size="MD_8">
                                     <b:Label>Relation between Gene Product and GO Term</b:Label>
 <!--                                    <b:SuggestBox ui:field="geneProductRelationshipField"/>-->
-                                    <b:SuggestBox ui:field="geneProductRelationshipField"/>
+                                    <b:ListBox ui:field="geneProductRelationshipField"/>
                                     <gwt:Anchor ui:field="geneProductRelationshipLink" target="_blank"/>
                                 </b:Column>
                                 <b:Column size="MD_2">

--- a/src/gwt/org/bbop/apollo/gwt/client/TrackPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/TrackPanel.java
@@ -247,6 +247,7 @@ public class TrackPanel extends Composite {
                 if (trackInfoList.isEmpty()) {
                     return true;
                 }
+                addTrackButton.setVisible(canAdminTracks());
                 return false;
             }
         }, delay);

--- a/src/gwt/org/bbop/apollo/gwt/client/dto/GoAnnotationConverter.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/dto/GoAnnotationConverter.java
@@ -2,6 +2,7 @@ package org.bbop.apollo.gwt.client.dto;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.json.client.*;
+import org.bbop.apollo.gwt.shared.go.Aspect;
 import org.bbop.apollo.gwt.shared.go.GoAnnotation;
 import org.bbop.apollo.gwt.shared.go.Reference;
 import org.bbop.apollo.gwt.shared.go.WithOrFrom;
@@ -23,6 +24,7 @@ public class GoAnnotationConverter {
         GWT.log("json object: "+object.toString());
 
         goAnnotation.setId(Math.round(object.get("id").isNumber().doubleValue()));
+        goAnnotation.setAspect(Aspect.valueOf(object.get("aspect").isString().stringValue()));
         goAnnotation.setGene(object.get("gene").isString().stringValue());
         goAnnotation.setGoTerm(object.get("goTerm").isString().stringValue());
         goAnnotation.setGeneRelationship(object.get("geneRelationship").isString().stringValue());

--- a/src/gwt/org/bbop/apollo/gwt/client/dto/GoAnnotationConverter.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/dto/GoAnnotationConverter.java
@@ -62,6 +62,7 @@ public class GoAnnotationConverter {
         if (goAnnotation.getId() != null) {
             object.put("id", new JSONNumber(goAnnotation.getId()));
         }
+        object.put("aspect", new JSONString(goAnnotation.getAspect().name()));
         object.put("gene", new JSONString(goAnnotation.getGene()));
         object.put("goTerm", new JSONString(goAnnotation.getGoTerm()));
         object.put("geneRelationship", new JSONString(goAnnotation.getGeneRelationship()));

--- a/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkOntologyOracle.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkOntologyOracle.java
@@ -23,11 +23,9 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
     private final Integer ROWS = 20;
     private final String FINAL_URL = "http://api.geneontology.org/api/search/entity/autocomplete/";
 
-    private String prefix = null;
+    private String prefix;
+    private String category = null;
     private JSONArray preferredSuggestions = new JSONArray();
-
-    public BiolinkOntologyOracle() {
-    }
 
     public BiolinkOntologyOracle(String prefix) {
         this.prefix = prefix;
@@ -47,6 +45,9 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
         String url = FINAL_URL + suggestRequest.getQuery() + "?rows=" + ROWS;
         if (prefix != null) {
             url += "&prefix=" + prefix;
+        }
+        if (category != null) {
+            url += "&category=" + category;
         }
 
         RequestBuilder rb = new RequestBuilder(RequestBuilder.GET, url);
@@ -124,5 +125,13 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
             Bootbox.alert("Request exception via " + e);
         }
 
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/rest/GoRestService.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/rest/GoRestService.java
@@ -44,7 +44,12 @@ public class GoRestService {
             public void onResponseReceived(Request request, Response response) {
                 JSONObject returnObject = JSONParser.parseStrict(response.getText()).isObject();
                 anchor.setHTML(returnObject.get("label").isString().stringValue());
-                anchor.setTitle(returnObject.get("definition").isString().stringValue());
+                if(returnObject.containsKey("definition")){
+                    anchor.setTitle(returnObject.get("definition").isString().stringValue());
+                }
+                else{
+                    anchor.setTitle(returnObject.get("label").isString().stringValue());
+                }
             }
 
             @Override

--- a/src/gwt/org/bbop/apollo/gwt/shared/go/Aspect.java
+++ b/src/gwt/org/bbop/apollo/gwt/shared/go/Aspect.java
@@ -1,0 +1,19 @@
+package org.bbop.apollo.gwt.shared.go;
+
+public enum Aspect {
+
+    BP("biological process"),
+    MF("molecular function"),
+    CC("cellular component"),
+    ;
+
+    private String lookup;
+
+    private Aspect(String lookupValue){
+        this.lookup = lookupValue ;
+    }
+
+    public String getLookup() {
+        return lookup;
+    }
+}

--- a/src/gwt/org/bbop/apollo/gwt/shared/go/GoAnnotation.java
+++ b/src/gwt/org/bbop/apollo/gwt/shared/go/GoAnnotation.java
@@ -8,6 +8,7 @@ public class GoAnnotation {
 
 
     private Long id ;
+    private Aspect aspect ;
     private String gene; // I think tis is the gene it refers to? I think the uniquename
     private String goTerm;
     private String geneRelationship;
@@ -16,6 +17,14 @@ public class GoAnnotation {
     private List<WithOrFrom> withOrFromList;
     private List<String> noteList;
     private Reference reference;
+
+    public Aspect getAspect() {
+        return aspect;
+    }
+
+    public void setAspect(Aspect aspect) {
+        this.aspect = aspect;
+    }
 
     public String getEvidenceCode() {
         return evidenceCode;

--- a/web-app/js/restapidoc/restapidoc.json
+++ b/web-app/js/restapidoc/restapidoc.json
@@ -2,14 +2,14 @@
    "basePath": "Fill with basePath config",
    "apis": [
       {
-         "jsondocId": "09b167ab-2a64-474b-b66b-801d7bb82da7",
+         "jsondocId": "d90fb729-462c-4701-9e56-67c8f37c1886",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4e49aa73-4857-412f-b60c-730a79a62b2a",
+                     "jsondocId": "f1c691c7-ee74-4cb8-a77e-dabd4fd0418d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -18,7 +18,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2664ae5a-620b-4e20-9a58-bde74332d0f9",
+                     "jsondocId": "a7c66b59-6512-4cad-8d59-84b99fb616b5",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -27,7 +27,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ce0b0265-c57f-47f3-abb3-45e9ac59e228",
+                     "jsondocId": "3538f1e5-f376-4cb1-b194-817d6bff3a54",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -36,7 +36,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1efcafdc-2dab-4046-a622-afa29beac288",
+                     "jsondocId": "85ce26b0-c972-41ff-b869-38cebad1b666",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -45,7 +45,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0df912d4-9ceb-47dd-aaa7-27bfdffb4f28",
+                     "jsondocId": "06a9def5-ef7c-4efa-8996-34008423d071",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','name':'gene01'}",
@@ -57,9 +57,9 @@
                "verb": "POST",
                "description": "Set name of a feature",
                "methodName": "setName",
-               "jsondocId": "f9c16a15-ef3b-4836-a3f7-f1918d90006c",
+               "jsondocId": "c1d99d71-f97d-4ab6-aae7-ca8c60aa9d17",
                "bodyobject": {
-                  "jsondocId": "1fc5b0f5-714d-468a-bd53-4d79778fa683",
+                  "jsondocId": "e7c2f1fa-7643-4c99-a352-c9b7faba7499",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -69,7 +69,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setName",
                "response": {
-                  "jsondocId": "4aa604c0-4e7f-4f3d-8b50-431ad4ee85ec",
+                  "jsondocId": "0d697bda-39cf-41ae-ac46-97d5b356f2dd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -82,7 +82,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b212e205-de4b-43af-83fb-9ffb0fb9256f",
+                     "jsondocId": "e421013b-5c68-4e9c-b392-7991a668b67c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -91,7 +91,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c5067129-fe80-4b08-8e9e-8ad1d9ae2305",
+                     "jsondocId": "abec2fe4-67e9-43fd-b829-6749397645c6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -100,7 +100,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "62e11174-6d37-44f7-a1a2-a77a3c8dbdd1",
+                     "jsondocId": "bbbe5ed4-900e-49be-a089-1a5507ea3868",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -109,7 +109,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "42952689-9a44-4c28-891a-a4f5e76786dc",
+                     "jsondocId": "ba843443-5f10-43fa-abad-75de6fd9f27e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -118,80 +118,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "172072ff-f1ce-4c83-9bef-a543d67d053e",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get comments",
-               "methodName": "getComments",
-               "jsondocId": "77989959-4ee2-4603-b6e5-97adeb960e0a",
-               "bodyobject": {
-                  "jsondocId": "b7affd85-e143-4316-bf77-783ff033938d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/getComments",
-               "response": {
-                  "jsondocId": "c0562607-fb4a-41f1-ae16-a6338b8b58cf",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "b1f334e4-1aea-4cfa-b750-9a3194964511",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "01ee258f-51cb-4303-aa39-86082b8445b7",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d41a76ee-05e2-4e10-ad35-e5e3618eeaea",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a4cc1d17-c696-4d03-aa9e-bbd5a84e4c71",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e4cf4cf4-f3d5-49c2-849d-dc7830dc9f0b",
+                     "jsondocId": "1ef688a7-ff7a-41a7-a173-d7d2a2b34b96",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','description':'some descriptive test'}",
@@ -203,9 +130,9 @@
                "verb": "POST",
                "description": "Set description for a feature",
                "methodName": "setDescription",
-               "jsondocId": "b3c20905-3482-4e7e-8b12-233760b0bae3",
+               "jsondocId": "9ce63b60-0f7a-4772-a76c-4d66364279a3",
                "bodyobject": {
-                  "jsondocId": "0cd29374-1af0-4258-b959-a09e7bcf125f",
+                  "jsondocId": "9c47c506-8aa1-4972-8724-819b8cdcdb6c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -215,7 +142,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setDescription",
                "response": {
-                  "jsondocId": "b45f8ee7-9407-4c8b-8d0c-9417ecd46b0b",
+                  "jsondocId": "202b1a1e-ac0e-4021-8dfe-e6a2ae45b12f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -228,7 +155,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b370ac2d-acc7-4fa1-ac45-5ba3f9e2cfd5",
+                     "jsondocId": "4771b408-4306-40d5-b2c8-472488303261",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -237,7 +164,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0771269f-6096-4c41-9ab5-46757f683bd2",
+                     "jsondocId": "552794bb-f241-4bd2-a726-914fc06ed894",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -246,7 +173,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1c75777c-c965-4130-b16a-16c6c991b843",
+                     "jsondocId": "b9f73a66-8c6b-4afc-a0c7-85034d0eaae4",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -255,7 +182,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "722a1166-b78c-4360-91d3-0dee7c3ee211",
+                     "jsondocId": "85a2f54e-b8ca-4da3-b013-19e2b9952784",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -264,7 +191,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d21722e1-3ebd-43f0-8a83-c47031ecf5bf",
+                     "jsondocId": "4db9a65e-6a89-48e5-aeed-6cc558feeddb",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','status':'existing-status-string'}.  Available status found here: /availableStatus/ ",
@@ -276,9 +203,9 @@
                "verb": "POST",
                "description": "Set status of a feature",
                "methodName": "setStatus",
-               "jsondocId": "5cd13cf3-db13-4d0e-941e-41fa9df6d917",
+               "jsondocId": "8e7ab7f9-565d-4aca-8ffc-1fa62aa53d09",
                "bodyobject": {
-                  "jsondocId": "249820ff-dc28-44c0-ab97-435d2e3fc423",
+                  "jsondocId": "46d56b10-9b70-498a-bd53-3f9246b99275",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -288,7 +215,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setStatus",
                "response": {
-                  "jsondocId": "90c823df-39b0-438e-b758-97685127dd1f",
+                  "jsondocId": "1e513723-4602-4cf7-a8db-3b8db6aa57e3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -301,7 +228,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4adfe712-7a98-410b-b757-34badf3f70a4",
+                     "jsondocId": "c5e3b91e-51aa-4a74-a7ae-b4600ae39120",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -310,7 +237,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "23c9de14-849a-432f-a4e1-7bfabc656367",
+                     "jsondocId": "da2a6e56-8055-4dac-b13e-47e2e22f11b7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -319,16 +246,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1295332-4824-4b0b-a339-0a6e7a925bbd",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2f8bd714-f842-47fd-813b-958123af452f",
+                     "jsondocId": "c49e84a3-d470-4b8c-a1ea-811aca778ce0",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -337,62 +255,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "633be3c5-0afb-49ec-9fce-9c7c4261b05b",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add attribute (key,value pair) to feature",
-               "methodName": "addAttribute",
-               "jsondocId": "23d757f9-6086-46cf-93b4-2d431beaf377",
-               "bodyobject": {
-                  "jsondocId": "58c13f56-af00-4109-aaf7-9fd2ce2ca45b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/addAttribute",
-               "response": {
-                  "jsondocId": "d42ec141-ad80-492d-bcab-a723fabadbd9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "63cfb63b-c39d-4336-9636-9ccff98e2a87",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "390cf2f2-7953-4831-96a9-081cb10407c4",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2b6d41a4-c173-4e04-ab73-c9031a37b09d",
+                     "jsondocId": "7b9ba183-d332-4ec0-bf2e-9a012aa5b990",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -401,89 +264,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "df2e5c4a-ae3e-4fa5-b6db-24b655d08ed5",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "08aa62d0-9e2a-499d-9628-0a882e2d7f35",
-                     "name": "features",
-                     "format": "",
-                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
-                     "type": "JSONArray",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Set symbol of a feature",
-               "methodName": "setSymbol",
-               "jsondocId": "dd52bd40-bfc8-41f8-b6b2-7daf1badfa5a",
-               "bodyobject": {
-                  "jsondocId": "0fe57372-338d-4c95-bf00-6b1b8fc5adbf",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "annotation editor"
-               },
-               "apierrors": [],
-               "path": "/annotationEditor/setSymbol",
-               "response": {
-                  "jsondocId": "4cf34595-4b17-437a-a3a2-302ee208dda8",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "annotation editor"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "a16d0141-67ee-4074-852b-0cea12a4b880",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "df0e693d-8d20-44da-9dc6-1d5d4299d238",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "86c720ce-6355-4039-8138-b0b0a12b2247",
-                     "name": "organism",
-                     "format": "",
-                     "description": "(optional) Organism ID or common name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "eb965d8a-50e9-4b50-8ab4-9204c8deab4c",
-                     "name": "sequence",
-                     "format": "",
-                     "description": "(optional) Sequence name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "87387731-67c8-44ac-9cbe-530e016ca1db",
+                     "jsondocId": "9c72a4a9-a0d0-45b4-a626-04686f259fa7",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -492,7 +273,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f00a68e5-58ce-4fd4-a308-c61cd17764b1",
+                     "jsondocId": "8437275d-9f3f-4180-a70d-db8456e91e62",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -501,7 +282,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "644cd34b-e530-4656-8e7d-9ea92fa10de9",
+                     "jsondocId": "3d7856a3-713e-4548-a3b1-56ef5c7174af",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -513,9 +294,9 @@
                "verb": "POST",
                "description": "Set exon feature boundaries",
                "methodName": "setExonBoundaries",
-               "jsondocId": "89b62f55-91ee-4de5-ae29-07d8fcc0b2a4",
+               "jsondocId": "866f0386-8a43-410f-b1f0-ae7f4847abff",
                "bodyobject": {
-                  "jsondocId": "aa850e50-0835-4cc2-86f9-8b53f187d774",
+                  "jsondocId": "e7ac6578-b2f1-4ccf-a2db-22e3f4baa6c1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -525,7 +306,153 @@
                "apierrors": [],
                "path": "/annotationEditor/setExonBoundaries",
                "response": {
-                  "jsondocId": "3cf993bb-8e44-4d04-a1d1-afe39846cd9a",
+                  "jsondocId": "af815c85-74e6-4a89-b04d-15dba5145884",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6c6a917b-4f33-4007-bf15-37690c2e2112",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dae1871e-1cbd-42ec-bb7c-7db746ffb9b0",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "66cf3018-f9bd-4a25-9ef2-65e519f1f0c4",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "24b5b461-7624-4dd6-a40f-4e2826d40e67",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "12034dbf-7731-4742-ad72-f223dd7e4ddb",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray of JSON feature objects ('uniquename' required) JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get comments",
+               "methodName": "getComments",
+               "jsondocId": "e6935604-dd66-406a-8fb7-260f9491bb67",
+               "bodyobject": {
+                  "jsondocId": "ead22899-c4de-41c9-b9f2-7a6a4421ef63",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/getComments",
+               "response": {
+                  "jsondocId": "e47f6fbb-9339-442f-952c-ea68c1cedde9",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "450e80b4-24fb-42af-bc09-4d58f62378c0",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1a634516-319e-41ca-9735-e8139041b302",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "69f53ea7-b844-4295-aaab-a1c3b170c0f8",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "db3a40cc-b324-4c66-9def-c2c498983e08",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3427d0b4-3d3a-4687-aa39-806ccd95c638",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','symbol':'Pax6a'}",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Set symbol of a feature",
+               "methodName": "setSymbol",
+               "jsondocId": "2b172fac-0ac9-4167-a8c9-6c7052a43219",
+               "bodyobject": {
+                  "jsondocId": "e59aaa57-47dc-45f0-8078-60a063c02433",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/setSymbol",
+               "response": {
+                  "jsondocId": "0b85afb3-0b47-4f8e-b2ab-6d6904019411",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -540,9 +467,9 @@
                "verb": "POST",
                "description": "Returns a translation table as JSON",
                "methodName": "getTranslationTable",
-               "jsondocId": "8ccc055e-f5d6-4a76-bea9-e2888f7bff61",
+               "jsondocId": "10d8ed43-6acd-4507-93f3-65724aac915a",
                "bodyobject": {
-                  "jsondocId": "8e34b693-ef52-44d6-9507-c8383448a551",
+                  "jsondocId": "b73c8e4a-75bf-434f-a613-0f8cbd4f079c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -552,7 +479,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getTranslationTable",
                "response": {
-                  "jsondocId": "4aff2c88-be3e-446e-8a85-f533d2620cb7",
+                  "jsondocId": "64471a0e-a823-4797-8155-c6e13694f8a1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -565,7 +492,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a70bf95e-09ba-4ca6-9f79-f3eb9052f484",
+                     "jsondocId": "8f4d7eac-4d8e-4f82-a98d-b141fbecd7f2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -574,7 +501,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4d2a29cc-3ce5-49e7-80c5-0cdd3d09cded",
+                     "jsondocId": "9e21b6cc-dfa4-4730-bfa4-046a3a72ce96",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -583,7 +510,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "613de8c6-1875-42e8-b531-a04bf38150af",
+                     "jsondocId": "c44ab22d-47b5-476e-8672-f3f70b281f41",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -592,7 +519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6268ef2c-9bf2-43d6-a640-d3a32a57fa7b",
+                     "jsondocId": "8563ef88-46e7-4d3a-9fa0-eca334babfab",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -601,7 +528,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c58fba76-07c8-4a6b-bdf1-1a0591403409",
+                     "jsondocId": "24c748f3-f39c-4942-8aef-9bae242b47de",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -610,7 +537,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4caa0ae-5344-4a8a-82ed-08a4b1a0f92b",
+                     "jsondocId": "050e11e0-b08c-4f1f-b1cd-9d02f8418fb9",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -619,7 +546,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f0965c2e-346b-4082-a502-9f8787c07fae",
+                     "jsondocId": "8fe8fcca-78fe-4f5a-944e-30d7118407a1",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -631,9 +558,9 @@
                "verb": "POST",
                "description": "Add non-coding genomic feature",
                "methodName": "addFeature",
-               "jsondocId": "dc08a9c0-4790-47b9-ac50-d55ac9c48d49",
+               "jsondocId": "76da7aac-9dd0-44c5-9d3a-29b37af7a1bc",
                "bodyobject": {
-                  "jsondocId": "8fa2f8f2-ab46-4eab-92b1-95f3ee9c5a72",
+                  "jsondocId": "4bcc2ab2-e8c3-4eb1-b6c9-c525aa52e724",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -643,7 +570,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addFeature",
                "response": {
-                  "jsondocId": "f81a8371-35cc-4134-9b86-12b2176be409",
+                  "jsondocId": "7eca2827-b207-450d-b70a-f8c42c90198a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -656,7 +583,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "eb6b25dc-dea0-4f2a-809b-f03dbd3f23a2",
+                     "jsondocId": "6ac5cddd-3aa3-48a8-972e-69ee31a17ea5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -665,7 +592,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "adae7af9-e091-455e-babe-40ba5bb6aa70",
+                     "jsondocId": "9b35c578-b233-4030-9612-2f4f4735eefb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -674,7 +601,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1ad332b-d876-4f23-bc59-48b4f75e10dc",
+                     "jsondocId": "ce13c23a-185c-4c29-a33a-6f924b865a4d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -683,7 +610,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6b96643c-cc26-4b44-ba24-29c44029a494",
+                     "jsondocId": "b9afdb9d-da12-4f88-9c80-12d53fbcee32",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -692,7 +619,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aeb546eb-7af7-4024-bc27-cd4250a1e7ab",
+                     "jsondocId": "4be40828-beaa-4046-a41b-bc376e39aaa7",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -701,7 +628,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9813ff5d-3ade-4949-bdb3-758b1b45975c",
+                     "jsondocId": "9934eb1a-ae5c-4346-b17f-25107da42a07",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -710,7 +637,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "868f7060-2249-4103-a7c7-b9c27c7fcbe9",
+                     "jsondocId": "56c817a1-f45b-4cfc-bebf-3ec9cfd81dc9",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -722,9 +649,9 @@
                "verb": "POST",
                "description": "Add an exon",
                "methodName": "addExon",
-               "jsondocId": "1bc1937c-66eb-4cec-abae-31819e467eec",
+               "jsondocId": "081d27cf-7ac9-4f7e-8e28-d745dfafcc72",
                "bodyobject": {
-                  "jsondocId": "4c6b9b66-b5a8-4ad0-8d34-6072f113a849",
+                  "jsondocId": "3534549f-ac04-4618-8216-590f017957fb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -734,7 +661,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addExon",
                "response": {
-                  "jsondocId": "fdcaf57b-45f7-40c1-97a7-23431044f832",
+                  "jsondocId": "5bf2df1a-bbbe-45f1-8f23-b381809dba7a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -747,7 +674,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f0fcac56-43fa-4b81-8ccc-ab8cc1be11df",
+                     "jsondocId": "7b91abac-9160-406f-a3e3-e68ac6db0d87",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -756,7 +683,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6eaf83e4-13c4-4061-876a-7f86b7b0b9fe",
+                     "jsondocId": "846972ca-c6df-4e27-b035-f99b8a0d0944",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -765,7 +692,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "364e9e3c-93d3-4c2f-a483-8626430aae48",
+                     "jsondocId": "d143d95a-2570-4a0d-a711-4b46c7582b4c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -774,7 +701,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db63bfde-7db9-4928-9c94-e33fbfe3427a",
+                     "jsondocId": "51a34b2f-fb3a-4ffc-902b-a8410e87924e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -783,7 +710,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d76d9789-9130-4274-b46a-5f8f127a8be9",
+                     "jsondocId": "35ac64e3-8c0a-49e7-96c4-a52654c7ee42",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -795,9 +722,9 @@
                "verb": "POST",
                "description": "Add comments",
                "methodName": "addComments",
-               "jsondocId": "d5f4f43a-5bd4-4e7d-ad38-8096dc52edb0",
+               "jsondocId": "b18c40aa-8faa-4e7b-895a-1c7480e1a3f2",
                "bodyobject": {
-                  "jsondocId": "0779be52-57a1-4e03-b85a-b180de7e7b8b",
+                  "jsondocId": "c1d48848-06f7-43f4-ad68-785d5bc8c00d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -807,7 +734,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addComments",
                "response": {
-                  "jsondocId": "4ce89f66-afd1-4395-b474-2ec00a649f15",
+                  "jsondocId": "67549a14-78e1-458a-a9cc-d41fcc9ecf9e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -820,7 +747,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "5bda2b23-a000-4851-a188-618689551659",
+                     "jsondocId": "e38323f8-1c43-48fa-ab33-18bc68d16920",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -829,7 +756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0dea5968-fffa-4e6c-a860-dca202981962",
+                     "jsondocId": "01d34e1d-f7b6-41ae-aa5a-ecac7f96f0d3",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -838,7 +765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f6c1a27c-dca3-4841-b340-1f134dbd196e",
+                     "jsondocId": "290f9c89-7547-40f8-8d63-ce162ed17d73",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -847,7 +774,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "516c43a5-13e1-4e1b-a00e-e899bb0f6d34",
+                     "jsondocId": "741e76a1-29e6-498c-ac23-ad10e0d29ec6",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -856,7 +783,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9b8c264a-034f-4673-8eb9-2e56745aa734",
+                     "jsondocId": "4a3024f8-dd15-4a44-a8a0-ae1bd6f601f6",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -868,9 +795,9 @@
                "verb": "POST",
                "description": "Delete comments",
                "methodName": "deleteComments",
-               "jsondocId": "6881ae88-f8ba-45a2-970e-8e46402defd2",
+               "jsondocId": "bfb9eb4d-490b-42d5-a4e9-e38d76b960b0",
                "bodyobject": {
-                  "jsondocId": "99bd9d56-e36b-4b9b-a82a-39959d6ca303",
+                  "jsondocId": "43a7046e-5bee-4e27-85f6-7bc63a3e3b27",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -880,7 +807,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteComments",
                "response": {
-                  "jsondocId": "e0b41d47-b281-44f0-80ec-7fd9a4249920",
+                  "jsondocId": "d5c50a56-9056-478c-be9b-356d32c75825",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -893,7 +820,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0c9cdd48-5f08-4880-a5eb-004c302459e5",
+                     "jsondocId": "7d6c5fb9-4183-41a5-9dd0-cd5572d2261c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -902,7 +829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c78054f0-de3c-4e14-86dd-bae9b157cf62",
+                     "jsondocId": "413bbd4c-9296-41b2-9caf-5ccf8ac095bc",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -911,7 +838,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6760247c-765f-4e01-9724-3457f217f63d",
+                     "jsondocId": "738e9edf-c7d1-458f-8509-381639dc4503",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -920,7 +847,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f03e0f79-a941-4461-ba9d-eb1710f14bfa",
+                     "jsondocId": "3c73d8c8-0732-46da-a8e8-4ce2a6c9123d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -929,7 +856,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8a87223b-da80-4657-ab78-ed6670da82ff",
+                     "jsondocId": "847972a8-0e4e-4663-b254-2196f043599a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects ('uniquename' required) that include an added 'old_comments','new_comments' JSONArray described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -941,9 +868,9 @@
                "verb": "POST",
                "description": "Update comments",
                "methodName": "updateComments",
-               "jsondocId": "1ee512d0-f998-445b-8d5c-fca9dcea46e9",
+               "jsondocId": "bb48935a-1254-481f-b36e-52c21cb3116a",
                "bodyobject": {
-                  "jsondocId": "1a631fbd-2d7b-4316-ab02-861455b42410",
+                  "jsondocId": "982314ab-303b-4e3d-91b6-ae71f8ae42c1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -953,7 +880,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateComments",
                "response": {
-                  "jsondocId": "c941dd3c-0672-491f-ada7-cce9e0104042",
+                  "jsondocId": "0b1578ca-8e78-4b95-b7c5-9972814171ac",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -966,7 +893,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b9e7852a-7d2c-4af7-a7ff-433b8a343f38",
+                     "jsondocId": "4ef90d85-4669-4d81-9070-189da497fa12",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -975,7 +902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "303e908e-b38c-4ca5-98f2-db8841cdb763",
+                     "jsondocId": "06d19e76-cbe7-4e68-8493-284513c7093e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -984,7 +911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "034fac58-d3ff-48ed-94e9-1fad8c6a4790",
+                     "jsondocId": "f036bb7a-faf6-4df7-81d0-19ad1c46b6e9",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -993,7 +920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ec48d3b6-b6fb-44bb-8660-5e28ab7e1861",
+                     "jsondocId": "6097338d-7f90-495a-b48e-563cd4a5868a",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1002,7 +929,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7d79bc62-e89f-49da-8faa-848ac8f3981d",
+                     "jsondocId": "7978c1da-e11d-49dd-b945-7abe926e44b0",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1011,7 +938,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d150401e-d861-4e97-aff1-e89448777ad7",
+                     "jsondocId": "7a32921f-ccb6-4ba5-930b-0a94012812db",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1020,7 +947,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fa400e70-4671-4f4a-bdd3-0775c46e2880",
+                     "jsondocId": "97fbad6c-71e6-4783-8b53-093e77342aea",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of JSON feature objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/Feature.groovy",
@@ -1032,9 +959,9 @@
                "verb": "POST",
                "description": "Add transcript",
                "methodName": "addTranscript",
-               "jsondocId": "62dfa961-9b51-444e-ae5b-f906ce4e1e90",
+               "jsondocId": "07ac1086-453a-419a-9479-a0c5fc7700d8",
                "bodyobject": {
-                  "jsondocId": "5fa66edf-6971-4351-afdb-7af8490b7bc1",
+                  "jsondocId": "4ed47f8e-9a41-4dff-959f-60e5830f4901",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1044,7 +971,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addTranscript",
                "response": {
-                  "jsondocId": "a0d85a1e-90cc-48b5-a36a-616873f32a6f",
+                  "jsondocId": "0757910e-a33e-470d-b338-aec44d93e9dc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1057,7 +984,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "65dc5e0e-bfb5-4766-9229-8da7cb60671b",
+                     "jsondocId": "54fec84e-268e-46d4-a0bc-57040e7537f9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1066,7 +993,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b8d09fda-406c-45ae-8e64-6a15d17c5c5c",
+                     "jsondocId": "8e7fad45-5cf8-4574-a638-56f85ef82b25",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1075,7 +1002,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fb136835-76e6-45de-a4b6-fdd59dd965ae",
+                     "jsondocId": "71c3ff54-ccbf-4894-bbcc-0eace602938b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1084,7 +1011,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8464f379-d2f5-4431-993e-86818a7a34fe",
+                     "jsondocId": "7e3b6920-dd5e-45d7-9cbb-5ecd63b5d256",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1093,7 +1020,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9916ba1d-8f9e-476d-a229-3b36113c515b",
+                     "jsondocId": "cb7b38c1-9a5f-4f4c-91d0-eb4c894123b0",
                      "name": "suppressHistory",
                      "format": "",
                      "description": "Suppress the history of this operation",
@@ -1102,7 +1029,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3bd22132-dc3f-4a2b-be29-d46a9cd78e6e",
+                     "jsondocId": "0bfadee3-47aa-4f02-985b-cf8176088e4c",
                      "name": "suppressEvents",
                      "format": "",
                      "description": "Suppress instant update of the user interface",
@@ -1111,7 +1038,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e206fcfd-28b1-4af6-aa0a-68134519cf23",
+                     "jsondocId": "9ed55d92-0d41-435f-beb2-d232ca824854",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains 'uniquename'",
@@ -1123,9 +1050,9 @@
                "verb": "POST",
                "description": "Duplicate transcript",
                "methodName": "duplicateTranscript",
-               "jsondocId": "2ebc7969-4d9d-4ea3-b290-3f449a2e9ac0",
+               "jsondocId": "940343d2-d06c-499f-a038-945bd44e3a9d",
                "bodyobject": {
-                  "jsondocId": "726607d1-9f0b-4293-bda8-25873c255324",
+                  "jsondocId": "fd475b76-dbb2-4a7e-aae8-bade78c54255",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1135,7 +1062,7 @@
                "apierrors": [],
                "path": "/annotationEditor/duplicateTranscript",
                "response": {
-                  "jsondocId": "5ebe2706-674b-4f34-ab17-5735b3ce32f8",
+                  "jsondocId": "27875da2-22e1-4f15-b067-62df0b700eeb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1148,7 +1075,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6fe6f92e-9862-4dca-af8f-232177fdd3ba",
+                     "jsondocId": "895bcf3b-918c-498a-85c6-2119e0d90aa6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1157,7 +1084,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "946539ae-2df2-448e-82be-a4d262882f37",
+                     "jsondocId": "d99d5eb8-440b-4d52-8cf6-a747dead43bf",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1166,7 +1093,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7190399d-c505-45ac-a710-6d11dd23b6c9",
+                     "jsondocId": "b5e758c5-6fe9-4783-8a17-474e470e7e3c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1175,7 +1102,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "03f6884f-c6f6-4b9a-b2ac-4581f4727502",
+                     "jsondocId": "80256033-8ed8-4323-8806-3cb6ddc6f72b",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1184,7 +1111,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5389c1d9-7502-427a-aa6a-1e57e79ccba7",
+                     "jsondocId": "af51fd3d-4f3a-447c-9cf2-686fdba7e87f",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -1196,9 +1123,9 @@
                "verb": "POST",
                "description": "Set translation start",
                "methodName": "setTranslationStart",
-               "jsondocId": "b3f87434-fda6-4894-b0b3-bfc96d3d8365",
+               "jsondocId": "31e01a37-7509-493d-a85d-29135dbed86b",
                "bodyobject": {
-                  "jsondocId": "99d650b4-34bc-490d-94c1-2fc988d4b854",
+                  "jsondocId": "1bf153bb-1f86-4879-bac4-89ae483a03c1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1208,7 +1135,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationStart",
                "response": {
-                  "jsondocId": "9bc9740d-22e7-489b-abdf-fcf38fd88b0d",
+                  "jsondocId": "c2fe5e8c-4fed-4662-9001-d48495a11249",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1221,7 +1148,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "cbab1aee-28f9-4824-ba0f-3653489ae958",
+                     "jsondocId": "aad55c49-49c1-4fa6-bbd4-8f26236bc876",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1230,7 +1157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4459628-2bc3-495b-8ea2-3a282797650b",
+                     "jsondocId": "0069aa25-3d5d-46d5-b74f-63d3c13b428f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1239,7 +1166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3831fd90-3aaf-4981-bd87-856faec1e6c5",
+                     "jsondocId": "6309f7dd-613d-4f77-ba0c-8137500df6c6",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1248,7 +1175,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c43bad0f-d50b-4fd3-8c80-200e2c2085c5",
+                     "jsondocId": "4cb2f90b-7e4b-450f-9e2f-214952d2f5fb",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1257,7 +1184,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aed96e3a-4908-4a94-9977-a59dc7a4239a",
+                     "jsondocId": "fb25fb02-1901-4509-a13b-c81c2615db83",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmax':12}}",
@@ -1269,9 +1196,9 @@
                "verb": "POST",
                "description": "Set translation end",
                "methodName": "setTranslationEnd",
-               "jsondocId": "047d127c-3efa-4c6d-a18b-5158d29a4556",
+               "jsondocId": "33b27561-da77-4a8e-b7ad-34ad3a618bc0",
                "bodyobject": {
-                  "jsondocId": "b51dd193-e095-407c-b7da-932c4be9b0e6",
+                  "jsondocId": "9404a441-7e13-4640-bec3-28e66d11019d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1281,7 +1208,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setTranslationEnd",
                "response": {
-                  "jsondocId": "762e4c67-be42-4c6f-bb91-54551e7e3b86",
+                  "jsondocId": "12fb1309-fc17-485b-bd13-ca4bfc9c47e9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1294,7 +1221,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "774bbaac-4eb3-4b48-950c-41eede624b0f",
+                     "jsondocId": "e73e356a-c60d-4421-82c0-6191d025da28",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1303,7 +1230,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f3ceec97-27d1-4a34-ad0b-292278444a93",
+                     "jsondocId": "60ce4ed5-f79f-476d-a0b7-bcadef4c76bd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1312,7 +1239,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "40e0e94a-5d6a-4481-8e28-a300b71f5c4a",
+                     "jsondocId": "36e2102a-a24d-4bd8-b7bf-4a49896ec7a6",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1321,7 +1248,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "156566e1-a896-4416-9277-2f97308a6eae",
+                     "jsondocId": "a9eada5e-3d25-42fa-9f3b-4ea14c889da5",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1330,7 +1257,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "daeabc66-5434-4e16-a501-75ac5b1296f6",
+                     "jsondocId": "553a7374-7c35-4c00-b47b-669c092df463",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234'}",
@@ -1342,9 +1269,9 @@
                "verb": "POST",
                "description": "Set longest ORF",
                "methodName": "setLongestOrf",
-               "jsondocId": "8b2e752d-12be-411f-a32b-bfa047f7afd7",
+               "jsondocId": "b20042ff-ddd6-48e3-a38f-e850bb5012c9",
                "bodyobject": {
-                  "jsondocId": "9f1ed6d7-616f-47db-8af0-a2e54b5bf5e0",
+                  "jsondocId": "28463217-a862-45de-a559-f1b802b000fa",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1354,7 +1281,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setLongestOrf",
                "response": {
-                  "jsondocId": "794eb419-8d61-45d9-8955-c319e3084ed8",
+                  "jsondocId": "d1170c9a-86d4-4626-bce8-c35a1cf3c99e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1367,7 +1294,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "55dd69e5-1286-4f1f-abe6-eb934f204a72",
+                     "jsondocId": "1352b35b-5fec-4d4e-a989-69517f5db82c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1376,7 +1303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0da7e49e-a715-487f-b38b-c6a242458b48",
+                     "jsondocId": "a75aeac9-e591-46ef-90b3-140b7da1e917",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1385,7 +1312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7637fe5d-eef8-424d-b01e-6f030979d0fe",
+                     "jsondocId": "a3e3a7d8-e73b-498b-ad8c-e9f731bbec9b",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1394,7 +1321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7badef49-ef7d-42a6-8827-7ef0ca1eaacc",
+                     "jsondocId": "60c7a0d1-e207-48ce-bfc9-5290d9bf8614",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1403,7 +1330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "14a59b0c-ed85-4d16-814a-143be6a717ef",
+                     "jsondocId": "a64355d4-2eec-48a8-bd5b-0fce520c0f79",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -1415,9 +1342,9 @@
                "verb": "POST",
                "description": "Set boundaries of genomic feature",
                "methodName": "setBoundaries",
-               "jsondocId": "ea767ab9-0c7f-43f5-a174-fb677b2c8a78",
+               "jsondocId": "e87aac58-fe75-4b4b-9923-b82454892bb5",
                "bodyobject": {
-                  "jsondocId": "bccfc7c8-101f-44d7-bc58-d3789ae5f459",
+                  "jsondocId": "719a6607-a9be-4085-a6d6-f26f646964fe",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1427,7 +1354,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setBoundaries",
                "response": {
-                  "jsondocId": "d05abdd8-a74a-44b5-b693-0d4f3db5884e",
+                  "jsondocId": "9dcfc758-94d9-4e1b-a266-dac99f3c63ff",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1440,7 +1367,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d8a098c3-7faa-487e-b8a5-57584d5949bd",
+                     "jsondocId": "d0133ea3-266c-44dc-8c2a-d81be9695a08",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1449,7 +1376,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bce0841e-bfc2-4d7a-99d9-1322629689ca",
+                     "jsondocId": "27c644ad-c25e-4694-9ec3-af06852062cd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1458,7 +1385,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9ee188b4-cec7-4c0d-b3fd-bad85ec8ce71",
+                     "jsondocId": "eed0b88d-0880-4232-b24d-3528d028d7eb",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1467,7 +1394,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c2251337-6409-4ce8-a93b-f45610bbf545",
+                     "jsondocId": "b7658b84-aec2-46fc-a2ea-ecbf49ffecd2",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1479,9 +1406,9 @@
                "verb": "POST",
                "description": "Get all annotated features for a sequence",
                "methodName": "getFeatures",
-               "jsondocId": "a0384163-ef6e-4dca-ba5f-007d6a3d42b4",
+               "jsondocId": "4ce44111-3441-4459-a947-4d371e50cbdb",
                "bodyobject": {
-                  "jsondocId": "5d81337b-db95-41cc-bda4-1689919f6901",
+                  "jsondocId": "b645e5cc-cbaf-4ff9-a0d4-deac580738dd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1491,7 +1418,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getFeatures",
                "response": {
-                  "jsondocId": "cb45219c-44ba-441c-9390-a34cbbb01d75",
+                  "jsondocId": "ab1c5065-39ff-4992-b24c-e172ae9764f8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1504,7 +1431,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6e97379b-802d-4840-a1a0-c9d97e31ac89",
+                     "jsondocId": "8158bde3-7d1a-4386-a003-723e727d9544",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1513,7 +1440,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "52285ed1-4f79-4cca-93d3-b522d6ff5d08",
+                     "jsondocId": "511718a9-7c9d-4ab9-a208-f89d55d3bff2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1522,7 +1449,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d9fb4330-ef63-4692-98c1-14a65dabf231",
+                     "jsondocId": "a5f8eac0-5865-4ade-9898-285a42d5b8f3",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1531,7 +1458,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "861663e6-dbc4-4902-a270-48806f1b8cfb",
+                     "jsondocId": "948f121a-bbe1-41d4-83da-5d37e4734774",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1543,9 +1470,9 @@
                "verb": "POST",
                "description": "Get sequence alterations for a given sequence",
                "methodName": "getSequenceAlterations",
-               "jsondocId": "34d0e883-524a-4363-8e3c-694dd6ba0e4f",
+               "jsondocId": "5a543430-143e-4f1d-91e9-d5d23ab90190",
                "bodyobject": {
-                  "jsondocId": "7656a9ba-414f-4714-8c3a-cea6b26c6c8a",
+                  "jsondocId": "814f0823-41f6-4f43-bb36-76b1b930a97b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1555,7 +1482,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequenceAlterations",
                "response": {
-                  "jsondocId": "dd2a84aa-9108-4ecb-8485-09c35b5efea6",
+                  "jsondocId": "f8f97417-71d0-4531-8a80-df77532cbc74",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1568,7 +1495,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c4d567b3-411c-4e1f-ab36-cb4a19293940",
+                     "jsondocId": "c405a328-a7ee-489a-8c80-4f63cbc68582",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1577,7 +1504,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2d16bfe8-c0c7-462d-93a4-b841c0efe94b",
+                     "jsondocId": "0e3647f2-87a1-4091-827d-a6831ebae55f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1586,7 +1513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "47552aa6-ce38-463b-a7fe-231fc23c6472",
+                     "jsondocId": "d1a7e90a-9ecf-4602-a324-4fab0f938e6f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1595,7 +1522,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "52bae1fa-abae-4048-8740-24a588532e63",
+                     "jsondocId": "93616e7c-c6aa-4904-931b-000052172fc3",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1604,7 +1531,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c46690e2-b3ff-41f5-899e-01b7a375261c",
+                     "jsondocId": "d5c9629e-64de-44a3-b0d3-5a4297e97021",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
@@ -1616,9 +1543,9 @@
                "verb": "POST",
                "description": "Delete attribute (key,value pair) for feature",
                "methodName": "deleteAttribute",
-               "jsondocId": "fcc0f50b-2d85-4caa-9d12-686de49feee1",
+               "jsondocId": "4a0cb9cf-108b-49ea-bb64-d19686120231",
                "bodyobject": {
-                  "jsondocId": "fc61ac06-b87f-445d-baa2-d2c64e7f5b1d",
+                  "jsondocId": "3e1b8354-c584-4144-8d16-695ee2550610",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1628,7 +1555,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteAttribute",
                "response": {
-                  "jsondocId": "825df5bf-d97b-4a18-a19f-8f0b471d96ed",
+                  "jsondocId": "fdb6bfe6-61d6-44cf-97ed-e2ca40ae1c5e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1641,7 +1568,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "35cf0d0f-78b0-4d14-b1d9-1f606476410b",
+                     "jsondocId": "2dba7415-f435-44b8-8416-33f92ad12dfc",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1650,7 +1577,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8e9a92c0-9143-4746-874b-3aa68dbde84a",
+                     "jsondocId": "bcc1cc2a-9da7-490d-b2c4-d2c244eec121",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1659,7 +1586,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e1b061d-615a-4421-9cea-788dca683141",
+                     "jsondocId": "d16a1aca-1bdb-4fb8-a319-445016206494",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1668,7 +1595,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c07b68c6-8b4d-4538-a6ac-b170f4ecab07",
+                     "jsondocId": "5777e58e-e8cf-4ecd-9def-a4b139e85a95",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1677,7 +1604,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "48130207-03ed-42ef-855d-b386fcd90ca8",
+                     "jsondocId": "1343b481-915c-49ea-82ce-33273854f4ab",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_non_reserved_properties':[{'color': 'red'}], 'new_non_reserved_properties': [{'color': 'green'}]}.",
@@ -1689,9 +1616,9 @@
                "verb": "POST",
                "description": "Update attribute (key,value pair) for feature",
                "methodName": "updateAttribute",
-               "jsondocId": "0e9d4dd9-c3c9-4292-86b2-008f4c8a9143",
+               "jsondocId": "ab0e362d-47a1-4e9d-9867-064dd9a0fa5b",
                "bodyobject": {
-                  "jsondocId": "c8ae6109-6bb0-4535-8262-c3ecc5f3e805",
+                  "jsondocId": "92af8403-06d6-4612-b3c6-d57e3ab6e594",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1701,7 +1628,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateAttribute",
                "response": {
-                  "jsondocId": "0720bac2-abdf-4175-bab5-6043e05055d3",
+                  "jsondocId": "14d62297-16e0-471b-a040-10b29c307d0d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1714,7 +1641,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8bf155bf-f08a-4f27-9f96-4d7f1deb1e0a",
+                     "jsondocId": "0dbaf840-47da-41c5-8fec-9959c147affb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1723,7 +1650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "61a31a38-4d0b-422f-ab30-6cdfd277af28",
+                     "jsondocId": "63564c5d-e382-4e36-be1d-7525eacf3546",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1732,7 +1659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2a8c78a4-2df8-47cd-9ba7-aac968f3bc5e",
+                     "jsondocId": "9e9b61a6-195f-4515-aa35-41f975f4a458",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1741,7 +1668,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4643d158-7b7e-4c3c-ae01-8884156fec76",
+                     "jsondocId": "6ab4acc4-838a-4f60-b448-d72ed65cf85e",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1750,7 +1677,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "545e60eb-6186-4602-9fc8-e2cae8503e4c",
+                     "jsondocId": "117bc3f3-5e9d-4d18-872f-db835fed1a78",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1762,9 +1689,9 @@
                "verb": "POST",
                "description": "Add dbxref (db,id pair) to feature",
                "methodName": "addDbxref",
-               "jsondocId": "4bdbeaae-ea93-4160-bd96-d532bdb072df",
+               "jsondocId": "414330f5-0f96-4bdf-ab01-edb044f0df35",
                "bodyobject": {
-                  "jsondocId": "25487ea7-dbb0-4ba4-931c-32ac44f3e623",
+                  "jsondocId": "36155326-0c79-47c6-9539-111a31b9048b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1774,7 +1701,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addDbxref",
                "response": {
-                  "jsondocId": "0ed16e2f-bd44-429b-bc2f-12b7d9db7ccf",
+                  "jsondocId": "871f98d7-5ab9-47f5-9b80-2fa76d67e953",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1787,7 +1714,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "3df12df6-ae7d-42ba-9715-6cc4fbc9c411",
+                     "jsondocId": "d4e80d59-b69c-4c2c-b8cf-dd8a2c7a1f50",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1796,7 +1723,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a218876a-c667-4011-a6f3-179e72b469ff",
+                     "jsondocId": "50fe4620-c841-4ef8-9f23-8306e550bb5a",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1805,7 +1732,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d84250b-8c41-418f-8642-4510566c7a98",
+                     "jsondocId": "bc6326ad-728a-4d99-b7c5-d6c69a93d24f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1814,7 +1741,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "007bd1ad-70de-4fd0-b1c2-5b94e3c61d9b",
+                     "jsondocId": "0e2efe78-ffb1-4893-8590-8ad101d36aa4",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1823,7 +1750,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "53c0d240-a4bc-43c0-9252-2ff98ab7fc9c",
+                     "jsondocId": "ebc4b18f-2bbb-407b-a3ab-1c12a661fdfa",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','old_dbxrefs': [{'db': 'PMID', 'accession': '19448641'}], 'new_dbxrefs': [{'db': 'PMID', 'accession': '19448642'}]}.",
@@ -1835,9 +1762,9 @@
                "verb": "POST",
                "description": "Update dbxrefs (db,id pairs) for a feature",
                "methodName": "updateDbxref",
-               "jsondocId": "1944ae72-2689-421d-8509-e3c0b2eb1378",
+               "jsondocId": "a32f7e49-021f-4328-8a50-13b466869f14",
                "bodyobject": {
-                  "jsondocId": "adc9c291-647a-4d7c-833d-e7263dcd53d4",
+                  "jsondocId": "6148a3ab-d49d-45d9-8cca-5e27f7805ff0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1847,7 +1774,7 @@
                "apierrors": [],
                "path": "/annotationEditor/updateDbxref",
                "response": {
-                  "jsondocId": "b6d3fde1-b246-41dd-85cf-06cb24acaab9",
+                  "jsondocId": "e1e3578c-0c29-4a26-98b5-f92649a1ec73",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1860,7 +1787,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b5bc98f8-dc85-4184-b979-fbed4ac0b80c",
+                     "jsondocId": "0fa30283-3009-446f-a882-b1dc7f75f144",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1869,7 +1796,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ea457775-b853-4b32-aacc-2959d998f569",
+                     "jsondocId": "1850f2d9-5806-4cd0-95f9-5a01f95d9eaf",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1878,7 +1805,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1bfbf628-7c97-4e1a-aef8-2ccb0ce66fa0",
+                     "jsondocId": "5bb80084-1846-433d-9743-3fde4f144dfc",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1887,7 +1814,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff3490fd-c0f4-4c7c-81f2-ce0aedf72bbb",
+                     "jsondocId": "b75aec77-faaa-43f8-b105-2eaebd638449",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1896,7 +1823,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b7ca12a-bfef-4d58-bfba-e7ff8726a9fe",
+                     "jsondocId": "13c17437-49af-4905-bd47-a7a8309fc0f8",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','dbxrefs': [{'db': 'PMID', 'accession': '19448641'}]}.",
@@ -1908,9 +1835,9 @@
                "verb": "POST",
                "description": "Delete dbxrefs (db,id pairs) for a feature",
                "methodName": "deleteDbxref",
-               "jsondocId": "2cbd52a9-2fa2-4cf8-b35f-303b07594658",
+               "jsondocId": "35e79adb-75d3-4be5-ac0d-1051fb710acc",
                "bodyobject": {
-                  "jsondocId": "53301bf5-031c-47b2-b33b-d8bb1356fa4d",
+                  "jsondocId": "d77c7c30-6db4-446f-bfff-bdfa6eaf010e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1920,7 +1847,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteDbxref",
                "response": {
-                  "jsondocId": "6b5bd222-fa72-4ef7-8274-3b68f6732d2a",
+                  "jsondocId": "96c7db32-e8ff-421d-b956-ee8f4b5edf47",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -1933,7 +1860,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "404b93e6-34dd-40cf-89e1-34c7300e54cc",
+                     "jsondocId": "3bf4c1c9-5185-4067-a0de-a2e712bffbf2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -1942,7 +1869,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "093bd5c5-a160-461b-b46e-30cd1d34402c",
+                     "jsondocId": "255f3bc5-85ec-4bb5-844b-a505f1c94241",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -1951,7 +1878,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "75a83ced-fcd5-432d-afb3-716205348e3b",
+                     "jsondocId": "f8acf8d4-c72f-425a-a9e4-53f78d3f60cd",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -1960,7 +1887,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7f0cb037-4dd0-42ab-a117-c74f06db4af7",
+                     "jsondocId": "4e826990-7ea3-46d8-9218-faef310c9869",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -1969,7 +1896,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "58313436-f128-44f1-aa73-57ae06232c85",
+                     "jsondocId": "ab3a8188-372e-4628-a6cc-f82ca46390e6",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with one feature object {'uniquename':'ABCD-1234'}",
@@ -1981,9 +1908,9 @@
                "verb": "POST",
                "description": "Set readthrough stop codon",
                "methodName": "setReadthroughStopCodon",
-               "jsondocId": "6b377a8e-4385-4b86-8138-63f9d60af708",
+               "jsondocId": "37c74339-6b18-47ef-b80e-240ad97b75c5",
                "bodyobject": {
-                  "jsondocId": "e5e6d461-ee25-4e3d-bf1c-26670a090341",
+                  "jsondocId": "8cb5d0f2-14c7-4a3b-a630-5e6c3f78a956",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -1993,7 +1920,7 @@
                "apierrors": [],
                "path": "/annotationEditor/setReadthroughStopCodon",
                "response": {
-                  "jsondocId": "a0b7459d-8be6-46c0-8b23-5f38dea91c2d",
+                  "jsondocId": "daec0e9b-6836-4917-8c23-f067cd0fd4ca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2006,7 +1933,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "82adaa72-0bd1-4d2d-b3db-0fee1319c249",
+                     "jsondocId": "94147c04-3e9f-42ca-af92-df70bb2b80ba",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2015,7 +1942,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e32000f6-5022-4fc1-b5a8-4928dcba331c",
+                     "jsondocId": "a3c5ef9a-b3cc-46d7-913e-716984152676",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2024,7 +1951,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "50446f77-e588-49e5-9507-77c90ad3bc56",
+                     "jsondocId": "e9beaec4-863b-4d08-9d8f-1240fc93eee4",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2033,7 +1960,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d4d1ed63-fe9a-4ae7-9d6c-36cbc617a628",
+                     "jsondocId": "de4c8cf5-f8b0-4ba1-9b16-22e4b36432e3",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2042,7 +1969,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ee90c9b2-3196-4b86-b42f-0e1e70e92bfb",
+                     "jsondocId": "0fe6d4c4-1598-4986-a647-aab3aab37824",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration (Insertion, Deletion, Substituion) objects described by https://github.com/GMOD/Apollo/blob/master/grails-app/domain/org/bbop/apollo/",
@@ -2054,9 +1981,9 @@
                "verb": "POST",
                "description": "Add sequence alteration",
                "methodName": "addSequenceAlteration",
-               "jsondocId": "c0994c9c-1757-4310-a1d8-c54fa3238dff",
+               "jsondocId": "b2aeab31-7a52-490c-a5cf-ccd54809f599",
                "bodyobject": {
-                  "jsondocId": "fa3e653c-2607-42ab-b4ea-af2574fdcce7",
+                  "jsondocId": "19e6037d-67ed-4bdd-a001-95bd725d06f3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2066,7 +1993,7 @@
                "apierrors": [],
                "path": "/annotationEditor/addSequenceAlteration",
                "response": {
-                  "jsondocId": "a897cbd6-494b-4a62-8dae-069823e47fd4",
+                  "jsondocId": "b724b69f-ff15-421d-ae85-6dab49e2587b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2079,7 +2006,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "eaea92ee-ee70-4e6e-979b-d4ff719f9af6",
+                     "jsondocId": "204d190b-9b7d-4903-b1a7-e1e60d58a9a8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2088,7 +2015,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b0ae7f88-7916-4399-9bf3-3a4d66b26d31",
+                     "jsondocId": "abafc652-c25d-41cb-9a8d-3d2f732df4fd",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2097,7 +2024,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "249d513d-d64e-4e0c-9ed9-91283f8c0b4a",
+                     "jsondocId": "b9c79b4b-899c-425c-8136-2790ff6257be",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2106,7 +2033,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ac6c27fd-2ccf-4a72-b65c-4b34ee70eb8d",
+                     "jsondocId": "cd7b2a30-a746-4a96-b18c-d9008c857d49",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2115,7 +2042,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "20581a83-9686-4ba1-bd8d-0b1cbd369836",
+                     "jsondocId": "585e12c7-0548-4d64-a905-5e8702a77b75",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with Sequence Alteration identified by unique names {'uniquename':'ABC123'}",
@@ -2127,9 +2054,9 @@
                "verb": "POST",
                "description": "Delete sequence alteration",
                "methodName": "deleteSequenceAlteration",
-               "jsondocId": "9d7e3fee-3ef7-4797-9141-31f09efed59e",
+               "jsondocId": "fae4a8d0-a96e-4352-9757-5e7ae6c90fea",
                "bodyobject": {
-                  "jsondocId": "6964dae5-d1db-4c21-8fbe-a51c5ff30a48",
+                  "jsondocId": "125ba099-935f-4afc-b5d0-0c6d1ba9de5e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2139,7 +2066,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteSequenceAlteration",
                "response": {
-                  "jsondocId": "f623fdca-f4e5-4d9e-a5b8-9c9a1547dfe0",
+                  "jsondocId": "41b6f415-73b5-477a-a4e6-46e756816f44",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2152,7 +2079,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "285f57bd-b861-4070-b740-632b912c946c",
+                     "jsondocId": "18e9e2a7-12c2-4141-b2f3-3bf33685a387",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2161,7 +2088,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f4d9281e-7e01-4f54-8331-2746e15d06b2",
+                     "jsondocId": "f3644f04-0fcc-4b29-bded-b24a44d6e788",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2170,7 +2097,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "056e66ff-2115-4476-92aa-57c76ab22aca",
+                     "jsondocId": "aa6265f4-b1f3-4646-be68-0be883011474",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2179,7 +2106,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1a2730c3-e0b6-4133-9f0f-8670f0c1071e",
+                     "jsondocId": "07aedb76-613b-4ccd-8985-37e5b89ce50f",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2188,7 +2115,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "64b7ae20-71cc-4997-9f24-ee2f00496d84",
+                     "jsondocId": "37dd9ec3-19a4-4c6a-952b-987f45e4e37a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with objects of features defined as {'uniquename':'ABC123'}",
@@ -2200,9 +2127,9 @@
                "verb": "POST",
                "description": "Flip strand",
                "methodName": "flipStrand",
-               "jsondocId": "71264a7a-5ec9-47d2-bb3c-9198d71e356e",
+               "jsondocId": "27145f08-08c9-44fd-abab-9c086bf9ebed",
                "bodyobject": {
-                  "jsondocId": "ea048897-592c-4c17-9793-b061d6b850e6",
+                  "jsondocId": "ab36dadd-0c8c-437c-ba02-1d43008d1861",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2212,7 +2139,7 @@
                "apierrors": [],
                "path": "/annotationEditor/flipStrand",
                "response": {
-                  "jsondocId": "87d8168c-7ad8-4eed-9eb6-746bdc999494",
+                  "jsondocId": "32b6c324-2679-4315-8676-e25e6390116a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2225,7 +2152,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "a1f3f183-85f9-4b57-9bcb-21db97d6239f",
+                     "jsondocId": "fd89d05e-ead4-4676-b10c-9169c3f7467e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2234,7 +2161,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "664a7137-7ff0-47a5-870e-17a2cb6aab5b",
+                     "jsondocId": "b6c946d7-50ea-4ae6-9498-08e3bd2798ef",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2243,7 +2170,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "673c9deb-3716-4204-8ee1-e82f129e9f79",
+                     "jsondocId": "81871f41-0adb-4173-864b-e0fdc3bbdc04",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2252,7 +2179,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ba033f8c-49ed-4a6b-8d2e-9706eb1c3c80",
+                     "jsondocId": "fc0bdce1-8ae3-41bb-8046-23e4d2a63bcf",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2261,7 +2188,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b33f6ef2-85b2-4079-996f-02ecb434000d",
+                     "jsondocId": "c65b0d74-9369-4290-aa1f-9473de1fe1ff",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two objects of referred to as defined as {'uniquename':'ABC123'}",
@@ -2273,9 +2200,9 @@
                "verb": "POST",
                "description": "Merge exons",
                "methodName": "mergeExons",
-               "jsondocId": "73fcf32b-9b2a-48bc-9d5f-fb539b855146",
+               "jsondocId": "b00961da-619e-4b7a-9811-91d9efb284cb",
                "bodyobject": {
-                  "jsondocId": "db4b56c7-6c8b-46b0-a0e4-128cc60f26fd",
+                  "jsondocId": "04210620-93a2-4df7-b745-b36c2a6bce6a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2285,7 +2212,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeExons",
                "response": {
-                  "jsondocId": "d657f44e-cbe0-4b6d-866d-36aee840cde6",
+                  "jsondocId": "32bffb9c-7380-4df5-92f8-91fee54f7860",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2298,7 +2225,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8ad6ed98-58e2-458c-ad8a-909c10ec7cb1",
+                     "jsondocId": "3fb15af6-88f1-4a69-81b0-9b9b3dab2f42",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2307,7 +2234,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3ccaca6a-b662-455f-a571-f4b759aa8345",
+                     "jsondocId": "7a478c25-55a8-4b21-b3f2-e62f98643e2f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2316,7 +2243,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9cf9fd7a-40ce-48f5-a01c-cb0068a534a8",
+                     "jsondocId": "bd611260-b571-4c07-9625-f6160106a428",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2325,7 +2252,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2021323a-d4b1-43e3-bfec-87868725acd0",
+                     "jsondocId": "b76f584d-2b05-411f-992b-0e4805561492",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2334,7 +2261,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63726746-2574-407a-80ab-8bad22684eb4",
+                     "jsondocId": "474fb863-0ac3-43e7-8d76-1cb90a297ccf",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing feature objects with the location object defined {'uniquename':'ABCD-1234','location':{'fmin':2,'fmax':12}}",
@@ -2346,9 +2273,9 @@
                "verb": "POST",
                "description": "Split exons",
                "methodName": "splitExon",
-               "jsondocId": "5f3918dc-f622-423f-a317-b90de09eb222",
+               "jsondocId": "1439275f-b1ad-4303-8906-0756fc8933ff",
                "bodyobject": {
-                  "jsondocId": "f05c276a-3fb4-4527-9b4b-db35c8770c5c",
+                  "jsondocId": "18023f57-9942-4eb8-9b79-df0946d2a70a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2358,7 +2285,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitExon",
                "response": {
-                  "jsondocId": "04ae004e-e80a-4a79-81b1-6aa628a5347c",
+                  "jsondocId": "832518d6-0e5e-40dd-8ebe-34ee145353dc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2371,7 +2298,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "086e0cba-6847-4ef1-bf08-2f94b642a5d3",
+                     "jsondocId": "304e3705-12e6-4ecb-9555-bf70d28c7151",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2380,7 +2307,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "755cbf4f-5346-4dc5-8ffe-4ab892444284",
+                     "jsondocId": "872e96e2-991a-4246-bd42-5270030795fa",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2389,7 +2316,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "76e9a34f-8503-4e57-9e98-cb0dd62e2906",
+                     "jsondocId": "5c47d941-223a-4174-bb43-f06cb2fe0a6f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2398,7 +2325,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bf0fdc96-9366-4da7-b4a1-9d1a46297a36",
+                     "jsondocId": "9a0e69e6-3e96-4119-b7ad-71709fa67af1",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2407,7 +2334,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b7c6e3eb-f6e4-48cc-8846-0ff2de959929",
+                     "jsondocId": "efcdc43c-c03c-488c-b40e-ad02e915ecd6",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to delete defined by unique name {'uniquename':'ABC123'}",
@@ -2419,9 +2346,9 @@
                "verb": "POST",
                "description": "Delete feature",
                "methodName": "deleteFeature",
-               "jsondocId": "9529ad14-18cc-4509-b8aa-bb3cf47b02f7",
+               "jsondocId": "28cedc15-9768-4c04-a101-564a9c611c1b",
                "bodyobject": {
-                  "jsondocId": "4bc2f1a6-f9ea-4b1a-87c2-26c65dc9d53f",
+                  "jsondocId": "c8bde278-b67d-4fbf-99f9-6c6561f18ac6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2431,7 +2358,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeature",
                "response": {
-                  "jsondocId": "e47d03c3-cd9a-439b-85a8-b1cb135c0163",
+                  "jsondocId": "07c9867b-cc94-4957-9fe6-f9927c91358a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2444,7 +2371,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f4c3d5c6-c451-4266-8c36-203cf7be7500",
+                     "jsondocId": "deb27ed4-caa3-4512-b413-7b3ab680aa03",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2453,7 +2380,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02ea73b7-a0a9-4143-a9f1-5eae60e86065",
+                     "jsondocId": "1e47c3b7-4c3f-49ba-a0c7-7fde076406bb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2462,7 +2389,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d151b9ed-ee77-46be-92ba-ae118e744f82",
+                     "jsondocId": "f9491f22-c530-4320-8552-227d74988324",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2471,7 +2398,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b69224b8-b7f7-49af-9e0b-bd98ad4212d0",
+                     "jsondocId": "740509b1-ee31-4d05-8499-c1ba24a4b672",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2480,7 +2407,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e9272606-3f1c-470e-aa2c-1f512a738039",
+                     "jsondocId": "0d6f5333-ffb7-42eb-898d-f290a811b213",
                      "name": "sequence",
                      "format": "",
                      "description": "JSONArray of sequence id object to delete defined by {id:<sequence.id>} ",
@@ -2492,9 +2419,9 @@
                "verb": "POST",
                "description": "Delete variant effects for sequences",
                "methodName": "deleteVariantEffectsForSequences",
-               "jsondocId": "f449c3f7-a261-42b5-ba24-d5c2bcd8815f",
+               "jsondocId": "e145d5cc-ec9e-4d24-a5e3-a09a83c3e16f",
                "bodyobject": {
-                  "jsondocId": "1e6308f0-91cb-4f26-b421-c6fb0893b470",
+                  "jsondocId": "3268a128-57f1-488a-bca8-cbbca0cd3249",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2504,7 +2431,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteVariantEffectsForSequences",
                "response": {
-                  "jsondocId": "4c77589f-57d9-484c-92cd-894abef949db",
+                  "jsondocId": "6330aad3-a770-4dfe-90a4-517d4975342c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2517,7 +2444,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1755bfa0-faea-43a2-9024-703bee55401e",
+                     "jsondocId": "ee240eb5-c0ee-405d-a633-059ab1d7d1d1",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2526,7 +2453,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "72db9f15-ca52-40dc-8dd8-83db0ff2690c",
+                     "jsondocId": "76eaa3f3-6331-4d69-9e84-e6e00fe07633",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2535,7 +2462,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "68cf27a8-b76d-4b97-bfd4-1adba75fa1bb",
+                     "jsondocId": "4e774fa4-f7a8-4f60-a18c-074d28b59727",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2544,7 +2471,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "573a6eaa-fc87-4145-8b0e-bebd67e69129",
+                     "jsondocId": "0a51e65b-5d0d-4aec-9313-019ba15fd818",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2553,7 +2480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "af2e8bfa-ea95-4ec1-9543-f04ff703a7a0",
+                     "jsondocId": "53a8736c-b384-4f1d-993e-111d702310a1",
                      "name": "sequence",
                      "format": "",
                      "description": "JSONArray of sequence id object to delete defined by {id:<sequence.id>} ",
@@ -2565,9 +2492,9 @@
                "verb": "POST",
                "description": "Delete features for sequences",
                "methodName": "deleteFeaturesForSequences",
-               "jsondocId": "6a651011-b6a5-4bad-99ac-785f3d8f5d3e",
+               "jsondocId": "70a978b9-4df3-466c-ab8a-1479e7ba0872",
                "bodyobject": {
-                  "jsondocId": "9c2b12b7-c517-46f5-92f3-475a411de015",
+                  "jsondocId": "bdbaeb37-4bb5-49e5-bd12-7d412427a7b0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2577,7 +2504,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteFeaturesForSequences",
                "response": {
-                  "jsondocId": "704cf0e7-76e1-486e-b89e-0fe1c54bc798",
+                  "jsondocId": "82c5788f-e16d-495b-8d8d-21250857a8b5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2590,7 +2517,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f9bb2a2a-65f7-4b45-b5f0-dbba2ec5097f",
+                     "jsondocId": "65c67612-42b9-43da-9348-da344f129efa",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2599,7 +2526,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55ac9276-6b31-4f78-8f29-2982b6aac227",
+                     "jsondocId": "40105314-80c0-4cba-b226-f18c2a3cddbb",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2608,7 +2535,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9bdb150-a63c-4c13-a9de-69d7d35670e3",
+                     "jsondocId": "583e1c56-305c-47dd-9686-4de03c9a79cd",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2617,7 +2544,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a74b85c6-d745-47e6-b53a-175f356176c5",
+                     "jsondocId": "53a82b7a-b276-4341-9138-420635fe7e73",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2626,7 +2553,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c3f8efd-bdfc-49fa-b666-1b7b06d24d0a",
+                     "jsondocId": "d4a6e44c-6ef9-4445-88e5-b0929401adb8",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects, where the first is the parent transcript and the remaining are exons all defined by a unique name {'uniquename':'ABC123'}",
@@ -2638,9 +2565,9 @@
                "verb": "POST",
                "description": "Delete exons",
                "methodName": "deleteExon",
-               "jsondocId": "7efb2dba-dbf9-47ef-83c7-0b0b5779fa78",
+               "jsondocId": "a77f2abb-bc2b-4b37-9a5a-f64ee80d7e3f",
                "bodyobject": {
-                  "jsondocId": "4da67549-1b6d-4360-80ca-badd9992c018",
+                  "jsondocId": "954bef15-82db-4946-b408-bf61c524eaa4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2650,7 +2577,7 @@
                "apierrors": [],
                "path": "/annotationEditor/deleteExon",
                "response": {
-                  "jsondocId": "502f176e-e305-4ecd-aac5-b6405a61f8ae",
+                  "jsondocId": "43de0499-bf86-4346-be20-4a12df815904",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2663,7 +2590,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b25ce1c6-88b9-4aba-983b-276663448ee4",
+                     "jsondocId": "60fcdca9-af2f-40de-8465-d34e8d69d61e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2672,7 +2599,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f6fa2246-bc81-4ff3-90b7-0d28864a9126",
+                     "jsondocId": "b579479f-d9b7-4e68-89ff-d28b300e8748",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2681,7 +2608,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f3d90365-680e-4704-923f-08b3cf2d162f",
+                     "jsondocId": "a3fbcecb-7905-4081-b6fe-8c43aadfe36c",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2690,7 +2617,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "29dd470b-d170-4eed-962d-891d33d7539b",
+                     "jsondocId": "d744f115-090f-405d-8028-a5842b90ccc1",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2699,7 +2626,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "68c357ee-0ac9-4ab2-a06b-9ecb10544bc6",
+                     "jsondocId": "66c1ee10-6f62-47c7-8f24-1380291ace6d",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray containing a single JSONObject feature that contains {'uniquename':'ABCD-1234','location':{'fmin':12}}",
@@ -2711,9 +2638,9 @@
                "verb": "POST",
                "description": "Make intron",
                "methodName": "makeIntron",
-               "jsondocId": "b12401e2-bdcf-4263-ac03-135cd9957b72",
+               "jsondocId": "8492da62-c027-43e5-8e51-325c97ab222b",
                "bodyobject": {
-                  "jsondocId": "b9ee835b-6014-4e9c-b721-ad4da16324da",
+                  "jsondocId": "84b581e2-4e17-4e09-a06e-2431fa8f473a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2723,7 +2650,7 @@
                "apierrors": [],
                "path": "/annotationEditor/makeIntron",
                "response": {
-                  "jsondocId": "9ca69d0d-a24e-4c4c-be38-dc5a4bd59ed1",
+                  "jsondocId": "6f6ca954-9a48-4ea0-8457-a0650b86dd77",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2736,7 +2663,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "736405b3-65c4-4747-a4d4-cfeae2a93d2a",
+                     "jsondocId": "17aff1bf-a004-4050-a6eb-20472514faee",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2745,7 +2672,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9435882c-8715-4eaf-b86c-a042695abbb9",
+                     "jsondocId": "17facb04-24f3-4617-9bb9-f23c179f2496",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2754,7 +2681,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "10471cd6-b267-45d0-be85-1606de92c363",
+                     "jsondocId": "e41a9a22-847f-4139-a49c-ae86ab822b61",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2763,7 +2690,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bae7a1ad-efcc-483a-9ea7-382ea8032c63",
+                     "jsondocId": "63610bd4-43ad-48f3-aa6d-5aca2256a03d",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2772,7 +2699,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c074828f-69e4-422c-b80f-ffe5fa09c78d",
+                     "jsondocId": "2814086a-b164-48d7-8757-333894f3b99a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two exon objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2784,9 +2711,9 @@
                "verb": "POST",
                "description": "Split transcript",
                "methodName": "splitTranscript",
-               "jsondocId": "d8a45439-77b2-457e-986a-367a90d14087",
+               "jsondocId": "2dd34204-b883-465d-a9ff-33add2660889",
                "bodyobject": {
-                  "jsondocId": "cc1a7e78-2972-47f4-a658-e1474f463405",
+                  "jsondocId": "72c79b76-a071-4dde-8d75-4c74908b19b0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2796,7 +2723,7 @@
                "apierrors": [],
                "path": "/annotationEditor/splitTranscript",
                "response": {
-                  "jsondocId": "0146553b-b354-4280-b2eb-e7a2ec2bff15",
+                  "jsondocId": "d860612d-2928-4437-9722-026152645bab",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2809,7 +2736,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "62982a62-6374-4d68-8003-4a786be04035",
+                     "jsondocId": "b543afbf-880d-4db9-bff8-6ffff82686c8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2818,7 +2745,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e5dd7af0-98dc-4cb9-bf5c-445f62f7e81b",
+                     "jsondocId": "2fbe20c6-c2be-48fc-a85f-2c4df0e51f02",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2827,7 +2754,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c0723aeb-46b0-495e-b750-61c9cb4f90e5",
+                     "jsondocId": "9e7acaf2-84c4-453e-bc6f-c67cc7e2774f",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2836,7 +2763,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "df926463-48b1-43ca-b26d-c6d737bd941a",
+                     "jsondocId": "86f44447-cf9a-47ab-9075-56975b52922c",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2845,7 +2772,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d5eafbc-21d2-4007-bb88-9fa52c589777",
+                     "jsondocId": "659b0715-131a-42cd-9eb7-c379de2c8bb2",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray with with two transcript objects referred to their unique names {'uniquename':'ABC123'}",
@@ -2857,9 +2784,9 @@
                "verb": "POST",
                "description": "Merge transcripts",
                "methodName": "mergeTranscripts",
-               "jsondocId": "ccf61312-83a0-4840-a316-981875eb3b88",
+               "jsondocId": "c5f42bc5-0424-4840-837e-d43da30c3e18",
                "bodyobject": {
-                  "jsondocId": "d7c7a0d3-9b82-47d2-913a-e836cc670188",
+                  "jsondocId": "0570def7-6e94-4ec4-b114-0978ac4acce7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2869,7 +2796,7 @@
                "apierrors": [],
                "path": "/annotationEditor/mergeTranscripts",
                "response": {
-                  "jsondocId": "e41c382d-ac00-47de-86d7-be275bb5abfb",
+                  "jsondocId": "94fcee51-d801-4991-873a-5c9ba7b9686e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2882,7 +2809,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "dc0bd4c2-3d52-4a39-a363-fb7db5680d9b",
+                     "jsondocId": "1e09930e-ce08-4fd6-81ea-7020ef862286",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2891,7 +2818,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b4e326ef-8b5a-42ad-a0d2-f4f9823de07b",
+                     "jsondocId": "cb73dfa3-70f1-472e-b4fb-f84ab9f8efa7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2900,7 +2827,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c2980d79-e911-4c96-8dbc-876d14578ef8",
+                     "jsondocId": "b0370efc-355d-479c-9d4d-d3f376ba4aaf",
                      "name": "sequence",
                      "format": "",
                      "description": "(optional) Sequence name",
@@ -2909,7 +2836,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4e18f0d5-4bc5-4aad-ad4d-e1c1596a4710",
+                     "jsondocId": "4b128155-8fe9-4ebe-8faf-632c7ff454ae",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) Organism ID or common name",
@@ -2918,7 +2845,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e97c96c4-a67d-4bbc-aa36-878b7a4205ec",
+                     "jsondocId": "30e867e0-c60a-4063-8479-83ebe937df57",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -2930,9 +2857,9 @@
                "verb": "POST",
                "description": "Get sequences for features",
                "methodName": "getSequence",
-               "jsondocId": "f968478e-05f2-489d-9eb4-f441a802876f",
+               "jsondocId": "3d704f2c-99c0-4521-ac67-89633f6f0236",
                "bodyobject": {
-                  "jsondocId": "acb7efc7-29a4-4a7f-9eac-a15154750db7",
+                  "jsondocId": "1fb04d00-ce9e-491e-9759-8cf18ab7e9fc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -2942,7 +2869,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getSequences",
                "response": {
-                  "jsondocId": "a0873964-5a16-4b25-a239-3d9215528523",
+                  "jsondocId": "20bbe236-e8ac-43df-aad0-6aec42fe0f70",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2951,7 +2878,7 @@
                "consumes": ["application/json"]
             },
             {
-               "jsondocId": "aec7a2ef-0841-479b-94e2-8acdb1be5350",
+               "jsondocId": "f809a87e-270b-48bd-bdf8-ac9962322e18",
                "bodyobject": null,
                "apierrors": [],
                "path": "/annotationEditor/getSequenceSearchTools",
@@ -2959,7 +2886,7 @@
                "pathparameters": [],
                "queryparameters": [],
                "response": {
-                  "jsondocId": "58448e99-50ca-4969-96cd-ef1c1cedca08",
+                  "jsondocId": "1b8fc675-8c82-4a1a-8a1f-07bb97d4ec2e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -2974,7 +2901,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "11d95279-a6b4-403e-ae79-eaeefcab7026",
+                     "jsondocId": "abd3d7df-2305-443b-b816-2bada7a84bdf",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -2983,7 +2910,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7ef2459e-b90c-4a56-84bc-2dd86e7999e2",
+                     "jsondocId": "2f6fe544-1e28-48e3-9669-62a501a9075c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -2995,9 +2922,9 @@
                "verb": "POST",
                "description": "Get canned comments",
                "methodName": "getCannedComments",
-               "jsondocId": "81d57810-05b6-455c-bee0-0f929cac825f",
+               "jsondocId": "96e58123-8bb5-4575-bf6a-b6f07bc68e11",
                "bodyobject": {
-                  "jsondocId": "a561559f-7005-4ad0-bbda-0d7354ec6927",
+                  "jsondocId": "85a8d108-0fcd-428c-a25a-7853982280c0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3007,7 +2934,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getCannedComments",
                "response": {
-                  "jsondocId": "c1f36527-1820-41d6-ba82-a3143b4138c6",
+                  "jsondocId": "19961de9-db79-4272-b2ca-fedbec62963e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3020,7 +2947,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9338232e-26c1-4d21-ab91-34062a33b0c2",
+                     "jsondocId": "1dc2dc82-18ae-4fd8-9c73-041a077b4c56",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3029,7 +2956,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "bc779e2b-6434-4776-8d5c-cb82d66f6ed7",
+                     "jsondocId": "6bf09bfe-0223-4dc7-bbdb-ecf7b9610d1b",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3038,7 +2965,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65c9671d-a32f-458c-a20e-43ec18eef4e1",
+                     "jsondocId": "00182cb8-8937-44f4-96e9-974c83e65f2c",
                      "name": "client_token",
                      "format": "",
                      "description": "Organism ID/Name or Client-generated ",
@@ -3047,7 +2974,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "843d966d-18a6-4985-bfe8-0504ffd11de8",
+                     "jsondocId": "ff80e776-db95-473f-9a8f-af8c87e4d35a",
                      "name": "search",
                      "format": "",
                      "description": "{'key':'blat','residues':'ATACTAGAGATAC':'database_id':'abc123'}",
@@ -3059,9 +2986,9 @@
                "verb": "POST",
                "description": "Search sequences",
                "methodName": "searchSequence",
-               "jsondocId": "6cbfb95a-a80d-463c-85c3-5b55b7c693e4",
+               "jsondocId": "451afc1b-a613-430d-9d19-8b9c05bd492a",
                "bodyobject": {
-                  "jsondocId": "ebcdc724-b086-4e16-a00b-215e4ef36e23",
+                  "jsondocId": "7f4a7f2a-98e9-40ca-ba6d-c3bf9781f280",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3071,7 +2998,7 @@
                "apierrors": [],
                "path": "/annotationEditor/searchSequences",
                "response": {
-                  "jsondocId": "13442941-403c-4035-ab58-73c3d13c9a53",
+                  "jsondocId": "4f210751-c1f0-49d3-bc26-fef341556d9c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3084,7 +3011,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "4a146190-2090-484f-886b-12f3881b4a9e",
+                     "jsondocId": "8bced42a-c63a-481b-9bd3-fd3066c4845c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3093,7 +3020,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2abdec67-24e0-40c2-b0fe-9024401bafc0",
+                     "jsondocId": "2af55140-280c-4b93-bab6-d9c000f9b0d9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3102,7 +3029,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "298d567d-3631-4f27-b918-ed769ea1102b",
+                     "jsondocId": "050ab122-fc9a-43c8-87f0-a17e8aa0932a",
                      "name": "features",
                      "format": "",
                      "description": "JSONArray of features objects to export defined by a unique name {'uniquename':'ABC123'}",
@@ -3114,9 +3041,9 @@
                "verb": "POST",
                "description": "Get gff3",
                "methodName": "getGff3",
-               "jsondocId": "76e00dac-66b5-4c83-9cce-d82c0db916dc",
+               "jsondocId": "117176cd-f19f-4a50-b03f-65930b5ca25c",
                "bodyobject": {
-                  "jsondocId": "cf631769-a8fb-4a35-af14-d27ac81b06a8",
+                  "jsondocId": "a9b45deb-ff48-46f7-80b6-4002d3953b40",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3126,7 +3053,7 @@
                "apierrors": [],
                "path": "/annotationEditor/getGff3",
                "response": {
-                  "jsondocId": "51606e9e-286c-475b-9d34-f84eb6282e0e",
+                  "jsondocId": "321787f8-55d7-4ab8-a4d2-30a7a990abfe",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3139,7 +3066,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e036d405-5479-41c4-b1d0-1c1b2ed0f15d",
+                     "jsondocId": "1c8d856e-fa13-4331-bdd4-0db9b2628f7a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3148,7 +3075,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b074fd61-afdc-4bcd-9e2a-75fbfcb5d270",
+                     "jsondocId": "4cf1c614-28cc-4ceb-98b9-d9e8a8199930",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3157,7 +3084,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "162de632-ff51-4c66-8bf7-5b7248d6554b",
+                     "jsondocId": "5630bc7f-b8d1-4f93-9c90-bf8aea611ead",
                      "name": "days",
                      "format": "",
                      "description": "Number of past days to retrieve annotations from.",
@@ -3169,9 +3096,9 @@
                "verb": "POST",
                "description": "Get genes created or updated in the past, Returns JSON hash gene_name:organism",
                "methodName": "getRecentAnnotations",
-               "jsondocId": "e04fb87f-a9b9-459a-a691-083516790ca9",
+               "jsondocId": "cdca0a95-3ee9-4aa1-8902-ae6209fa564d",
                "bodyobject": {
-                  "jsondocId": "6a28b338-c1d1-442b-9fab-95dd4de99f82",
+                  "jsondocId": "f9411343-1412-4d6d-9dff-afab83ec59c4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3181,7 +3108,80 @@
                "apierrors": [],
                "path": "/annotationEditor/getRecentAnnotations",
                "response": {
-                  "jsondocId": "8a296b94-226c-405e-81dd-98889791e682",
+                  "jsondocId": "622848f1-7093-46aa-b5c5-c908ecb58c70",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "annotation editor"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "85772835-0e72-4df6-8901-1cada9170ca3",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "09a50592-95f7-4e93-ae41-3e727a685970",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5cd02cee-505a-4fa3-b06c-0fcb939a203f",
+                     "name": "sequence",
+                     "format": "",
+                     "description": "(optional) Sequence name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "cd3276ee-281d-4bb2-836f-01161a48c8c1",
+                     "name": "organism",
+                     "format": "",
+                     "description": "(optional) Organism ID or common name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0f328f17-d03a-4911-ab5f-d6405f840c28",
+                     "name": "features",
+                     "format": "",
+                     "description": "JSONArray containing JSON objects with {'uniquename':'ABCD-1234','non_reserved_properties':[{'tag':'clockwork','value':'orange'},{'tag':'color','value':'purple'}]}.  Available status found here: /availableStatus/ ",
+                     "type": "JSONArray",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add attribute (key,value pair) to feature",
+               "methodName": "addAttribute",
+               "jsondocId": "636bc2cb-38b2-45b9-9d08-bda7335f3e3b",
+               "bodyobject": {
+                  "jsondocId": "43f86802-5cc4-40e8-aca8-5239cc57f740",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "annotation editor"
+               },
+               "apierrors": [],
+               "path": "/annotationEditor/addAttribute",
+               "response": {
+                  "jsondocId": "f4cc3c03-bc30-416f-a255-321ecffde690",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotation editor"
@@ -3194,14 +3194,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "c0a011ea-eac2-4612-ae24-b30f28f374ae",
+         "jsondocId": "5cabb54b-b4d9-4ba8-b3ed-3fccaf7d8d03",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "01c9801a-642e-4b61-8e9c-7e75d5049095",
+                     "jsondocId": "f67824c3-a099-468d-8577-6414f1fc28b4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3210,7 +3210,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "10777b6c-88cc-47e1-abcc-2efc8aa1ecfb",
+                     "jsondocId": "b686fc62-a6c6-4203-8667-5563e9dac583",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3219,7 +3219,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "324d1356-adc7-4c3e-9015-54220c5e2954",
+                     "jsondocId": "366176fe-eef9-4977-9901-bc3b8f292da5",
                      "name": "uniquename",
                      "format": "",
                      "description": "Uniquename (UUID) of the feature we are editing",
@@ -3228,7 +3228,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2715c368-4960-4be2-8750-f3bb1870a3d8",
+                     "jsondocId": "488c03fa-fa1a-483e-a242-0fe311971e8b",
                      "name": "name",
                      "format": "",
                      "description": "Updated feature name",
@@ -3237,7 +3237,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db2a0fbe-ce03-4ad8-9a7d-5eca2eb10df3",
+                     "jsondocId": "3ef2d5e7-d10e-46e0-8785-e11403e2559b",
                      "name": "symbol",
                      "format": "",
                      "description": "Updated feature symbol",
@@ -3246,7 +3246,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b793983a-4e80-4a92-a195-4aca43b0177a",
+                     "jsondocId": "61f3d3f4-af98-4b85-8962-980e51d15fe8",
                      "name": "description",
                      "format": "",
                      "description": "Updated feature description",
@@ -3258,9 +3258,9 @@
                "verb": "POST",
                "description": "Update shallow feature properties",
                "methodName": "updateFeature",
-               "jsondocId": "12f1d890-fa22-4d3f-b4fa-bea905edf5f9",
+               "jsondocId": "0676801f-fb3f-48c0-872c-b9087a529e14",
                "bodyobject": {
-                  "jsondocId": "7da07312-319d-4d61-b948-74f8f56b0521",
+                  "jsondocId": "bdfd5894-ed32-45bb-a15f-528a9e74435a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3270,7 +3270,7 @@
                "apierrors": [],
                "path": "/annotator/updateFeature",
                "response": {
-                  "jsondocId": "e8246da7-1e53-4dcd-8716-b80ca059625d",
+                  "jsondocId": "d1f2e5ef-3000-444e-86d6-a2dda18734e6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3283,7 +3283,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "784997c8-ba56-4915-8306-333b971aa6d8",
+                     "jsondocId": "7cbe4fed-caf5-47f1-8e15-969a67d6f5fb",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3292,7 +3292,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "564772fc-527e-4f2e-b1ed-b0d099b52c08",
+                     "jsondocId": "26dc1be4-1476-414b-ab96-90f6a898eea2",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3301,7 +3301,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9d24b784-824d-43a7-adec-568313707f4b",
+                     "jsondocId": "e0e92e61-3f1b-4745-84c2-144a8eea772e",
                      "name": "uniquename",
                      "format": "",
                      "description": "Uniquename (UUID) of the exon we are editing",
@@ -3310,7 +3310,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d2752036-d289-49d7-a7eb-5ca7d2d9c9eb",
+                     "jsondocId": "d06af77c-5188-486e-a347-85fd691c4788",
                      "name": "fmin",
                      "format": "",
                      "description": "fmin for Exon Location",
@@ -3319,7 +3319,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "625120ca-a117-405a-b31b-3a252dbc73a0",
+                     "jsondocId": "b2c754e1-e134-431d-a378-7037cd2f2ef1",
                      "name": "fmax",
                      "format": "",
                      "description": "fmax for Exon Location",
@@ -3328,7 +3328,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6cb05123-e2b2-4aa6-b2d0-2343a1dc514c",
+                     "jsondocId": "a84fab69-91d8-443f-bd6d-58924433ca19",
                      "name": "strand",
                      "format": "",
                      "description": "strand for Feature Location 1 or -1",
@@ -3340,9 +3340,9 @@
                "verb": "POST",
                "description": "Update exon boundaries",
                "methodName": "setExonBoundaries",
-               "jsondocId": "c2ee4802-0de7-498e-9377-be7d1543f2ba",
+               "jsondocId": "5136758e-72f7-4833-91cc-2bc9f3163044",
                "bodyobject": {
-                  "jsondocId": "de14e021-4e2e-40ac-9f8b-b36055d833df",
+                  "jsondocId": "15595a31-1030-481f-9aba-f04f54644459",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3352,7 +3352,7 @@
                "apierrors": [],
                "path": "/annotator/setExonBoundaries",
                "response": {
-                  "jsondocId": "067bf072-3eb1-4f01-a62e-7216782600f8",
+                  "jsondocId": "9f89c5f5-fdd6-4f70-94a1-b64e908a3c35",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3365,7 +3365,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "55247522-ff18-4093-b7da-163aa92714ef",
+                     "jsondocId": "847e5848-0678-481c-8d29-46084808719c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3374,7 +3374,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d69bd3b6-4099-410a-b400-fbaf975c0291",
+                     "jsondocId": "e8bda787-8219-472f-854f-ef30a37a486d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3383,7 +3383,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "be3bdd1b-1d23-4b88-94ce-dba63ab06a40",
+                     "jsondocId": "f7170b5d-287c-4208-9369-1668634c2aa4",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -3392,7 +3392,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0a737f6b-ca99-4c5e-9beb-c96826aa580a",
+                     "jsondocId": "1caaa3ab-25d3-4351-b246-c03577ddbb38",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -3404,9 +3404,9 @@
                "verb": "POST",
                "description": "Get annotators report for group",
                "methodName": "getAnnotatorsReportForGroup",
-               "jsondocId": "3ea71c26-48e1-4bd6-a4e5-9f2cd9214f62",
+               "jsondocId": "d63b4102-9a8f-454f-b049-22e7b63f8a04",
                "bodyobject": {
-                  "jsondocId": "074c9a8c-325c-4af7-aafb-edd300932f07",
+                  "jsondocId": "9a7b0955-7383-4ae0-ab95-ec5a22bfc13b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3416,7 +3416,7 @@
                "apierrors": [],
                "path": "/group/getAnnotatorsReportForGroup",
                "response": {
-                  "jsondocId": "2fa1c27a-2627-4f35-9f77-c86772c75ce3",
+                  "jsondocId": "1dc48953-cfe0-4f18-a70d-d76dcb469615",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "annotator"
@@ -3429,14 +3429,14 @@
          "description": "Methods for running the annotation engine"
       },
       {
-         "jsondocId": "ae09ca75-f4f8-48b3-9626-240e86801188",
+         "jsondocId": "79d41b68-62db-4d45-bf24-679f48217581",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "2e55f6bc-26f1-4f6b-8684-4125676bd429",
+                     "jsondocId": "6ae57660-af61-43bb-b742-1167cb05db45",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3445,7 +3445,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2c82f67c-705e-4895-bd88-0b77d070a947",
+                     "jsondocId": "52a5df2a-82a2-4d87-a5e1-f9a7cef93db7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3454,7 +3454,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a560fde0-17eb-42c4-975b-68d62c009d2c",
+                     "jsondocId": "d59cba1a-a51f-40d9-9df9-7e6b97c5e461",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to update (or specify the old_value)",
@@ -3463,7 +3463,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0348e6ef-0885-463d-a845-369f5b44f19d",
+                     "jsondocId": "87c1bf31-a2b0-480e-a9af-aec4e121c82f",
                      "name": "old_value",
                      "format": "",
                      "description": "Status name to update",
@@ -3472,7 +3472,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "139cc9e7-87b1-42fc-a77d-dfbdc3957e58",
+                     "jsondocId": "c77bd4b2-0d2a-4267-aa21-f355cdd80a2c",
                      "name": "new_value",
                      "format": "",
                      "description": "Status name to change to (the only editable option)",
@@ -3484,9 +3484,9 @@
                "verb": "POST",
                "description": "Update status",
                "methodName": "updateStatus",
-               "jsondocId": "db56c6f1-4b36-4bfc-8fd9-b7dab13b7aac",
+               "jsondocId": "9a77dd85-997e-4aed-930c-4007d8ef7785",
                "bodyobject": {
-                  "jsondocId": "b0d9b0dd-47b7-4752-a92c-6b4d526fc9c1",
+                  "jsondocId": "9e92d346-1855-48ef-8806-2494440dbc1d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3496,7 +3496,7 @@
                "apierrors": [],
                "path": "/availableStatus/updateStatus",
                "response": {
-                  "jsondocId": "c26cf632-6da0-440d-accb-f6b94f58415e",
+                  "jsondocId": "0645fd12-84e4-4d62-a2fb-9f893d35ecdc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3509,7 +3509,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1ef25cd3-65a4-43ae-8562-6ef5ab86c847",
+                     "jsondocId": "e408de58-e921-4d20-89e5-5cd6e8a1f524",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3518,7 +3518,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97fb5f91-e465-4206-a4b0-b68771a765d4",
+                     "jsondocId": "f71b6c13-be1e-46ae-937f-923319c455c7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3527,7 +3527,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1b1726c-8380-42c8-8e06-1dea694958be",
+                     "jsondocId": "f84af747-4048-4cfe-b13e-4c72fe697799",
                      "name": "value",
                      "format": "",
                      "description": "Status name to add",
@@ -3539,9 +3539,9 @@
                "verb": "POST",
                "description": "Create status",
                "methodName": "createStatus",
-               "jsondocId": "280a9077-a3cf-4754-927f-cd01e65d989b",
+               "jsondocId": "127cc31e-669c-48f0-8097-bc55e2144fc9",
                "bodyobject": {
-                  "jsondocId": "4e2276c7-acdc-4199-8585-b051e526ed99",
+                  "jsondocId": "d2953c98-b95d-4b7e-8cdc-365e8c4a604f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3551,7 +3551,7 @@
                "apierrors": [],
                "path": "/availableStatus/createStatus",
                "response": {
-                  "jsondocId": "c0207425-0682-4367-a683-9f8efa0f5521",
+                  "jsondocId": "30761ca1-c3a4-4053-a586-4f871aeeaee4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3564,7 +3564,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "51bab2d6-5b32-4c15-a800-769eb3ebb855",
+                     "jsondocId": "a647caa0-76bc-461f-921c-3ae8c9e813b2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3573,7 +3573,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "03553f2c-1789-4b29-8e45-2995f38f3ac3",
+                     "jsondocId": "18b5e2fc-f22c-4f9f-9afa-0f937c2ab471",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3582,7 +3582,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c973c8b2-07a3-49d3-8972-b0422c4aa56e",
+                     "jsondocId": "c3367a4e-d855-421f-b8a8-12871efbdb0e",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to remove (or specify the name)",
@@ -3591,7 +3591,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "24778fb3-4da7-45a1-8c26-abd531e3c5b5",
+                     "jsondocId": "b79125fb-66b0-47a0-b599-298adb8c86ed",
                      "name": "value",
                      "format": "",
                      "description": "Status name to delete",
@@ -3603,9 +3603,9 @@
                "verb": "POST",
                "description": "Remove a status",
                "methodName": "deleteStatus",
-               "jsondocId": "18399fc4-a949-4ee9-ac1a-3afeea4bd187",
+               "jsondocId": "91902d55-8210-4ce8-9d02-dc87a05571eb",
                "bodyobject": {
-                  "jsondocId": "30056074-30c4-41cd-9094-d23fba41cb71",
+                  "jsondocId": "974d9bf3-9397-4a8d-8ca4-b87a92889d8a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3615,7 +3615,7 @@
                "apierrors": [],
                "path": "/availableStatus/deleteStatus",
                "response": {
-                  "jsondocId": "a6b21b9e-2e01-4b18-8e18-5132f931b04e",
+                  "jsondocId": "d378965b-8c1c-4d4f-8267-b7caef358ef9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3628,7 +3628,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "876b6d87-4c96-4bdc-a7f4-b171e4895e32",
+                     "jsondocId": "c74aadd9-69aa-45bf-bd1f-140c1a237e14",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3637,7 +3637,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d2db549e-3185-40e4-b879-b74a2fe8f1d5",
+                     "jsondocId": "fa2970b6-b49a-48dc-97f1-22ef00ae8770",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3646,7 +3646,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e1af610a-b657-43fe-bced-df8135d9b266",
+                     "jsondocId": "40826c02-3fe8-487f-8e68-3b80f0a218a0",
                      "name": "id",
                      "format": "",
                      "description": "Status ID to show (or specify a name)",
@@ -3655,7 +3655,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3080d7ca-92c1-4bc5-bc7e-5436a3af1df8",
+                     "jsondocId": "58e43745-0a30-43b7-97ab-a2c34b9ec6d2",
                      "name": "name",
                      "format": "",
                      "description": "Status name to show",
@@ -3667,9 +3667,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all statuses, or optionally, gets information about a specific status",
                "methodName": "showStatus",
-               "jsondocId": "61627bb7-3da0-498b-b1c9-e32ed53939d2",
+               "jsondocId": "de60b89f-cf61-4f53-99d2-6753469dc96e",
                "bodyobject": {
-                  "jsondocId": "065982f5-f0da-4877-92e8-837af1801316",
+                  "jsondocId": "0c6ccd60-cd5e-489c-80df-9e6a194f3562",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3679,7 +3679,7 @@
                "apierrors": [],
                "path": "/availableStatus/showStatus",
                "response": {
-                  "jsondocId": "3c0d69b8-73dd-4dfb-bba5-6891721b7391",
+                  "jsondocId": "4a9d8781-5b4a-4c36-abac-5d18d4b82d06",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "available status"
@@ -3692,14 +3692,14 @@
          "description": "Methods for managing available statuses"
       },
       {
-         "jsondocId": "5c7fa0df-f294-4177-ad8e-4742f8867601",
+         "jsondocId": "65123336-e9f6-4f87-b7de-14b6c738d23f",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "80001877-c98d-4ee5-866e-4d55fcb5e77c",
+                     "jsondocId": "d135c362-5f1f-475b-863c-db4063082b42",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3708,7 +3708,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "098584d9-1a95-4e65-9b5e-c2fc85fd00ce",
+                     "jsondocId": "4f369ca9-6ad2-48bd-92a1-c588301bb64d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3717,71 +3717,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0827e1f9-5635-4ccd-b508-5dbef27f7208",
-                     "name": "comment",
-                     "format": "",
-                     "description": "Canned comment to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "d9ab1560-a198-4928-ba2b-1a70e57da276",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "Optional additional information",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create canned comment",
-               "methodName": "createComment",
-               "jsondocId": "df61dfda-b25a-42fd-9dfa-03888f6ba680",
-               "bodyobject": {
-                  "jsondocId": "088bb74d-35fc-4027-bcab-8f97d70e42b1",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned comment"
-               },
-               "apierrors": [],
-               "path": "/cannedComment/createComment",
-               "response": {
-                  "jsondocId": "1fd4f52a-7c75-4f68-a4fb-8f67c9e4bba1",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned comment"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "3fc591ca-b7b3-4972-9058-d54d38633592",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "dcda4eed-a6ff-4e26-ad47-4e2649fcef2c",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ddc613c1-51b6-492f-b786-bf96d2a3a9ac",
+                     "jsondocId": "0b97d5e8-ce55-43f0-acb0-9afc1503f79f",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to update (or specify the old_comment)",
@@ -3790,7 +3726,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3357d315-4169-408d-850d-34085f1f181e",
+                     "jsondocId": "0be44faa-d17d-4ce7-ba0a-c8c61c1f6f26",
                      "name": "old_comment",
                      "format": "",
                      "description": "Canned comment to update",
@@ -3799,7 +3735,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d1d98a1e-2b7b-4af8-a13f-b467eb84ea98",
+                     "jsondocId": "9e09bf97-00f8-4fda-91af-a86fbb71ba39",
                      "name": "new_comment",
                      "format": "",
                      "description": "Canned comment to change to (the only editable option)",
@@ -3808,7 +3744,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "23e87619-1aa0-4458-a171-527094646958",
+                     "jsondocId": "a74d78d3-de02-44a5-ae70-1ecf9039ad4c",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -3820,9 +3756,9 @@
                "verb": "POST",
                "description": "Update canned comment",
                "methodName": "updateComment",
-               "jsondocId": "910b5aa5-f8fc-46fd-8422-2a54eb8b1a60",
+               "jsondocId": "bf22a6c6-e434-45c3-9f00-3c9a5dbe4214",
                "bodyobject": {
-                  "jsondocId": "04273c80-f3ec-45d8-bc21-dd3ffea5a933",
+                  "jsondocId": "b9dd71e4-dc5e-42a8-bf6f-729871f7b03f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3832,7 +3768,7 @@
                "apierrors": [],
                "path": "/cannedComment/updateComment",
                "response": {
-                  "jsondocId": "f4548ea1-a556-4c99-9746-e17be58003ad",
+                  "jsondocId": "54159742-a95c-4c6c-9673-fb9b53ee8375",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3845,7 +3781,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ecd339d9-2ee6-4075-9948-9ea0046cf462",
+                     "jsondocId": "d6d778b8-4f4d-4df3-baf9-52c79cf4797e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3854,7 +3790,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8ea3ed10-f16d-4799-96e5-0d9a261850e5",
+                     "jsondocId": "a9e96f9c-230c-4dbf-8d2d-61e841240818",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3863,7 +3799,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "65881cf4-3e2c-4c43-9283-5077a50ef243",
+                     "jsondocId": "18ccee8f-4306-4e49-b009-9d14debd58fc",
                      "name": "id",
                      "format": "",
                      "description": "Canned comment ID to remove (or specify the name)",
@@ -3872,7 +3808,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8f7ee641-befd-4124-852c-02789b275718",
+                     "jsondocId": "ef4a7618-9051-4161-ace8-f86319720a1b",
                      "name": "comment",
                      "format": "",
                      "description": "Canned comment to delete",
@@ -3884,9 +3820,9 @@
                "verb": "POST",
                "description": "Remove a canned comment",
                "methodName": "deleteComment",
-               "jsondocId": "54fe1842-5487-40a6-84e5-b32debd62eed",
+               "jsondocId": "fed85310-b474-4470-a468-e013ef7a9848",
                "bodyobject": {
-                  "jsondocId": "9e425e8d-c158-454e-8aed-afc0e9fdf106",
+                  "jsondocId": "6c598cd7-6b94-43dd-b9ec-bea7b7aa834a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3896,7 +3832,7 @@
                "apierrors": [],
                "path": "/cannedComment/deleteComment",
                "response": {
-                  "jsondocId": "685d7073-3879-47b4-97f7-fa6ac99d3f81",
+                  "jsondocId": "bd5174ba-3d03-43c3-a1a1-cb2316efcad9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3909,7 +3845,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9687c3e8-67a5-4b57-89e5-6024eaf8145a",
+                     "jsondocId": "3bbe3dcf-117d-49e3-b54c-57eb4fbff234",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3918,7 +3854,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0d4eba90-f2be-4ccd-a019-ac01ee90fb76",
+                     "jsondocId": "9c72498c-616c-46d1-a0de-fd469b37c27f",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3927,7 +3863,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "40e52308-6f2f-446d-ace1-0beff66d4316",
+                     "jsondocId": "da7dd390-75d9-48c4-98fb-f9c8e98d5a41",
                      "name": "id",
                      "format": "",
                      "description": "Comment ID to show (or specify a comment)",
@@ -3936,7 +3872,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7a9ca1cf-3d59-4468-a847-eca74f2d00ca",
+                     "jsondocId": "d197f49f-b7f4-4e90-936e-47e6f2e037de",
                      "name": "comment",
                      "format": "",
                      "description": "Comment to show",
@@ -3948,9 +3884,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned comments, or optionally, gets information about a specific canned comment",
                "methodName": "showComment",
-               "jsondocId": "477a9bd9-4a58-48af-ba01-84bf851ce616",
+               "jsondocId": "dc3a9f03-e980-4554-a942-241b1c6e18ac",
                "bodyobject": {
-                  "jsondocId": "81c4b7d4-a530-4b2d-8f3e-44f1e1ddb1d9",
+                  "jsondocId": "1768a199-4a69-4c00-8afa-7347eb7fac15",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -3960,7 +3896,71 @@
                "apierrors": [],
                "path": "/cannedComment/showComment",
                "response": {
-                  "jsondocId": "993995dc-8beb-4e84-a830-cfb90d982857",
+                  "jsondocId": "e73adca6-3012-4de8-a49a-34e7da1342cb",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned comment"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "8e2ab290-deb5-4860-af96-680520c72b55",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "395489c4-3315-410e-9bb0-d9ed02632bd2",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b51bfc2a-41d2-4815-b28d-6bfbbc28c95c",
+                     "name": "comment",
+                     "format": "",
+                     "description": "Canned comment to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e2dfcf4c-6fde-40eb-93f4-882267fd3c29",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create canned comment",
+               "methodName": "createComment",
+               "jsondocId": "fd75ee9b-5300-4122-83eb-9b9f16d5c593",
+               "bodyobject": {
+                  "jsondocId": "ef52936f-d9d4-45a1-a79c-5e52809ee8f7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned comment"
+               },
+               "apierrors": [],
+               "path": "/cannedComment/createComment",
+               "response": {
+                  "jsondocId": "abf2cfe9-0d69-46ac-a8aa-8f5b4cf20380",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned comment"
@@ -3973,14 +3973,14 @@
          "description": "Methods for managing canned comments"
       },
       {
-         "jsondocId": "41ded2dd-0f37-41be-b072-872e5503b472",
+         "jsondocId": "a2f30f6e-1f1a-41d9-a224-cbd4a47cf88a",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0684437e-3739-4a69-8d11-db86e98b4ffe",
+                     "jsondocId": "2c630a78-12a7-4dc5-b210-3409723e06c9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -3989,7 +3989,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "83265564-2de4-4ee7-a907-14098234af91",
+                     "jsondocId": "b89bf1a8-ad08-4998-91ee-96f2e0d5b94c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -3998,7 +3998,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c0479c30-257e-4fa9-8283-bf3f58be6293",
+                     "jsondocId": "cada29fc-15d3-4b29-86cd-5d76843610eb",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to update (or specify the old_key)",
@@ -4007,7 +4007,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d8201df1-053f-4922-9e14-d055c6bb0253",
+                     "jsondocId": "7fc3f900-a217-4d5f-ac33-1989ac847697",
                      "name": "old_key",
                      "format": "",
                      "description": "Canned key to update",
@@ -4016,7 +4016,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84ae1659-9220-4f45-b225-43b3fac1a16e",
+                     "jsondocId": "16003bde-8eb9-4051-aa9a-5e836fe88794",
                      "name": "new_key",
                      "format": "",
                      "description": "Canned key to change to (the only editable option)",
@@ -4025,7 +4025,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b3091177-0d0f-45d5-9b7c-e7e4b6874dbf",
+                     "jsondocId": "4fa59eb8-9a98-4e36-bb95-fa03d0ba296b",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4037,9 +4037,9 @@
                "verb": "POST",
                "description": "Update canned key",
                "methodName": "updateKey",
-               "jsondocId": "4cabb821-d5f0-439e-96d4-8faea8489c64",
+               "jsondocId": "3f203537-4560-40c1-8e00-8a7826816370",
                "bodyobject": {
-                  "jsondocId": "345436e7-6744-4e59-8b80-7c6663731d10",
+                  "jsondocId": "db9a3f8a-1539-4bf2-a579-49b16bc5d24c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4049,7 +4049,7 @@
                "apierrors": [],
                "path": "/cannedKey/updateKey",
                "response": {
-                  "jsondocId": "09e48b26-c499-479e-afdc-9cd71bcb6c6e",
+                  "jsondocId": "fd134028-a709-49ce-aa85-743671705e49",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4062,7 +4062,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "fbc4030e-9c40-4d4b-9b4d-26f359d603df",
+                     "jsondocId": "1829938f-78e2-419d-a960-e04fff86f52a",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4071,7 +4071,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fc501589-c319-4780-a5b2-0bdaf024de18",
+                     "jsondocId": "26395964-6802-4953-8bfc-615ddfe27fe8",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4080,7 +4080,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "64f452be-f743-4ac3-be31-b8affd981603",
+                     "jsondocId": "a48c8c96-5614-4f31-b106-6df61cc4fcb7",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to add",
@@ -4089,7 +4089,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97e32e04-4b24-486e-a48d-a87ec7acc2df",
+                     "jsondocId": "bc0043d0-b585-4314-9125-f81a4e96d023",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4101,9 +4101,9 @@
                "verb": "POST",
                "description": "Create canned key",
                "methodName": "createKey",
-               "jsondocId": "06db1782-0a91-4a7a-b1a2-d7400a25aa92",
+               "jsondocId": "9f9be5d2-274c-4b87-9c60-b124c875d371",
                "bodyobject": {
-                  "jsondocId": "f7c93387-ce3d-4ce9-aef9-09f98bf6db62",
+                  "jsondocId": "45dfd86b-178c-43cf-a59c-f1554430c1eb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4113,7 +4113,7 @@
                "apierrors": [],
                "path": "/cannedKey/createKey",
                "response": {
-                  "jsondocId": "3532aa60-5eff-483b-9e99-b3ce35d8615e",
+                  "jsondocId": "bf8ba5ca-6d21-45c4-8f2f-e2b8640d02dd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4126,7 +4126,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "6f9e8c70-3276-4eb9-852c-f662ace5b145",
+                     "jsondocId": "35a51f35-2b6b-460e-9284-6a8216b5a69d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4135,7 +4135,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c9698715-0e70-409e-9e9f-bcb3327264af",
+                     "jsondocId": "3f7b0771-3eb0-4804-883b-3e2452d0ed33",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4144,7 +4144,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dc550de2-fcf8-4049-a4c8-437183fdf6a5",
+                     "jsondocId": "7238f5fd-929c-41d1-bdaa-16d4e2be7cd8",
                      "name": "id",
                      "format": "",
                      "description": "Canned key ID to remove (or specify the name)",
@@ -4153,7 +4153,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "89b08b9f-9367-412c-8af5-8d11aaf0276c",
+                     "jsondocId": "66e75e87-db24-47e2-942c-cd27c2f25913",
                      "name": "key",
                      "format": "",
                      "description": "Canned key to delete",
@@ -4165,9 +4165,9 @@
                "verb": "POST",
                "description": "Remove a canned key",
                "methodName": "deleteKey",
-               "jsondocId": "ef5cc0be-2703-4fca-aa53-4a306ceaf1a5",
+               "jsondocId": "37bade29-8185-448a-8d51-1a30f95f5e8c",
                "bodyobject": {
-                  "jsondocId": "468ff6f4-ab34-4efe-82dd-f72738bd5b1b",
+                  "jsondocId": "8a7664fb-9256-4b50-a8ad-72818d1552f2",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4177,7 +4177,7 @@
                "apierrors": [],
                "path": "/cannedKey/deleteKey",
                "response": {
-                  "jsondocId": "53db5a82-8c12-497d-8f38-d9c5b095f7ab",
+                  "jsondocId": "6d3cf5ec-2c61-42c1-928b-8e5e97a2494c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4190,7 +4190,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "502ae3ae-75d4-49af-a2ea-cd705681da49",
+                     "jsondocId": "ef515d45-2c75-4079-9300-91703f5261ab",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4199,7 +4199,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "78eceacc-6a00-4167-957b-550c133fae21",
+                     "jsondocId": "2a2eaf5a-8459-434d-9ccc-08be08bf73c0",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4208,7 +4208,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "4ae97d67-0eaf-48c2-9d26-5ea8b04d2909",
+                     "jsondocId": "733273b5-4c2c-4400-a21e-6a22786629d2",
                      "name": "id",
                      "format": "",
                      "description": "Key ID to show (or specify a key)",
@@ -4217,7 +4217,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e58f8749-2936-45df-8259-29d80ca86a63",
+                     "jsondocId": "23fe264f-258e-4c33-8151-e53ec305a36a",
                      "name": "key",
                      "format": "",
                      "description": "Key to show",
@@ -4229,9 +4229,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned keys, or optionally, gets information about a specific canned key",
                "methodName": "showKey",
-               "jsondocId": "30b24f57-0c0f-4e84-b9c1-ad39e60925fa",
+               "jsondocId": "14c925f6-6758-4831-8f57-a8f665eef78a",
                "bodyobject": {
-                  "jsondocId": "a958df39-e056-4f45-94d1-907f3d5624b9",
+                  "jsondocId": "b64b5fe9-332c-4434-bb16-19d9a3b34950",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4241,7 +4241,7 @@
                "apierrors": [],
                "path": "/cannedKey/showKey",
                "response": {
-                  "jsondocId": "0cc229e1-d796-464c-8f2c-a977c59fd2d9",
+                  "jsondocId": "762ddb15-a4a8-4de0-b17e-2d18259ad65b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned key"
@@ -4254,14 +4254,14 @@
          "description": "Methods for managing canned keys"
       },
       {
-         "jsondocId": "a616a496-b2ae-4fff-bade-bcb3ff380897",
+         "jsondocId": "77f2d320-bba5-4023-91b8-7bb0731d81e7",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8a8089d5-7c5d-41e9-9904-a28ed0009c14",
+                     "jsondocId": "5c279e30-daa6-471c-a377-d28d294e5bd4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4270,7 +4270,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0023eaa2-c6ea-4a0b-ba8e-31da91ceeb23",
+                     "jsondocId": "2c62d591-3b99-48b9-932c-b3d7a11b4eb4",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4279,71 +4279,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "741ffc9c-fac6-4ada-98e1-2c9e02b8352b",
-                     "name": "value",
-                     "format": "",
-                     "description": "Canned value to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b9babdbd-f1e6-4f1d-abff-147c841782a5",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "Optional additional information",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create canned value",
-               "methodName": "createValue",
-               "jsondocId": "5d5894c7-9c21-48f7-bfdc-7ff25b6300c7",
-               "bodyobject": {
-                  "jsondocId": "18e08b2c-dc88-4de5-88cc-73f2c79bfa77",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "canned value"
-               },
-               "apierrors": [],
-               "path": "/cannedValue/createValue",
-               "response": {
-                  "jsondocId": "6f026206-56c7-4634-afdc-adaedd796d05",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "canned value"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "af147b71-702c-4213-8cca-75b48099af6a",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e9a48ea2-7da6-4563-a753-4c6f06109f44",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "be2a0c36-0fc9-4fc7-9b51-8b54a6b399b8",
+                     "jsondocId": "056cd8c6-d0e9-4fed-87b5-76bb403fdfb2",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to update (or specify the old_value)",
@@ -4352,7 +4288,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "11fb7cfc-8bc6-4893-977e-a12b3c84485f",
+                     "jsondocId": "d96092f8-6d19-4b55-8763-5030b64168e2",
                      "name": "old_value",
                      "format": "",
                      "description": "Canned value to update",
@@ -4361,7 +4297,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "58a950de-2640-41c2-8c40-c24e39d96e7c",
+                     "jsondocId": "5744d455-7526-44fc-9718-cf5c2d521108",
                      "name": "new_value",
                      "format": "",
                      "description": "Canned value to change to (the only editable option)",
@@ -4370,7 +4306,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "adcc1a40-3a5c-49e2-8aac-7368596f7c11",
+                     "jsondocId": "57a4a05a-5ccc-4fd3-9f0c-d65f8d16592d",
                      "name": "metadata",
                      "format": "",
                      "description": "Optional additional information",
@@ -4382,9 +4318,9 @@
                "verb": "POST",
                "description": "Update canned value",
                "methodName": "updateValue",
-               "jsondocId": "fda9bfbb-202d-4daf-ae2c-ebb404cae3bd",
+               "jsondocId": "b21338ba-9932-48f3-9b90-34d18501fdc6",
                "bodyobject": {
-                  "jsondocId": "95074843-c059-4149-935a-805f31f5a375",
+                  "jsondocId": "d96f9582-4084-465a-9759-34d36702e9fa",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4394,7 +4330,7 @@
                "apierrors": [],
                "path": "/cannedValue/updateValue",
                "response": {
-                  "jsondocId": "d8839c27-8cec-4c12-95d2-84ebe87580c4",
+                  "jsondocId": "145e38f7-1ec1-4ae2-beeb-f69bdbfe1316",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4407,7 +4343,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b1eeca6d-afda-4e09-97fb-65cec2a4382b",
+                     "jsondocId": "b26cc713-ac37-4152-aed1-112dd8ef15e8",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4416,7 +4352,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9fb0d20d-f5f5-4b75-b8b4-6ad9c2115c53",
+                     "jsondocId": "c7b6213f-006d-4e42-b20c-a96732854c8c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4425,7 +4361,71 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e5886267-b356-45ed-ac8c-64f04a845616",
+                     "jsondocId": "e2fc7a4f-cb37-4527-98d9-a27a2296d6da",
+                     "name": "value",
+                     "format": "",
+                     "description": "Canned value to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "df87739d-1544-4529-87db-173bc3797d02",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "Optional additional information",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create canned value",
+               "methodName": "createValue",
+               "jsondocId": "8af70e2f-d989-48db-b5f5-d7f3331804ed",
+               "bodyobject": {
+                  "jsondocId": "5911a112-239a-4be7-ada4-b2497dd5f701",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "canned value"
+               },
+               "apierrors": [],
+               "path": "/cannedValue/createValue",
+               "response": {
+                  "jsondocId": "aacc6435-79ac-41bb-b6d5-8072e0463204",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "canned value"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "5033970c-762e-42b4-ae91-a071d24fe35f",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "448aef4d-d91b-4231-9e7f-8c1bcebb8207",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e41e8f23-d7ec-4867-9cc0-498ce9b0af62",
                      "name": "id",
                      "format": "",
                      "description": "Canned value ID to remove (or specify the name)",
@@ -4434,7 +4434,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "20dfb37b-6955-4062-96c3-5ab9c098ea19",
+                     "jsondocId": "4b75365a-93da-446e-9ccf-ad9beaadd08c",
                      "name": "value",
                      "format": "",
                      "description": "Canned value to delete",
@@ -4446,9 +4446,9 @@
                "verb": "POST",
                "description": "Remove a canned value",
                "methodName": "deleteValue",
-               "jsondocId": "a32674d2-67d2-4de6-bbdf-59cb37c761b3",
+               "jsondocId": "2e009acb-c917-4caa-a9cf-80e2ea398653",
                "bodyobject": {
-                  "jsondocId": "e8c047fe-7074-4eea-98ef-91704d9e4a7a",
+                  "jsondocId": "da4990f5-b73a-4f09-956d-7b85f8db3ecc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4458,7 +4458,7 @@
                "apierrors": [],
                "path": "/cannedValue/deleteValue",
                "response": {
-                  "jsondocId": "67061fb1-7359-4d6a-8ab3-1eaf6c87dd4c",
+                  "jsondocId": "2df24502-ba40-42ef-ab5f-94e27ad83455",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4471,7 +4471,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b93906ae-425e-44af-926f-c238f057f759",
+                     "jsondocId": "5e99ad2e-c533-49a4-a86a-430aa64a7f9d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4480,7 +4480,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "227effe1-25d6-4313-ac6d-248190299f1b",
+                     "jsondocId": "92b03831-af2a-49c2-bf7a-6a659beeb405",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4489,7 +4489,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "418d8470-a152-4c89-ace9-966338700ada",
+                     "jsondocId": "45e508eb-684c-4159-a2b2-1eb5dc287055",
                      "name": "id",
                      "format": "",
                      "description": "Value ID to show (or specify a value)",
@@ -4498,7 +4498,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2176f17f-be78-45a3-b023-04201683c318",
+                     "jsondocId": "619b1600-bdf4-4857-98a7-25260d3e58ac",
                      "name": "value",
                      "format": "",
                      "description": "Value to show",
@@ -4510,9 +4510,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all canned values, or optionally, gets information about a specific canned value",
                "methodName": "showValue",
-               "jsondocId": "b2e376fe-e8cb-44f2-8c33-80007b204c74",
+               "jsondocId": "d760be61-9366-4b5d-a234-f056381a9be2",
                "bodyobject": {
-                  "jsondocId": "f5eb3ebe-ee1f-4bd3-8b66-7d22bc9723ef",
+                  "jsondocId": "33f131b9-f869-467a-a384-d4aeea259aca",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4522,7 +4522,7 @@
                "apierrors": [],
                "path": "/cannedValue/showValue",
                "response": {
-                  "jsondocId": "ff50b0e4-df5b-4530-bb69-c0829a7aa6a8",
+                  "jsondocId": "e7d857d3-6d68-4a71-b221-1c71e2b6fb7b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "canned value"
@@ -4535,14 +4535,14 @@
          "description": "Methods for managing canned values"
       },
       {
-         "jsondocId": "0cda5479-6310-46f7-85db-f415fa34ce08",
+         "jsondocId": "01584ee5-3cc6-4ec0-86d1-b208a24d5a78",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "cf294741-6fc4-4762-a14b-41397db79d22",
+                     "jsondocId": "084dd396-5da6-49bf-922e-28f5d11b8dbc",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4551,7 +4551,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "348da249-1462-4ca5-858b-bdd4cda4189e",
+                     "jsondocId": "d31b8d0a-77cc-4834-a8de-8314aaacff51",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4560,62 +4560,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "70bd0fe0-f99b-4bf8-b2ea-7ad864837ba3",
-                     "name": "name",
-                     "format": "",
-                     "description": "Group name to add, or a comma-delimited list of names",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create group",
-               "methodName": "createGroup",
-               "jsondocId": "a3f94581-3a7f-425a-9a6e-89aee995b174",
-               "bodyobject": {
-                  "jsondocId": "aec09a31-8935-4cb5-8dd6-010794234334",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "group"
-               },
-               "apierrors": [],
-               "path": "/group/createGroup",
-               "response": {
-                  "jsondocId": "80b761c8-39ed-43f2-95f7-a37cc5ec7485",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "group"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "1f52f82c-a480-4f1e-bb21-897c72c97de3",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "cb566c16-1ed2-4910-8f00-3fd0e10c8ac2",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "211d14f1-4e9e-4f88-ba77-c5dbdfd93dae",
+                     "jsondocId": "fbdae54d-1bb4-41a4-9454-8b0d2675407b",
                      "name": "id",
                      "format": "",
                      "description": "Group ID (or specify the name)",
@@ -4624,7 +4569,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a0033dca-2978-4208-8f67-a19f21a5b1f1",
+                     "jsondocId": "ca9ea5f5-066a-4796-9886-e5c3410ed381",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -4636,9 +4581,9 @@
                "verb": "POST",
                "description": "Get organism permissions for group",
                "methodName": "getOrganismPermissionsForGroup",
-               "jsondocId": "e8e00d06-626d-4b03-8b09-f66d02a38075",
+               "jsondocId": "ec8fb0c7-cc30-47bd-a59f-dd95e2ed746a",
                "bodyobject": {
-                  "jsondocId": "a95c6ba3-7146-461e-8629-2535fcf2a6e8",
+                  "jsondocId": "06018ca9-33ff-4917-8682-125e982245b9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4648,7 +4593,7 @@
                "apierrors": [],
                "path": "/group/getOrganismPermissionsForGroup",
                "response": {
-                  "jsondocId": "fe652bf8-01ce-481e-a80e-58d988c27a07",
+                  "jsondocId": "a842cade-e8e9-4e8f-9cc2-043b45dfcee7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4661,7 +4606,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "541066a9-f358-483b-aa22-d398af865c0a",
+                     "jsondocId": "f8e47f9c-c3ba-4559-a2be-3a2088693942",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4670,7 +4615,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "15f56c50-fb1d-416b-8267-9eb2bf037bd7",
+                     "jsondocId": "a27ab22c-5673-4f3f-9254-a3d979d8563e",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4679,7 +4624,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "26853190-f5bd-4e2d-9c21-089db260e7e2",
+                     "jsondocId": "91dfc69d-0919-4aee-ac25-e538072c37d9",
                      "name": "groupId",
                      "format": "",
                      "description": "Optional only load a specific groupId",
@@ -4691,9 +4636,9 @@
                "verb": "POST",
                "description": "Load all groups",
                "methodName": "loadGroups",
-               "jsondocId": "36091f1d-cc69-49fd-91d0-360aa28282d2",
+               "jsondocId": "95c0c739-9c0f-4260-b36f-aca62520c66b",
                "bodyobject": {
-                  "jsondocId": "bff64721-7353-422a-8cb5-da92231e4f05",
+                  "jsondocId": "9853d648-0f2c-4b55-8824-25f331e3677a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4703,7 +4648,7 @@
                "apierrors": [],
                "path": "/group/loadGroups",
                "response": {
-                  "jsondocId": "0dec05ce-099e-485f-b057-ea9298b116d9",
+                  "jsondocId": "e11b6d26-a52c-49ed-99ea-ca8485027f41",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4716,7 +4661,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "53498e5e-fb71-42e9-b8e5-68ede8da957b",
+                     "jsondocId": "6d48b5e0-cbe3-4954-865b-e4b2fca8fbe2",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4725,7 +4670,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d95d1d35-b955-483f-a3ab-cc57995df01d",
+                     "jsondocId": "231e0260-11f1-456c-aa8d-064305750de6",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4734,7 +4679,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "abd997aa-5b63-418c-b4d1-dc634a47827a",
+                     "jsondocId": "36191852-0a12-4f82-a46e-cb95eb61fe1c",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to remove (or specify the name)",
@@ -4743,7 +4688,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "06667693-190e-4526-879c-d29a2dce253b",
+                     "jsondocId": "38086694-3f93-4625-a2e4-7a4ad6ecd8ed",
                      "name": "name",
                      "format": "",
                      "description": "Group name or comma-delimited list of names to remove",
@@ -4755,9 +4700,9 @@
                "verb": "POST",
                "description": "Delete a group",
                "methodName": "deleteGroup",
-               "jsondocId": "9e6df8b3-0a0f-440b-95b2-2eef4a2fa817",
+               "jsondocId": "7cfe9bc4-e258-4a9d-b3ab-f153113de3cb",
                "bodyobject": {
-                  "jsondocId": "7c7de9a4-defb-409d-a8b7-6b2680de9eac",
+                  "jsondocId": "e65e16ca-7769-48b1-a841-cd3a1d8f0b3a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4767,7 +4712,7 @@
                "apierrors": [],
                "path": "/group/deleteGroup",
                "response": {
-                  "jsondocId": "1bffcd31-dd9b-4a74-863a-3d4690ea62a6",
+                  "jsondocId": "19e29d68-f8f1-48d9-af02-b9387d8c94ec",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4780,7 +4725,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1a7391a2-7c78-4192-ba1a-ebbeda3a9bcb",
+                     "jsondocId": "62888a09-96f6-402f-8e9d-4f0883d986e9",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4789,7 +4734,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "914bed14-7233-45ee-bf33-5bb9dbade3cf",
+                     "jsondocId": "1e668417-b979-4e9a-a399-6324a3262c5c",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4798,7 +4743,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "694a5773-e980-4ef4-9f62-12d855a4c3d5",
+                     "jsondocId": "e21bee4e-608b-4126-9438-5cad07505043",
                      "name": "id",
                      "format": "",
                      "description": "Group ID to update",
@@ -4807,7 +4752,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0e269905-b435-4379-a200-278756b09195",
+                     "jsondocId": "84530ec5-c17e-4eb5-9f5e-ad1781563289",
                      "name": "name",
                      "format": "",
                      "description": "Group name to change to (the only editable optoin)",
@@ -4819,9 +4764,9 @@
                "verb": "POST",
                "description": "Update group",
                "methodName": "updateGroup",
-               "jsondocId": "ac3756c4-b333-475c-9d0c-c288fc3d23e6",
+               "jsondocId": "7d68e11b-d483-4acf-b990-5470adbe157d",
                "bodyobject": {
-                  "jsondocId": "0fe17e78-1f41-418d-9849-45794aeeae64",
+                  "jsondocId": "a2f07d46-1b84-4b18-92e7-62f1a6ff1f3e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4831,7 +4776,7 @@
                "apierrors": [],
                "path": "/group/updateGroup",
                "response": {
-                  "jsondocId": "8b298f0c-3575-4542-b596-e2ced7d3e1c9",
+                  "jsondocId": "a8d5cd48-ea16-4b4d-9da1-bd839506cd29",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4844,7 +4789,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9857a8e7-e886-4809-96ec-6a2fdeb656b8",
+                     "jsondocId": "3b858349-8bfb-4473-bcc3-e78e98249c7c",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4853,7 +4798,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "70568050-22b5-4eb8-a2ec-43dd480052fa",
+                     "jsondocId": "5b75f054-0814-4b76-b580-0254a65bacbe",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4862,7 +4807,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "856de891-629b-4356-b1dd-6d5d4da18657",
+                     "jsondocId": "737841e9-11db-495d-a9d1-19c2df5d85cb",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to modify permissions for (must provide this or 'name')",
@@ -4871,7 +4816,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e2ac32e-e7d1-482f-8ae4-621fdc7e40d0",
+                     "jsondocId": "988ada06-ac06-4397-83d3-8cee015707e3",
                      "name": "name",
                      "format": "",
                      "description": "Group name to modify permissions for (must provide this or 'groupId')",
@@ -4880,7 +4825,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b1f58d6-83f7-4c7e-99d3-a40e0a5c7ce3",
+                     "jsondocId": "a53278a6-6e91-4584-975f-7031d0940d72",
                      "name": "organism",
                      "format": "",
                      "description": "Organism common name",
@@ -4889,7 +4834,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "83c75084-b31a-435e-9c97-18fb9e009b5a",
+                     "jsondocId": "1ed10bfa-8e71-4e12-8afb-74e4b43a4f54",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -4898,7 +4843,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "40ec5c0d-693f-42c6-a971-8fd516c79435",
+                     "jsondocId": "49ff05bd-186f-4cb2-a3c5-e474f7ec3ff2",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -4907,7 +4852,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ad2cefb5-4bb6-454d-b377-1dcb468e263d",
+                     "jsondocId": "aa0f3bbf-cf9d-479e-b1b1-6ec57cf273c3",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -4916,7 +4861,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "89ec0556-e2ed-4b4d-8e16-80201fd58072",
+                     "jsondocId": "f11934cf-c0fd-42ad-9e3f-6b04f7aada68",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -4928,9 +4873,9 @@
                "verb": "POST",
                "description": "Update organism permission",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "2eaa288b-fafa-45e7-82ef-f0793fd4bb24",
+               "jsondocId": "1e8cc012-99ce-40d2-aec7-c9fef27f35f9",
                "bodyobject": {
-                  "jsondocId": "df09b2d3-7225-4fa5-98b9-0bf001f4e370",
+                  "jsondocId": "e44a9758-990e-48f3-bc3b-9c564a7aebf5",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -4940,7 +4885,7 @@
                "apierrors": [],
                "path": "/group/updateOrganismPermission",
                "response": {
-                  "jsondocId": "eda3daf7-59ea-48bb-a607-4da9a9476856",
+                  "jsondocId": "c055df0e-db53-4707-bbd4-36415e00254d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -4953,7 +4898,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "8202a44a-1c60-4054-8757-291df2a90755",
+                     "jsondocId": "4007b3e7-8e10-47bb-907a-61652cdc7f11",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -4962,7 +4907,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "99fa8fcb-0103-43ad-82e2-46033055e79b",
+                     "jsondocId": "8017df2c-9c4f-45ce-98a5-95b5f5357b15",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -4971,7 +4916,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "04830d9e-0dc8-4598-8f96-10d373f1bf36",
+                     "jsondocId": "f57cd0ca-f282-4415-879a-63d31bbb5180",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -4980,7 +4925,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c82f5244-68d7-4945-8324-3d8fd59ae714",
+                     "jsondocId": "556c405e-8787-426a-9685-794a3912fbd8",
                      "name": "users",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -4989,7 +4934,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "157021c4-84f7-432b-85c3-91515109e412",
+                     "jsondocId": "05541230-5e17-4a7f-a9f6-30530e556128",
                      "name": "memberships",
                      "format": "",
                      "description": "Bulk memberships (instead of users and groupId) to update of the form: [ {groupId: <groupId>,users: [\"user1\", \"user2\", \"user3\"]}, {groupId:<another-groupId>, users: [\"user2\", \"user8\"]}]",
@@ -5001,9 +4946,9 @@
                "verb": "POST",
                "description": "Update group membership",
                "methodName": "updateMembership",
-               "jsondocId": "86452129-12b2-4642-b2f5-c55255fb55cf",
+               "jsondocId": "fefee152-cb0e-4feb-92f4-227690fbb726",
                "bodyobject": {
-                  "jsondocId": "491be53b-f126-4c13-8d14-8a3cbdac511d",
+                  "jsondocId": "cbc7d9e5-7107-4700-aa50-0bcc1c88fde8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5013,7 +4958,7 @@
                "apierrors": [],
                "path": "/group/updateMembership",
                "response": {
-                  "jsondocId": "429e1b92-167b-4109-94ac-672cc566bf42",
+                  "jsondocId": "2ad3587a-3cf3-465a-9f86-d354227ea35b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5026,7 +4971,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "af29d5cd-a63f-4d97-9467-b00f58ac2f8b",
+                     "jsondocId": "7002d0ec-a39b-4e86-9a15-d05170888b3b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5035,7 +4980,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1e89f5ea-a503-4623-b5d6-1f6f84c5c213",
+                     "jsondocId": "1007c35d-ab23-46f2-b9c0-ebaa432de203",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5044,7 +4989,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f2685672-d055-46f9-9713-8c8254904277",
+                     "jsondocId": "2ff7257a-25e3-4ddb-8b97-8f8faa6020a2",
                      "name": "groupId",
                      "format": "",
                      "description": "Group ID to alter membership of",
@@ -5053,7 +4998,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c331c71e-6302-4de2-8742-a574473663c3",
+                     "jsondocId": "6deeb340-8fb4-4493-99d4-186c548c73e3",
                      "name": "users",
                      "format": "",
                      "description": "A JSON array of strings of emails of users the now belong to the group",
@@ -5065,9 +5010,9 @@
                "verb": "POST",
                "description": "Update group admin",
                "methodName": "updateGroupAdmin",
-               "jsondocId": "5590036f-5408-4647-bde4-3aeee3f2e027",
+               "jsondocId": "32def597-14cc-437c-adfa-ba59071ce728",
                "bodyobject": {
-                  "jsondocId": "09adefa6-b91e-4232-b9e3-25a90baecce6",
+                  "jsondocId": "f3f8e6c7-90fa-4b1d-a0e2-85deec1ee81a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5077,7 +5022,7 @@
                "apierrors": [],
                "path": "/group/updateGroupAdmin",
                "response": {
-                  "jsondocId": "c0f121ad-d36a-4dce-8e56-4d1083fc40d7",
+                  "jsondocId": "7d228153-5067-4d09-bd5e-cba723d3324c",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5090,7 +5035,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b40e1ba8-d830-4cf1-9cce-6e3660502b3f",
+                     "jsondocId": "b977d0a5-33dc-4a12-9f9a-d75ab95da9a4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5099,7 +5044,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e9110465-74eb-4528-a06d-d508d642a111",
+                     "jsondocId": "8ae29ee1-489e-4bad-9e14-14c570813f18",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5108,7 +5053,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "33186421-3136-4d73-98fc-5993184efbc8",
+                     "jsondocId": "0f0c3920-df7b-428b-a0b0-84a7464ef1a8",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -5120,9 +5065,9 @@
                "verb": "POST",
                "description": "Get group admins, returns group admins as JSONArray",
                "methodName": "getGroupAdmin",
-               "jsondocId": "8c706a6a-daab-4643-a7ab-67e18dc927b8",
+               "jsondocId": "cf7b7c13-557e-4250-b4e2-d608d8ea3d4f",
                "bodyobject": {
-                  "jsondocId": "b6b741a7-c533-42fc-a541-afd6e0cfbc77",
+                  "jsondocId": "899e39d0-7d6d-4045-809f-77d705e28b6e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5132,7 +5077,7 @@
                "apierrors": [],
                "path": "/group/getGroupAdmin",
                "response": {
-                  "jsondocId": "b532cf9f-59c1-41bd-a38d-0c2909baf0d1",
+                  "jsondocId": "07297be9-b704-4912-8d67-e7a6f0231188",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5145,7 +5090,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "69e3c4b3-73d9-42d4-a43e-982ce361ef87",
+                     "jsondocId": "889a7d6b-5473-4a5b-ab3d-7e5464402c22",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5154,7 +5099,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5e23be36-6f6e-4172-a23f-69c4827165d9",
+                     "jsondocId": "ac37f9c6-f580-47a9-8e6c-e7d58ef76b23",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5163,7 +5108,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "593e3ee5-539b-43b6-9045-dff69f82af68",
+                     "jsondocId": "309db686-e02c-4aa4-aae2-ec86b9a56824",
                      "name": "name",
                      "format": "",
                      "description": "Group name",
@@ -5175,9 +5120,9 @@
                "verb": "POST",
                "description": "Get creator metadata for group, returns userId as JSONObject",
                "methodName": "getGroupCreator",
-               "jsondocId": "5b669eb4-6371-45cd-9b21-6fd00055b376",
+               "jsondocId": "32796924-8e53-42ce-a4bf-39683fb30c90",
                "bodyobject": {
-                  "jsondocId": "25be8dbe-21f4-4c4a-a281-58341abd9b30",
+                  "jsondocId": "4ead956b-9069-43bd-94c4-9465a27aac7d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5187,7 +5132,62 @@
                "apierrors": [],
                "path": "/group/getGroupCreator",
                "response": {
-                  "jsondocId": "9fbe680e-c77d-4fc6-8869-210c9c5c62bd",
+                  "jsondocId": "20b23d53-b3d3-469e-b518-9f27d4c68c77",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "group"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "e56f279a-41a6-446d-b68b-f3aebf815a23",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "09e94c52-6ac0-442e-9177-d0c25178caa0",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "54d700f0-d858-488e-9ddd-fbe466b30c1b",
+                     "name": "name",
+                     "format": "",
+                     "description": "Group name to add, or a comma-delimited list of names",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create group",
+               "methodName": "createGroup",
+               "jsondocId": "485a596a-d09f-4f86-bbf3-5799f0363467",
+               "bodyobject": {
+                  "jsondocId": "256ea348-cfe3-4635-97e8-de69f5c89366",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "group"
+               },
+               "apierrors": [],
+               "path": "/group/createGroup",
+               "response": {
+                  "jsondocId": "d611acd8-534f-48a3-ad7f-45e9449cd582",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "group"
@@ -5200,13 +5200,13 @@
          "description": "Methods for managing groups"
       },
       {
-         "jsondocId": "ce825744-4dcd-4ffe-970a-3e00bbbe76d3",
+         "jsondocId": "eb5d42cf-3c60-4a70-8efa-60ff36aefa0b",
          "methods": [{
             "headers": [],
             "pathparameters": [],
             "queryparameters": [
                {
-                  "jsondocId": "6d7a813e-c95f-45a2-a0c6-384b69ea148f",
+                  "jsondocId": "88c28879-984f-481c-8508-749856ea95af",
                   "name": "username",
                   "format": "",
                   "description": "",
@@ -5215,7 +5215,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "7d68170d-122d-4c0b-b29f-3d2974bd4bde",
+                  "jsondocId": "3be33eca-5588-4d6f-8f35-ddb2128d6311",
                   "name": "password",
                   "format": "",
                   "description": "",
@@ -5224,7 +5224,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "df89bd2c-a1db-4e77-ba27-fafb1960b044",
+                  "jsondocId": "0a5de43d-b91b-43c5-b061-cdef90f6adf8",
                   "name": "date",
                   "format": "",
                   "description": "Date to query yyyy-MM-dd:HH:mm:ss or yyyy-MM-dd",
@@ -5233,7 +5233,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "f527546f-51d9-4401-b166-6c15716280bc",
+                  "jsondocId": "5e42150a-f8e2-4a92-be7d-384244d73be4",
                   "name": "afterDate",
                   "format": "",
                   "description": "Search after or on the given date.",
@@ -5242,7 +5242,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "bdf1e3cf-4e48-4621-b14b-6b0349e186dd",
+                  "jsondocId": "c10ce54d-5db6-4964-97c8-37c63f51e71c",
                   "name": "beforeDate",
                   "format": "",
                   "description": "Search before or on the given date.",
@@ -5251,7 +5251,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "fc6c1046-0405-4131-8484-40778e9e2d1d",
+                  "jsondocId": "e9e4f546-0a17-401d-9c4b-18ad46144b27",
                   "name": "max",
                   "format": "",
                   "description": "Max to return",
@@ -5260,7 +5260,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "177e2b5b-ee6f-41af-b521-30669b02aab3",
+                  "jsondocId": "22eae150-8bcc-4fc6-b790-74db68f1e1fd",
                   "name": "sort",
                   "format": "",
                   "description": "Sort parameter (lastUpdated).  See FeatureEvent object/table.",
@@ -5269,7 +5269,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "67591ecd-4c73-4fd9-909e-66e69f9b9fee",
+                  "jsondocId": "ac6cbfb7-7aa2-4b48-bdb1-c39c4de5583f",
                   "name": "order",
                   "format": "",
                   "description": "desc/asc sort order by sort param",
@@ -5281,9 +5281,9 @@
             "verb": "POST",
             "description": "Returns a JSON representation of all current Annotations before or after a given date.",
             "methodName": "findChanges",
-            "jsondocId": "0d70dc01-cacd-4663-8927-d0ac44240478",
+            "jsondocId": "526cffa7-dd4b-4dc6-b340-e636d4e56045",
             "bodyobject": {
-               "jsondocId": "ca4ca83d-e237-48a2-8181-e916b79690ae",
+               "jsondocId": "ef5b7ef7-11a0-44e0-b988-d6fcac187663",
                "mapValueObject": "",
                "mapKeyObject": "",
                "multiple": "Unknow",
@@ -5293,7 +5293,7 @@
             "apierrors": [],
             "path": "/featureEvent/findChanges",
             "response": {
-               "jsondocId": "c605a3f6-9cd0-4ea7-ac4d-62f78132005a",
+               "jsondocId": "2fad3b47-0eba-41e0-a295-7df9e20646c3",
                "mapValueObject": "",
                "mapKeyObject": "",
                "object": "feature event"
@@ -5305,14 +5305,14 @@
          "description": "Methods for querying history"
       },
       {
-         "jsondocId": "d76c9745-ee7a-47ea-94a0-eb3f2de2f9ff",
+         "jsondocId": "ac0521fd-4c21-4ea9-af25-5240e3c57991",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "7ff758ef-2b22-4a4b-9a69-1ff108f0a5a4",
+                     "jsondocId": "35a6d66b-a0d5-4130-ba2a-d0b13ca951e6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5321,7 +5321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "30e4625e-e8a1-47e2-b4b2-7c1ed0bcbae9",
+                     "jsondocId": "dc062475-ed64-4f2b-9027-a8b64b02f7b7",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5330,7 +5330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b55ca4f2-5021-428f-b161-9a360dffd4f8",
+                     "jsondocId": "d7c435e9-7347-45ea-b113-ff1f5d2c76d3",
                      "name": "type",
                      "format": "",
                      "description": "Type of annotated genomic features to export 'FASTA','GFF3','CHADO'.",
@@ -5339,7 +5339,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "11640d20-f4bd-491e-aa0a-50717cceed7b",
+                     "jsondocId": "ff5fcd12-b7c7-4e34-b2b5-69ffb121f42f",
                      "name": "seqType",
                      "format": "",
                      "description": "Type of output sequence 'peptide','cds','cdna','genomic'.",
@@ -5348,7 +5348,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "43c55dc0-ebb6-4417-ae41-98357a2d4a32",
+                     "jsondocId": "f4049439-81be-4504-8326-a117208b01cd",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -5357,7 +5357,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "63d85551-455c-43fd-9d1d-aacaa05b3b74",
+                     "jsondocId": "4272ce63-28c8-4934-b37b-4536f83bc294",
                      "name": "sequences",
                      "format": "",
                      "description": "Names of references sequences to add (default is all).",
@@ -5366,7 +5366,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1843b61-8b53-40cc-a9e5-f2c3a0ea6954",
+                     "jsondocId": "f8af01d3-12fe-470e-bd0d-0a0cebf8d786",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism that sequences belong to (will default to last organism).",
@@ -5375,7 +5375,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e937847c-6882-42a2-aba2-b329cac954cb",
+                     "jsondocId": "c8fbfcb0-4f56-4efd-8a86-34b901ebc28e",
                      "name": "output",
                      "format": "",
                      "description": "Output method 'file','text'",
@@ -5384,7 +5384,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "90fd7ecb-900a-45df-a54e-6ba503a7ffb2",
+                     "jsondocId": "250e5ad5-ad67-41b2-80dd-a9f90ed10091",
                      "name": "exportAllSequences",
                      "format": "",
                      "description": "Export all reference sequences for an organism (over-rides 'sequences')",
@@ -5393,7 +5393,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ce8bb22b-af1b-42a9-a23d-465209971c6b",
+                     "jsondocId": "24dad79a-c1eb-4226-a8fc-277f22b3a080",
                      "name": "region",
                      "format": "",
                      "description": "Highlighted genomic region to export in form sequence:min..max  e.g., chr3:1001..1034",
@@ -5405,9 +5405,9 @@
                "verb": "POST",
                "description": "Write out genomic data.  An example script is used in the https://github.com/GMOD/Apollo/blob/master/docs/web_services/examples/groovy/get_gff3.groovy",
                "methodName": "write",
-               "jsondocId": "b59cf5c7-823c-488b-a9f1-80e5cd94d5c5",
+               "jsondocId": "5b7df0cd-3029-40e0-924f-632b5da5f2a7",
                "bodyobject": {
-                  "jsondocId": "8557c41c-cfe6-4a96-9900-d2d8ba25bde8",
+                  "jsondocId": "fcac6e23-27a6-401d-9b1d-5db2161192dc",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5417,7 +5417,7 @@
                "apierrors": [],
                "path": "/IOService/write",
                "response": {
-                  "jsondocId": "9648b587-44c3-4b1a-9e2c-7164389aa664",
+                  "jsondocId": "6a13f80e-8d33-45e4-bac6-0e0b2b7e5663",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -5430,7 +5430,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b9028757-0841-43e8-b067-3c076620038f",
+                     "jsondocId": "e4b594b2-e1e0-485d-835f-3a84e8eb8726",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5439,7 +5439,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "921d8077-8753-418e-992e-949f7a11c845",
+                     "jsondocId": "12821b99-fe21-4e20-8d56-056fde7b3cae",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5448,7 +5448,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "595d89aa-597f-41ac-bd6c-d181a63c5995",
+                     "jsondocId": "b43fe00e-2795-4686-9666-67280aae1095",
                      "name": "uuid",
                      "format": "",
                      "description": "UUID that holds the key to the stored download.",
@@ -5457,7 +5457,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ccea7bea-ed29-479c-b56f-a5cf22353f9a",
+                     "jsondocId": "7cb96362-01f8-4fbf-ba8f-bebe05cf46de",
                      "name": "format",
                      "format": "",
                      "description": "'gzip' or 'text'",
@@ -5469,9 +5469,9 @@
                "verb": "POST",
                "description": "This is used to retrieve the a download link once the write operation was initialized using output: file.",
                "methodName": "download",
-               "jsondocId": "922374f7-3bb0-4f7a-b84c-f36e02b318d9",
+               "jsondocId": "53a701a6-9378-405b-acbc-af63a4d53ae5",
                "bodyobject": {
-                  "jsondocId": "b3a85419-d396-4ecf-b050-c4f8ab1b84d1",
+                  "jsondocId": "db4ab181-8cba-4742-979d-d26c003bd655",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5481,7 +5481,7 @@
                "apierrors": [],
                "path": "/IOService/download",
                "response": {
-                  "jsondocId": "abcc4bc4-5870-4aca-a5ee-5d2fb9c0cb90",
+                  "jsondocId": "1836f7ed-4959-4567-b2aa-6f1b969a2cd3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "i o service"
@@ -5494,14 +5494,14 @@
          "description": "Methods for bulk importing and exporting sequence data"
       },
       {
-         "jsondocId": "8923c902-df50-4823-ab89-7bad6053d325",
+         "jsondocId": "12f7ecb2-c94f-43fd-8e2b-9284e4432a69",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "27d080d9-5e2d-4f47-a219-b2f495afc3ce",
+                     "jsondocId": "6abdced0-7d9f-4419-a8a9-898036b9a880",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5510,7 +5510,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1be43a8-0c2d-4e37-9bf8-1ffe95522d78",
+                     "jsondocId": "282fd019-8ddb-496e-94fd-69850cd63b12",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5519,7 +5519,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "389837b7-f124-4aa3-a453-1b9188e70a86",
+                     "jsondocId": "7003fd98-331c-4f9a-9a6c-4d1009d706e8",
                      "name": "organism",
                      "format": "",
                      "description": "Pass an Organism JSON object with an 'id' that corresponds to the organism to be removed",
@@ -5531,9 +5531,9 @@
                "verb": "POST",
                "description": "Remove an organism",
                "methodName": "deleteOrganism",
-               "jsondocId": "a840339b-a607-4819-8ed4-0d849f17fc91",
+               "jsondocId": "6f973155-5cf0-47e2-8b50-fa6160b3962d",
                "bodyobject": {
-                  "jsondocId": "f16f8a31-d953-435c-851f-8f4dc5de5a7c",
+                  "jsondocId": "b471ae65-b48c-4b9e-80ed-aec87d2c3b03",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5543,7 +5543,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganism",
                "response": {
-                  "jsondocId": "45662c6e-17ac-472e-afce-499f67d5bdab",
+                  "jsondocId": "ccccaf10-bc8b-469e-b91b-d7e3174569d7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5556,7 +5556,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "c5f7871d-d05a-46dc-b164-3d75107c4f0d",
+                     "jsondocId": "c313ee9a-5631-4e45-9db4-c215e2fa81d6",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5565,7 +5565,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "db778023-93ae-4963-a318-7d4ace37a5cf",
+                     "jsondocId": "327b61c2-12c3-42f6-8197-e3686abcd9f9",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5574,7 +5574,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55d4cdfe-95d2-4846-a42b-e266b536ab78",
+                     "jsondocId": "94b16506-629e-49ba-880b-27e02f4119e6",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5586,9 +5586,9 @@
                "verb": "POST",
                "description": "Delete an organism along with its data directory and returns a JSON object containing properties of the deleted organism",
                "methodName": "deleteOrganismWithSequence",
-               "jsondocId": "16328a36-b283-439c-8ca7-725c9ba99a38",
+               "jsondocId": "64d06eb9-0cd0-46df-9daf-05ae8ad16732",
                "bodyobject": {
-                  "jsondocId": "f4e04f3f-7b1b-4897-87e5-81e7a01ac8e7",
+                  "jsondocId": "0cdc71f5-e8af-44bc-931c-d33c35f81598",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5598,7 +5598,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismWithSequence",
                "response": {
-                  "jsondocId": "e8a7353d-7612-42ba-ad76-78b3fdb81027",
+                  "jsondocId": "8f3f8e7f-a20d-4ad3-9a9f-b879696d588e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5611,7 +5611,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e0e4c09d-74c7-4bee-a910-71815bc7a1a5",
+                     "jsondocId": "a0b0436d-198e-4192-bcf8-5fd501737354",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5620,7 +5620,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55759649-ed0b-472e-9327-67dc43211f37",
+                     "jsondocId": "d2476b9a-17d1-42cb-9577-b59b1d2af202",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5629,7 +5629,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5942e1dd-e97c-488a-a45c-b0c7184fc00e",
+                     "jsondocId": "716aa9de-fa36-4bad-83cb-59c73f909bc0",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism.",
@@ -5638,7 +5638,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "efc937ef-299e-4fae-a87b-66d4c4b42ad7",
+                     "jsondocId": "4c5b2878-bc32-43cd-a803-aff2cdf01429",
                      "name": "sequences",
                      "format": "",
                      "description": "(optional) Comma-delimited sequence names on that organism if only certain sequences should be deleted.",
@@ -5650,9 +5650,9 @@
                "verb": "POST",
                "description": "Remove features from an organism",
                "methodName": "deleteOrganismFeatures",
-               "jsondocId": "4ff144da-de63-433b-8de2-c4ee0c57b027",
+               "jsondocId": "7d3b1a46-1b05-4dfc-a8e9-e980946cacf6",
                "bodyobject": {
-                  "jsondocId": "0911d7ac-92e6-4a9a-b629-83862d9d9ffb",
+                  "jsondocId": "19ba03c6-85b9-4c6a-b48c-b6b8de8218a4",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5662,7 +5662,7 @@
                "apierrors": [],
                "path": "/organism/deleteOrganismFeatures",
                "response": {
-                  "jsondocId": "d1752ad4-6180-42d9-a776-a8ba6f7fe431",
+                  "jsondocId": "0919ea9a-83a7-4bef-9bf4-8ca9ace6dfe6",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5675,7 +5675,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "ed70e718-4c30-4887-a9bf-10794beafd5a",
+                     "jsondocId": "554f272e-25b8-4707-bcec-b5b490b5045e",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5684,7 +5684,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0700923d-5ff4-4c52-be2f-12aa1e84aab5",
+                     "jsondocId": "386931ee-e765-43d9-ba31-5f9ff0667daa",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5693,7 +5693,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "55960b2f-0bd7-4878-83dd-56a32165ce79",
+                     "jsondocId": "5293c695-5b33-4672-96d0-ee9333f3dd3c",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -5702,7 +5702,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "48b05d99-9f5a-443f-a917-ebceef6b96b1",
+                     "jsondocId": "122c5d9a-7fed-4cb0-9d6e-9eec7a6e0440",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -5711,7 +5711,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2f4fed2f-83b3-4a25-8ee3-ab64fcec040d",
+                     "jsondocId": "e02b6f93-c0cb-48a5-bb53-a934b35c2a22",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -5720,7 +5720,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3ff145f3-eb12-4971-8ecd-4253748ffa9c",
+                     "jsondocId": "1338fab7-2f70-48f8-89c5-9e4bfad9773a",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -5729,7 +5729,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6e5c8494-421a-4410-972b-4381bec26adb",
+                     "jsondocId": "4b979462-c4c0-4916-b168-d7b0380b7c5d",
                      "name": "commonName",
                      "format": "",
                      "description": "commonName for an organism",
@@ -5738,7 +5738,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1786da1a-13ff-43ad-b5d8-ab73e6fbd753",
+                     "jsondocId": "95add9a1-f7f4-4c21-bdc1-87235ebcec73",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -5747,7 +5747,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "0cc7f624-ffa2-417d-a38f-734a68690acc",
+                     "jsondocId": "d91b38e4-0821-43f6-9df0-581997d748a7",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -5756,7 +5756,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dae05112-dafe-494a-b9e6-b1137fca8779",
+                     "jsondocId": "21c6826b-c60f-4321-89e5-092ee05fe058",
                      "name": "organismData",
                      "format": "",
                      "description": "zip or tar.gz compressed data directory",
@@ -5765,7 +5765,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "6d0f8cae-1f0c-464a-86ee-5cfed1d89b49",
+                     "jsondocId": "1bf2e525-babe-4b5a-9ff6-599176ef6983",
                      "name": "sequenceData",
                      "format": "",
                      "description": "FASTA file (optionally compressed) to automatically upload with",
@@ -5777,9 +5777,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganismWithSequence",
-               "jsondocId": "9015881a-158f-49e6-839e-fe67829b3fec",
+               "jsondocId": "dce0cabd-16e7-42ca-b8d0-9a2ded5eb020",
                "bodyobject": {
-                  "jsondocId": "a07d0d3e-ab99-45fd-b688-c86776fc83c9",
+                  "jsondocId": "28ac02a9-644f-412a-b607-18f061912bcd",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5789,7 +5789,7 @@
                "apierrors": [],
                "path": "/organism/addOrganismWithSequence",
                "response": {
-                  "jsondocId": "dff589b6-534d-4db7-b5d6-a7dc18a52f45",
+                  "jsondocId": "92633116-86af-46ed-bc7d-906b95aae81b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5802,7 +5802,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "82776302-c9b0-4e19-bc02-c9d4740e369a",
+                     "jsondocId": "21f18439-6929-4af7-a2ae-744f3d03c3c3",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5811,7 +5811,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c13eaaec-2413-4b4f-93c6-76e90c753c2a",
+                     "jsondocId": "ab95f573-67d9-481d-a9ae-233075d3f320",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5820,7 +5820,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "862b8478-097e-4f96-8769-6893370a1b36",
+                     "jsondocId": "10c288d1-899a-40df-9a0c-6feb2ceb82e2",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5829,7 +5829,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "23ac0ebd-7d8d-4c04-832e-372d39457d89",
+                     "jsondocId": "43af4ef2-da27-4b50-b675-d0c1dda0c0c2",
                      "name": "trackLabel",
                      "format": "",
                      "description": "Name of track",
@@ -5841,9 +5841,9 @@
                "verb": "POST",
                "description": "Removes an added track from an existing organism returning a JSON object containing all tracks for the current organism.",
                "methodName": "removeTrackFromOrganism",
-               "jsondocId": "a4e4a4d2-790b-4259-aee7-6ba0ab1473a2",
+               "jsondocId": "a65f288c-3d56-4dea-83c8-d9ff4d98840b",
                "bodyobject": {
-                  "jsondocId": "592cf614-daf8-4f0e-af25-e84c160e68d3",
+                  "jsondocId": "5325e008-e258-44df-8dd7-2b0d92cdfbb7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5853,7 +5853,7 @@
                "apierrors": [],
                "path": "/organism/removeTrackFromOrganism",
                "response": {
-                  "jsondocId": "4bba8b8b-900e-4a5a-b718-6effa749b3e1",
+                  "jsondocId": "6744010a-5685-47c9-bf7c-7c7b3a3401d3",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5866,7 +5866,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d9158ecd-64c3-47a9-ac8b-348ed021b290",
+                     "jsondocId": "0a08c26b-e2e6-4636-882d-eb8825a339f4",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5875,7 +5875,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "97fe47e9-b3c3-461e-b29b-dd938cf04754",
+                     "jsondocId": "2ce2f873-8ffa-462c-8f87-e1400c5ff4e5",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5884,7 +5884,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3c9da0c9-b47e-496b-b810-f8db0dd84e71",
+                     "jsondocId": "f29b76e5-fdc5-4b5d-8894-002b460635fd",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5893,7 +5893,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "37ff5680-7bd3-44b2-8bb1-fca8c71774e0",
+                     "jsondocId": "4ba19323-ebf1-4112-9feb-2360d0498273",
                      "name": "trackData",
                      "format": "",
                      "description": "zip or tar.gz compressed track data",
@@ -5902,7 +5902,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "3d1f3d2f-f92b-4ccf-957d-ffb91ad96cf3",
+                     "jsondocId": "0a7edf57-1a07-4447-9186-3b9d7a1ec6bc",
                      "name": "trackFile",
                      "format": "",
                      "description": "track file (*.bam, *.vcf, *.bw, *gff)",
@@ -5911,7 +5911,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c1740238-efbe-4d4c-ab59-b256e0c7110d",
+                     "jsondocId": "ec06cc78-4846-4a54-b70e-b17c07bc3e4d",
                      "name": "trackFileIndex",
                      "format": "",
                      "description": "index (*.bai, *.tbi)",
@@ -5920,7 +5920,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84734709-d088-4563-a0ad-30d119092d06",
+                     "jsondocId": "3bce519a-434f-4af6-aaaa-75900aad1383",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -5932,9 +5932,9 @@
                "verb": "POST",
                "description": "Adds a track to an existing organism returning a JSON object containing all tracks for the current organism.",
                "methodName": "addTrackToOrganism",
-               "jsondocId": "6a2d4ccd-e10a-4c15-996f-5eb35f3d4095",
+               "jsondocId": "a9cdb641-d2f5-49ba-bfe9-a366c5c53c63",
                "bodyobject": {
-                  "jsondocId": "4b794390-bc35-47a6-bf10-8f50b3f9c674",
+                  "jsondocId": "3e166bf7-6a13-4aed-a12a-dfb2963635c1",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -5944,7 +5944,7 @@
                "apierrors": [],
                "path": "/organism/addTrackToOrganism",
                "response": {
-                  "jsondocId": "456eb395-8843-43fc-bdae-bc7c159b6abd",
+                  "jsondocId": "302ec9e4-d299-4944-be7b-e4016b57518b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -5957,7 +5957,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "1717a911-cbcd-45d9-9df9-fb968ac6a8b0",
+                     "jsondocId": "3f7b2403-d1cb-464a-b0e3-fe729c560f59",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -5966,7 +5966,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "48b8833b-4477-44b5-b711-ebdf021a3232",
+                     "jsondocId": "fe398ad5-40f9-49fd-b248-651f41e78174",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -5975,7 +5975,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b5f02371-0f85-4972-96bc-f576f25ec141",
+                     "jsondocId": "801749c9-392c-4ce5-a186-c27f06fb52c0",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -5984,7 +5984,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "134e381c-d341-4e9a-9f06-1a7b00ff28c2",
+                     "jsondocId": "f229ed98-77fa-40f7-a4fd-f18eb6676fdd",
                      "name": "trackLabel",
                      "format": "",
                      "description": "Track label corresponding to the track that is to be deleted",
@@ -5996,9 +5996,9 @@
                "verb": "POST",
                "description": "Deletes a track from an existing organism and returns a JSON object of the deleted track's configuration",
                "methodName": "deleteTrackFromOrganism",
-               "jsondocId": "cffd17fd-5e0e-407d-9b3a-61c870cbca5e",
+               "jsondocId": "2a993d74-a3ef-4b7e-9152-cb85af9acfc3",
                "bodyobject": {
-                  "jsondocId": "f036f2c1-c685-48f9-9bfb-ac670a7c5d54",
+                  "jsondocId": "b2ac5838-0693-49bf-9eec-78795f2cf72f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6008,7 +6008,7 @@
                "apierrors": [],
                "path": "/organism/deleteTrackFromOrganism",
                "response": {
-                  "jsondocId": "b2b967d9-3861-4f19-ae8e-c7fc7009b24a",
+                  "jsondocId": "405dbb64-958d-4f03-b646-3de7d1f8565d",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6021,7 +6021,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "d29c53ad-466a-4db2-87b2-069aacae49c3",
+                     "jsondocId": "6bb4e62b-6154-4c99-8c1e-66a5aad4a59b",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6030,7 +6030,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f1ea9226-de0b-4018-8d2b-35f3f703b167",
+                     "jsondocId": "6aa0c97c-efae-40c5-8726-a2126a4cb313",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6039,7 +6039,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b5a4bda8-a5fc-4e88-bdb5-41ca55c927a7",
+                     "jsondocId": "09c563aa-3000-47e8-bd2e-f4bcef9a91cd",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -6048,7 +6048,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "9ab94f48-ebe3-4bd9-b092-511278d42393",
+                     "jsondocId": "c621c24b-2976-4db4-a3a1-42b84e64a972",
                      "name": "trackConfig",
                      "format": "",
                      "description": "Track configuration (JBrowse JSON)",
@@ -6060,9 +6060,9 @@
                "verb": "POST",
                "description": "Update a track in an existing organism returning a JSON object containing old and new track configurations",
                "methodName": "updateTrackForOrganism",
-               "jsondocId": "c9747c62-7ada-4aef-9a2f-e7c2a8b39501",
+               "jsondocId": "228757d0-5c6a-4b44-99ae-fc1a7ce7a3e7",
                "bodyobject": {
-                  "jsondocId": "1bea906c-620e-445d-a0c9-d7ee4693af34",
+                  "jsondocId": "02e9e25b-fb8d-4ba9-812f-08761d01f8bb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6072,7 +6072,7 @@
                "apierrors": [],
                "path": "/organism/updateTrackForOrganism",
                "response": {
-                  "jsondocId": "5b77b674-6f41-4c8d-85f7-aef9da2c1b79",
+                  "jsondocId": "1050f30c-be31-467d-90a1-bb5bbf4d1ab8",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6085,7 +6085,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f473825d-3b9a-4c87-ba47-6d6a4cc6d3f4",
+                     "jsondocId": "12e0422d-0d70-4505-a435-17ff7d87c443",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6094,7 +6094,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d2bf0862-e713-444f-93ec-ee16656b2005",
+                     "jsondocId": "76323777-e4c8-4670-9188-22fc06654606",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6103,7 +6103,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66f205a2-8d08-43fe-ae3b-e84a162a752c",
+                     "jsondocId": "fcd99832-99d4-484d-bea4-a4bf10cd854b",
                      "name": "directory",
                      "format": "",
                      "description": "Filesystem path for the organisms data directory (required)",
@@ -6112,7 +6112,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "666e373b-f148-4d4a-a3fd-7dfc2ae952e4",
+                     "jsondocId": "a2f98648-7a60-4a96-9a0e-82ff848d82d7",
                      "name": "commonName",
                      "format": "",
                      "description": "A name used for the organism",
@@ -6121,7 +6121,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "511cdfb0-4afb-4fd4-ac93-f4cd597cc07c",
+                     "jsondocId": "0a9af526-c530-481a-97ae-52f144ed5a83",
                      "name": "species",
                      "format": "",
                      "description": "(optional) Species name",
@@ -6130,7 +6130,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "042fc23d-2da5-4e59-b2f2-d51b9054ba86",
+                     "jsondocId": "4591b5f7-6918-4961-a1ff-b1cf87547c2d",
                      "name": "genus",
                      "format": "",
                      "description": "(optional) Species genus",
@@ -6139,7 +6139,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "51236c1d-c832-45b1-9872-371661c6eba0",
+                     "jsondocId": "d5cf2012-b454-42aa-8777-dd8ec9bcd638",
                      "name": "blatdb",
                      "format": "",
                      "description": "(optional) Filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -6148,7 +6148,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d0801a83-a955-496d-80b7-e4eb5892c06e",
+                     "jsondocId": "70f2115b-6dc8-4b27-99e9-df80c58f7a39",
                      "name": "publicMode",
                      "format": "",
                      "description": "(optional) A flag for whether the organism appears as in the public genomes list (default false)",
@@ -6157,7 +6157,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1f93c974-8501-44f0-87b6-bf3ed474c0d5",
+                     "jsondocId": "8f0e1b3d-a841-4490-8566-e0afa8438b29",
                      "name": "metadata",
                      "format": "",
                      "description": "(optional) Organism metadata",
@@ -6166,7 +6166,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2a54e98f-3a43-4b6c-8256-e66d463892da",
+                     "jsondocId": "bab0a6c8-3664-42ff-bed9-bd5bc4229b20",
                      "name": "returnAllOrganisms",
                      "format": "",
                      "description": "(optional) Return all organisms (true / false) (default true)",
@@ -6178,9 +6178,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "addOrganism",
-               "jsondocId": "3c69d6ec-adf7-49c6-bc7c-4fdd8e737f8a",
+               "jsondocId": "53c9b720-8350-462b-9a40-7dc676afd658",
                "bodyobject": {
-                  "jsondocId": "32a776a0-51be-4064-bbf1-6abb1ce53858",
+                  "jsondocId": "9161139c-0947-4bca-9e30-8bfd47f4cb85",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6190,7 +6190,7 @@
                "apierrors": [],
                "path": "/organism/addOrganism",
                "response": {
-                  "jsondocId": "93119481-4477-4211-9614-4b544f20d98a",
+                  "jsondocId": "ee835981-6b57-4409-b23a-2d0dbddabc7a",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6203,7 +6203,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "9ae8c66b-84dd-430f-ac45-9bd4ba1f7d58",
+                     "jsondocId": "bbac89a6-e00d-4eef-bbf5-9da196d934f5",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6212,7 +6212,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fe0e1773-581b-4260-92cc-32180e3b5d1b",
+                     "jsondocId": "860dfd5a-3ea6-4be2-855b-e542975c7007",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6221,7 +6221,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "18b1da14-cd53-406d-af41-4f9e0e99b95d",
+                     "jsondocId": "ba5c878c-035e-437c-841d-819c5b508908",
                      "name": "organism",
                      "format": "",
                      "description": "Common name or ID for the organism",
@@ -6233,9 +6233,9 @@
                "verb": "POST",
                "description": "Finds sequences for a given organism and returns a JSON object including the username, organism and a JSONArray of sequences",
                "methodName": "getSequencesForOrganism",
-               "jsondocId": "169b9c2f-4918-4784-9ce3-8a100697a0a1",
+               "jsondocId": "aaff0357-5376-42e5-9f36-c7d2ba8bf7bb",
                "bodyobject": {
-                  "jsondocId": "42391a59-758d-4e98-8446-c4e3cbb42aa2",
+                  "jsondocId": "8b673c5b-e003-4f12-9b9e-2b49330e6e20",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6245,7 +6245,7 @@
                "apierrors": [],
                "path": "/organism/getSequencesForOrganism",
                "response": {
-                  "jsondocId": "c69de90a-7797-42ee-bc4b-78a1dbc3b8cd",
+                  "jsondocId": "e08dfa93-1420-4715-949e-53733a4cf114",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6258,7 +6258,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "f9bf8d35-f767-46b6-9fc9-066fa0f9755d",
+                     "jsondocId": "2b07e7f0-61b7-40f8-953b-ea8b9a40c8aa",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6267,7 +6267,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "37ef523e-265a-4058-8ad1-d3e7b6498e83",
+                     "jsondocId": "13f2c790-959a-425e-974a-cdf23d50f688",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6276,7 +6276,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "aa498f67-7f2f-4e2c-bcd2-61267ce2d7f0",
+                     "jsondocId": "6aa6f3e8-85a9-46ad-bd27-fa513ffc4c0b",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -6285,7 +6285,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e65d1d66-714d-41f1-9534-5f0f0bfdb634",
+                     "jsondocId": "5d0a8574-1cb0-4e46-a07c-1d870152be41",
                      "name": "directory",
                      "format": "",
                      "description": "filesystem path for the organisms data directory (required)",
@@ -6294,7 +6294,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f89bffb9-3ece-4cb1-a2cb-0281bbcffea9",
+                     "jsondocId": "c797c5c6-2079-4c29-9587-51919ed8bc8f",
                      "name": "species",
                      "format": "",
                      "description": "species name",
@@ -6303,7 +6303,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "44cf9bd0-e19f-4a44-acaf-0341d2802690",
+                     "jsondocId": "04f20a37-b037-42fa-9d98-aa0bd760ea27",
                      "name": "genus",
                      "format": "",
                      "description": "species genus",
@@ -6312,7 +6312,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ff202f68-680b-41f0-846c-eef0788f2c2e",
+                     "jsondocId": "242491e5-6180-47d9-9a78-f89f1a81fc94",
                      "name": "blatdb",
                      "format": "",
                      "description": "filesystem path for a BLAT database (e.g. a .2bit file)",
@@ -6321,7 +6321,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "2fb3ae05-6abb-444b-a0ce-3bac17daedc0",
+                     "jsondocId": "7edfaa8f-30be-4119-8f0a-6e24b7e208c3",
                      "name": "publicMode",
                      "format": "",
                      "description": "a flag for whether the organism appears as in the public genomes list",
@@ -6330,7 +6330,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "372670d5-7709-440a-ad76-297b0c08fec0",
+                     "jsondocId": "9e055ec6-5c1f-4d3f-a21a-48bdfdf5986e",
                      "name": "name",
                      "format": "",
                      "description": "a common name used for the organism",
@@ -6339,7 +6339,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "dbb3dc64-fb59-4dbd-b6d7-486160ab8c81",
+                     "jsondocId": "d67c328b-0e8e-41bc-9174-4b115a715153",
                      "name": "nonDefaultTranslationTable",
                      "format": "",
                      "description": "non-default translation table",
@@ -6348,7 +6348,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f46cce73-89f5-4899-8322-d94071104c5c",
+                     "jsondocId": "2c55e358-733e-48cb-a8fa-ff328faa5a02",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -6360,9 +6360,9 @@
                "verb": "POST",
                "description": "Adds an organism returning a JSON array of all organisms",
                "methodName": "updateOrganismInfo",
-               "jsondocId": "f1d61588-468b-4895-9b33-f363c5b1e941",
+               "jsondocId": "7d72bd43-260c-499f-8148-8561ad112e8b",
                "bodyobject": {
-                  "jsondocId": "633f18b2-3aa9-47e8-8c63-af71bfe4c37a",
+                  "jsondocId": "d9430d5c-a996-402c-a7d9-187fb4e0bd68",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6372,7 +6372,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismInfo",
                "response": {
-                  "jsondocId": "0c0cb7da-a8a6-456a-9c86-a5b70c213a37",
+                  "jsondocId": "edcddb02-c235-4e4b-af92-91f58fea01bb",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6385,7 +6385,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "364deff3-d335-4721-a7e5-8413ab193286",
+                     "jsondocId": "f72c4dc7-3764-4fdb-802a-2fef2e6c8efc",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6394,7 +6394,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ee04b509-9099-45d2-976c-61653ee03f78",
+                     "jsondocId": "2f4886ae-2c96-4371-9674-4d868e252d80",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6403,7 +6403,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e23eb9b8-519e-4baa-bdd2-61c4d52f424a",
+                     "jsondocId": "86bfc87a-9d4a-4588-b5d6-967527d3fdb7",
                      "name": "id",
                      "format": "",
                      "description": "unique id of organism to change",
@@ -6412,7 +6412,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "92262182-1e0e-4d2e-8c99-738f5587045c",
+                     "jsondocId": "75ca1a27-79d9-4b1a-bca3-850b55239db2",
                      "name": "metadata",
                      "format": "",
                      "description": "organism metadata",
@@ -6424,9 +6424,9 @@
                "verb": "POST",
                "description": "Update organism metadata",
                "methodName": "updateOrganismMetadata",
-               "jsondocId": "0d095b13-8089-4330-959a-8a27648c70b9",
+               "jsondocId": "391ef982-6bf4-4e3f-9a51-b2e73c8948f3",
                "bodyobject": {
-                  "jsondocId": "923a8148-b20a-4235-9334-ae127b21f203",
+                  "jsondocId": "ed475468-f14d-4ec2-a1d0-d3f38ef9e651",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6436,7 +6436,7 @@
                "apierrors": [],
                "path": "/organism/updateOrganismMetadata",
                "response": {
-                  "jsondocId": "d8568c90-8905-4377-b5d9-fa7c7468b1a4",
+                  "jsondocId": "ab2493d6-7fed-416f-a45d-fc43398cf476",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6449,7 +6449,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "70592d7a-4272-498a-85df-e479a5950dee",
+                     "jsondocId": "32e52c61-8a76-4112-94da-03ce7f5a7de0",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6458,7 +6458,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c6fdd1f9-f042-4af3-8660-60237be246e9",
+                     "jsondocId": "a9d971c8-f632-4ed8-bb83-5a8d301489a1",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6467,7 +6467,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cd2cee61-2648-463e-a72c-7995879e1ecf",
+                     "jsondocId": "f9f0fc72-e650-4a44-997b-ddee04887187",
                      "name": "organism",
                      "format": "",
                      "description": "ID or commonName that can be used to uniquely identify an organism",
@@ -6479,9 +6479,9 @@
                "verb": "POST",
                "description": "Get creator metadata for organism, returns userId as String",
                "methodName": "getOrganismCreator",
-               "jsondocId": "8d252c9b-21e8-4530-ba33-e6056b4a700b",
+               "jsondocId": "9c0643cb-5712-4a25-9c9a-3c7299b7ca6c",
                "bodyobject": {
-                  "jsondocId": "e1500874-b617-4640-b8ca-5689930081d7",
+                  "jsondocId": "ec941d3d-486f-49be-a4c3-e8e10e4b2498",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6491,7 +6491,7 @@
                "apierrors": [],
                "path": "/organism/getOrganismCreator",
                "response": {
-                  "jsondocId": "871d86eb-69ba-4ac6-969a-26894ce096b2",
+                  "jsondocId": "08ebb66d-748c-4ea2-a7d2-72c95a7ca961",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6504,7 +6504,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "e0368f61-7a63-4b62-863f-2cb041700689",
+                     "jsondocId": "ed546a5a-1349-46e0-bf30-12e6c9300a8d",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -6513,7 +6513,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c971d619-4064-4009-9149-07c122784b66",
+                     "jsondocId": "e570ed6b-036e-47c5-8686-a78d14101487",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -6522,7 +6522,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "128dcec8-6bf2-4b6a-a4dc-03f6ee77f653",
+                     "jsondocId": "3fef94fc-43de-42fa-820b-cd1a340d1310",
                      "name": "organism",
                      "format": "",
                      "description": "(optional) ID or commonName that can be used to uniquely identify an organism",
@@ -6534,9 +6534,9 @@
                "verb": "POST",
                "description": "Returns a JSON array of all organisms, or optionally, gets information about a specific organism",
                "methodName": "findAllOrganisms",
-               "jsondocId": "fcc595bc-edba-473c-b0a1-288d3da6907d",
+               "jsondocId": "9af48914-09fb-415e-9bfe-eb80ad1fe03f",
                "bodyobject": {
-                  "jsondocId": "854aa854-d55d-4414-afa5-eb10bf725638",
+                  "jsondocId": "c4b90abc-c5eb-4ebc-9447-6b2d72c3ab13",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -6546,7 +6546,7 @@
                "apierrors": [],
                "path": "/organism/findAllOrganisms",
                "response": {
-                  "jsondocId": "7875506a-dcb0-442f-a9c5-fc9dc2f06f59",
+                  "jsondocId": "f4b4ff63-db43-413b-9596-66b65895917e",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "organism"
@@ -6559,14 +6559,14 @@
          "description": "Methods for managing organisms"
       },
       {
-         "jsondocId": "c88c4c47-70a7-4aba-a386-5adfd0c65dca",
+         "jsondocId": "1de3555f-b76e-433a-be3b-6e4d2a03cd1f",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b7fcc998-ae14-4129-be24-ad1ab8a1d06b",
+                     "jsondocId": "e39041d2-4d7b-4816-a98b-f4a7cf8c311c",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -6575,7 +6575,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "182917bd-e8dc-4ac7-a83e-f3fc58afc98e",
+                     "jsondocId": "70cc9ead-24d6-4e95-a508-9b6a96da23f4",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -6584,7 +6584,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8b0dac6a-fdd8-4efc-a544-48fbb563e211",
+                     "jsondocId": "227f2e91-bf75-47fe-a374-9e338aab6bf1",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -6593,7 +6593,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "89f1e41c-cf78-47e5-be80-16d2db90a15b",
+                     "jsondocId": "76b96181-0ca9-4f8e-846e-4d07841e8c0a",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -6602,7 +6602,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "02e725a1-5339-46ff-9e2e-16413ad4e08c",
+                     "jsondocId": "44916b38-d2f0-4f09-8a8e-6fe65824a101",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6614,12 +6614,12 @@
                "verb": "GET",
                "description": "Get sequence data within a range",
                "methodName": "sequenceByLocation",
-               "jsondocId": "541e87ce-a710-4acd-80f2-21f10a1b8b9c",
+               "jsondocId": "fb3337e3-9975-4aec-8e90-37a4f2018d0f",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/<organism name>/<sequence name>:<fmin>..<fmax>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "5a39c1e2-fe00-43b9-95f1-b61fdf7bcb1e",
+                  "jsondocId": "62225fe7-1fac-49bd-839c-ae1cf44a07c7",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6632,7 +6632,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "b9f86b7b-ced9-42cb-bdeb-38130ccbaa31",
+                     "jsondocId": "ea633ad3-1e03-48bb-a1fc-5de82f993036",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID (required)",
@@ -6641,7 +6641,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7bacc10-ec20-4f38-af2a-2a7f7d099e51",
+                     "jsondocId": "30e8d208-82d7-4060-9e49-1daa6011732a",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name (required)",
@@ -6650,7 +6650,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "682607c4-f3e6-4f71-a1c6-a69b115a7b5d",
+                     "jsondocId": "a5b71a69-5c7b-4687-a31c-875deabf0ac6",
                      "name": "featureName",
                      "format": "",
                      "description": "The uniqueName (UUID) or given name of the feature (typically transcript) of the element to retrieve sequence from",
@@ -6659,7 +6659,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "8bfaa37a-2261-420c-955a-6184ef808b0e",
+                     "jsondocId": "403965ad-3970-4629-a74f-6e9bd175f38c",
                      "name": "type",
                      "format": "",
                      "description": "(default genomic) Return type: genomic, cds, cdna, peptide",
@@ -6668,7 +6668,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e8dae7d5-4ecf-4a7f-b4f9-d0b015d914bd",
+                     "jsondocId": "391b37cb-59c0-4dcb-97a4-ba94ea9f4fb9",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6680,12 +6680,12 @@
                "verb": "GET",
                "description": "Get sequence data as for a selected name",
                "methodName": "sequenceByName",
-               "jsondocId": "33980d63-8b93-4726-b7a5-eca68eb762da",
+               "jsondocId": "cc8ff46e-c762-423d-a2b5-e9b5ac5008df",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/<organism name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "2875ba19-85b4-4d05-8d99-570edc858207",
+                  "jsondocId": "c6677855-823b-4991-99fb-138825b55566",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6698,7 +6698,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "858f2d75-2489-4c9a-922f-2ca3b3cdcc16",
+                     "jsondocId": "2ade2a73-aee9-464e-af47-45fede0b876e",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -6707,7 +6707,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "702c4119-ee69-4361-b0df-ebc81b6c1dc8",
+                     "jsondocId": "e35f9511-8456-4194-99c9-09808ca8163e",
                      "name": "sequenceName",
                      "format": "",
                      "description": "Sequence name (required)",
@@ -6719,12 +6719,12 @@
                "verb": "GET",
                "description": "Remove sequence cache for an organism and sequence",
                "methodName": "clearSequenceCache",
-               "jsondocId": "b1b0b645-e05a-46ce-9e44-36d0eaf9fe03",
+               "jsondocId": "f4a32505-eef1-4e2a-8d3c-80b2b0395284",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/cache/clear/<organism name>/<sequence name>",
                "response": {
-                  "jsondocId": "0117afef-0926-459e-a00e-7901b7bed6c7",
+                  "jsondocId": "0e1c33db-b318-4b64-bf76-46d194576b6b",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6736,7 +6736,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "b9cb8a56-1271-47a3-8d55-52ca344af17f",
+                  "jsondocId": "8280f752-719b-4902-a30c-fdf6552ad965",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required) or 'ALL' if admin",
@@ -6747,12 +6747,12 @@
                "verb": "GET",
                "description": "Remove sequence cache for an organism",
                "methodName": "clearOrganismCache",
-               "jsondocId": "9e95929c-f430-4440-b0d2-cda8a2bd6388",
+               "jsondocId": "99784ea7-c162-43b8-aefa-d5f3f40cb61d",
                "bodyobject": null,
                "apierrors": [],
                "path": "/sequence/cache/clear/<organism name>",
                "response": {
-                  "jsondocId": "59d573e4-9a15-4ef6-8d63-9ae1a384462a",
+                  "jsondocId": "05a141ba-7949-4b1d-a148-ed72747a5eb9",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "sequence"
@@ -6765,42 +6765,14 @@
          "description": "Methods for retrieving sequence data"
       },
       {
-         "jsondocId": "e6280d5e-e3e2-42f1-895e-39d8287b0a96",
+         "jsondocId": "f591a16a-7ec2-456c-9c1f-70431c22d411",
          "methods": [
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [{
-                  "jsondocId": "ac986d75-4594-4edc-a8c2-8783ac94a4be",
-                  "name": "organismName",
-                  "format": "",
-                  "description": "Organism common name (required) or 'ALL' if admin",
-                  "type": "string",
-                  "required": "true",
-                  "allowedvalues": []
-               }],
-               "verb": "GET",
-               "description": "Remove track cache for an organism",
-               "methodName": "clearOrganismCache",
-               "jsondocId": "a0196885-7bdb-429c-9db2-970d72cc3288",
-               "bodyobject": null,
-               "apierrors": [],
-               "path": "/track/cache/clear/<organism name>",
-               "response": {
-                  "jsondocId": "a9aa95ff-4369-451a-85fa-2f936f92fb7f",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "track"
-               },
-               "produces": ["application/json"],
-               "consumes": []
-            },
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0efc442e-322f-4fcb-a94d-ddb5f2258476",
+                     "jsondocId": "d639dfb4-387c-40bf-ad83-669e030172ac",
                      "name": "organismName",
                      "format": "",
                      "description": "Organism common name (required)",
@@ -6809,7 +6781,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "c7d530d4-7380-4e6b-a962-d3e571fd211c",
+                     "jsondocId": "860913f8-6345-4e3c-bcc7-c4f3fbf352aa",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name (required)",
@@ -6821,12 +6793,12 @@
                "verb": "GET",
                "description": "Remove track cache for an organism and track",
                "methodName": "clearTrackCache",
-               "jsondocId": "b6acc32e-ae61-4c18-85db-7942c6b3ca36",
+               "jsondocId": "24799083-6e7b-4855-8f6d-d5c156d361ca",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/cache/clear/<organism name>/<track name>",
                "response": {
-                  "jsondocId": "99fe020d-edaf-4a9d-b759-5fb827ac08d9",
+                  "jsondocId": "9ac54c60-0044-4a9d-b6db-2cb4d33d8c62",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -6838,7 +6810,7 @@
                "headers": [],
                "pathparameters": [],
                "queryparameters": [{
-                  "jsondocId": "2621fae8-fe20-495f-b971-f942e02881b8",
+                  "jsondocId": "553ee3f9-2357-4c27-bbbe-2f7ccd690df9",
                   "name": "organismName",
                   "format": "",
                   "description": "Organism common name (required)",
@@ -6849,12 +6821,12 @@
                "verb": "GET",
                "description": "List all tracks for an organism",
                "methodName": "getTracks",
-               "jsondocId": "35ed3548-d9ce-43b6-97b9-fc3e802b2d22",
+               "jsondocId": "2672663c-50b7-4f99-bd0e-d31f2330afc8",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/list/<organism name>",
                "response": {
-                  "jsondocId": "be8d76ed-5158-4646-bbb1-4b5a36f43089",
+                  "jsondocId": "4d709920-9c0b-4c56-b739-c6f2803c1d95",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -6867,7 +6839,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "27b7cb8f-8095-434c-a437-a0fb268abb29",
+                     "jsondocId": "572a10bc-d33a-4896-a7e1-f44bca4e09d4",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -6876,7 +6848,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e1960d6b-05cc-43ea-9c71-0e25be8458b7",
+                     "jsondocId": "d6d62ecc-d959-4246-890c-8f6423aceab5",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -6885,7 +6857,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "1b353b71-6797-418b-8f5b-357552ec8b5d",
+                     "jsondocId": "fe7b99a7-6d79-4001-a153-e98676d16d4f",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -6894,7 +6866,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "7d92814d-0ade-4507-a463-b8876848c0c3",
+                     "jsondocId": "72bb8e48-141e-4d78-a29b-740f3543daed",
                      "name": "featureName",
                      "format": "",
                      "description": "If top-level feature 'id' matches, then annotate with 'selected'=1",
@@ -6903,7 +6875,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f808a601-0872-4f18-81c0-a06bcc8490fc",
+                     "jsondocId": "54d6406b-1a9b-4040-85d0-86ae40ddfa14",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -6912,7 +6884,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "93b2f967-32e1-4421-9961-e3168ed4bd31",
+                     "jsondocId": "cd1044f5-20fa-407c-9665-cd2d966ad96b",
                      "name": "flatten",
                      "format": "",
                      "description": "Brings nested top-level components to the root level.  If not provided or 'false' it will not flatten.  Default is 'gene'.",
@@ -6921,7 +6893,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e64bec8b-186b-4cc0-aadd-19f5bbcc543a",
+                     "jsondocId": "d434d039-e712-4768-9ae2-6c0ba4a64d0a",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -6933,12 +6905,12 @@
                "verb": "GET",
                "description": "Get track data as an JSON within but only for the selected name",
                "methodName": "featuresByName",
-               "jsondocId": "52cc5ef7-086b-4b40-a126-2f6f5e7b465e",
+               "jsondocId": "24ff5ca1-9a8b-428a-b38f-0140a1f4a530",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>/<feature name>.<type>?ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "a002eff4-eee6-46c4-936f-4f325dad3066",
+                  "jsondocId": "492d3ca9-740f-4a56-a1e3-d7f2d7f217f0",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -6951,7 +6923,7 @@
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "0d92ad0c-1747-498f-b286-d7032a539f61",
+                     "jsondocId": "30a4a664-39c0-4f0c-ab6a-50409246e22a",
                      "name": "organismString",
                      "format": "",
                      "description": "Organism common name or ID(required)",
@@ -6960,7 +6932,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a4cfbe62-f738-4dbb-8f02-1de196d4b835",
+                     "jsondocId": "1403f701-ce38-4ca5-b0f6-c6651843df3e",
                      "name": "trackName",
                      "format": "",
                      "description": "Track name(required)",
@@ -6969,7 +6941,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "84839d41-12f8-4389-809f-0d9513d1ec5b",
+                     "jsondocId": "3a381ef3-14af-42ea-bd5e-84b9848231f4",
                      "name": "sequence",
                      "format": "",
                      "description": "Sequence name(required)",
@@ -6978,7 +6950,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "da2ff211-5153-4a90-bd78-7c1951a0a310",
+                     "jsondocId": "ddc281b7-dda1-495d-b8fe-c175fe839c54",
                      "name": "fmin",
                      "format": "",
                      "description": "Minimum range(required)",
@@ -6987,7 +6959,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "f734b0d9-f0f7-4a1e-9064-1f3e40914525",
+                     "jsondocId": "e7315a41-2b4e-4fdf-b7a2-5096f0c12c85",
                      "name": "fmax",
                      "format": "",
                      "description": "Maximum range (required)",
@@ -6996,7 +6968,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "e93cb6c5-c13d-452a-976c-243d19beb8dc",
+                     "jsondocId": "939d7967-3b8f-44d7-8975-19446d4ba8d2",
                      "name": "name",
                      "format": "",
                      "description": "If top-level feature 'name' matches, then annotate with 'selected'=true.  Multiple names can be passed in.",
@@ -7005,7 +6977,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b6b855f5-d7bc-413f-a107-8e50e62b8103",
+                     "jsondocId": "9a55955c-6409-4739-a2a5-a903b3ccd509",
                      "name": "onlySelected",
                      "format": "",
                      "description": "(default false).  If 'selected'!=1 one, then exclude.",
@@ -7014,7 +6986,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "455b257c-a59f-428b-b54d-1055b2b76275",
+                     "jsondocId": "a35d1200-4031-4eb3-8a7c-b439fb656239",
                      "name": "ignoreCache",
                      "format": "",
                      "description": "(default false).  Use cache for request if available.",
@@ -7023,7 +6995,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "a7c042c9-3644-41d3-a44f-fb3213658f5e",
+                     "jsondocId": "bae25e22-7916-4781-be6d-00ae462554f7",
                      "name": "flatten",
                      "format": "",
                      "description": "Brings nested top-level components to the root level.  If not provided or 'false' it will not flatten.  Default is 'gene'.",
@@ -7032,7 +7004,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "03ef3422-b690-445a-b3db-09ab13708a2c",
+                     "jsondocId": "b43c9003-d7dc-4be0-899d-1380d74bbe3e",
                      "name": "type",
                      "format": "",
                      "description": ".json or .svg",
@@ -7044,12 +7016,40 @@
                "verb": "GET",
                "description": "Get track data as an JSON within an range",
                "methodName": "featuresByLocation",
-               "jsondocId": "ec930909-68a7-4a9d-83f9-004870f1a02d",
+               "jsondocId": "70253a9b-1581-4291-a815-f6b037adfb05",
                "bodyobject": null,
                "apierrors": [],
                "path": "/track/<organism name>/<track name>/<sequence name>:<fmin>..<fmax>.<type>?name=<name>&onlySelected=<onlySelected>&ignoreCache=<ignoreCache>",
                "response": {
-                  "jsondocId": "a9ea855f-cbd2-4976-9365-0635728c72a9",
+                  "jsondocId": "b16586fa-5bb4-4623-8204-47edcc252131",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "track"
+               },
+               "produces": ["application/json"],
+               "consumes": []
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [{
+                  "jsondocId": "d6beb45c-e823-4f40-9c09-2800baf94884",
+                  "name": "organismName",
+                  "format": "",
+                  "description": "Organism common name (required) or 'ALL' if admin",
+                  "type": "string",
+                  "required": "true",
+                  "allowedvalues": []
+               }],
+               "verb": "GET",
+               "description": "Remove track cache for an organism",
+               "methodName": "clearOrganismCache",
+               "jsondocId": "5b1ba37c-c0bb-454b-b7c8-23e622ae9c1a",
+               "bodyobject": null,
+               "apierrors": [],
+               "path": "/track/cache/clear/<organism name>",
+               "response": {
+                  "jsondocId": "308d3591-8a08-48e9-9f47-2a77d19b5060",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "track"
@@ -7062,14 +7062,14 @@
          "description": "Methods for retrieving track data"
       },
       {
-         "jsondocId": "09faf7f5-8761-444a-9b54-8489f6575e54",
+         "jsondocId": "418fbb30-7a21-4731-a2d1-c8851563b3ef",
          "methods": [
             {
                "headers": [],
                "pathparameters": [],
                "queryparameters": [
                   {
-                     "jsondocId": "195ac9e6-e9bd-48de-a258-1f990acccb55",
+                     "jsondocId": "d256c0d8-1d43-49d2-a478-41cd00f877ed",
                      "name": "username",
                      "format": "",
                      "description": "",
@@ -7078,7 +7078,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d957d1f1-8fd9-42ab-9c89-b5e59b3a750f",
+                     "jsondocId": "3ce4a632-c067-4b15-b65a-7a059273f79d",
                      "name": "password",
                      "format": "",
                      "description": "",
@@ -7087,773 +7087,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "036d346c-6956-44ae-acd9-9afb4b80463d",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to fetch",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get organism permissions for user, returns an array of permission objects",
-               "methodName": "getOrganismPermissionsForUser",
-               "jsondocId": "f65e71dd-79e1-46a0-ac32-48559181b5fe",
-               "bodyobject": {
-                  "jsondocId": "7a88d4f9-12ea-45e6-9491-0c0bfe58f207",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/getOrganismPermissionsForUser",
-               "response": {
-                  "jsondocId": "53db4297-7719-4a9e-a75c-b165c393a9f6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "495f4fa0-8182-4cee-99d4-2cbf200e4d42",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9d869f4b-0877-4be4-b4e2-b65a823d3f39",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "80f1c635-bfd8-4ded-8e7a-572f9b18e7e4",
-                     "name": "userId",
-                     "format": "",
-                     "description": "Optionally only user a specific userId as an integer database id or a username string",
-                     "type": "long / string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "8beb9b8e-4e53-475e-873b-8ed2e15d8951",
-                     "name": "start",
-                     "format": "",
-                     "description": "(optional) Result start / offset",
-                     "type": "long / string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "53a941c8-c453-4f03-96cd-ac284763ed9c",
-                     "name": "length",
-                     "format": "",
-                     "description": "(optional) Result length",
-                     "type": "long / string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2b8fad1b-6888-4cc0-86ff-2afb765111c0",
-                     "name": "name",
-                     "format": "",
-                     "description": "(optional) Search name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f4369caf-4182-471d-833d-832e2b87b9ba",
-                     "name": "sortColumn",
-                     "format": "",
-                     "description": "(optional) Sort column, default 'name'",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "60398377-3bd0-4f9c-ba98-744eff823930",
-                     "name": "sortAscending",
-                     "format": "",
-                     "description": "(optional) Sort column is ascending if true (default false)",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "e80dad32-a40a-48c3-8cac-3068ad5689ad",
-                     "name": "omitEmptyOrganisms",
-                     "format": "",
-                     "description": "(optional) Omits empty organism permissions from return (default false)",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "af4ae168-bd82-4601-9c19-b9466ccb66da",
-                     "name": "showInactiveUsers",
-                     "format": "",
-                     "description": "(optional) Shows inactive users without permissions (default false)",
-                     "type": "boolean",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Load all users and their permissions",
-               "methodName": "loadUsers",
-               "jsondocId": "cf83c590-1c96-4f9d-b671-4782db633c5b",
-               "bodyobject": {
-                  "jsondocId": "d3960b8d-8924-4cb9-8fe1-eb45f667d67b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/loadUsers",
-               "response": {
-                  "jsondocId": "bc2ed5d2-be40-4ca9-9fd7-07bb6a543446",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "64256775-0a56-4a25-a63c-83d6a7274262",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c9d627e7-dbe6-442a-ba10-54c99d4c3e1a",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "89076d3e-c6a6-4c37-8980-7274bb41b722",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "35685fe3-20cd-4956-9083-5ba44bad2a7f",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ebdcb330-c47b-403a-8a72-21f431122e16",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Add user to group",
-               "methodName": "addUserToGroup",
-               "jsondocId": "2a9764ba-56bf-454e-864b-aaf9777af047",
-               "bodyobject": {
-                  "jsondocId": "19e288fa-15b9-4278-9142-476afc275bf1",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/addUserToGroup",
-               "response": {
-                  "jsondocId": "1ef2414e-9c03-478a-8d48-62dd7ed2931d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "f9e2c021-b652-439e-8a05-a912182c92d4",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5dbb5466-04c0-413c-96f8-aaa213d568aa",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a6d980c5-cc01-4a74-932c-dd899336929f",
-                     "name": "group",
-                     "format": "",
-                     "description": "Group name",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "497d7da2-a09b-4ccd-8596-5dce51fa365f",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User id",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "2fb249f7-4681-4561-aef3-13467273612d",
-                     "name": "user",
-                     "format": "",
-                     "description": "User email/username (supplied if user id unknown)",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Remove user from group",
-               "methodName": "removeUserFromGroup",
-               "jsondocId": "a8ba62c6-fa16-4e50-812f-584965c0ef9c",
-               "bodyobject": {
-                  "jsondocId": "c6ab6eeb-e010-4e4b-9426-ae651efea7c8",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/removeUserFromGroup",
-               "response": {
-                  "jsondocId": "c30f778c-8fd2-40b3-8be9-5e3bcfbbe2a1",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "c0d750dd-a0bd-43ab-8310-bc9551c3f6b1",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "72fda543-e1b3-45ed-aa20-b2a7df6a4a8e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b39b1718-be2c-4c31-bd04-95e4284fe24f",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to add",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1c1e74f4-5f1a-44ad-8d81-c599aa492625",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "42aef65a-cba2-4738-9bec-ff9dd2cd7ede",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a0cdd22f-c80e-4034-9ada-f2aa5e6e1d38",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "User metadata (optional)",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0efed6fe-159f-4024-a765-e548144eab49",
-                     "name": "role",
-                     "format": "",
-                     "description": "User role USER / ADMIN (optional: default USER) ",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "940315a2-0974-43f5-b3b6-ac122295524d",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to add",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Create user",
-               "methodName": "createUser",
-               "jsondocId": "d3f08dd2-228d-47eb-9d47-9635b98b8250",
-               "bodyobject": {
-                  "jsondocId": "ebeece61-a1ea-4362-afd0-5f87ceb4fa27",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/createUser",
-               "response": {
-                  "jsondocId": "f982560e-2601-4fb2-a7e0-73370f608edc",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "426c08e6-893f-4c9b-b8af-582f6fc975c4",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "c3bf3273-ad47-4ee2-a87c-f2ce0b34ce04",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ca0df9a1-dbb1-43bc-9391-b8ab9447e202",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to delete",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "301776cd-bb7c-40ab-9df6-37e82abe5ae8",
-                     "name": "userToDelete",
-                     "format": "",
-                     "description": "Username (email) to inactivate",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Inactivate user, removing all permsissions and setting flag",
-               "methodName": "inactivateUser",
-               "jsondocId": "a9146a07-2451-44a4-97d8-eac5456fb9dd",
-               "bodyobject": {
-                  "jsondocId": "b5628252-fe67-45d0-a2c6-69a5af04667b",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/inactivateUser",
-               "response": {
-                  "jsondocId": "7fddcea0-ecfd-4952-8d38-687fd5d82bbb",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "7922a7ff-788c-45d1-895c-81c21c804ee5",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "9fed8937-4b86-4ce7-be9c-3ce1c8126803",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b628b11b-f923-4d4a-bc07-0f8cf6c9cda0",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to delete",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "ae5dc646-f447-4e14-a113-f44b68a0258e",
-                     "name": "userToActivate",
-                     "format": "",
-                     "description": "Username (email) to inactivate",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Activate user",
-               "methodName": "activateUser",
-               "jsondocId": "2783d3ec-5495-4d90-b79f-36a15da729b3",
-               "bodyobject": {
-                  "jsondocId": "3c631e18-6cb5-4d26-af8a-a00a15986ce6",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/activateUser",
-               "response": {
-                  "jsondocId": "bc8eb9f9-a644-4860-80af-537cb94d04be",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "fbebc91f-c95a-4eea-9e53-0ebde3de7911",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "dfbcd023-f614-4726-8fa3-f9ae9f598ad3",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "4cef3d72-e062-4e15-8c07-dfbf49accc17",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to delete",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "8f2fca9c-07ac-45b7-b57f-3e57108ae44e",
-                     "name": "userToDelete",
-                     "format": "",
-                     "description": "Username (email) to delete",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Delete user",
-               "methodName": "deleteUser",
-               "jsondocId": "13512067-ec8e-443f-b976-40d829662316",
-               "bodyobject": {
-                  "jsondocId": "ddc46538-0771-4008-b4a8-fb9776e577d9",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/deleteUser",
-               "response": {
-                  "jsondocId": "f1b4cd3b-5ea3-4916-82a0-6345addeeffa",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "914f44f9-785c-4272-b8d9-59b699e367f4",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "057ad693-cd26-4752-8b07-1f3618c9621e",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "1fb478d5-44c7-4bca-8a7d-a8b0e2878c23",
-                     "name": "userId",
-                     "format": "",
-                     "description": "User ID to update",
-                     "type": "long",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "7a297331-cca4-4d7f-8b72-7ec3b8dfa043",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user to update",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "0baf3cc2-0c18-4fcd-8bd1-9f0b9a4501dd",
-                     "name": "firstName",
-                     "format": "",
-                     "description": "First name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "b9a251f1-c6d7-4a5e-82a2-60ab4aac19f7",
-                     "name": "lastName",
-                     "format": "",
-                     "description": "Last name of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "96a44261-14f1-4da4-ae45-eef223ff0f52",
-                     "name": "metadata",
-                     "format": "",
-                     "description": "User metadata (optional)",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "788e3c3f-2768-4f7e-8ef6-c60395df3094",
-                     "name": "newPassword",
-                     "format": "",
-                     "description": "Password of user to update",
-                     "type": "string",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Update user",
-               "methodName": "updateUser",
-               "jsondocId": "9cf74baf-773e-40aa-9e90-85b443f90268",
-               "bodyobject": {
-                  "jsondocId": "4ac08491-e139-4e87-b01f-72bfec3bd2a8",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/updateUser",
-               "response": {
-                  "jsondocId": "5aa6052a-dd09-4a0e-a882-bd98b1b2fd76",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "c3ff7217-283e-4f27-8ecb-b51705198e79",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "f870a0a8-b7a8-4c47-a400-7f1fa10624cc",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "a9e75123-7785-46b7-bdeb-632a6c67ca70",
-                     "name": "email",
-                     "format": "",
-                     "description": "Email of the user",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  }
-               ],
-               "verb": "POST",
-               "description": "Get creator metadata for user, returns creator userId as JSONObject",
-               "methodName": "getUserCreator",
-               "jsondocId": "4841628b-4fee-400c-b2d5-0cc605556967",
-               "bodyobject": {
-                  "jsondocId": "465416c5-5666-497b-8d9a-02f1eb14ed5d",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "multiple": "Unknow",
-                  "map": "",
-                  "object": "user"
-               },
-               "apierrors": [],
-               "path": "/user/getUserCreator",
-               "response": {
-                  "jsondocId": "d4a04893-1dcb-43c8-bcc8-530d7c6c6934",
-                  "mapValueObject": "",
-                  "mapKeyObject": "",
-                  "object": "user"
-               },
-               "produces": ["application/json"],
-               "consumes": ["application/json"]
-            },
-            {
-               "headers": [],
-               "pathparameters": [],
-               "queryparameters": [
-                  {
-                     "jsondocId": "f333207b-482a-4699-a9da-04488e0d9e91",
-                     "name": "username",
-                     "format": "",
-                     "description": "",
-                     "type": "email",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "5f7afd9b-0ab4-4ef4-807a-5cda05b79ddb",
-                     "name": "password",
-                     "format": "",
-                     "description": "",
-                     "type": "password",
-                     "required": "true",
-                     "allowedvalues": []
-                  },
-                  {
-                     "jsondocId": "12df7578-25b4-4e58-8e75-f360423f1248",
+                     "jsondocId": "fb1dbbf7-7b7c-4354-bd08-9573d0b1dbee",
                      "name": "userId",
                      "format": "",
                      "description": "User ID to modify permissions for",
@@ -7862,7 +7096,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "cab73443-05ed-41df-98eb-3a639322f699",
+                     "jsondocId": "3cb1eb49-f7fc-4125-8eab-1e5592ce807d",
                      "name": "user",
                      "format": "",
                      "description": "(Optional) user email of the user to modify permissions for if User ID is not provided",
@@ -7871,7 +7105,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "fab4148f-ced9-4399-b8af-801fe3c40ad4",
+                     "jsondocId": "4502b3cf-73cd-46ae-b125-ea31e1e8f13f",
                      "name": "organism",
                      "format": "",
                      "description": "Name of organism to update",
@@ -7880,7 +7114,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "5b245343-dc8f-478f-8568-fbbdc06beb0b",
+                     "jsondocId": "d2764e32-e3c0-4ac0-838f-20f249ef36a5",
                      "name": "id",
                      "format": "",
                      "description": "Permission ID to update (can get from userId/organism instead)",
@@ -7889,7 +7123,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "d415fa0c-4f01-43b8-8d83-8be073193f97",
+                     "jsondocId": "35db5729-d0c2-44b8-814d-37d906fb7ff8",
                      "name": "ADMINISTRATE",
                      "format": "",
                      "description": "Indicate if user has administrative and all lesser (including user/group) privileges for the organism",
@@ -7898,7 +7132,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "ca051aa1-8425-4b2c-a432-a762fd770564",
+                     "jsondocId": "cc8bb883-b54c-4e0a-b024-f230b2d6fc5f",
                      "name": "WRITE",
                      "format": "",
                      "description": "Indicate if user has write and all lesser privileges for the organism",
@@ -7907,7 +7141,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "b56009b0-7a77-4690-96c7-65ec51510cc5",
+                     "jsondocId": "f270b29d-4735-4564-af0f-d86f164bb1fd",
                      "name": "EXPORT",
                      "format": "",
                      "description": "Indicate if user has export and all lesser privileges for the organism",
@@ -7916,7 +7150,7 @@
                      "allowedvalues": []
                   },
                   {
-                     "jsondocId": "66e77ec1-cc89-4d60-8cbd-06d1176f843e",
+                     "jsondocId": "8f6e312b-9f98-4373-b935-f26109e3d545",
                      "name": "READ",
                      "format": "",
                      "description": "Indicate if user has read and all lesser privileges for the organism",
@@ -7928,9 +7162,9 @@
                "verb": "POST",
                "description": "Update organism permissions",
                "methodName": "updateOrganismPermission",
-               "jsondocId": "9224a01f-9011-4d19-9194-fab834db8d82",
+               "jsondocId": "dd461e06-3be0-41de-ae14-fd96d45fddb1",
                "bodyobject": {
-                  "jsondocId": "c3727ae9-d634-4bad-803a-175a3a9cdfca",
+                  "jsondocId": "86bb6f8b-1a5b-4be7-816c-ab7c7df8988f",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "multiple": "Unknow",
@@ -7940,7 +7174,773 @@
                "apierrors": [],
                "path": "/user/updateOrganismPermission",
                "response": {
-                  "jsondocId": "51be7705-1e9e-4ef8-b969-ea538449c457",
+                  "jsondocId": "996b66cd-da14-4398-8b97-80fb2d6825d6",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "68edde46-d206-4640-98be-a24ce1789fbb",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b5d1273b-9d42-4727-9416-7e9a7fc67048",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8e19923c-4c1a-4191-ba9c-8ddadd634e3a",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to fetch",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get organism permissions for user, returns an array of permission objects",
+               "methodName": "getOrganismPermissionsForUser",
+               "jsondocId": "9cfb6bd1-7825-4b70-85b3-884315ee97d5",
+               "bodyobject": {
+                  "jsondocId": "7bcc627a-2aba-4ae0-b170-9c0493de727b",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/getOrganismPermissionsForUser",
+               "response": {
+                  "jsondocId": "12b5e43f-15a4-400f-a0aa-1adfff13aa25",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "085db146-6896-4d62-9bf2-f56ab94f51c9",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "95111548-d095-41a4-ac0c-f20b53433e6c",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "156ffc83-6b39-40e1-aecf-80d458ff07ce",
+                     "name": "userId",
+                     "format": "",
+                     "description": "Optionally only user a specific userId as an integer database id or a username string",
+                     "type": "long / string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "0f8507c2-0991-4dc8-b097-fa4cb5116720",
+                     "name": "start",
+                     "format": "",
+                     "description": "(optional) Result start / offset",
+                     "type": "long / string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "dc48eb49-e7c1-408c-9183-b1de92ac9ec9",
+                     "name": "length",
+                     "format": "",
+                     "description": "(optional) Result length",
+                     "type": "long / string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f8ddcb7c-02b5-4920-bb96-b486ae6963b1",
+                     "name": "name",
+                     "format": "",
+                     "description": "(optional) Search name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "543d758b-289f-467c-a539-0df71561b1de",
+                     "name": "sortColumn",
+                     "format": "",
+                     "description": "(optional) Sort column, default 'name'",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f70bd683-820d-4d98-a674-831102890252",
+                     "name": "sortAscending",
+                     "format": "",
+                     "description": "(optional) Sort column is ascending if true (default false)",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d59b1f84-c8d0-496a-a3c6-867f6e5330cf",
+                     "name": "omitEmptyOrganisms",
+                     "format": "",
+                     "description": "(optional) Omits empty organism permissions from return (default false)",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "b584a73a-2355-4060-8074-07d493502003",
+                     "name": "showInactiveUsers",
+                     "format": "",
+                     "description": "(optional) Shows inactive users without permissions (default false)",
+                     "type": "boolean",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Load all users and their permissions",
+               "methodName": "loadUsers",
+               "jsondocId": "bc4fd57d-c40e-4267-8fde-7b6318670efb",
+               "bodyobject": {
+                  "jsondocId": "6016f2c9-babf-4746-97dd-227993a3ba94",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/loadUsers",
+               "response": {
+                  "jsondocId": "5baae64c-640f-471b-9701-4303d2b6d627",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "69895d9f-4300-417b-b45e-e4d3ff23d054",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "29ea9c9a-11f6-493e-95bb-0fb8d9b2bc87",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "e735d2c4-fc85-4120-b551-52d42ec51250",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6e58ea57-233c-4bdc-bc90-a0e1fb836d9d",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a1dcd2b8-8b46-4426-9569-8309c8836cca",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Add user to group",
+               "methodName": "addUserToGroup",
+               "jsondocId": "f136853e-d5f4-469a-b5d5-7d8dff4292ea",
+               "bodyobject": {
+                  "jsondocId": "e3e4989c-4fd5-4124-beea-357a5dc2dc04",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/addUserToGroup",
+               "response": {
+                  "jsondocId": "888a8a48-d56f-40d3-9fb1-9239f2a72c39",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "82404678-2109-44e1-8b75-769a9f4153bc",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "023476f5-9d93-46ed-8b97-a44f3a8e47bb",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "fa1404da-8c00-4af9-9d74-a44d6565d304",
+                     "name": "group",
+                     "format": "",
+                     "description": "Group name",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "1e4c5412-b104-456e-ab1f-35bd4776102b",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User id",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "35e7bdda-37ee-4ff4-b36e-655bf8278cb7",
+                     "name": "user",
+                     "format": "",
+                     "description": "User email/username (supplied if user id unknown)",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Remove user from group",
+               "methodName": "removeUserFromGroup",
+               "jsondocId": "1d61715c-e8f9-44da-858e-02c54cc37a06",
+               "bodyobject": {
+                  "jsondocId": "9cadae83-d037-4489-bd63-f0f234a93f97",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/removeUserFromGroup",
+               "response": {
+                  "jsondocId": "4a5f5095-4ba4-4c3e-8c26-1c9be76acf53",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "d7b92f64-f8cd-47dc-a311-fd80648c647c",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "bf6ecfb7-8a18-40c3-813d-b41e545826ba",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "644b717a-340c-4766-a5a5-fbaae4099144",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to add",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9f69a4ba-7f85-448e-87e3-3e77c2834dd4",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "a14af7e4-3b72-4e6a-a500-4ffd2a456d6d",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "caae03d6-658b-40d1-9bfa-bb408cc88f4b",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "User metadata (optional)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "03530298-f0ae-4978-aded-4240d9af9f4f",
+                     "name": "role",
+                     "format": "",
+                     "description": "User role USER / ADMIN (optional: default USER) ",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c3df3c63-ee3a-43ab-93e7-4a1bebd9a5e4",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to add",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Create user",
+               "methodName": "createUser",
+               "jsondocId": "156997f6-73d9-48e3-866a-54b54e9b98c3",
+               "bodyobject": {
+                  "jsondocId": "b31c9365-2fc2-4cff-9191-f73b62a40710",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/createUser",
+               "response": {
+                  "jsondocId": "b09bcf07-b6a4-48a5-9062-ac4ec50d56ba",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "cd55da39-6b93-4254-8bb6-975242e79abc",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "c779a844-8662-4f82-9d4d-8bc66e798098",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8d5d2217-d114-4c8a-81dd-064832bed02d",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "8a048af5-f5ca-414c-8071-d947b6d2aeda",
+                     "name": "userToDelete",
+                     "format": "",
+                     "description": "Username (email) to inactivate",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Inactivate user, removing all permsissions and setting flag",
+               "methodName": "inactivateUser",
+               "jsondocId": "73590f75-3689-4ded-902c-30fbc5898975",
+               "bodyobject": {
+                  "jsondocId": "347b6b16-c0a5-4c63-a0f2-79527b0f24ff",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/inactivateUser",
+               "response": {
+                  "jsondocId": "7e3fb191-a8f6-470f-929c-d24569a473b7",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "f0d34c7a-a900-4739-a1ec-ae903b6d90a4",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "619fcefd-fd27-4aaf-a52c-bb616aca0f60",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "14be9228-4f61-4b26-9fe0-ccf3303bad47",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "74baa3d0-0cfa-4779-a069-943389bee285",
+                     "name": "userToActivate",
+                     "format": "",
+                     "description": "Username (email) to inactivate",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Activate user",
+               "methodName": "activateUser",
+               "jsondocId": "fca7dec5-56ca-4efd-bd29-eb85bb094608",
+               "bodyobject": {
+                  "jsondocId": "5c9d9d7f-3117-446d-8c85-67d00989251f",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/activateUser",
+               "response": {
+                  "jsondocId": "95692475-5df0-49a4-9e2e-8eebfa3f2fb2",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "6a92144a-373a-480e-8d8b-ea16727032de",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "05a857ba-d7e7-416d-ac67-681a680b76ce",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "9266af23-5b84-4d26-a429-08a54f64521d",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to delete",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "d121caf2-a172-41cc-81ec-5ca7e42d1faa",
+                     "name": "userToDelete",
+                     "format": "",
+                     "description": "Username (email) to delete",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Delete user",
+               "methodName": "deleteUser",
+               "jsondocId": "ddd6ae96-f23a-4f24-8bf5-6bc793178d28",
+               "bodyobject": {
+                  "jsondocId": "0d3cc7a3-60d7-4f59-892f-3434a828b5ca",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/deleteUser",
+               "response": {
+                  "jsondocId": "d366f109-6ceb-40f9-9d73-3345504d6e07",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "b85fdcf7-1018-4f25-b10a-da0f87677428",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "af92ba8a-3061-47f7-a9a4-41297826fd66",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "3db757ee-b16d-4e8a-a35d-7f6d9625c46e",
+                     "name": "userId",
+                     "format": "",
+                     "description": "User ID to update",
+                     "type": "long",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "09c8ddc3-77d7-44cf-8bdf-1becc1bffefa",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user to update",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "89795c1b-c454-4b2b-862f-b0fed9c598fa",
+                     "name": "firstName",
+                     "format": "",
+                     "description": "First name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "f7e10240-162f-4723-b621-307e83e544c9",
+                     "name": "lastName",
+                     "format": "",
+                     "description": "Last name of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "6c290201-cfee-44eb-a326-1e19a805ac01",
+                     "name": "metadata",
+                     "format": "",
+                     "description": "User metadata (optional)",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "289f93ce-7f73-4cd4-aee4-97c090bbc919",
+                     "name": "newPassword",
+                     "format": "",
+                     "description": "Password of user to update",
+                     "type": "string",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Update user",
+               "methodName": "updateUser",
+               "jsondocId": "d2463b7e-b6b8-401e-8cf0-414d96bdca4c",
+               "bodyobject": {
+                  "jsondocId": "b2f8fe4f-21eb-4dcb-8144-e7a666199e20",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/updateUser",
+               "response": {
+                  "jsondocId": "d625d647-f300-4c09-b158-e30b3d0246b8",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "object": "user"
+               },
+               "produces": ["application/json"],
+               "consumes": ["application/json"]
+            },
+            {
+               "headers": [],
+               "pathparameters": [],
+               "queryparameters": [
+                  {
+                     "jsondocId": "ef619632-1da2-43b2-89b8-73f644539369",
+                     "name": "username",
+                     "format": "",
+                     "description": "",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "5e243d0a-6809-4ef0-8c55-a2832a6ac19a",
+                     "name": "password",
+                     "format": "",
+                     "description": "",
+                     "type": "password",
+                     "required": "true",
+                     "allowedvalues": []
+                  },
+                  {
+                     "jsondocId": "4d0c7726-0899-4f1c-a5de-26a358629940",
+                     "name": "email",
+                     "format": "",
+                     "description": "Email of the user",
+                     "type": "email",
+                     "required": "true",
+                     "allowedvalues": []
+                  }
+               ],
+               "verb": "POST",
+               "description": "Get creator metadata for user, returns creator userId as JSONObject",
+               "methodName": "getUserCreator",
+               "jsondocId": "d71814de-c6da-4734-b73a-e84ce339fc85",
+               "bodyobject": {
+                  "jsondocId": "bdaec8ef-0de6-42f8-b2e1-6fe0d18cd2f4",
+                  "mapValueObject": "",
+                  "mapKeyObject": "",
+                  "multiple": "Unknow",
+                  "map": "",
+                  "object": "user"
+               },
+               "apierrors": [],
+               "path": "/user/getUserCreator",
+               "response": {
+                  "jsondocId": "348b274d-1b72-49b2-8edb-94acc8539408",
                   "mapValueObject": "",
                   "mapKeyObject": "",
                   "object": "user"
@@ -7953,13 +7953,13 @@
          "description": "Methods for managing users"
       },
       {
-         "jsondocId": "450deb57-e928-4b04-977c-095b2f4dcaa3",
+         "jsondocId": "ddf4d034-ed15-4034-9df8-fcff6a27ac1b",
          "methods": [{
             "headers": [],
             "pathparameters": [],
             "queryparameters": [
                {
-                  "jsondocId": "85aad7eb-e500-4d58-95e7-8508f6bb00e0",
+                  "jsondocId": "4e0998e7-25e4-4ecc-976b-4843a1dfc57f",
                   "name": "organismString",
                   "format": "",
                   "description": "Organism common name or ID (required)",
@@ -7968,7 +7968,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "8f89299c-a2d3-49de-b85d-99464ff4c66a",
+                  "jsondocId": "4f3fb757-5116-413b-81ec-07f9ee29f5c0",
                   "name": "trackName",
                   "format": "",
                   "description": "Track name by label in trackList.json (required)",
@@ -7977,7 +7977,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "99af9287-3a08-445c-8c11-8fe151fe1cd2",
+                  "jsondocId": "def56864-bf93-4a05-ac19-778d722ddc1e",
                   "name": "sequence",
                   "format": "",
                   "description": "Sequence name (required)",
@@ -7986,7 +7986,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "e4b6fde9-8905-485b-9f7a-93e4a343fee4",
+                  "jsondocId": "2029d8b8-5557-4ed9-a682-35b918237450",
                   "name": "fmin",
                   "format": "",
                   "description": "Minimum range (required)",
@@ -7995,7 +7995,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "c640b5e6-fd38-485c-a78f-15fd507607ac",
+                  "jsondocId": "3366a32f-12bd-420d-9db8-746f8d9db668",
                   "name": "fmax",
                   "format": "",
                   "description": "Maximum range (required)",
@@ -8004,7 +8004,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "481b8c84-a211-4867-8cef-a5f7eff69bdb",
+                  "jsondocId": "a7073d58-2615-440a-bdaa-17d8f02d28b3",
                   "name": "type",
                   "format": "",
                   "description": ".json (required)",
@@ -8013,7 +8013,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "13d295e7-cb2b-41d5-9e16-06bafa4fb172",
+                  "jsondocId": "3d8d6dcb-a9f8-434b-9712-9f387e722ad2",
                   "name": "includeGenotypes",
                   "format": "",
                   "description": "(default: false).  If true, will include genotypes associated with variants from VCF.",
@@ -8022,7 +8022,7 @@
                   "allowedvalues": []
                },
                {
-                  "jsondocId": "c722367b-ab96-4024-b874-c12d5c13f097",
+                  "jsondocId": "6a114814-804c-4f7c-8cfa-7d0ca9fbf16c",
                   "name": "ignoreCache",
                   "format": "",
                   "description": "(default: false).  Use cache for request, if available.",
@@ -8034,12 +8034,12 @@
             "verb": "GET",
             "description": "Get VCF track data for a given range as JSON",
             "methodName": "featuresByLocation",
-            "jsondocId": "53e7fadc-a9c9-43b1-8962-40e1de5c3f94",
+            "jsondocId": "dcae0565-f1f6-4d9a-bd79-e4029e905cd6",
             "bodyobject": null,
             "apierrors": [],
             "path": "/vcf/<organism_name>/<track_name>/<sequence_name>:<fmin>..<fmax>.<type>?includeGenotypes=<includeGenotypes>&ignoreCache=<ignoreCache>",
             "response": {
-               "jsondocId": "dab61f1f-48eb-4345-82ec-fbcf1e14ddf5",
+               "jsondocId": "7f6c6538-9296-4918-a1d5-bdc0b1fbb427",
                "mapValueObject": "",
                "mapKeyObject": "",
                "object": "vcf"


### PR DESCRIPTION
fixes #2172 

- [x] handle cancel and re-edit (currently grays it out), maybe should just reset? 
- [x] restrict save of edit (if there is a problem, does it detect errors
- [x] check save new error detection for all parts (and have it catch / throw errors)
- [x] able to view edit in existing on load
- [x] able to view edit in existing after update
- ~~based on aspect update to use other restrictions?~~
- [x] able to update
- [x] gray out fields if aspect not selected
- [x] confirm that we can add
- [x] filter into API using category: https://api.monarchinitiative.org/api/search/entity/autocomplete/gene?category=molecular%20entity&category=biological%20process&category=cellular%20component&prefix=GO&rows=20&start=0
- [x] change RO to drop-down based on what is below
- [x] add a drop-down for term lookup using the 3 aspects
