### PR TITLE
tar.gz extraction: make sure parent directory exists

### DIFF
--- a/grails-app/services/org/bbop/apollo/FileService.groovy
+++ b/grails-app/services/org/bbop/apollo/FileService.groovy
@@ -195,6 +195,7 @@ class FileService {
                         log.info("Archive includes a symlink outside the current path $entry.name -> ${dest.toString()}")
 //                        throw new RuntimeException("Archive includes an invalid symlink: " + entry.getName() + " -> " + dest);
                     }
+                    Files.createDirectories(path.getParent());
                     Files.createSymbolicLink(path, Paths.get(dest));
                     fileNames.add(destAbsPath.toString())
                 }


### PR DESCRIPTION
A little bug fix for creating/updating an organism in remote mode: when extracting symlinks, we need to make sure the parent dir exists as is done for non-symlink files
Tested and approved on bipaa.genouest.org/apollo/ :)