### PR TITLE
refactor for default ECO codes

### DIFF
--- a/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.java
@@ -100,6 +100,7 @@ public class GeneProductPanel extends Composite {
   private static ListDataProvider<GeneProduct> dataProvider = new ListDataProvider<>();
   private static List<GeneProduct> annotationInfoList = dataProvider.getList();
   private SingleSelectionModel<GeneProduct> selectionModel = new SingleSelectionModel<>();
+  private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle("ECO");
 
   private AnnotationInfo annotationInfo;
 
@@ -177,21 +178,6 @@ public class GeneProductPanel extends Composite {
 
   private void initLookups() {
     // most from here: http://geneontology.org/docs/guide-go-evidence-codes/
-    BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle("ECO");
-    ecoLookup.addPreferredSuggestion("experimental evidence used in manual assertion (EXP)", "http://www.evidenceontology.org/term/ECO:0000269/", "ECO:0000269");
-    ecoLookup.addPreferredSuggestion("direct assay evidence used in manual assertion (IDA)", "http://www.evidenceontology.org/term/ECO:0000314/", "ECO:0000314");
-    ecoLookup.addPreferredSuggestion("physical interaction evidence used in manual assertion (IPI)", "http://www.evidenceontology.org/term/ECO:0000353/", "ECO:0000353");
-    ecoLookup.addPreferredSuggestion("mutant phenotype evidence used in manual assertion (IMP)", "http://www.evidenceontology.org/term/ECO:0000315/", "ECO:0000315");
-    ecoLookup.addPreferredSuggestion("genetic interaction evidence used in manual assertion (IGI)", "http://www.evidenceontology.org/term/ECO:0000316/", "ECO:0000316");
-    ecoLookup.addPreferredSuggestion("biological aspect of ancestor evidence used in manual assertion (IBA)", "http://www.evidenceontology.org/term/ECO:0000318/", "ECO:0000318");
-    ecoLookup.addPreferredSuggestion("biological aspect of descendant evidence used in manual assertion (IBD)", "http://www.evidenceontology.org/term/ECO:0000319/", "ECO:0000319");
-    ecoLookup.addPreferredSuggestion("sequence similarity evidence used in manual assertion (ISS)", "http://www.evidenceontology.org/term/ECO:0000250/", "ECO:0000250");
-    ecoLookup.addPreferredSuggestion("sequence orthology evidence used in manual assertion (ISO)", "http://www.evidenceontology.org/term/ECO:0000266/", "ECO:0000266");
-    ecoLookup.addPreferredSuggestion("sequence alignment evidence used in manual assertion (ISA)", "http://www.evidenceontology.org/term/ECO:0000247/", "ECO:0000247");
-    ecoLookup.addPreferredSuggestion("no biological data found used in manual assertion (ND)", "http://www.evidenceontology.org/term/ECO:0000307/", "ECO:0000307");
-    ecoLookup.addPreferredSuggestion("curator inference used in manual assertion (IC)", "http://www.evidenceontology.org/term/ECO:0000305/", "ECO:0000305");
-    ecoLookup.addPreferredSuggestion("evidence used in automatic assertion (IEA)", "http://www.evidenceontology.org/term/ECO:0000501/", "ECO:0000501");
-    ecoLookup.addPreferredSuggestion("high throughput direct assay evidence used in manual assertion (HDA)", "http://www.evidenceontology.org/term/ECO:0007005/", "ECO:0007005");
     evidenceCodeField = new SuggestBox(ecoLookup);
   }
 

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.java
@@ -21,6 +21,7 @@ import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.bbop.apollo.gwt.client.dto.AnnotationInfo;
 import org.bbop.apollo.gwt.client.dto.GeneProductConverter;
+import org.bbop.apollo.gwt.client.oracles.BiolinkLookup;
 import org.bbop.apollo.gwt.client.oracles.BiolinkOntologyOracle;
 import org.bbop.apollo.gwt.client.resources.TableResources;
 import org.bbop.apollo.gwt.client.rest.GeneProductRestService;
@@ -37,12 +38,12 @@ import org.gwtbootstrap3.extras.bootbox.client.callback.ConfirmCallback;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.bbop.apollo.gwt.client.oracles.BiolinkOntologyOracle.ECO_BASE;
+
 /**
  * Created by ndunn on 1/9/15.
  */
 public class GeneProductPanel extends Composite {
-
-  private final String ECO_BASE = "http://www.evidenceontology.org/term/";
 
   interface GeneProductUiBinder extends UiBinder<Widget, GeneProductPanel> {
   }
@@ -100,7 +101,7 @@ public class GeneProductPanel extends Composite {
   private static ListDataProvider<GeneProduct> dataProvider = new ListDataProvider<>();
   private static List<GeneProduct> annotationInfoList = dataProvider.getList();
   private SingleSelectionModel<GeneProduct> selectionModel = new SingleSelectionModel<>();
-  private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle("ECO");
+  private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle(BiolinkLookup.ECO);
 
   private AnnotationInfo annotationInfo;
 

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.java
@@ -23,6 +23,7 @@ import org.bbop.apollo.gwt.client.dto.AnnotationInfo;
 import org.bbop.apollo.gwt.client.dto.GeneProductConverter;
 import org.bbop.apollo.gwt.client.oracles.BiolinkLookup;
 import org.bbop.apollo.gwt.client.oracles.BiolinkOntologyOracle;
+import org.bbop.apollo.gwt.client.oracles.BiolinkSuggestBox;
 import org.bbop.apollo.gwt.client.resources.TableResources;
 import org.bbop.apollo.gwt.client.rest.GeneProductRestService;
 import org.bbop.apollo.gwt.shared.geneProduct.GeneProduct;
@@ -58,7 +59,7 @@ public class GeneProductPanel extends Composite {
   @UiField
   TextBox geneProductField;
   @UiField(provided = true)
-  SuggestBox evidenceCodeField;
+  BiolinkSuggestBox evidenceCodeField;
   @UiField
   TextBox withFieldPrefix;
   @UiField
@@ -97,6 +98,10 @@ public class GeneProductPanel extends Composite {
 //    Button referenceValidateButton;
   @UiField
   HTML geneProductTitle;
+  @UiField
+  org.gwtbootstrap3.client.ui.CheckBox allEcoCheckBox;
+  @UiField
+  Anchor helpLink;
 
   private static ListDataProvider<GeneProduct> dataProvider = new ListDataProvider<>();
   private static List<GeneProduct> annotationInfoList = dataProvider.getList();
@@ -179,7 +184,7 @@ public class GeneProductPanel extends Composite {
 
   private void initLookups() {
     // most from here: http://geneontology.org/docs/guide-go-evidence-codes/
-    evidenceCodeField = new SuggestBox(ecoLookup);
+    evidenceCodeField = new BiolinkSuggestBox(ecoLookup);
   }
 
   private void loadData() {
@@ -306,6 +311,17 @@ public class GeneProductPanel extends Composite {
     notesFlexTable.removeAllRows();
     selectionModel.clear();
     editGoModal.show();
+  }
+
+  @UiHandler("allEcoCheckBox")
+  public void allEcoCheckBox(ClickEvent e) {
+    ecoLookup.setUseAllEco(allEcoCheckBox.getValue());
+    if(allEcoCheckBox.getValue()){
+      helpLink.setHref("https://www.ebi.ac.uk/ols/ontologies/eco");
+    }
+    else {
+      helpLink.setHref("http://geneontology.org/docs/guide-go-evidence-codes/");
+    }
   }
 
   @UiHandler("editGoButton")

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.ui.xml
@@ -1,7 +1,7 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+             xmlns:apollo="urn:import:org.bbop.apollo.gwt.client.oracles"
              xmlns:gwt="urn:import:com.google.gwt.user.client.ui"
-             xmlns:select="urn:import:org.gwtbootstrap3.extras.select.client.ui"
              xmlns:cellview="urn:import:com.google.gwt.user.cellview.client"
 >
     <ui:style>
@@ -48,7 +48,7 @@
                     <b:ModalBody>
                         <b:Container fluid="true" width="100%">
                             <b:Row addStyleNames="{style.row}">
-                                <b:Column size="MD_6">
+                                <b:Column size="MD_5">
                                     <b:Label>Product</b:Label>
 <!--                                    <b:SuggestBox ui:field="geneProductRelationshipField"/>-->
                                     <b:TextBox ui:field="geneProductField"/>
@@ -57,9 +57,13 @@
                                     <b:CheckBox text="Alternate" width="100%" ui:field="alternateCheckBox"/>
                                 </b:Column>
                                 <b:Column size="MD_3">
-                                  <b:Label>Evidence and Conclusion Ontology</b:Label>
-                                  <b:SuggestBox ui:field="evidenceCodeField"/>
-                                  <gwt:Anchor ui:field="evidenceCodeLink" target="_blank"/>
+                                  <b:Label>Evidence</b:Label>
+                                    <apollo:BiolinkSuggestBox ui:field="evidenceCodeField"/>
+                                    <gwt:Anchor ui:field="evidenceCodeLink" target="_blank"/>
+                                </b:Column>
+                                <b:Column size="MD_1">
+                                    <b:CheckBox text="All ECO Evidence" width="100%" ui:field="allEcoCheckBox"/>
+                                    <gwt:Anchor text="Info" target="_blank" ui:field="helpLink"/>
                                 </b:Column>
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -23,6 +23,7 @@ import org.bbop.apollo.gwt.client.dto.AnnotationInfo;
 import org.bbop.apollo.gwt.client.dto.GoAnnotationConverter;
 import org.bbop.apollo.gwt.client.oracles.BiolinkLookup;
 import org.bbop.apollo.gwt.client.oracles.BiolinkOntologyOracle;
+import org.bbop.apollo.gwt.client.oracles.BiolinkSuggestBox;
 import org.bbop.apollo.gwt.client.resources.TableResources;
 import org.bbop.apollo.gwt.client.rest.GoRestService;
 import org.bbop.apollo.gwt.shared.go.Aspect;
@@ -61,7 +62,7 @@ public class GoPanel extends Composite {
   @UiField
   org.gwtbootstrap3.client.ui.ListBox geneProductRelationshipField;
   @UiField(provided = true)
-  SuggestBox evidenceCodeField;
+  BiolinkSuggestBox evidenceCodeField;
   @UiField
   TextBox withFieldPrefix;
   @UiField
@@ -262,7 +263,7 @@ public class GoPanel extends Composite {
 
   private void initLookups() {
     goTermField = new SuggestBox(goLookup);
-    evidenceCodeField = new SuggestBox(ecoLookup);
+    evidenceCodeField = new BiolinkSuggestBox(ecoLookup);
   }
 
   private void loadData() {

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -21,6 +21,7 @@ import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.bbop.apollo.gwt.client.dto.AnnotationInfo;
 import org.bbop.apollo.gwt.client.dto.GoAnnotationConverter;
+import org.bbop.apollo.gwt.client.oracles.BiolinkLookup;
 import org.bbop.apollo.gwt.client.oracles.BiolinkOntologyOracle;
 import org.bbop.apollo.gwt.client.resources.TableResources;
 import org.bbop.apollo.gwt.client.rest.GoRestService;
@@ -38,14 +39,12 @@ import org.gwtbootstrap3.extras.bootbox.client.callback.ConfirmCallback;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.bbop.apollo.gwt.client.oracles.BiolinkOntologyOracle.*;
+
 /**
  * Created by ndunn on 1/9/15.
  */
 public class GoPanel extends Composite {
-
-  private final String ECO_BASE = "http://www.evidenceontology.org/term/";
-  private final String GO_BASE = "http://amigo.geneontology.org/amigo/term/";
-  private final String RO_BASE = "http://www.ontobee.org/ontology/RO?iri=http://purl.obolibrary.org/obo/";
 
   interface GoPanelUiBinder extends UiBinder<Widget, GoPanel> {
   }
@@ -119,7 +118,7 @@ public class GoPanel extends Composite {
   private SingleSelectionModel<GoAnnotation> selectionModel = new SingleSelectionModel<>();
 
   private AnnotationInfo annotationInfo;
-  private BiolinkOntologyOracle goLookup = new BiolinkOntologyOracle("GO");
+  private BiolinkOntologyOracle goLookup = new BiolinkOntologyOracle(BiolinkLookup.GO);
   private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle();
 
   public GoPanel() {

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -112,6 +112,8 @@ public class GoPanel extends Composite {
   org.gwtbootstrap3.client.ui.ListBox aspectField;
   @UiField
   HTML aspectLabel;
+  @UiField
+  org.gwtbootstrap3.client.ui.CheckBox allEcoCheckBox;
 
   private static ListDataProvider<GoAnnotation> dataProvider = new ListDataProvider<>();
   private static List<GoAnnotation> annotationInfoList = dataProvider.getList();
@@ -415,6 +417,11 @@ public class GoPanel extends Composite {
   @UiHandler("editGoButton")
   public void editGoAnnotation(ClickEvent e) {
     editGoModal.show();
+  }
+
+  @UiHandler("allEcoCheckBox")
+  public void allEcoCheckBox(ClickEvent e) {
+    ecoLookup.setUseAllEco(allEcoCheckBox.getValue());
   }
 
   @UiHandler("addWithButton")

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -43,8 +43,8 @@ import java.util.List;
  */
 public class GoPanel extends Composite {
 
-  private final String GO_BASE = "http://amigo.geneontology.org/amigo/term/";
   private final String ECO_BASE = "http://www.evidenceontology.org/term/";
+  private final String GO_BASE = "http://amigo.geneontology.org/amigo/term/";
   private final String RO_BASE = "http://www.ontobee.org/ontology/RO?iri=http://purl.obolibrary.org/obo/";
 
   interface GoPanelUiBinder extends UiBinder<Widget, GoPanel> {
@@ -120,6 +120,7 @@ public class GoPanel extends Composite {
 
   private AnnotationInfo annotationInfo;
   private BiolinkOntologyOracle goLookup = new BiolinkOntologyOracle("GO");
+  private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle();
 
   public GoPanel() {
 
@@ -260,23 +261,6 @@ public class GoPanel extends Composite {
 
   private void initLookups() {
     goTermField = new SuggestBox(goLookup);
-
-    // most from here: http://geneontology.org/docs/guide-go-evidence-codes/
-    BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle("ECO");
-    ecoLookup.addPreferredSuggestion("experimental evidence used in manual assertion (EXP)", "http://www.evidenceontology.org/term/ECO:0000269/", "ECO:0000269");
-    ecoLookup.addPreferredSuggestion("direct assay evidence used in manual assertion (IDA)", "http://www.evidenceontology.org/term/ECO:0000314/", "ECO:0000314");
-    ecoLookup.addPreferredSuggestion("physical interaction evidence used in manual assertion (IPI)", "http://www.evidenceontology.org/term/ECO:0000353/", "ECO:0000353");
-    ecoLookup.addPreferredSuggestion("mutant phenotype evidence used in manual assertion (IMP)", "http://www.evidenceontology.org/term/ECO:0000315/", "ECO:0000315");
-    ecoLookup.addPreferredSuggestion("genetic interaction evidence used in manual assertion (IGI)", "http://www.evidenceontology.org/term/ECO:0000316/", "ECO:0000316");
-    ecoLookup.addPreferredSuggestion("biological aspect of ancestor evidence used in manual assertion (IBA)", "http://www.evidenceontology.org/term/ECO:0000318/", "ECO:0000318");
-    ecoLookup.addPreferredSuggestion("biological aspect of descendant evidence used in manual assertion (IBD)", "http://www.evidenceontology.org/term/ECO:0000319/", "ECO:0000319");
-    ecoLookup.addPreferredSuggestion("sequence similarity evidence used in manual assertion (ISS)", "http://www.evidenceontology.org/term/ECO:0000250/", "ECO:0000250");
-    ecoLookup.addPreferredSuggestion("sequence orthology evidence used in manual assertion (ISO)", "http://www.evidenceontology.org/term/ECO:0000266/", "ECO:0000266");
-    ecoLookup.addPreferredSuggestion("sequence alignment evidence used in manual assertion (ISA)", "http://www.evidenceontology.org/term/ECO:0000247/", "ECO:0000247");
-    ecoLookup.addPreferredSuggestion("no biological data found used in manual assertion (ND)", "http://www.evidenceontology.org/term/ECO:0000307/", "ECO:0000307");
-    ecoLookup.addPreferredSuggestion("curator inference used in manual assertion (IC)", "http://www.evidenceontology.org/term/ECO:0000305/", "ECO:0000305");
-    ecoLookup.addPreferredSuggestion("evidence used in automatic assertion (IEA)", "http://www.evidenceontology.org/term/ECO:0000501/", "ECO:0000501");
-    ecoLookup.addPreferredSuggestion("high throughput direct assay evidence used in manual assertion (HDA)", "http://www.evidenceontology.org/term/ECO:0007005/", "ECO:0007005");
     evidenceCodeField = new SuggestBox(ecoLookup);
   }
 

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -115,6 +115,8 @@ public class GoPanel extends Composite {
   HTML aspectLabel;
   @UiField
   org.gwtbootstrap3.client.ui.CheckBox allEcoCheckBox;
+  @UiField
+  Anchor helpLink;
 
   private static ListDataProvider<GoAnnotation> dataProvider = new ListDataProvider<>();
   private static List<GoAnnotation> annotationInfoList = dataProvider.getList();
@@ -133,6 +135,8 @@ public class GoPanel extends Composite {
     dataGrid.setSelectionModel(selectionModel);
 
     initWidget(ourUiBinder.createAndBindUi(this));
+
+    allEcoCheckBox(null);
 
     aspectField.addItem("Choose", "");
     for (Aspect aspect : Aspect.values()) {
@@ -423,6 +427,12 @@ public class GoPanel extends Composite {
   @UiHandler("allEcoCheckBox")
   public void allEcoCheckBox(ClickEvent e) {
     ecoLookup.setUseAllEco(allEcoCheckBox.getValue());
+    if(allEcoCheckBox.getValue()){
+      helpLink.setHref("https://www.ebi.ac.uk/ols/ontologies/eco");
+    }
+    else {
+      helpLink.setHref("http://geneontology.org/docs/guide-go-evidence-codes/");
+    }
   }
 
   @UiHandler("addWithButton")

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
@@ -76,6 +76,7 @@
                                 </b:Column>
                                 <b:Column size="MD_1">
                                     <b:CheckBox text="All ECO Evidence" width="100%" ui:field="allEcoCheckBox"/>
+                                    <gwt:Anchor text="Info" target="_blank" ui:field="helpLink"/>
                                 </b:Column>
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
@@ -60,19 +60,22 @@
                                 </b:Column>
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">
-                                <b:Column size="MD_6">
+                                <b:Column size="MD_5">
                                     <b:Label>Relationship between Gene Product and GO Term</b:Label>
 <!--                                    <b:SuggestBox ui:field="geneProductRelationshipField"/>-->
                                     <b:ListBox ui:field="geneProductRelationshipField"/>
                                     <gwt:Anchor ui:field="geneProductRelationshipLink" target="_blank"/>
                                 </b:Column>
-                                <b:Column size="MD_2">
+                                <b:Column size="MD_1">
                                     <b:CheckBox text="Not" width="100%" ui:field="notQualifierCheckBox"/>
                                 </b:Column>
-                                <b:Column size="MD_3">
-                                  <b:Label>Evidence and Conclusion Ontology</b:Label>
+                                <b:Column size="MD_4">
+                                  <b:Label>Evidence</b:Label>
                                   <b:SuggestBox ui:field="evidenceCodeField"/>
                                   <gwt:Anchor ui:field="evidenceCodeLink" target="_blank"/>
+                                </b:Column>
+                                <b:Column size="MD_1">
+                                    <b:CheckBox text="All ECO Evidence" width="100%" ui:field="allEcoCheckBox"/>
                                 </b:Column>
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
@@ -1,7 +1,7 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+             xmlns:apollo="urn:import:org.bbop.apollo.gwt.client.oracles"
              xmlns:gwt="urn:import:com.google.gwt.user.client.ui"
-             xmlns:select="urn:import:org.gwtbootstrap3.extras.select.client.ui"
              xmlns:cellview="urn:import:com.google.gwt.user.cellview.client"
 >
     <ui:style>
@@ -71,7 +71,7 @@
                                 </b:Column>
                                 <b:Column size="MD_4">
                                   <b:Label>Evidence</b:Label>
-                                  <b:SuggestBox ui:field="evidenceCodeField"/>
+                                  <apollo:BiolinkSuggestBox ui:field="evidenceCodeField"/>
                                   <gwt:Anchor ui:field="evidenceCodeLink" target="_blank"/>
                                 </b:Column>
                                 <b:Column size="MD_1">

--- a/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.java
@@ -24,6 +24,7 @@ import org.bbop.apollo.gwt.client.dto.AnnotationInfo;
 import org.bbop.apollo.gwt.client.dto.ProvenanceConverter;
 import org.bbop.apollo.gwt.client.oracles.BiolinkLookup;
 import org.bbop.apollo.gwt.client.oracles.BiolinkOntologyOracle;
+import org.bbop.apollo.gwt.client.oracles.BiolinkSuggestBox;
 import org.bbop.apollo.gwt.client.resources.TableResources;
 import org.bbop.apollo.gwt.client.rest.ProvenanceRestService;
 import org.bbop.apollo.gwt.shared.provenance.Provenance;
@@ -60,7 +61,7 @@ public class ProvenancePanel extends Composite {
   @UiField
   ListBox provenanceField;
   @UiField(provided = true)
-  SuggestBox evidenceCodeField;
+  BiolinkSuggestBox evidenceCodeField;
   @UiField
   TextBox withFieldPrefix;
   @UiField
@@ -97,6 +98,10 @@ public class ProvenancePanel extends Composite {
 //    Button referenceValidateButton;
   @UiField
   HTML provenanceTitle;
+  @UiField
+  org.gwtbootstrap3.client.ui.CheckBox allEcoCheckBox;
+  @UiField
+  Anchor helpLink;
 
   private static ListDataProvider<Provenance> dataProvider = new ListDataProvider<>();
   private static List<Provenance> annotationInfoList = dataProvider.getList();
@@ -115,6 +120,7 @@ public class ProvenancePanel extends Composite {
 
     initWidget(ourUiBinder.createAndBindUi(this));
     initFields();
+    allEcoCheckBox(null);
 
 
     selectionModel.addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
@@ -185,7 +191,7 @@ public class ProvenancePanel extends Composite {
   }
 
   private void initLookups() {
-    evidenceCodeField = new SuggestBox(ecoLookup);
+    evidenceCodeField = new BiolinkSuggestBox(ecoLookup);
   }
 
   private void loadData() {
@@ -357,6 +363,17 @@ public class ProvenancePanel extends Composite {
     for (int i = 0; i < annotationsArray.size(); i++) {
       Provenance provenanceInstance = ProvenanceConverter.convertFromJson(annotationsArray.get(i).isObject());
       annotationInfoList.add(provenanceInstance);
+    }
+  }
+
+  @UiHandler("allEcoCheckBox")
+  public void allEcoCheckBox(ClickEvent e) {
+    ecoLookup.setUseAllEco(allEcoCheckBox.getValue());
+    if(allEcoCheckBox.getValue()){
+      helpLink.setHref("https://www.ebi.ac.uk/ols/ontologies/eco");
+    }
+    else {
+      helpLink.setHref("http://geneontology.org/docs/guide-go-evidence-codes/");
     }
   }
 

--- a/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.java
@@ -100,6 +100,7 @@ public class ProvenancePanel extends Composite {
   private static ListDataProvider<Provenance> dataProvider = new ListDataProvider<>();
   private static List<Provenance> annotationInfoList = dataProvider.getList();
   private SingleSelectionModel<Provenance> selectionModel = new SingleSelectionModel<>();
+  private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle("ECO");
 
   private AnnotationInfo annotationInfo;
 
@@ -183,22 +184,6 @@ public class ProvenancePanel extends Composite {
   }
 
   private void initLookups() {
-    // most from here: http://geneontology.org/docs/guide-go-evidence-codes/
-    BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle("ECO");
-    ecoLookup.addPreferredSuggestion("experimental evidence used in manual assertion (EXP)", "http://www.evidenceontology.org/term/ECO:0000269/", "ECO:0000269");
-    ecoLookup.addPreferredSuggestion("direct assay evidence used in manual assertion (IDA)", "http://www.evidenceontology.org/term/ECO:0000314/", "ECO:0000314");
-    ecoLookup.addPreferredSuggestion("physical interaction evidence used in manual assertion (IPI)", "http://www.evidenceontology.org/term/ECO:0000353/", "ECO:0000353");
-    ecoLookup.addPreferredSuggestion("mutant phenotype evidence used in manual assertion (IMP)", "http://www.evidenceontology.org/term/ECO:0000315/", "ECO:0000315");
-    ecoLookup.addPreferredSuggestion("genetic interaction evidence used in manual assertion (IGI)", "http://www.evidenceontology.org/term/ECO:0000316/", "ECO:0000316");
-    ecoLookup.addPreferredSuggestion("biological aspect of ancestor evidence used in manual assertion (IBA)", "http://www.evidenceontology.org/term/ECO:0000318/", "ECO:0000318");
-    ecoLookup.addPreferredSuggestion("biological aspect of descendant evidence used in manual assertion (IBD)", "http://www.evidenceontology.org/term/ECO:0000319/", "ECO:0000319");
-    ecoLookup.addPreferredSuggestion("sequence similarity evidence used in manual assertion (ISS)", "http://www.evidenceontology.org/term/ECO:0000250/", "ECO:0000250");
-    ecoLookup.addPreferredSuggestion("sequence orthology evidence used in manual assertion (ISO)", "http://www.evidenceontology.org/term/ECO:0000266/", "ECO:0000266");
-    ecoLookup.addPreferredSuggestion("sequence alignment evidence used in manual assertion (ISA)", "http://www.evidenceontology.org/term/ECO:0000247/", "ECO:0000247");
-    ecoLookup.addPreferredSuggestion("no biological data found used in manual assertion (ND)", "http://www.evidenceontology.org/term/ECO:0000307/", "ECO:0000307");
-    ecoLookup.addPreferredSuggestion("curator inference used in manual assertion (IC)", "http://www.evidenceontology.org/term/ECO:0000305/", "ECO:0000305");
-    ecoLookup.addPreferredSuggestion("evidence used in automatic assertion (IEA)", "http://www.evidenceontology.org/term/ECO:0000501/", "ECO:0000501");
-    ecoLookup.addPreferredSuggestion("high throughput direct assay evidence used in manual assertion (HDA)", "http://www.evidenceontology.org/term/ECO:0007005/", "ECO:0007005");
     evidenceCodeField = new SuggestBox(ecoLookup);
   }
 

--- a/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.java
@@ -22,6 +22,7 @@ import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.bbop.apollo.gwt.client.dto.AnnotationInfo;
 import org.bbop.apollo.gwt.client.dto.ProvenanceConverter;
+import org.bbop.apollo.gwt.client.oracles.BiolinkLookup;
 import org.bbop.apollo.gwt.client.oracles.BiolinkOntologyOracle;
 import org.bbop.apollo.gwt.client.resources.TableResources;
 import org.bbop.apollo.gwt.client.rest.ProvenanceRestService;
@@ -39,12 +40,12 @@ import org.gwtbootstrap3.extras.bootbox.client.callback.ConfirmCallback;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.bbop.apollo.gwt.client.oracles.BiolinkOntologyOracle.ECO_BASE;
+
 /**
  * Created by ndunn on 1/9/15.
  */
 public class ProvenancePanel extends Composite {
-
-  private final String ECO_BASE = "http://www.evidenceontology.org/term/";
 
   interface ProvenancePanelUiBinder extends UiBinder<Widget, ProvenancePanel> {
   }
@@ -100,7 +101,7 @@ public class ProvenancePanel extends Composite {
   private static ListDataProvider<Provenance> dataProvider = new ListDataProvider<>();
   private static List<Provenance> annotationInfoList = dataProvider.getList();
   private SingleSelectionModel<Provenance> selectionModel = new SingleSelectionModel<>();
-  private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle("ECO");
+  private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle(BiolinkLookup.ECO);
 
   private AnnotationInfo annotationInfo;
 

--- a/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.ui.xml
@@ -1,5 +1,6 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+             xmlns:apollo="urn:import:org.bbop.apollo.gwt.client.oracles"
              xmlns:gwt="urn:import:com.google.gwt.user.client.ui"
              xmlns:cellview="urn:import:com.google.gwt.user.cellview.client"
 >
@@ -40,7 +41,8 @@
         </gwt:center>
         <gwt:south size="30">
             <b:Container width="100%" height="100%">
-                <b:Modal ui:field="provenanceModal" closable="true" fade="true" dataBackdrop="STATIC" dataKeyboard="true">
+                <b:Modal ui:field="provenanceModal" closable="true" fade="true" dataBackdrop="STATIC"
+                         dataKeyboard="true">
                     <b:ModalHeader>
                         <gwt:HTML ui:field="provenanceTitle"/>
                     </b:ModalHeader>
@@ -51,10 +53,14 @@
                                     <b:Label>Field</b:Label>
                                     <b:ListBox ui:field="provenanceField"/>
                                 </b:Column>
-                                <b:Column size="MD_5">
-                                  <b:Label>Evidence and Conclusion Ontology</b:Label>
-                                  <b:SuggestBox ui:field="evidenceCodeField"/>
-                                  <gwt:Anchor ui:field="evidenceCodeLink" target="_blank"/>
+                                <b:Column size="MD_4">
+                                    <b:Label>Evidence</b:Label>
+                                    <apollo:BiolinkSuggestBox ui:field="evidenceCodeField"/>
+                                    <gwt:Anchor ui:field="evidenceCodeLink" target="_blank"/>
+                                </b:Column>
+                                <b:Column size="MD_1">
+                                    <b:CheckBox text="All ECO Evidence" width="100%" ui:field="allEcoCheckBox"/>
+                                    <gwt:Anchor text="Info" target="_blank" ui:field="helpLink"/>
                                 </b:Column>
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">
@@ -93,11 +99,11 @@
                                     <gwt:HTML text=":"/>
                                 </b:Column>
                                 <b:Column size="MD_3">
-                                    <b:TextBox ui:field="referenceFieldId"  placeholder="ID"/>
+                                    <b:TextBox ui:field="referenceFieldId" placeholder="ID"/>
                                 </b:Column>
-<!--                                <b:Column size="MD_1">-->
-<!--                                    <b:Button icon="PLUS" ui:field="referenceValidateButton">Validate</b:Button>-->
-<!--                                </b:Column>-->
+                                <!--                                <b:Column size="MD_1">-->
+                                <!--                                    <b:Button icon="PLUS" ui:field="referenceValidateButton">Validate</b:Button>-->
+                                <!--                                </b:Column>-->
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">
                                 <b:Column size="MD_8">
@@ -105,7 +111,9 @@
                                     <b:TextBox ui:field="noteField"/>
                                 </b:Column>
                                 <b:Column size="MD_2">
-                                    <b:Button icon="PLUS" ui:field="addNoteButton" addStyleNames="{style.addButton}">Add</b:Button>
+                                    <b:Button icon="PLUS" ui:field="addNoteButton" addStyleNames="{style.addButton}">
+                                        Add
+                                    </b:Button>
                                 </b:Column>
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">
@@ -120,8 +128,10 @@
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">
                                 <b:Column size="MD_6">
-                                    <b:Button icon="SAVE" ui:field="saveNewProvenance" type="PRIMARY" addStyleNames="{style.saveButton}">Save</b:Button>
-                                    <b:Button  ui:field="cancelNewProvenance">Cancel</b:Button>
+                                    <b:Button icon="SAVE" ui:field="saveNewProvenance" type="PRIMARY"
+                                              addStyleNames="{style.saveButton}">Save
+                                    </b:Button>
+                                    <b:Button ui:field="cancelNewProvenance">Cancel</b:Button>
                                 </b:Column>
                             </b:Row>
                         </b:Container>

--- a/src/gwt/org/bbop/apollo/gwt/client/go/GoEvidenceCode.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/go/GoEvidenceCode.java
@@ -1,0 +1,67 @@
+package org.bbop.apollo.gwt.client.go;
+
+/**
+ * Matching order and descriptions here
+ */
+public enum GoEvidenceCode {
+
+    EXP("experimental evidence used in manual assertion","ECO:0000269"),
+    IDA("direct assay evidence used in manual assertion","ECO:0000314"),
+    IPI("physical interaction evidence used in manual assertion","ECO:0000353"),
+    IMP("mutant phenotype evidence used in manual assertion","ECO:0000315"),
+    IGI("genetic interaction evidence used in manual assertion","ECO:0000316"),
+    IEP("inferred from expression pattern","ECO:0000270"),
+
+
+    HTP("inferred from high throughput experiment","ECO:0000270"),
+    HDA("inferred from high throughput direct assay","ECO:0007005"),
+    HMP("inferred from high throughput mutant phenotype","ECO:0007001"),
+    HGI("inferred from high throughput genetic interaction","ECO:0007003"),
+    HEP("inferred from high throughput expression pattern","ECO:0007007"),
+
+
+    IBA("inferred from biological aspect of ancestor","ECO:0000318"),
+    IBD("inferred from biological aspect of descendants","ECO:0000319"),
+    IKR("inferred from key residues","ECO:0000320"),
+    IRD("inferred from rapid divergence","ECO:0000321"),
+
+
+    ISS("sequence similarity evidence used in manual assertion","ECO:0000250"),
+    ISO("sequence orthology evidence used in manual assertion","ECO:0000266"),
+    ISA("sequence alignment evidence used in manual assertion","ECO:0000247"),
+    ISM("inferred from sequence model","ECO:0000255"),
+    IGC("inferred from genome context","ECO:0000317"),
+    RCA ("inferred from reviewed computational analysis","ECO:0000245"),
+
+
+    TAS("traceable author statement","ECO:0000304"),
+    NAS("non-traceable author statement","ECO:0000303"),
+
+
+    IC("inferred by curator","ECO:0000305"),
+    ND("no biological data available","ECO:0000307"),
+
+    IEA("evidence used in automatic assertion","ECO:0000501"),
+
+
+
+    ;
+
+
+    GoEvidenceCode(String description, String curie) {
+        this.description = description;
+        this.curie = curie;
+    }
+
+
+    private String description;
+    private String curie;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getCurie() {
+        return curie;
+    }
+}

--- a/src/gwt/org/bbop/apollo/gwt/client/go/GoEvidenceCode.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/go/GoEvidenceCode.java
@@ -1,7 +1,7 @@
 package org.bbop.apollo.gwt.client.go;
 
 /**
- * Matching order and descriptions here
+ * Matching order and descriptions here:  http://geneontology.org/docs/guide-go-evidence-codes/
  */
 public enum GoEvidenceCode {
 
@@ -42,9 +42,6 @@ public enum GoEvidenceCode {
     ND("no biological data available","ECO:0000307"),
 
     IEA("evidence used in automatic assertion","ECO:0000501"),
-
-
-
     ;
 
 

--- a/src/gwt/org/bbop/apollo/gwt/client/go/GoService.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/go/GoService.java
@@ -1,0 +1,6 @@
+package org.bbop.apollo.gwt.client.go;
+
+public class GoService {
+
+
+}

--- a/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkLookup.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkLookup.java
@@ -1,0 +1,8 @@
+package org.bbop.apollo.gwt.client.oracles;
+
+public enum BiolinkLookup {
+
+    GO,
+    ECO,
+    RO
+}

--- a/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkOntologyOracle.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkOntologyOracle.java
@@ -8,6 +8,7 @@ import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONParser;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.user.client.ui.MultiWordSuggestOracle;
+import org.bbop.apollo.gwt.client.go.GoEvidenceCode;
 import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
 
 import java.util.ArrayList;
@@ -22,19 +23,49 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
 
     private final Integer ROWS = 20;
     private final String FINAL_URL = "http://api.geneontology.org/api/search/entity/autocomplete/";
+    public final static String ECO_BASE = "http://www.evidenceontology.org/term/";
+    public final static String GO_BASE = "http://amigo.geneontology.org/amigo/term/";
+    public final static String RO_BASE = "http://www.ontobee.org/ontology/RO?iri=http://purl.obolibrary.org/obo/";
 
     private String prefix;
+    private String baseUrl;
     private String category = null;
     private JSONArray preferredSuggestions = new JSONArray();
+    private Boolean usePreferredSuggestions = true ;
 
-    public BiolinkOntologyOracle(String prefix) {
-        this.prefix = prefix;
+    public BiolinkOntologyOracle() {
+        this("ECO", ECO_BASE);
     }
 
-    public void addPreferredSuggestion(String label, String query, String id) {
+    public BiolinkOntologyOracle(String prefix) {
+        this(prefix,null);
+        if(prefix.equals("ECO")){
+            baseUrl = ECO_BASE;
+        }
+        if(prefix.equals("GO")){
+            baseUrl = GO_BASE;
+        }
+        if(prefix.equals("RO")){
+            baseUrl = RO_BASE;
+        }
+    }
+
+    public BiolinkOntologyOracle(String prefix, String baseUrl) {
+        super();
+        this.prefix = prefix;
+        this.baseUrl = baseUrl;
+
+        if(this.prefix.equals("ECO")){
+            for(GoEvidenceCode goEvidenceCode : GoEvidenceCode.values()){
+                addPreferredSuggestion(goEvidenceCode.name() , goEvidenceCode.getDescription(),goEvidenceCode.getCurie());
+            }
+        }
+    }
+
+    public void addPreferredSuggestion(String name, String label, String id) {
         JSONObject jsonObject = new JSONObject();
+        jsonObject.put("name", new JSONString(name));
         jsonObject.put("label", new JSONString(label));
-        jsonObject.put("query", new JSONString(query));
         jsonObject.put("id", new JSONString(id));
         preferredSuggestions.set(preferredSuggestions.size(), jsonObject);
     }
@@ -133,5 +164,13 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
 
     public void setCategory(String category) {
         this.category = category;
+    }
+
+    public Boolean getUsePreferredSuggestions() {
+        return usePreferredSuggestions;
+    }
+
+    public void setUsePreferredSuggestions(Boolean usePreferredSuggestions) {
+        this.usePreferredSuggestions = usePreferredSuggestions;
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkOntologyOracle.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkOntologyOracle.java
@@ -8,6 +8,7 @@ import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONParser;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.user.client.ui.MultiWordSuggestOracle;
+import com.ibm.icu.impl.BOCU;
 import org.bbop.apollo.gwt.client.go.GoEvidenceCode;
 import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
 
@@ -34,30 +35,35 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
     private Boolean usePreferredSuggestions = true ;
 
     public BiolinkOntologyOracle() {
-        this("ECO", ECO_BASE);
+        this(BiolinkLookup.ECO, ECO_BASE);
     }
 
-    public BiolinkOntologyOracle(String prefix) {
-        this(prefix,null);
-        if(prefix.equals("ECO")){
-            baseUrl = ECO_BASE;
-        }
-        if(prefix.equals("GO")){
-            baseUrl = GO_BASE;
-        }
-        if(prefix.equals("RO")){
-            baseUrl = RO_BASE;
-        }
+    public BiolinkOntologyOracle(BiolinkLookup biolinkLookup) {
+        this(biolinkLookup,null);
     }
 
-    public BiolinkOntologyOracle(String prefix, String baseUrl) {
+    public BiolinkOntologyOracle(BiolinkLookup biolinkLookup, String baseUrl) {
         super();
-        this.prefix = prefix;
-        this.baseUrl = baseUrl;
-
-        if(this.prefix.equals("ECO")){
-            for(GoEvidenceCode goEvidenceCode : GoEvidenceCode.values()){
-                addPreferredSuggestion(goEvidenceCode.name() , goEvidenceCode.getDescription(),goEvidenceCode.getCurie());
+        this.prefix = biolinkLookup.name();
+        if(baseUrl!=null){
+            this.baseUrl = baseUrl;
+        }
+        else{
+            switch (biolinkLookup){
+                case ECO:
+                    this.baseUrl = ECO_BASE;
+                    for(GoEvidenceCode goEvidenceCode : GoEvidenceCode.values()){
+                        addPreferredSuggestion(goEvidenceCode.name() , goEvidenceCode.getDescription(),goEvidenceCode.getCurie());
+                    }
+                    break;
+                case GO:
+                    this.baseUrl = GO_BASE;
+                    break;
+                case RO:
+                    this.baseUrl = RO_BASE;
+                    break;
+                default:
+                    this.baseUrl = null ;
             }
         }
     }

--- a/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkOntologyOracle.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkOntologyOracle.java
@@ -134,22 +134,11 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
 
     private void requestDefaultGo(final Request suggestRequest, final Callback suggestCallback) {
         List<Suggestion> suggestionList = new ArrayList<>();
-//        Set<String> ids = new HashSet<>();
-
-        this.preferredSuggestions = new JSONArray();
         String query = suggestRequest.getQuery().toLowerCase().trim();
-
-        GWT.log("should be adding preferred suggestions: " + GoEvidenceCode.values().length);
-        for (GoEvidenceCode goEvidenceCode : GoEvidenceCode.values()) {
-            addPreferredSuggestion(goEvidenceCode.name(), goEvidenceCode.getDescription(), goEvidenceCode.getCurie());
-        }
-        GWT.log("final preferred suggestions: " + this.preferredSuggestions.size());
-
-        GWT.log("getting preferred suggestions: " + this.preferredSuggestions.size());
         for (final GoEvidenceCode goEvidenceCode : GoEvidenceCode.values()) {
-            if (query.contains(goEvidenceCode.name().toLowerCase())
-                    || query.contains(goEvidenceCode.getCurie().toLowerCase())
-                    || query.contains(goEvidenceCode.getDescription().toLowerCase())
+            if (goEvidenceCode.name().toLowerCase().contains(query)
+                    || goEvidenceCode.getCurie().toLowerCase().contains(query)
+                    || goEvidenceCode.getDescription().toLowerCase().contains(query)
                     || query.length()==0
             ) {
                 Suggestion suggestion = new Suggestion() {
@@ -169,8 +158,7 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
                 suggestionList.add(suggestion);
             }
         }
-        GWT.log("preferrred suggestions:" + preferredSuggestions.size());
-        GWT.log("list size:" + suggestionList.size());
+        GWT.log("list size:" + query + " vs " + suggestionList.size());
         Response r = new Response();
         r.setSuggestions(suggestionList);
         suggestCallback.onSuggestionsReady(suggestRequest, r);

--- a/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkOntologyOracle.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkOntologyOracle.java
@@ -31,8 +31,6 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
     private String prefix;
     private String baseUrl;
     private String category = null;
-    private JSONArray preferredSuggestions = new JSONArray();
-    private Boolean usePreferredSuggestions = true;
     private Boolean useAllEco = false;
 
     public BiolinkOntologyOracle() {
@@ -46,7 +44,6 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
     public BiolinkOntologyOracle(BiolinkLookup biolinkLookup, String baseUrl) {
         super();
         this.prefix = biolinkLookup.name();
-        GWT.log("initting Oracle with " + baseUrl + " " + this.prefix + " " + biolinkLookup);
         if (baseUrl != null) {
             this.baseUrl = baseUrl;
         } else {
@@ -64,15 +61,6 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
                     this.baseUrl = null;
             }
         }
-    }
-
-    public void addPreferredSuggestion(String name, String label, String id) {
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("name", new JSONString(name));
-        jsonObject.put("label", new JSONString(label));
-        jsonObject.put("id", new JSONString(id));
-        this.preferredSuggestions.set(this.preferredSuggestions.size(), jsonObject);
-//        GWT.log("added: " + preferredSuggestions.size() + " " + jsonObject.toString());
     }
 
     private void requestRemoteData(final Request suggestRequest, final Callback suggestCallback) {
@@ -158,7 +146,6 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
                 suggestionList.add(suggestion);
             }
         }
-        GWT.log("list size:" + query + " vs " + suggestionList.size());
         Response r = new Response();
         r.setSuggestions(suggestionList);
         suggestCallback.onSuggestionsReady(suggestRequest, r);
@@ -183,19 +170,8 @@ public class BiolinkOntologyOracle extends MultiWordSuggestOracle {
         this.category = category;
     }
 
-    public Boolean getUsePreferredSuggestions() {
-        return usePreferredSuggestions;
-    }
-
-    public void setUsePreferredSuggestions(Boolean usePreferredSuggestions) {
-        this.usePreferredSuggestions = usePreferredSuggestions;
-    }
 
     public void setUseAllEco(Boolean useAllEco) {
         this.useAllEco = useAllEco;
-    }
-
-    public Boolean getUseAllEco() {
-        return useAllEco;
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkSuggestBox.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/oracles/BiolinkSuggestBox.java
@@ -1,0 +1,18 @@
+package org.bbop.apollo.gwt.client.oracles;
+
+
+import org.gwtbootstrap3.client.ui.SuggestBox;
+
+public class BiolinkSuggestBox extends SuggestBox {
+
+    public BiolinkSuggestBox(BiolinkOntologyOracle oracle) {
+        super(oracle);
+    }
+
+    @Override
+    public void showSuggestionList() {
+        if(getText().length()>=0){
+            super.showSuggestionList();
+        }
+    }
+}


### PR DESCRIPTION
fixes #2421

- [x] provide a boolean for ECO vs default 
- [x] suppress query if not using ECO
- [x] if ECO, ignore preferred suggestsions
- [x] add a link to http://geneontology.org/docs/guide-go-evidence-codes/ in a question icon
- [x] follow pattern for provenance
- [x] follow pattern for gene productr

---

- [ ] fix autoscroll down (maybe)
- [x] add rest of default terms
