### PR TITLE
use master branch of python-apollo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
       set -ex
       cp test/config/python-apollo.travis apollo-config.groovy
       ./grailsw run-app &
-      git clone --single-branch --branch updateorg --depth=1 https://github.com/galaxy-genome-annotation/python-apollo
+      git clone --single-branch --branch master --depth=1 https://github.com/galaxy-genome-annotation/python-apollo
       cd python-apollo
       pyenv global 3.6.3
       sed -i 's|8888|8080/apollo|' `pwd`/test-data/arrow.yml


### PR DESCRIPTION
Using the master branch now that https://github.com/galaxy-genome-annotation/python-apollo/pull/22 is merged