### PR TITLE
fixes subselection

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/TrackController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/TrackController.groovy
@@ -234,6 +234,7 @@ class TrackController {
         try {
             JSONArray filteredList = trackService.getNCList(trackName, organismString, sequence, fmin, fmax)
           // there should be 2 nclists, one for 20 and one for 40
+          println "input location ${fmin} ${fmax}"
           renderedArray = trackService.convertAllNCListToObject(filteredList, sequenceDTO,fmin,fmax)
         } catch (FileNotFoundException fnfe) {
             log.warn(fnfe.message)

--- a/grails-app/controllers/org/bbop/apollo/TrackController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/TrackController.groovy
@@ -234,7 +234,9 @@ class TrackController {
         try {
             JSONArray filteredList = trackService.getNCList(trackName, organismString, sequence, fmin, fmax)
           // there should be 2 nclists, one for 20 and one for 40
-          renderedArray = trackService.convertAllNCListToObject(filteredList, sequenceDTO)
+          renderedArray = trackService.convertAllNCListToObject(filteredList, sequenceDTO,fmin,fmax)
+          println "rendered array ${renderedArray.size()}"
+          println "rendered array as JSON${renderedArray as JSON}"
         } catch (FileNotFoundException fnfe) {
             log.warn(fnfe.message)
             response.status = 404

--- a/grails-app/controllers/org/bbop/apollo/TrackController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/TrackController.groovy
@@ -233,7 +233,8 @@ class TrackController {
         )
         try {
             JSONArray filteredList = trackService.getNCList(trackName, organismString, sequence, fmin, fmax)
-            renderedArray = trackService.convertAllNCListToObject(filteredList, sequenceDTO)
+          // there should be 2 nclists, one for 20 and one for 40
+          renderedArray = trackService.convertAllNCListToObject(filteredList, sequenceDTO)
         } catch (FileNotFoundException fnfe) {
             log.warn(fnfe.message)
             response.status = 404

--- a/grails-app/controllers/org/bbop/apollo/TrackController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/TrackController.groovy
@@ -235,8 +235,6 @@ class TrackController {
             JSONArray filteredList = trackService.getNCList(trackName, organismString, sequence, fmin, fmax)
           // there should be 2 nclists, one for 20 and one for 40
           renderedArray = trackService.convertAllNCListToObject(filteredList, sequenceDTO,fmin,fmax)
-          println "rendered array ${renderedArray.size()}"
-          println "rendered array as JSON${renderedArray as JSON}"
         } catch (FileNotFoundException fnfe) {
             log.warn(fnfe.message)
             response.status = 404

--- a/grails-app/controllers/org/bbop/apollo/TrackController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/TrackController.groovy
@@ -266,6 +266,8 @@ class TrackController {
             renderedArray = returnArray
         }
 
+        renderedArray = renderedArray.unique{  it.name }
+
         if (type == "json") {
             trackService.cacheRequest(renderedArray.toString(), organismString, trackName, sequence, fmin, fmax, type, paramMap)
             render renderedArray as JSON

--- a/grails-app/services/org/bbop/apollo/TrackService.groovy
+++ b/grails-app/services/org/bbop/apollo/TrackService.groovy
@@ -120,8 +120,11 @@ class TrackService {
         JSONArray nclistArray = trackObject.getJSONObject("intervals").getJSONArray("nclist")
 
         // 1 - extract the appropriate region for fmin / fmax
+      println "filtering ${nclistArray}"
         JSONArray filteredList = filterList(nclistArray, fmin, fmax)
-        log.debug "filtered list size ${filteredList.size()} from original ${nclistArray.size()}"
+        println "filtered list size ${filteredList.size()} from original ${nclistArray.size()}"
+
+      println "filtered list ${filteredList}"
 
         // if the first featured array has a chunk, then we need to evaluate the chunks instead
         if (filteredList) {
@@ -245,6 +248,21 @@ class TrackService {
         for (innerArray in inputArray) {
             // if there is an overlap
             if (!(innerArray[2] < fmin || innerArray[1] > fmax)) {
+              println "inner array ${innerArray}"
+
+              // if it contains a subList, filter the sublist and addd to this array, can maybe leave that there
+              for(input in innerArray){
+                if(input instanceof JSONObject && input.containsKey("Sublist")){
+                  println "input is object ${input}"
+                  // promot the subArray
+                  JSONArray subArrayList = filterList(input.get("Sublist"),fmin,fmax)
+                  subArrayList.each{ jsonArray.add(it)}
+                  println "subArrayList ${subArrayList}"
+                }
+                else{
+                  println "not object ${input}"
+                }
+              }
                 // then no
                 jsonArray.add(innerArray)
             }

--- a/grails-app/services/org/bbop/apollo/TrackService.groovy
+++ b/grails-app/services/org/bbop/apollo/TrackService.groovy
@@ -120,11 +120,7 @@ class TrackService {
         JSONArray nclistArray = trackObject.getJSONObject("intervals").getJSONArray("nclist")
 
         // 1 - extract the appropriate region for fmin / fmax
-      println "filtering ${nclistArray}"
         JSONArray filteredList = filterList(nclistArray, fmin, fmax)
-        println "filtered list size ${filteredList.size()} from original ${nclistArray.size()}"
-
-      println "filtered list ${filteredList}"
 
         // if the first featured array has a chunk, then we need to evaluate the chunks instead
         if (filteredList) {
@@ -251,22 +247,19 @@ class TrackService {
         for (innerArray in inputArray) {
             // if there is an overlap
             if (!(innerArray[2] < fmin || innerArray[1] > fmax)) {
-//              println "inner array ${innerArray}"
-
               // if it contains a subList, filter the sublist and addd to this array, can maybe leave that there
               int foundSublistIndex = -1
               int subListIndex = 0
               for(input in innerArray){
                 if(input instanceof JSONObject && input.containsKey("Sublist")){
-//                  println "input is object ${input}"
-                  // promot the subArray
                   JSONArray subArrayList = filterList(input.get("Sublist"),fmin,fmax)
                   subArrayList.each{ jsonArray.add(it)}
                   foundSublistIndex = subListIndex
-//                  println "subArrayList ${subArrayList}"
                 }
                 ++subListIndex
               }
+
+              // remove the sublist here, as its already been promoted
               if(foundSublistIndex>=0){
                 jsonArray.add(   (innerArray as List).subList(0,foundSublistIndex) )
               }

--- a/grails-app/services/org/bbop/apollo/TrackService.groovy
+++ b/grails-app/services/org/bbop/apollo/TrackService.groovy
@@ -129,7 +129,8 @@ class TrackService {
                 List<JSONArray> chunkList = []
                 for (JSONArray chunkArray in filteredList) {
                     JSONArray chunk = getChunkData(sequenceDTO, chunkArray.getInt(trackIndex.getChunk()))
-                    chunkList.add(filterList(chunk, fmin, fmax))
+                    def filteredChunkList = filterList(chunk, fmin, fmax)
+                    if(filteredChunkList) chunkList.add(filteredChunkList)
                 }
                 JSONArray chunkReturnArray = new JSONArray()
                 chunkList.each { ch ->
@@ -168,7 +169,6 @@ class TrackService {
 
         if (featureArray.size() > 3) {
             if (featureArray[0] instanceof Integer && !(featureArray[2] < fmin || featureArray[1] > fmax)) {
-              println "featuer array  added ${featureArray} ${fmin} ${fmax}"
                 JSONObject jsonObject = new JSONObject()
                 TrackIndex trackIndex = trackMapperService.getIndices(sequenceDTO, featureArray.getInt(0))
 
@@ -210,11 +210,18 @@ class TrackService {
                     def subArray = featureArray.get(subIndex)
                     if (subArray instanceof JSONArray) {
                         def subArray2 = convertAllNCListToObject(subArray, sequenceDTO,fmin,fmax)
-                        childArray.addAll(subArray2)
+                        if(subArray2){
+                          childArray.addAll(subArray2)
+                        }
                     }
                     if (subArray instanceof JSONObject && subArray.containsKey("Sublist")) {
                         def subArrays2 = subArray.getJSONArray("Sublist")
-                        childArray.add(convertIndividualNCListToObject(subArrays2, sequenceDTO,fmin,fmax))
+                        if(subArrays2){
+                          def ncListChildArray = convertIndividualNCListToObject(subArrays2, sequenceDTO,fmin,fmax)
+                          if(ncListChildArray){
+                            childArray.add(ncListChildArray)
+                          }
+                        }
                     }
                 }
                 if (childArray) {
@@ -233,7 +240,10 @@ class TrackService {
         for (def jsonArray in fullArray) {
             if (jsonArray instanceof JSONArray) {
               if (!(jsonArray[2] < fmin || jsonArray[1] > fmax)) {
-                returnArray.add(convertIndividualNCListToObject(jsonArray, sequenceDTO,fmin,fmax))
+                def convertedObject = convertIndividualNCListToObject(jsonArray, sequenceDTO,fmin,fmax)
+                if(convertedObject) {
+                  returnArray.add(convertedObject)
+                }
               }
             }
         }


### PR DESCRIPTION
fixes #2216 
- [x] populate sublist into nclist
- [x] filter out genome features that are not overlapping when returning chunk data
- [x] filter out genome features overlap, but are an order of magnitude larger
- [x] remove genes without children
- [x] remove duplicate names
- [ ] remove empty arrays
- [x] Bmp4 example should contain 8 mRNA's + 3 "neighborhood" mRNA's and `3 genes` . . . should remove genes without children
- [x] Lirt2 example should contain exactly 3 mRNA's
- [x] test against local agr_ui pointing to local apollo
- [ ] remove ignorecache