### PR TITLE
Fixes Docker Image Build Failure: "UnicodeDecodeError" on pip3 apollo install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM ubuntu:18.04
 MAINTAINER Nathan Dunn <nathandunn@lbl.gov>
 ENV DEBIAN_FRONTEND noninteractive
 
+# fix for pip install decode error 
+ENV LC_CTYPE en_US.UTF-8
+ENV LANG en_US.UTF-8
+
 # where bin directories are
 ENV CATALINA_HOME /usr/share/tomcat9
 # where webapps are deployed

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM ubuntu:18.04
 MAINTAINER Nathan Dunn <nathandunn@lbl.gov>
 ENV DEBIAN_FRONTEND noninteractive
 
-# fix for pip install decode error 
-ENV LC_CTYPE en_US.UTF-8
-ENV LANG en_US.UTF-8
 
 # where bin directories are
 ENV CATALINA_HOME /usr/share/tomcat9
@@ -66,9 +63,14 @@ RUN chown -R apollo:apollo /apollo
 # install grails and python libraries
 USER apollo
 
+# fix for pip install decode error 
+ENV LC_CTYPE en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
 RUN pip3 install setuptools
 RUN pip3 install wheel
-RUN pip3 install nose "apollo==4.2.4"
+RUN pip3 install nose apollo==4.2.4
 
 RUN curl -s get.sdkman.io | bash && \
      /bin/bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && yes | sdk install grails 2.5.5" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 RUN apt-get -qq update --fix-missing && \
 	apt-get --no-install-recommends -y install \
-	git build-essential libpq-dev wget python3-pip \
+	git locales locales-all build-essential libpq-dev wget python3-pip \
 	lsb-release gnupg2 wget xmlstarlet netcat libpng-dev postgresql-common \
 	zlib1g-dev libexpat1-dev curl ssl-cert zip unzip openjdk-8-jdk-headless
 
@@ -64,7 +64,9 @@ RUN chown -R apollo:apollo /apollo
 USER apollo
 
 # fix for pip install decode error 
+# RUN locale-gen en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 


### PR DESCRIPTION
I kept getting an error on building the docker image for Apollo at the `pip3 install nose apollo==4.2.4` stage. 

From Quay.io build log:
```
RUN pip3 install nose apollo==4.2.4
7/27/2020, 8:12:47 PM
7/27/2020, 8:12:47 PM---> Running in 463b33386a8e
7/27/2020, 8:12:48 PMCollecting nose
7/27/2020, 8:12:48 PMDownloading https://files.pythonhosted.org/packages/15/d8/dd071918c040f50fa1cf80da16423af51ff8ce4a0f2399b7bf8de45ac3d9/nose-1.3.7-py3-none-any.whl (154kB)
7/27/2020, 8:12:48 PMCollecting apollo==4.2.4
7/27/2020, 8:12:48 PMDownloading https://files.pythonhosted.org/packages/4d/74/4c1488902216ba732cd18a816fb06e8200596ff63f8c98e3deb1e26f00a3/apollo-4.2.4.tar.gz (42kB)
7/27/2020, 8:12:48 PMComplete output from command python setup.py egg_info:
7/27/2020, 8:12:48 PMTraceback (most recent call last): File "<string>", line 1, in <module> File "/tmp/pip-build-p7h56g7m/apollo/setup.py", line 13, in <module> readme = open('README.rst').read() File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode return codecs.ascii_decode(input, self.errors)[0] UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 676: ordinal not in range(128) ----------------------------------------
7/27/2020, 8:12:49 PMCommand "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-p7h56g7m/apollo/
```

Found some notes on other issues and stack overflow posts pointing that Docker Build defaults to POSIX/ASCII locale rather than UTF-8 and it causes issues with some pip installs. Put the commands in place from https://leimao.github.io/blog/Docker-Locale/