### PR TITLE
fixes link and adds info boxes

### DIFF
--- a/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.java
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.java
@@ -123,6 +123,7 @@ public class GeneProductPanel extends Composite {
 
     initWidget(ourUiBinder.createAndBindUi(this));
 
+    allEcoCheckBox(null);
 
     selectionModel.addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
       @Override

--- a/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneProductPanel.ui.xml
@@ -47,6 +47,13 @@
                     </b:ModalHeader>
                     <b:ModalBody>
                         <b:Container fluid="true" width="100%">
+                            <b:Row>
+                                <b:Column size="MD_8">
+                                    <gwt:HTML>
+                                        <a href="http://geneontology.org/docs/go-annotations/" target="_blank">GO Annotation Guidance</a>
+                                    </gwt:HTML>
+                                </b:Column>
+                            </b:Row>
                             <b:Row addStyleNames="{style.row}">
                                 <b:Column size="MD_5">
                                     <b:Label>Product</b:Label>
@@ -60,10 +67,10 @@
                                   <b:Label>Evidence</b:Label>
                                     <apollo:BiolinkSuggestBox ui:field="evidenceCodeField"/>
                                     <gwt:Anchor ui:field="evidenceCodeLink" target="_blank"/>
+                                    <gwt:Anchor text="Evidence Code Info" target="_blank" ui:field="helpLink"/>
                                 </b:Column>
                                 <b:Column size="MD_1">
                                     <b:CheckBox text="All ECO Evidence" width="100%" ui:field="allEcoCheckBox"/>
-                                    <gwt:Anchor text="Info" target="_blank" ui:field="helpLink"/>
                                 </b:Column>
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">

--- a/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GoPanel.ui.xml
@@ -26,6 +26,9 @@
         .goButtons {
             margin-top: 5px;
         }
+        .infoRow {
+        margin-top: 5px;
+        }
 
         .saveButton {
             margin-right: 3px;
@@ -47,6 +50,13 @@
                     </b:ModalHeader>
                     <b:ModalBody>
                         <b:Container fluid="true" width="100%">
+                            <b:Row>
+                                <b:Column size="MD_8">
+                                    <gwt:HTML>
+                                        <a href="http://geneontology.org/docs/go-annotations/" target="_blank">GO Annotation Guidance</a>
+                                    </gwt:HTML>
+                                </b:Column>
+                            </b:Row>
                             <b:Row addStyleNames="{style.row}">
                                 <b:Column size="MD_3">
                                     <b:Label>Aspect</b:Label>
@@ -73,10 +83,10 @@
                                   <b:Label>Evidence</b:Label>
                                   <apollo:BiolinkSuggestBox ui:field="evidenceCodeField"/>
                                   <gwt:Anchor ui:field="evidenceCodeLink" target="_blank"/>
+                                    <gwt:Anchor text="Evidence Code Info" target="_blank" ui:field="helpLink"/>
                                 </b:Column>
                                 <b:Column size="MD_1">
                                     <b:CheckBox text="All ECO Evidence" width="100%" ui:field="allEcoCheckBox"/>
-                                    <gwt:Anchor text="Info" target="_blank" ui:field="helpLink"/>
                                 </b:Column>
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">

--- a/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/ProvenancePanel.ui.xml
@@ -7,33 +7,34 @@
     <ui:style>
 
         .container {
-            margin-left: 20px;
-            margin-top: 10px;
+        margin-left: 20px;
+        margin-top: 10px;
         }
 
         .widgetPanel {
-            display: inline-table;
-            margin-right: 10px;
-            margin-bottom: 5px;
+        display: inline-table;
+        margin-right: 10px;
+        margin-bottom: 5px;
         }
 
         .row {
-            margin-left: 5px;
-            margin-right: 5px;
-            margin-top: 5px;
+        margin-left: 5px;
+        margin-right: 5px;
+        margin-top: 5px;
         }
 
         .goButtons {
-            margin-top: 5px;
+        margin-top: 5px;
         }
 
         .saveButton {
-            margin-right: 3px;
+        margin-right: 3px;
         }
 
         .addButton {
-            margin-top: 14px;
-        }</ui:style>
+        margin-top: 14px;
+        }
+    </ui:style>
 
     <gwt:DockLayoutPanel>
         <gwt:center>
@@ -48,6 +49,16 @@
                     </b:ModalHeader>
                     <b:ModalBody>
                         <b:Container fluid="true" width="100%">
+                            <b:Row>
+                                <b:Column size="MD_8">
+                                    <b:Popover
+                                            title="Provenance Info"
+                                            content="Provenance describes why annotation details have been set or changed."
+                                    >
+                                        <b:Button text="Provenance Info"/>
+                                    </b:Popover>
+                                </b:Column>
+                            </b:Row>
                             <b:Row addStyleNames="{style.row}">
                                 <b:Column size="MD_6">
                                     <b:Label>Field</b:Label>
@@ -57,10 +68,10 @@
                                     <b:Label>Evidence</b:Label>
                                     <apollo:BiolinkSuggestBox ui:field="evidenceCodeField"/>
                                     <gwt:Anchor ui:field="evidenceCodeLink" target="_blank"/>
+                                    <gwt:Anchor text="Evidence Code Info" target="_blank" ui:field="helpLink"/>
                                 </b:Column>
                                 <b:Column size="MD_1">
                                     <b:CheckBox text="All ECO Evidence" width="100%" ui:field="allEcoCheckBox"/>
-                                    <gwt:Anchor text="Info" target="_blank" ui:field="helpLink"/>
                                 </b:Column>
                             </b:Row>
                             <b:Row addStyleNames="{style.row}">


### PR DESCRIPTION
fixes #2507 

- [x] I'll add this link for GO reference:  http://geneontology.org/docs/go-annotations/
- [x] I'll fix the link on the gene product column
- [x] In terms of how to annotate Gene Product, this should be similar to GO, I can add the link there.
- [x] the provenance is just an explanation of why you annotated a field. 
