### PR TITLE
fixed typo and added debugging

### DIFF
--- a/grails-app/services/org/bbop/apollo/SequenceSearchService.groovy
+++ b/grails-app/services/org/bbop/apollo/SequenceSearchService.groovy
@@ -32,7 +32,7 @@ class SequenceSearchService {
             JsonBuilder json = new JsonBuilder ()
             json.matches results, { TabDelimittedAlignment result ->
                 "identity" result.percentId
-                "significance" result.eValue
+                "significance" result.getEValue()
                 "subject"({
                     "location" ({
                         "fmin" result.subjectStart

--- a/src/groovy/org/bbop/apollo/sequence/search/blast/BlastAlignment.java
+++ b/src/groovy/org/bbop/apollo/sequence/search/blast/BlastAlignment.java
@@ -91,4 +91,23 @@ public class BlastAlignment {
       return subjectStrand;
     }
 
+  @Override
+  public String toString() {
+    return "BlastAlignment{" +
+      "queryId='" + queryId + '\'' +
+      ", subjectId='" + subjectId + '\'' +
+      ", percentId=" + percentId +
+      ", alignmentLength=" + alignmentLength +
+      ", numMismatches=" + numMismatches +
+      ", numGaps=" + numGaps +
+      ", queryStrand=" + queryStrand +
+      ", subjectStrand=" + subjectStrand +
+      ", queryStart=" + queryStart +
+      ", queryEnd=" + queryEnd +
+      ", subjectStart=" + subjectStart +
+      ", subjectEnd=" + subjectEnd +
+      ", eValue=" + eValue +
+      ", bitscore=" + bitscore +
+      '}';
+  }
 }

--- a/src/groovy/org/bbop/apollo/sequence/search/blat/BlatCommandLine.java
+++ b/src/groovy/org/bbop/apollo/sequence/search/blat/BlatCommandLine.java
@@ -45,24 +45,14 @@ public class BlatCommandLine extends SequenceSearchTool {
         File dir = null;
         Path p = null;
         try {
-          System.out.println("A: "+tmpDir);
-            if(tmpDir==null) {
-              System.out.println("B: "+tmpDir);
-                p = Files.createTempDirectory("blat_tmp");
-              System.out.println("C: "+p);
-            }
-            else {
-              System.out.println("D: "+tmpDir);
-                p = Files.createTempDirectory(new File(tmpDir).toPath(),"blat_tmp");
-              System.out.println("E: "+tmpDir);
-            }
-          System.out.println("F: "+p);
+          if(tmpDir==null) {
+              p = Files.createTempDirectory("blat_tmp");
+          }
+          else {
+              p = Files.createTempDirectory(new File(tmpDir).toPath(),"blat_tmp");
+          }
           dir = p.toFile();
-          System.out.println("G: "+dir.getAbsolutePath());
-
-          System.out.println("exists: "+dir.exists()+ " is writable: "+dir.canWrite());
-
-            return runSearch(dir, query, databaseId);
+          return runSearch(dir, query, databaseId);
         }
         catch (IOException e) {
             throw new SequenceSearchToolException("Error running search: " + e.getMessage(), e);
@@ -108,9 +98,12 @@ public class BlatCommandLine extends SequenceSearchTool {
         BufferedReader in = new BufferedReader(new FileReader(outputArg));
         String line;
         while ((line = in.readLine()) != null) {
+          System.out.println("line: "+line);
             matches.add(new TabDelimittedAlignment(line));
+          System.out.println("matches: "+matches);
         }
-        in.close();
+      System.out.println("finished");
+      in.close();
         return matches;
     }
 

--- a/src/groovy/org/bbop/apollo/sequence/search/blat/BlatCommandLine.java
+++ b/src/groovy/org/bbop/apollo/sequence/search/blat/BlatCommandLine.java
@@ -52,6 +52,7 @@ public class BlatCommandLine extends SequenceSearchTool {
               p = Files.createTempDirectory(new File(tmpDir).toPath(),"blat_tmp");
           }
           dir = p.toFile();
+          
           return runSearch(dir, query, databaseId);
         }
         catch (IOException e) {

--- a/src/groovy/org/bbop/apollo/sequence/search/blat/BlatCommandLine.java
+++ b/src/groovy/org/bbop/apollo/sequence/search/blat/BlatCommandLine.java
@@ -98,12 +98,9 @@ public class BlatCommandLine extends SequenceSearchTool {
         BufferedReader in = new BufferedReader(new FileReader(outputArg));
         String line;
         while ((line = in.readLine()) != null) {
-          System.out.println("line: "+line);
             matches.add(new TabDelimittedAlignment(line));
-          System.out.println("matches: "+matches);
         }
-      System.out.println("finished");
-      in.close();
+        in.close();
         return matches;
     }
 

--- a/src/groovy/org/bbop/apollo/sequence/search/blat/BlatCommandLine.java
+++ b/src/groovy/org/bbop/apollo/sequence/search/blat/BlatCommandLine.java
@@ -21,7 +21,7 @@ public class BlatCommandLine extends SequenceSearchTool {
     private String tmpDir;
     private boolean removeTmpDir;
     protected String [] blatOptions;
-    
+
     @Override
     public void parseConfiguration(JSONObject config) throws SequenceSearchToolException {
         try {
@@ -45,13 +45,22 @@ public class BlatCommandLine extends SequenceSearchTool {
         File dir = null;
         Path p = null;
         try {
+          System.out.println("A: "+tmpDir);
             if(tmpDir==null) {
+              System.out.println("B: "+tmpDir);
                 p = Files.createTempDirectory("blat_tmp");
+              System.out.println("C: "+p);
             }
             else {
+              System.out.println("D: "+tmpDir);
                 p = Files.createTempDirectory(new File(tmpDir).toPath(),"blat_tmp");
+              System.out.println("E: "+tmpDir);
             }
-            dir = p.toFile();
+          System.out.println("F: "+p);
+          dir = p.toFile();
+          System.out.println("G: "+dir.getAbsolutePath());
+
+          System.out.println("exists: "+dir.exists()+ " is writable: "+dir.canWrite());
 
             return runSearch(dir, query, databaseId);
         }
@@ -70,7 +79,7 @@ public class BlatCommandLine extends SequenceSearchTool {
             }
         }
     }
-    
+
     private Collection<BlastAlignment> runSearch(File dir, String query, String databaseId)
             throws IOException, AlignmentParsingException, InterruptedException {
         PrintWriter log = new PrintWriter(new BufferedWriter(new FileWriter(dir + "/search.log")));
@@ -149,5 +158,5 @@ public class BlatCommandLine extends SequenceSearchTool {
         out.close();
         return queryFileName;
     }
-    
+
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/SearchPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/SearchPanel.java
@@ -329,7 +329,13 @@ public class SearchPanel extends Composite {
         searchHitList.clear();
         loadingDialog.hide();
         try {
-          JSONArray hitArray = JSONParser.parseStrict(response.getText()).isObject().get("matches").isArray();
+          JSONObject responseObject = JSONParser.parseStrict(response.getText()).isObject();
+          if(responseObject.get("matches")==null){
+            String errorString = responseObject.get("error").isString().stringValue();
+            Bootbox.alert("Error: "+errorString);
+            return ;
+          }
+          JSONArray hitArray = responseObject.get("matches").isArray();
           for (int i = 0; i < hitArray.size(); i++) {
             JSONObject hit = hitArray.get(i).isObject();
             SearchHit searchHit = new SearchHit();

--- a/src/gwt/org/bbop/apollo/gwt/client/SearchPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/SearchPanel.java
@@ -344,7 +344,7 @@ public class SearchPanel extends Composite {
             searchHitList.add(searchHit);
           }
         } catch (Exception e) {
-          Bootbox.alert("Unable to to perform search" + e.getMessage() + " " + response.getText() + " " + response.getStatusCode());
+          Bootbox.alert("Unable to perform search" + e.getMessage() + " " + response.getText() + " " + response.getStatusCode());
         }
         dataGrid.getColumnSortList().clear();
         dataGrid.getColumnSortList().push(scoreColumn);


### PR DESCRIPTION
fixes #2317 

was a bad blat configuration

- [x] add better error handling if `matches` is null because we have a server-side error
- [x] now we are getting this error when searching for protein:

```
Unable to perform search(TypeError) : Cannot read property 'isArray_3_g$' of null {"error":"No such property: eValue for class: org.bbop.apollo.sequence.search.blast.TabDelimittedAlignment\nPossible solutions: EValue"} 200
```
