### PR TITLE
make postgres start optional for Docker container

### DIFF
--- a/docker-files/createenv.sh
+++ b/docker-files/createenv.sh
@@ -14,6 +14,9 @@ echo "export WEBAPOLLO_DB_NAME=${WEBAPOLLO_DB_NAME}" >> $SET_ENV_FILE
 echo "export WEBAPOLLO_DB_USERNAME=${WEBAPOLLO_DB_USERNAME}" >> $SET_ENV_FILE
 echo "export WEBAPOLLO_DB_PASSWORD=${WEBAPOLLO_DB_PASSWORD}" >> $SET_ENV_FILE
 
+# Indicates if we want to start our own postgres server
+echo "export WEBAPOLLO_START_POSTGRES=${WEBAPOLLO_START_POSTGRES}" >> $SET_ENV_FILE
+
 # Indicates if we use Chado.  Default 'true'.
 echo "export WEBAPOLLO_USE_CHADO=${WEBAPOLLO_USE_CHADO}" >> $SET_ENV_FILE
 

--- a/docker-files/launch.sh
+++ b/docker-files/launch.sh
@@ -23,7 +23,11 @@ if [ ! -e "${WEBAPOLLO_DB_DATA}/PG_VERSION" ];then
 	su -c "/usr/lib/postgresql/9.6/bin/initdb -D ${WEBAPOLLO_DB_DATA}" postgres
 fi
 
-service postgresql start
+export WEBAPOLLO_START_POSTGRES="${WEBAPOLLO_START_POSTGRES:true}"
+
+if [[ "${WEBAPOLLO_START_POSTGRES}" == "true" ]]; then
+    service postgresql start
+fi
 
 export WEBAPOLLO_DB_HOST="${WEBAPOLLO_DB_HOST:-127.0.0.1}"
 export WEBAPOLLO_DB_NAME="${WEBAPOLLO_DB_NAME:-apollo}"


### PR DESCRIPTION
While there is existing support for using a separate container/install of postgres when using docker, the postgres service inside the apollo container is started regardless.  This is what I image adding a flag to turn it off would look like.  You could argue that the if statement should cover all postgres setup, but I'll leave that to you - there is probably some value to leaving it there, in case you want your brand new external container to get the setup.  