### PR TITLE
Fix empty attribute list in annotation panel

### DIFF
--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -754,7 +754,7 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
             Feature feature = Feature.findByUniqueName(uniqueName)
             JSONArray attributes = new JSONArray()
             feature.featureProperties.each {
-                if (it.ontologyId != Comment.ontologyId) {
+                if (it.ontologyId != Comment.ontologyId && it.tag != null ) {
                     JSONObject attributeObject = new JSONObject()
                     attributeObject.put(FeatureStringEnum.TAG.value, it.tag)
                     attributeObject.put(FeatureStringEnum.VALUE.value, it.value)


### PR DESCRIPTION
A fix for a bug I found on 2.6.2: for some of my genes, the attributes were not displayed in the annotation panel.
It turns out the list of attributes returned by getattributes contained some entries with no tag defined. In particular, Status which were defined for theses genes.