### PR TITLE
removed jdk8 from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Apollo2
+# Apollo2.X
 FROM tomcat:9-jdk8
 MAINTAINER Nathan Dunn <nathandunn@lbl.gov>
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ RUN apt-get -qq update --fix-missing && \
 
 RUN npm i -g yarn
 
-# RUN cp /usr/lib/jvm/java-8-openjdk-amd64/lib/tools.jar /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/tools.jar && \
-#     useradd -ms /bin/bash -d /apollo apollo
 RUN useradd -ms /bin/bash -d /apollo apollo
 
 RUN curl -s "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/blat/blat" -o /usr/local/bin/blat && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV CONTEXT_PATH ROOT
 
 RUN apt-get -qq update --fix-missing && \
 	apt-get --no-install-recommends -y install \
-	git build-essential maven libpq-dev postgresql-common openjdk-8-jdk wget \
+	git build-essential maven libpq-dev postgresql-common wget \
 	postgresql postgresql-client xmlstarlet netcat libpng-dev \
 	zlib1g-dev libexpat1-dev ant curl ssl-cert zip unzip
 
@@ -19,8 +19,9 @@ RUN apt-get -qq update --fix-missing && \
 
 RUN npm i -g yarn
 
-RUN cp /usr/lib/jvm/java-8-openjdk-amd64/lib/tools.jar /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/tools.jar && \
-	useradd -ms /bin/bash -d /apollo apollo
+# RUN cp /usr/lib/jvm/java-8-openjdk-amd64/lib/tools.jar /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/tools.jar && \
+#     useradd -ms /bin/bash -d /apollo apollo
+RUN useradd -ms /bin/bash -d /apollo apollo
 
 RUN curl -s "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/blat/blat" -o /usr/local/bin/blat && \
  		chmod +x /usr/local/bin/blat && \

--- a/docker-files/build.sh
+++ b/docker-files/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 cd /apollo/ && \
-    ./apollo clean-all && ./apollo deploy && \
+	# note that clean-all does more than remove the target directory files (which it does not do in its entirety)
+    ./apollo clean-all && rm -rf target/* && ./apollo deploy && \
     cp /apollo/target/apollo*.war /tmp/apollo.war && \
 	# here we save the tools directory
 	# So we can remove ~1.6 GB of cruft from the image. Ignore errors because cannot remove parent dir /apollo/

--- a/docker-files/launch.sh
+++ b/docker-files/launch.sh
@@ -101,4 +101,5 @@ cp ${CATALINA_HOME}/apollo.war ${WAR_FILE}
 bash /createenv.sh
 
 # Launch tomcat, stopping of already running.
+catalina.sh stop 5 -force 
 catalina.sh run

--- a/docker-files/launch.sh
+++ b/docker-files/launch.sh
@@ -101,4 +101,4 @@ cp ${CATALINA_HOME}/apollo.war ${WAR_FILE}
 bash /createenv.sh
 
 # Launch tomcat, stopping of already running.
-catalina.sh restart
+catalina.sh stop 5 -force && catalina.sh start

--- a/docker-files/launch.sh
+++ b/docker-files/launch.sh
@@ -100,5 +100,5 @@ cp ${CATALINA_HOME}/apollo.war ${WAR_FILE}
 # Set environment variables for tomcat
 bash /createenv.sh
 
-# Launch tomcat
-catalina.sh run
+# Launch tomcat, stopping of already running.
+catalina.sh restart

--- a/docker-files/launch.sh
+++ b/docker-files/launch.sh
@@ -101,4 +101,4 @@ cp ${CATALINA_HOME}/apollo.war ${WAR_FILE}
 bash /createenv.sh
 
 # Launch tomcat, stopping of already running.
-catalina.sh start
+catalina.sh run

--- a/docker-files/launch.sh
+++ b/docker-files/launch.sh
@@ -101,4 +101,4 @@ cp ${CATALINA_HOME}/apollo.war ${WAR_FILE}
 bash /createenv.sh
 
 # Launch tomcat, stopping of already running.
-catalina.sh stop 5 -force && catalina.sh start
+catalina.sh start


### PR DESCRIPTION
This has been failing builds:

https://quay.io/repository/gmod/apollo?tab=builds

It looks like openjdk was already installed, so not sure why it was in there in the first place.

This seems to fix it.

- [x] verify build working
- [x] verify that image runs
- [ ] merge 
- [ ] merge into agr_ui codebase'
- [ ] do a quick announcement