### PR TITLE
fixing UI for permissions

### DIFF
--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -6435,14 +6435,21 @@ define([
                     url: url ,
                     handleAs: "json",
                     load: function (response, ioArgs) {
-                        dojo.create("a", {
-                            innerHTML: response.filename,
-                            href: context_path + "/IOService/download?uuid=" + response.uuid + "&exportType=" + response.exportType + "&seqType=" + response.sequenceType + "&format=" + response.format,
-                            onclick:  function(){
-                                track.closeDialog();
-                            }
+                        if(response.error){
+                            // dojo.style(waitingDiv, {display: "none"});
+                            responseDiv.innerHTML = response.error
+                            // track.handleError(response);
+                        }
+                        else{
+                            dojo.create("a", {
+                                innerHTML: response.filename,
+                                href: context_path + "/IOService/download?uuid=" + response.uuid + "&exportType=" + response.exportType + "&seqType=" + response.sequenceType + "&format=" + response.format,
+                                onclick:  function(){
+                                    track.closeDialog();
+                                }
 
-                        }, content);
+                            }, content);
+                        }
                         dojo.style(waitingDiv, {display: "none"});
                     },
                     // The ERROR function will be called in an error case.

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -6005,9 +6005,7 @@ define([
                         },
                         // The ERROR function will be called in an error case.
                         error: function (response, ioArgs) { //
-                            console.log('response error',response)
                             track.handleError(response);
-                            console.log('response ',response)
                             return response; //
                         }
 

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -6005,7 +6005,9 @@ define([
                         },
                         // The ERROR function will be called in an error case.
                         error: function (response, ioArgs) { //
+                            console.log('response error',response)
                             track.handleError(response);
+                            console.log('response ',response)
                             return response; //
                         }
 
@@ -6295,15 +6297,21 @@ define([
                         timeout: 5000 * 1000, // Time in milliseconds
                         load: function (response, ioArgs) {
                             var textAreaContent = "";
-                            for (var i = 0; i < response.features.length; ++i) {
-                                var feature = response.features[i];
-                                var cvterm = feature.type;
-                                var residues = feature.residues;
-                                var loc = feature.location;
-                                textAreaContent += "&gt;" + feature.uniquename + " (" + cvterm.cv.name + ":" + cvterm.name + ") " + residues.length + " residues [" + track.refSeq.name + ":" + (loc.fmin + 1) + "-" + loc.fmax + " " + (loc.strand == -1 ? "-" : loc.strand == 1 ? "+" : "no") + " strand] [" + type + (flank > 0 ? " +/- " + flank + " bases" : "") + "]\n";
-                                var lineLength = 60;
-                                for (var j = 0; j < residues.length; j += lineLength) {
-                                    textAreaContent += residues.substr(j, lineLength) + "\n";
+                            if(response.error){
+                                textAreaContent = response.error ;
+                                // track.handleError(response)
+                            }
+                            else{
+                                for (var i = 0; i < response.features.length; ++i) {
+                                    var feature = response.features[i];
+                                    var cvterm = feature.type;
+                                    var residues = feature.residues;
+                                    var loc = feature.location;
+                                    textAreaContent += "&gt;" + feature.uniquename + " (" + cvterm.cv.name + ":" + cvterm.name + ") " + residues.length + " residues [" + track.refSeq.name + ":" + (loc.fmin + 1) + "-" + loc.fmax + " " + (loc.strand == -1 ? "-" : loc.strand == 1 ? "+" : "no") + " strand] [" + type + (flank > 0 ? " +/- " + flank + " bases" : "") + "]\n";
+                                    var lineLength = 60;
+                                    for (var j = 0; j < residues.length; j += lineLength) {
+                                        textAreaContent += residues.substr(j, lineLength) + "\n";
+                                    }
                                 }
                             }
                             dojo.attr(textArea, "innerHTML", textAreaContent);

--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -124,19 +124,19 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         render jre as JSON
     }
 
-  @RestApiMethod(description = "Gets history for features", path = "/annotationEditor/getHistoryForFeatures", verb = RestApiVerb.POST)
-  @RestApiParams(params = [
-    @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
-    , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
-    , @RestApiParam(name = "sequence", type = "string", paramType = RestApiParamType.QUERY, description = "Sequence name")
-    , @RestApiParam(name = "features", type = "JSONArray", paramType = RestApiParamType.QUERY, description = "JSONArray of JSON feature objects unique names.")
-  ])
-  @Timed
-  def getHistoryForFeatures() {
-    log.debug "getHistoryForFeatures ${params}"
+    @RestApiMethod(description = "Gets history for features", path = "/annotationEditor/getHistoryForFeatures", verb = RestApiVerb.POST)
+    @RestApiParams(params = [
+            @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "sequence", type = "string", paramType = RestApiParamType.QUERY, description = "Sequence name")
+            , @RestApiParam(name = "features", type = "JSONArray", paramType = RestApiParamType.QUERY, description = "JSONArray of JSON feature objects unique names.")
+    ])
+    @Timed
+    def getHistoryForFeatures() {
+        log.debug "getHistoryForFeatures ${params}"
         JSONObject inputObject = permissionService.handleInput(request, params)
-        if(!inputObject.track && inputObject.sequence){
-          inputObject.track = inputObject.sequence  // support some legacy
+        if (!inputObject.track && inputObject.sequence) {
+            inputObject.track = inputObject.sequence  // support some legacy
         }
         inputObject.put(FeatureStringEnum.USERNAME.value, SecurityUtils.subject.principal)
         JSONArray featuresArray = inputObject.getJSONArray(FeatureStringEnum.FEATURES.value)
@@ -168,10 +168,10 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         JSONArray startProteins = new JSONArray()
         JSONArray stopProteins = new JSONArray()
 
-        for(String startCodon in translationTable.getStartCodons()){
+        for (String startCodon in translationTable.getStartCodons()) {
             startProteins.add(translationTable.getTranslationTable().get(startCodon))
         }
-        for(String stopCodon in translationTable.getStopCodons()){
+        for (String stopCodon in translationTable.getStopCodons()) {
             stopProteins.add(translationTable.getTranslationTable().get(stopCodon))
         }
 
@@ -460,7 +460,6 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
     }
 
 
-
     @RestApiMethod(description = "Get sequence alterations for a given sequence", path = "/annotationEditor/getSequenceAlterations", verb = RestApiVerb.POST)
     @RestApiParams(params = [
             @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
@@ -689,10 +688,10 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
             Feature feature = Feature.findByUniqueName(uniqueName)
             JSONArray attributes = new JSONArray()
             feature.featureProperties.each {
-                if(it.ontologyId!=Comment.ontologyId){
+                if (it.ontologyId != Comment.ontologyId) {
                     JSONObject attributeObject = new JSONObject()
-                    attributeObject.put(FeatureStringEnum.TAG.value,it.tag)
-                    attributeObject.put(FeatureStringEnum.VALUE.value,it.value)
+                    attributeObject.put(FeatureStringEnum.TAG.value, it.tag)
+                    attributeObject.put(FeatureStringEnum.VALUE.value, it.value)
                     attributes.add(attributeObject)
                 }
             }
@@ -720,8 +719,8 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
             JSONArray annotations = new JSONArray()
             feature.featureDBXrefs.each {
                 JSONObject dbxrefObject = new JSONObject()
-                dbxrefObject.put(FeatureStringEnum.TAG.value,it.db.name)
-                dbxrefObject.put(FeatureStringEnum.VALUE.value,it.accession)
+                dbxrefObject.put(FeatureStringEnum.TAG.value, it.db.name)
+                dbxrefObject.put(FeatureStringEnum.VALUE.value, it.accession)
                 annotations.add(dbxrefObject)
 
             }
@@ -885,13 +884,13 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
             // create features from sequences
             JSONArray features = new JSONArray()
             inputObject.features = features
-            List<Long> sequenceList = inputObject.sequence.collect{
+            List<Long> sequenceList = inputObject.sequence.collect {
                 return Long.valueOf(it.id)
             }
             List<String> featureUniqueNames = Feature.executeQuery("select f.uniqueName from Feature f left join f.parentFeatureRelationships pfr  join f.featureLocations fl join fl.sequence s   where f.childFeatureRelationships is empty and s.id in (:sequenceList) and f.class in (:viewableTypes) ", [sequenceList: sequenceList, viewableTypes: requestHandlingService.viewableAnnotationList])
-            featureUniqueNames.each{
+            featureUniqueNames.each {
                 def jsonObject = new JSONObject()
-                jsonObject.put(FeatureStringEnum.UNIQUENAME.value,it)
+                jsonObject.put(FeatureStringEnum.UNIQUENAME.value, it)
                 features.add(jsonObject)
             }
             inputObject.remove("sequence")
@@ -980,14 +979,17 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
     def getSequence() {
         log.debug "getSequence ${params.data}"
         JSONObject inputObject = permissionService.handleInput(request, params)
-        if (!permissionService.hasPermissions(inputObject, PermissionEnum.EXPORT)) {
-            render status: HttpStatus.UNAUTHORIZED
-            return
+        try{
+            permissionService.hasPermissions(inputObject, PermissionEnum.EXPORT)
+            JSONObject featureContainer = jsonWebUtilityService.createJSONFeatureContainer()
+            JSONObject sequenceObject = sequenceService.getSequenceForFeatures(inputObject)
+            featureContainer.getJSONArray(FeatureStringEnum.FEATURES.value).put(sequenceObject)
+            render featureContainer
         }
-        JSONObject featureContainer = jsonWebUtilityService.createJSONFeatureContainer()
-        JSONObject sequenceObject = sequenceService.getSequenceForFeatures(inputObject)
-        featureContainer.getJSONArray(FeatureStringEnum.FEATURES.value).put(sequenceObject)
-        render featureContainer
+        catch (AnnotationException ae) {
+            def error = [error: ae.message]
+            render error as JSON
+        }
     }
 
     @RestApiMethod(description = "Get sequences search tools", path = "/annotationEditor/getSequenceSearchTools")
@@ -999,24 +1001,23 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         render jre as JSON
     }
 
-    private String getOntologyIdForType(String type){
+    private String getOntologyIdForType(String type) {
         JSONObject cvTerm = new JSONObject()
-        if(type.toUpperCase()==Gene.cvTerm.toUpperCase()){
+        if (type.toUpperCase() == Gene.cvTerm.toUpperCase()) {
             JSONObject cvTermName = new JSONObject()
-            cvTermName.put(FeatureStringEnum.NAME.value,FeatureStringEnum.CV.value)
-            cvTerm.put(FeatureStringEnum.CV.value,cvTermName)
-            cvTerm.put(FeatureStringEnum.NAME.value,type)
-        }
-        else{
+            cvTermName.put(FeatureStringEnum.NAME.value, FeatureStringEnum.CV.value)
+            cvTerm.put(FeatureStringEnum.CV.value, cvTermName)
+            cvTerm.put(FeatureStringEnum.NAME.value, type)
+        } else {
             JSONObject cvTermName = new JSONObject()
-            cvTermName.put(FeatureStringEnum.NAME.value,FeatureStringEnum.SEQUENCE.value)
-            cvTerm.put(FeatureStringEnum.CV.value,cvTermName)
-            cvTerm.put(FeatureStringEnum.NAME.value,type)
+            cvTermName.put(FeatureStringEnum.NAME.value, FeatureStringEnum.SEQUENCE.value)
+            cvTerm.put(FeatureStringEnum.CV.value, cvTermName)
+            cvTerm.put(FeatureStringEnum.NAME.value, type)
         }
         return featureService.convertJSONToOntologyId(cvTerm)
     }
 
-    private List<FeatureType> getFeatureTypeListForType(String type){
+    private List<FeatureType> getFeatureTypeListForType(String type) {
         String ontologyId = getOntologyIdForType(type)
         return FeatureType.findAllByOntologyId(ontologyId)
     }
@@ -1037,7 +1038,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         Organism organism = Organism.findById(inputObject.getLong(FeatureStringEnum.ORGANISM_ID.value))
         String type = inputObject.getString(FeatureStringEnum.TYPE.value)
         List<FeatureType> featureTypeList = getFeatureTypeListForType(type)
-        render cannedCommentService.getCannedComments(organism,featureTypeList) as JSON
+        render cannedCommentService.getCannedComments(organism, featureTypeList) as JSON
     }
 
     @RestApiMethod(description = "Get canned keys", path = "/annotationEditor/getCannedKeys", verb = RestApiVerb.POST)
@@ -1056,7 +1057,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         Organism organism = Organism.findById(inputObject.getLong(FeatureStringEnum.ORGANISM_ID.value))
         String type = inputObject.getString(FeatureStringEnum.TYPE.value)
         List<FeatureType> featureTypeList = getFeatureTypeListForType(type)
-        render cannedAttributeService.getCannedKeys(organism,featureTypeList) as JSON
+        render cannedAttributeService.getCannedKeys(organism, featureTypeList) as JSON
     }
 
     @RestApiMethod(description = "Get canned values", path = "/annotationEditor/getCannedValues", verb = RestApiVerb.POST)
@@ -1075,7 +1076,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         Organism organism = Organism.findById(inputObject.getLong(FeatureStringEnum.ORGANISM_ID.value))
         String type = inputObject.getString(FeatureStringEnum.TYPE.value)
         List<FeatureType> featureTypeList = getFeatureTypeListForType(type)
-        render cannedAttributeService.getCannedValues(organism,featureTypeList) as JSON
+        render cannedAttributeService.getCannedValues(organism, featureTypeList) as JSON
     }
 
     @RestApiMethod(description = "Get available statuses", path = "/annotationEditor/getAvailableStatuses", verb = RestApiVerb.POST)
@@ -1095,12 +1096,12 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
 
         Organism organism = Organism.findById(inputObject.getLong(FeatureStringEnum.ORGANISM_ID.value))
         String type = null
-        if(inputObject.containsKey(FeatureStringEnum.TYPE.value)){
+        if (inputObject.containsKey(FeatureStringEnum.TYPE.value)) {
             type = inputObject.getString(FeatureStringEnum.TYPE.value)
         }
         List<FeatureType> featureTypeList = type ? getFeatureTypeListForType(type) : []
         log.debug "type ${type} ${featureTypeList}"
-        render availableStatusService.getAvailableStatuses(organism,featureTypeList) as JSON
+        render availableStatusService.getAvailableStatuses(organism, featureTypeList) as JSON
     }
 
     @RestApiMethod(description = "Search sequences", path = "/annotationEditor/searchSequences", verb = RestApiVerb.POST)
@@ -1110,13 +1111,16 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
     def searchSequence() {
         log.debug "sequenceSearch data ${params.data}"
         JSONObject inputObject = permissionService.handleInput(request, params)
-        if (!permissionService.hasPermissions(inputObject, PermissionEnum.READ)) {
-            render status: HttpStatus.UNAUTHORIZED
-            return
+        try{
+            permissionService.hasPermissions(inputObject, PermissionEnum.READ)
+            Organism organism = preferenceService.getCurrentOrganismForCurrentUser(inputObject.getString(FeatureStringEnum.CLIENT_TOKEN.value))
+            log.debug "Organism to string:  ${organism as JSON}"
+            render sequenceSearchService.searchSequence(inputObject, organism.getBlatdb())
         }
-        Organism organism = preferenceService.getCurrentOrganismForCurrentUser(inputObject.getString(FeatureStringEnum.CLIENT_TOKEN.value))
-        log.debug "Organism to string:  ${organism as JSON}"
-        render sequenceSearchService.searchSequence(inputObject, organism.getBlatdb())
+        catch (AnnotationException ae) {
+            def error = [error: ae.message]
+            render error as JSON
+        }
     }
 
 
@@ -1129,12 +1133,9 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
     def getGff3() {
         log.debug "getGff3 ${params.data}"
         JSONObject inputObject = permissionService.handleInput(request, params)
-        if (!permissionService.hasPermissions(inputObject, PermissionEnum.EXPORT)) {
-            render status: HttpStatus.UNAUTHORIZED
-            return
-        }
         try {
-            File outputFile = File.createTempFile("feature", ".gff3");
+            permissionService.hasPermissions(inputObject, PermissionEnum.EXPORT)
+            File outputFile = File.createTempFile("feature", ".gff3")
             sequenceService.getGff3ForFeature(inputObject, outputFile)
             Charset encoding = Charset.defaultCharset()
             byte[] encoded = Files.readAllBytes(Paths.get(outputFile.getAbsolutePath()))
@@ -1142,8 +1143,13 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
             outputFile.delete() // deleting temp file
             render gff3String
 
-        } catch (IOException e) {
-            log.debug("Cannot create a temp file for 'get GFF3' operation")
+        }
+        catch (AnnotationException ae) {
+            def error = [error: ae.message]
+            render error as JSON
+        }
+        catch (IOException e) {
+            log.debug("Cannot create a temp file for 'get GFF3' operation", e)
             e.printStackTrace()
         }
     }
@@ -1151,28 +1157,26 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
     @RestApiMethod(description = "Get genes created or updated in the past, Returns JSON hash gene_name:organism", path = "/annotationEditor/getRecentAnnotations", verb = RestApiVerb.POST)
     @RestApiParams(params = [
             @RestApiParam(name = "username", type = "email", paramType = RestApiParamType.QUERY)
-            ,@RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
-            ,@RestApiParam(name = "days", type = "Integer", paramType = RestApiParamType.QUERY, description = "Number of past days to retrieve annotations from.")
+            , @RestApiParam(name = "password", type = "password", paramType = RestApiParamType.QUERY)
+            , @RestApiParam(name = "days", type = "Integer", paramType = RestApiParamType.QUERY, description = "Number of past days to retrieve annotations from.")
 
     ])
 
-    def getRecentAnnotations(){
-    	JSONObject inputObject = permissionService.handleInput(request, params)
+    def getRecentAnnotations() {
+        JSONObject inputObject = permissionService.handleInput(request, params)
         if (!permissionService.hasPermissions(inputObject, PermissionEnum.EXPORT)) {
             render status: HttpStatus.UNAUTHORIZED
             return
         }
 
-        if(inputObject.get('days') instanceof Integer){
-        	JsonBuilder updatedGenes = annotationEditorService.recentAnnotations(inputObject.get('days'))
-        	render updatedGenes
-        }else{
-        	def error = [error: inputObject.get('days') + ' Param days must be an Integer']
+        if (inputObject.get('days') instanceof Integer) {
+            JsonBuilder updatedGenes = annotationEditorService.recentAnnotations(inputObject.get('days'))
+            render updatedGenes
+        } else {
+            def error = [error: inputObject.get('days') + ' Param days must be an Integer']
             render error as JSON
         }
     }
-
-
 
 
     @MessageMapping("/AnnotationNotification")

--- a/src/gwt/org/bbop/apollo/gwt/client/AnnotatorPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/AnnotatorPanel.java
@@ -488,6 +488,17 @@ public class AnnotatorPanel extends Composite {
                                 geneDetailPanel.setEditable(editable);
                                 exonDetailPanel.setEditable(editable);
                                 repeatRegionDetailPanel.setEditable(editable);
+//                                variantAllelesPanel.setEditable(editable);
+//                                variantInfoPanel.setEditable(editable);
+//                                alleleInfoPanel.setEditable(editable);
+                                goPanel.setEditable(editable);
+                                geneProductPanel.setEditable(editable);
+                                provenancePanel.setEditable(editable);
+                                attributePanel.setEditable(editable);
+
+
+                                dbXrefPanel.setEditable(editable);
+                                commentPanel.setEditable(editable);
                                 reload();
                                 break;
                         }

--- a/src/gwt/org/bbop/apollo/gwt/client/AttributePanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/AttributePanel.java
@@ -20,7 +20,6 @@ import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent;
 import com.google.gwt.user.cellview.client.DataGrid;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.Widget;
@@ -39,7 +38,6 @@ import org.gwtbootstrap3.client.ui.ListBox;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
 
-import java.awt.*;
 import java.util.Comparator;
 import java.util.List;
 

--- a/src/gwt/org/bbop/apollo/gwt/client/AttributePanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/AttributePanel.java
@@ -20,6 +20,7 @@ import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent;
 import com.google.gwt.user.cellview.client.DataGrid;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.Widget;
@@ -38,6 +39,7 @@ import org.gwtbootstrap3.client.ui.ListBox;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
 
+import java.awt.*;
 import java.util.Comparator;
 import java.util.List;
 
@@ -78,6 +80,7 @@ public class AttributePanel extends Composite {
     private SingleSelectionModel<AttributeInfo> selectionModel = new SingleSelectionModel<>();
     EditTextCell tagCell = new EditTextCell();
     EditTextCell valueCell = new EditTextCell();
+    private Boolean editable  = false ;
 
     public AttributePanel() {
 
@@ -96,7 +99,7 @@ public class AttributePanel extends Composite {
                     deleteAttributeButton.setEnabled(false);
                 } else {
                     selectAttributeData(selectionModel.getSelectedObject());
-                    deleteAttributeButton.setEnabled(true);
+                    deleteAttributeButton.setEnabled(true && editable);
                 }
             }
         });
@@ -145,6 +148,10 @@ public class AttributePanel extends Composite {
         tagColumn.setFieldUpdater(new FieldUpdater<AttributeInfo, String>() {
             @Override
             public void update(int i, AttributeInfo object, String s) {
+                if(!editable) {
+                    Bootbox.alert("Not editable");
+                    return ;
+                }
                 if (s == null || s.trim().length() == 0) {
                     Bootbox.alert("Tag can not be blank");
                     tagCell.clearViewData(object);
@@ -169,6 +176,10 @@ public class AttributePanel extends Composite {
         valueColumn.setFieldUpdater(new FieldUpdater<AttributeInfo, String>() {
             @Override
             public void update(int i, AttributeInfo object, String s) {
+                if(!editable) {
+                    Bootbox.alert("Not editable");
+                    return ;
+                }
                 if (s == null || s.trim().length() == 0) {
                     Bootbox.alert("Value can not be blank");
                     valueCell.clearViewData(object);
@@ -433,5 +444,13 @@ public class AttributePanel extends Composite {
         if (this.internalAnnotationInfo != null) {
             AttributeRestService.getAttributes(requestCallback, this.internalAnnotationInfo,MainPanel.getInstance().getCurrentOrganism());
         }
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
+        addAttributeButton.setEnabled(editable);
+        deleteAttributeButton.setEnabled(editable);
+        valueInputBox.setEnabled(editable);
+        tagInputBox.setEnabled(editable);
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/CommentPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/CommentPanel.java
@@ -65,6 +65,7 @@ public class CommentPanel extends Composite {
     private SingleSelectionModel<CommentInfo> selectionModel = new SingleSelectionModel<>();
     EditTextCell commentCell = new EditTextCell();
     private static List<String> cannedComments = new ArrayList<>();
+    private Boolean editable  = false ;
 
 
     public CommentPanel() {
@@ -130,6 +131,10 @@ public class CommentPanel extends Composite {
         commentColumn.setFieldUpdater(new FieldUpdater<CommentInfo, String>() {
             @Override
             public void update(int i, CommentInfo object, String s) {
+                if(!editable) {
+                    Bootbox.alert("Not editable");
+                    return ;
+                }
                 if (s == null || s.trim().length() == 0) {
                     Bootbox.alert("Accession can not be blank");
                     commentCell.clearViewData(object);
@@ -329,5 +334,12 @@ public class CommentPanel extends Composite {
         if (this.internalAnnotationInfo != null) {
             CommentRestService.getComments(requestCallback, this.internalAnnotationInfo,MainPanel.getInstance().getCurrentOrganism());
         }
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
+        commentInputBox.setEnabled(editable);
+        addCommentButton.setEnabled(editable);
+        deleteCommentButton.setEnabled(editable);
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/DbXrefPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/DbXrefPanel.java
@@ -78,6 +78,7 @@ public class DbXrefPanel extends Composite {
     private SingleSelectionModel<DbXrefInfo> selectionModel = new SingleSelectionModel<>();
     EditTextCell tagCell = new EditTextCell();
     EditTextCell valueCell = new EditTextCell();
+    private Boolean editable  = false ;
 
     public DbXrefPanel() {
 
@@ -92,6 +93,7 @@ public class DbXrefPanel extends Composite {
         selectionModel.addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
             @Override
             public void onSelectionChange(SelectionChangeEvent selectionChangeEvent) {
+                if(!editable) return ;
                 if (selectionModel.getSelectedSet().isEmpty()) {
                     deleteDbXrefButton.setEnabled(false);
                 } else {
@@ -145,6 +147,10 @@ public class DbXrefPanel extends Composite {
         tagColumn.setFieldUpdater(new FieldUpdater<DbXrefInfo, String>() {
             @Override
             public void update(int i, DbXrefInfo object, String s) {
+                if(!editable) {
+                    Bootbox.alert("Not editable");
+                    return ;
+                }
                 if (s == null || s.trim().length() == 0) {
                     Bootbox.alert("Prefix can not be blank");
                     tagCell.clearViewData(object);
@@ -169,6 +175,10 @@ public class DbXrefPanel extends Composite {
         valueColumn.setFieldUpdater(new FieldUpdater<DbXrefInfo, String>() {
             @Override
             public void update(int i, DbXrefInfo object, String s) {
+                if(!editable) {
+                    Bootbox.alert("Not editable");
+                    return ;
+                }
                 if (s == null || s.trim().length() == 0) {
                     Bootbox.alert("Accession can not be blank");
                     valueCell.clearViewData(object);
@@ -429,5 +439,18 @@ public class DbXrefPanel extends Composite {
             };
             DbXrefRestService.deleteDbXref(requestCallBack, this.internalAnnotationInfo, this.internalDbXrefInfo);
         }
+    }
+
+    public void setEditable(boolean editable) {
+        this.editable = editable;
+
+        addPmidButton.setEnabled(editable);
+        addDbXrefButton.setEnabled(editable);
+        deleteDbXrefButton.setEnabled(editable);
+
+        tagInputBox.setEnabled(editable);
+        valueInputBox.setEnabled(editable);
+        pmidInputBox.setEnabled(editable);
+
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/ExonDetailPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/ExonDetailPanel.java
@@ -75,9 +75,9 @@ public class ExonDetailPanel extends Composite {
     DataGrid<AnnotationInfo> dataGrid = new DataGrid<>(200, tablecss);
     @UiField
     HTML notePanel;
-    private static ListDataProvider<AnnotationInfo> dataProvider = new ListDataProvider<>();
-    private static List<AnnotationInfo> annotationInfoList = dataProvider.getList();
-    private SingleSelectionModel<AnnotationInfo> selectionModel = new SingleSelectionModel<>();
+    private static final ListDataProvider<AnnotationInfo> dataProvider = new ListDataProvider<>();
+    private static final List<AnnotationInfo> annotationInfoList = dataProvider.getList();
+    private final SingleSelectionModel<AnnotationInfo> selectionModel = new SingleSelectionModel<>();
 
     private Boolean editable = false;
 
@@ -242,14 +242,14 @@ public class ExonDetailPanel extends Composite {
     }
 
     private void enableFields(boolean enabled) {
-        decreaseFivePrime.setEnabled(enabled);
-        increaseFivePrime.setEnabled(enabled);
-        decreaseThreePrime.setEnabled(enabled);
-        increaseThreePrime.setEnabled(enabled);
+        decreaseFivePrime.setEnabled(enabled && this.editable);
+        increaseFivePrime.setEnabled(enabled && this.editable);
+        decreaseThreePrime.setEnabled(enabled && this.editable);
+        increaseThreePrime.setEnabled(enabled && this.editable);
     }
 
     public void setEditable(boolean editable) {
-        this.editable = editable;
+        this.editable = editable ;
     }
 
     private boolean isEditableType(String type) {

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.java
@@ -148,6 +148,7 @@ public class GeneDetailPanel extends Composite {
         symbolField.setEnabled(enabled);
         descriptionField.setEnabled(enabled);
         synonymsField.setEnabled(enabled);
+        deleteAnnotation.setEnabled(enabled);
     }
 
 
@@ -195,7 +196,6 @@ public class GeneDetailPanel extends Composite {
         userField.setText(internalAnnotationInfo.getOwner());
         dateCreatedField.setText(DateFormatService.formatTimeAndDate(internalAnnotationInfo.getDateCreated()));
         lastUpdatedField.setText(DateFormatService.formatTimeAndDate(internalAnnotationInfo.getDateLastModified()));
-        deleteAnnotation.setEnabled(MainPanel.getInstance().isCurrentUserAdmin() || MainPanel.getInstance().getHighestPermissionForUser().getRank()>= PermissionEnum.WRITE.getRank());
 
         if (internalAnnotationInfo.getMin() != null) {
             String locationText = internalAnnotationInfo.getMin().toString();
@@ -339,6 +339,7 @@ public class GeneDetailPanel extends Composite {
         symbolField.setEnabled(editable);
         descriptionField.setEnabled(editable);
         synonymsField.setEnabled(editable);
+        deleteAnnotation.setEnabled(editable);
 
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.java
@@ -22,6 +22,7 @@ import org.bbop.apollo.gwt.client.rest.AnnotationRestService;
 import org.bbop.apollo.gwt.client.rest.AvailableStatusRestService;
 import org.bbop.apollo.gwt.client.rest.RestService;
 import org.bbop.apollo.gwt.shared.FeatureStringEnum;
+import org.bbop.apollo.gwt.shared.PermissionEnum;
 import org.gwtbootstrap3.client.ui.*;
 import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
 import org.gwtbootstrap3.extras.bootbox.client.callback.ConfirmCallback;
@@ -194,6 +195,7 @@ public class GeneDetailPanel extends Composite {
         userField.setText(internalAnnotationInfo.getOwner());
         dateCreatedField.setText(DateFormatService.formatTimeAndDate(internalAnnotationInfo.getDateCreated()));
         lastUpdatedField.setText(DateFormatService.formatTimeAndDate(internalAnnotationInfo.getDateLastModified()));
+        deleteAnnotation.setEnabled(MainPanel.getInstance().isCurrentUserAdmin() || MainPanel.getInstance().getHighestPermissionForUser().getRank()>= PermissionEnum.WRITE.getRank());
 
         if (internalAnnotationInfo.getMin() != null) {
             String locationText = internalAnnotationInfo.getMin().toString();

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.ui.xml
@@ -51,7 +51,7 @@
                           ui:field="annotationIdButton" enabled="true" addStyleNames="{style.action-buttons}"/>
                 <b:Button type="DANGER" icon="TRASH_O" title="Go To" iconSize="LARGE"
                           text="Delete" pull="RIGHT"
-                          ui:field="deleteAnnotation" enabled="true"
+                          ui:field="deleteAnnotation" enabled="false"
                           addStyleNames="{style.action-buttons}"/>
             </b:Column>
         </b:Row>

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.java
@@ -108,6 +108,7 @@ public class GeneProductPanel extends Composite {
   private SingleSelectionModel<GeneProduct> selectionModel = new SingleSelectionModel<>();
   private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle(BiolinkLookup.ECO);
   private SuggestedGeneProductOracle suggestedGeneProductOracle = new SuggestedGeneProductOracle();
+  private Boolean editable  = false ;
 
   private AnnotationInfo annotationInfo;
 
@@ -133,7 +134,7 @@ public class GeneProductPanel extends Composite {
     selectionModel.addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
       @Override
       public void onSelectionChange(SelectionChangeEvent event) {
-        if (selectionModel.getSelectedObject() != null) {
+        if (selectionModel.getSelectedObject() != null && editable) {
           deleteGoButton.setEnabled(true);
           editGoButton.setEnabled(true);
         } else {
@@ -147,9 +148,11 @@ public class GeneProductPanel extends Composite {
     dataGrid.addDomHandler(new DoubleClickHandler() {
       @Override
       public void onDoubleClick(DoubleClickEvent event) {
-        geneProductTitle.setText("Edit Gene Product for " + AnnotatorPanel.selectedAnnotationInfo.getName());
-        handleSelection();
-        editGoModal.show();
+        if(editable) {
+          geneProductTitle.setText("Edit Gene Product for " + AnnotatorPanel.selectedAnnotationInfo.getName());
+          handleSelection();
+          editGoModal.show();
+        }
       }
     }, DoubleClickEvent.getType());
 
@@ -574,5 +577,12 @@ public class GeneProductPanel extends Composite {
     loadData();
   }
 
+  public void setEditable(boolean editable) {
+    this.editable = editable;
+//    dataGrid.setEnabled(editable);
+    newGoButton.setEnabled(editable);
+    editGoButton.setEnabled(editable);
+    deleteGoButton.setEnabled(editable);
+  }
 
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.java
@@ -126,6 +126,7 @@ public class GoPanel extends Composite {
   private AnnotationInfo annotationInfo;
   private BiolinkOntologyOracle goLookup = new BiolinkOntologyOracle(BiolinkLookup.GO);
   private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle();
+  private Boolean editable  = false ;
 
   public GoPanel() {
 
@@ -161,7 +162,7 @@ public class GoPanel extends Composite {
     selectionModel.addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
       @Override
       public void onSelectionChange(SelectionChangeEvent event) {
-        if (selectionModel.getSelectedObject() != null) {
+        if (selectionModel.getSelectedObject() != null && editable) {
           deleteGoButton.setEnabled(true);
           editGoButton.setEnabled(true);
         } else {
@@ -175,9 +176,11 @@ public class GoPanel extends Composite {
     dataGrid.addDomHandler(new DoubleClickHandler() {
       @Override
       public void onDoubleClick(DoubleClickEvent event) {
-        goAnnotationTitle.setText("Edit GO Annotation for " + AnnotatorPanel.selectedAnnotationInfo.getName());
-        handleSelection();
-        editGoModal.show();
+        if(editable){
+          goAnnotationTitle.setText("Edit GO Annotation for " + AnnotatorPanel.selectedAnnotationInfo.getName());
+          handleSelection();
+          editGoModal.show();
+        }
       }
     }, DoubleClickEvent.getType());
 
@@ -714,5 +717,13 @@ public class GoPanel extends Composite {
     loadData();
   }
 
+
+  public void setEditable(boolean editable) {
+    this.editable = editable;
+//    dataGrid.setEnabled(editable);
+    newGoButton.setEnabled(editable);
+    editGoButton.setEnabled(editable);
+    deleteGoButton.setEnabled(editable);
+  }
 
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/GroupPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GroupPanel.java
@@ -52,7 +52,7 @@ public class GroupPanel extends Composite {
     interface UserGroupBrowserPanelUiBinder extends UiBinder<Widget, GroupPanel> {
     }
 
-    private static UserGroupBrowserPanelUiBinder ourUiBinder = GWT.create(UserGroupBrowserPanelUiBinder.class);
+    private static final UserGroupBrowserPanelUiBinder ourUiBinder = GWT.create(UserGroupBrowserPanelUiBinder.class);
     @UiField
     TextBox name;
 
@@ -94,12 +94,12 @@ public class GroupPanel extends Composite {
     @UiField
     static TextBox nameSearchBox;
 
-    static private ListDataProvider<GroupInfo> dataProvider = new ListDataProvider<>();
-    private static List<GroupInfo> groupInfoList = new ArrayList<>();
-    private static List<GroupInfo> filteredGroupInfoList = dataProvider.getList();
+    private static final ListDataProvider<GroupInfo> dataProvider = new ListDataProvider<>();
+    private static final List<GroupInfo> groupInfoList = new ArrayList<>();
+    private static final List<GroupInfo> filteredGroupInfoList = dataProvider.getList();
 
 
-    private SingleSelectionModel<GroupInfo> selectionModel = new SingleSelectionModel<>();
+    private final SingleSelectionModel<GroupInfo> selectionModel = new SingleSelectionModel<>();
     private GroupInfo selectedGroupInfo;
     private ColumnSortEvent.ListHandler<GroupInfo> groupSortHandler = new ColumnSortEvent.ListHandler<>(groupInfoList);
     private List<UserInfo> allUsersList = new ArrayList<>();

--- a/src/gwt/org/bbop/apollo/gwt/client/MainPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/MainPanel.java
@@ -65,7 +65,7 @@ public class MainPanel extends Composite {
     private static List<OrganismInfo> organismInfoList = new ArrayList<>(); // list of organisms for user
     private static final String trackListViewString = "&tracklist=";
     private static final String openAnnotatorPanelString = "&openAnnotatorPanel=";
-
+    private PermissionEnum highestPermissionForUser = PermissionEnum.NONE;
     private static boolean handlingNavEvent = false;
 
 
@@ -1308,6 +1308,16 @@ public class MainPanel extends Composite {
         currentSequence.setStartBp(currentStartBp);
         currentSequence.setEndBp(currentEndBp);
         return currentSequence;
+    }
+
+
+    public void setHighestPermissionForUser(PermissionEnum highestPermissionForUser) {
+
+        this.highestPermissionForUser = highestPermissionForUser;
+    }
+
+    public PermissionEnum getHighestPermissionForUser() {
+        return highestPermissionForUser;
     }
 
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.java
@@ -107,6 +107,7 @@ public class ProvenancePanel extends Composite {
   private static List<Provenance> annotationInfoList = dataProvider.getList();
   private SingleSelectionModel<Provenance> selectionModel = new SingleSelectionModel<>();
   private BiolinkOntologyOracle ecoLookup = new BiolinkOntologyOracle(BiolinkLookup.ECO);
+  private Boolean editable  = false ;
 
   private AnnotationInfo annotationInfo;
 
@@ -133,7 +134,7 @@ public class ProvenancePanel extends Composite {
     selectionModel.addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
       @Override
       public void onSelectionChange(SelectionChangeEvent event) {
-        if (selectionModel.getSelectedObject() != null) {
+        if (selectionModel.getSelectedObject() != null && editable) {
           deleteGoButton.setEnabled(true);
           editGoButton.setEnabled(true);
         } else {
@@ -147,9 +148,11 @@ public class ProvenancePanel extends Composite {
     dataGrid.addDomHandler(new DoubleClickHandler() {
       @Override
       public void onDoubleClick(DoubleClickEvent event) {
-        provenanceTitle.setText("Edit Annotations for " + AnnotatorPanel.selectedAnnotationInfo.getName());
-        handleSelection();
-        provenanceModal.show();
+        if(editable) {
+          provenanceTitle.setText("Edit Annotations for " + AnnotatorPanel.selectedAnnotationInfo.getName());
+          handleSelection();
+          provenanceModal.show();
+        }
       }
     }, DoubleClickEvent.getType());
 
@@ -591,5 +594,12 @@ public class ProvenancePanel extends Composite {
     loadData();
   }
 
+  public void setEditable(boolean editable) {
+    this.editable = editable;
+//    dataGrid.setEnabled(editable);
+    newGoButton.setEnabled(editable);
+    editGoButton.setEnabled(editable);
+    deleteGoButton.setEnabled(editable);
+  }
 
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/RepeatRegionDetailPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/RepeatRegionDetailPanel.java
@@ -303,5 +303,6 @@ public class RepeatRegionDetailPanel extends Composite {
         nameField.setEnabled(editable);
         descriptionField.setEnabled(editable);
         synonymsField.setEnabled(editable);
+        deleteAnnotation.setEnabled(editable);
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/SequencePanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/SequencePanel.java
@@ -53,6 +53,7 @@ import java.util.Set;
  */
 public class SequencePanel extends Composite {
 
+
     interface SequencePanelUiBinder extends UiBinder<Widget, SequencePanel> {
     }
 
@@ -108,6 +109,8 @@ public class SequencePanel extends Composite {
     private Integer selectedCount = 0;
     private Boolean exportAll = false;
     private Boolean chadoExportStatus = false;
+    private Boolean allowExport = false ;
+
 
     public SequencePanel() {
 
@@ -150,13 +153,14 @@ public class SequencePanel extends Composite {
             @Override
             public void onSelectionChange(SelectionChangeEvent event) {
                 Set<SequenceInfo> selectedSequenceInfo = multiSelectionModel.getSelectedSet();
+                if(!getAllowExport()) return;
                 if (selectedSequenceInfo.size() == 1) {
                     setSequenceInfo(selectedSequenceInfo.iterator().next());
                     selectSelectedButton.setEnabled(true);
                 } else {
                     setSequenceInfo(null);
                 }
-                if (selectedSequenceInfo.size() > 0) {
+                if (selectedSequenceInfo.size() > 0 && getAllowExport()) {
                     exportSelectedButton.setText("Selected (" + selectedSequenceInfo.size() + ")");
                     deleteSequencesButton.setText("Annotations on " + selectedSequenceInfo.size() + " seq");
                 } else {
@@ -291,6 +295,7 @@ public class SequencePanel extends Composite {
                                 exportAllButton.setEnabled(allowExport);
                                 exportSelectedButton.setEnabled(allowExport);
                                 selectedSequenceDisplay.setEnabled(allowExport);
+                                setAllowExport(allowExport);
                                 break;
                         }
                     }
@@ -316,6 +321,7 @@ public class SequencePanel extends Composite {
     }
 
     private void updatedExportSelectedButton() {
+        if(!this.allowExport) return ;
         if (selectedCount > 0) {
             exportSelectedButton.setEnabled(true);
             exportSelectedButton.setText("Selected (" + multiSelectionModel.getSelectedSet().size() + ")");
@@ -571,5 +577,13 @@ public class SequencePanel extends Composite {
     public void setChadoExportStatus(String exportStatus) {
         this.chadoExportStatus = exportStatus.equals("true");
         this.exportChadoButton.setEnabled(this.chadoExportStatus);
+    }
+
+    public void setAllowExport(boolean allowExport) {
+        this.allowExport = allowExport;
+    }
+
+    public boolean getAllowExport() {
+        return allowExport;
     }
 }

--- a/src/gwt/org/bbop/apollo/gwt/client/TranscriptDetailPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/TranscriptDetailPanel.java
@@ -297,9 +297,10 @@ public class TranscriptDetailPanel extends Composite {
     }
 
     private void enableFields(boolean enabled) {
-        nameField.setEnabled(enabled && editable);
-        descriptionField.setEnabled(enabled && editable);
-        synonymsField.setEnabled(enabled && editable);
+        nameField.setEnabled(enabled && this.editable);
+        descriptionField.setEnabled(enabled && this.editable);
+        synonymsField.setEnabled(enabled && this.editable);
+        deleteAnnotation.setEnabled(enabled && this.editable);
     }
 
     public void setEditable(boolean editable) {
@@ -307,5 +308,6 @@ public class TranscriptDetailPanel extends Composite {
         nameField.setEnabled(this.editable);
         descriptionField.setEnabled(this.editable);
         synonymsField.setEnabled(this.editable);
+        deleteAnnotation.setEnabled(this.editable);
     }
 }


### PR DESCRIPTION
fixes #2431 

Should reflect change here: 
https://github.com/GMOD/Apollo/commit/4c09bfac53de025102412c55bcbabaedf1ec6a52

- [x] handle enable other tabs for gene, transcript, repeat region, and exon detail panels for write permissions
- [x] handle error on `view GFF3`, `view FASTA`, with right-click
- [x] handle when downloaded from annotation track panel in geneome browser
- [x] handle delete from gene browser


---

- [x] handle when download from Sequence Panel
- [x] verify that it is handled from the web service
- [x] handle deletes from annotator panel
- [x] handle deletes from the sequence panel
