### PR TITLE
added routes to explore web socket security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Apollo2.X
 FROM ubuntu:18.04
-MAINTAINER Nathan Dunn <nathandunn@lbl.gov>
+MAINTAINER Nathan Dunn GH @nathandunn
 ENV DEBIAN_FRONTEND noninteractive
 
 

--- a/apollo
+++ b/apollo
@@ -189,7 +189,6 @@ function check_configs(){
 
     check_node
     check_java
-    check_grails
 }
 
 function copy_configs(){

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -458,15 +458,8 @@ define([
                         console.log(JSON.stringify(changeData));
                     }
 
-                    alert('operation '+JSON.stringify(changeData))
-                    alert('track username: '+track.username)
-                    alert('track client token: '+track.getClientToken())
-
                     if (changeData.operation == "logout" && changeData.username == track.username) {
-                        console.log('track.getClientToken()',track.getClientToken())
-                        console.log('change data',changeData.clientToken)
                         if(track.getClientToken()!=changeData.clientToken){
-                            alert('track tokens do not agree so logging out')
                             track.logout();
                         }
                         else{

--- a/client/apollo/js/View/Track/AnnotTrack.js
+++ b/client/apollo/js/View/Track/AnnotTrack.js
@@ -458,8 +458,15 @@ define([
                         console.log(JSON.stringify(changeData));
                     }
 
+                    alert('operation '+JSON.stringify(changeData))
+                    alert('track username: '+track.username)
+                    alert('track client token: '+track.getClientToken())
+
                     if (changeData.operation == "logout" && changeData.username == track.username) {
+                        console.log('track.getClientToken()',track.getClientToken())
+                        console.log('change data',changeData.clientToken)
                         if(track.getClientToken()!=changeData.clientToken){
+                            alert('track tokens do not agree so logging out')
                             track.logout();
                         }
                         else{

--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -1274,6 +1274,10 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         inputString = annotationEditorService.cleanJSONString(inputString)
         JSONObject rootElement = (JSONObject) JSON.parse(inputString)
         rootElement.put(FeatureStringEnum.USERNAME.value, principal.name)
+        println "has a prinicpal name ${principal}"
+        User user = permissionService.getCurrentUser(rootElement)
+        println "getting USER ${user}"
+
 
         String operation = ((JSONObject) rootElement).get(REST_OPERATION)
 
@@ -1281,6 +1285,10 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         log.debug "operationName: ${operationName}"
         def p = task {
             switch (operationName) {
+                case "currentUser":
+                    user = permissionService.getCurrentUser(rootElement)
+                    return user as JSON
+            // test case
                 case "ping":
                     return "pong"
                     break

--- a/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/AnnotationEditorController.groovy
@@ -1274,9 +1274,6 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         inputString = annotationEditorService.cleanJSONString(inputString)
         JSONObject rootElement = (JSONObject) JSON.parse(inputString)
         rootElement.put(FeatureStringEnum.USERNAME.value, principal.name)
-        println "has a prinicpal name ${principal}"
-        User user = permissionService.getCurrentUser(rootElement)
-        println "getting USER ${user}"
 
 
         String operation = ((JSONObject) rootElement).get(REST_OPERATION)
@@ -1286,9 +1283,9 @@ class AnnotationEditorController extends AbstractApolloController implements Ann
         def p = task {
             switch (operationName) {
                 case "currentUser":
-                    user = permissionService.getCurrentUser(rootElement)
+                    User user = permissionService.getCurrentUser(rootElement)
                     return user as JSON
-            // test case
+            // test case for websocket
                 case "ping":
                     return "pong"
                     break

--- a/grails-app/controllers/org/bbop/apollo/LoginController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/LoginController.groovy
@@ -85,9 +85,9 @@ class LoginController extends AbstractApolloController {
             jsonObj = request.JSON
             if(!jsonObj){
                 jsonObj = JSON.parse(params.data)
-                log.debug "jsonObj ${jsonObj}"
+                println "jsonObj ${jsonObj}"
             }
-            log.debug "login -> the jsonObj ${jsonObj}"
+            println "login -> the jsonObj ${jsonObj}"
             String username = jsonObj.username
             String password = jsonObj.password
             Boolean rememberMe = jsonObj.rememberMe
@@ -98,8 +98,8 @@ class LoginController extends AbstractApolloController {
             if (rememberMe) {
                 authToken.rememberMe = true
             }
-            log.debug "rememberMe: ${rememberMe}"
-            log.debug "authToken : ${authToken.rememberMe}"
+            println "rememberMe: ${rememberMe}"
+            println "authToken : ${authToken.rememberMe}"
 
             // If a controller redirected to this page, redirect back
             // to it. Otherwise redirect to the root URI.
@@ -124,9 +124,9 @@ class LoginController extends AbstractApolloController {
                 throw new IncorrectCredentialsException("Bad credentaisl for user ${username}")
             }
 //            subject.login(authToken)
-            log.debug "IS AUTHENTICATED: " + subject.isAuthenticated()
-            log.debug "SESSION ${session}"
-            log.debug "LOGIN SESSION ${SecurityUtils.subject.getSession(false).id}"
+            println "IS AUTHENTICATED: " + subject.isAuthenticated()
+            println "SESSION ${session}"
+            println "LOGIN SESSION ${SecurityUtils.subject.getSession(false).id}"
 
             session.setAttribute("username", username);
             session.setAttribute("permissions", new HashMap<String, Integer>());

--- a/grails-app/controllers/org/bbop/apollo/LoginController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/LoginController.groovy
@@ -27,7 +27,6 @@ class LoginController extends AbstractApolloController {
 
     def handleOperation(String operation) {
         JSONObject postObject = findPost()
-        println "hanldling operation ${operation}"
         if(postObject?.containsKey(REST_OPERATION)){
             operation = postObject.get(REST_OPERATION)
         }
@@ -85,9 +84,9 @@ class LoginController extends AbstractApolloController {
             jsonObj = request.JSON
             if(!jsonObj){
                 jsonObj = JSON.parse(params.data)
-                println "jsonObj ${jsonObj}"
+                log.debug "jsonObj ${jsonObj}"
             }
-            println "login -> the jsonObj ${jsonObj}"
+            log.debug "login -> the jsonObj ${jsonObj}"
             String username = jsonObj.username
             String password = jsonObj.password
             Boolean rememberMe = jsonObj.rememberMe
@@ -98,8 +97,8 @@ class LoginController extends AbstractApolloController {
             if (rememberMe) {
                 authToken.rememberMe = true
             }
-            println "rememberMe: ${rememberMe}"
-            println "authToken : ${authToken.rememberMe}"
+            log.debug "rememberMe: ${rememberMe}"
+            log.debug "authToken : ${authToken.rememberMe}"
 
             // If a controller redirected to this page, redirect back
             // to it. Otherwise redirect to the root URI.
@@ -124,9 +123,9 @@ class LoginController extends AbstractApolloController {
                 throw new IncorrectCredentialsException("Bad credentaisl for user ${username}")
             }
 //            subject.login(authToken)
-            println "IS AUTHENTICATED: " + subject.isAuthenticated()
-            println "SESSION ${session}"
-            println "LOGIN SESSION ${SecurityUtils.subject.getSession(false).id}"
+            log.debug "IS AUTHENTICATED: " + subject.isAuthenticated()
+            log.debug "SESSION ${session}"
+            log.debug "LOGIN SESSION ${SecurityUtils.subject.getSession(false).id}"
 
             session.setAttribute("username", username);
             session.setAttribute("permissions", new HashMap<String, Integer>());
@@ -198,24 +197,22 @@ class LoginController extends AbstractApolloController {
 
 
     def logout(){
-        println "LOGOUT SESSION ${SecurityUtils?.subject?.getSession(false)?.id}"
-        println "logging out with params: ${params}"
+        log.debug "LOGOUT SESSION ${SecurityUtils?.subject?.getSession(false)?.id}"
+        log.debug "logging out with params: ${params}"
         // have to retrive the username first
         String username = SecurityUtils.subject.principal ?: params.username
-        println "sending logout for username ${username}"
+        log.debug "sending logout for username ${username}"
         sendLogout(username,params.get(FeatureStringEnum.CLIENT_TOKEN.value).toString())
-        println "sent logout"
+        log.debug "sent logout"
         sleep(1000)
-        println "doing local logout"
+        log.debug "doing local logout"
         SecurityUtils.subject.logout()
         sleep(1000)
-        println "logged out"
+        log.debug "logged out"
         if(params.targetUri){
-            println "redirecting"
             redirect(uri:"/auth/login?targetUri=${params.targetUri}")
         }
         else{
-            println "just doing JSON output"
             render new JSONObject() as JSON
         }
     }
@@ -231,7 +228,7 @@ class LoginController extends AbstractApolloController {
         jsonObject.put(FeatureStringEnum.USERNAME.value,username)
         jsonObject.put(FeatureStringEnum.CLIENT_TOKEN.value,clientToken)
         jsonObject.put(REST_OPERATION,"logout")
-        println "sending to: '/topic/AnnotationNotification/user/' + ${user.username}"
+        log.debug "sending to: '/topic/AnnotationNotification/user/' + ${user.username}"
         try {
             brokerMessagingTemplate.convertAndSend "/topic/AnnotationNotification/user/" + username, jsonObject.toString()
         } catch (e) {

--- a/grails-app/controllers/org/bbop/apollo/LoginController.groovy
+++ b/grails-app/controllers/org/bbop/apollo/LoginController.groovy
@@ -219,7 +219,7 @@ class LoginController extends AbstractApolloController {
 
     def sendLogout(String username,String clientToken) {
         User user = User.findByUsername(username)
-        println "sending logout for ${user} via ${username} with ${clientToken}"
+        log.debug "sending logout for ${user} via ${username} with ${clientToken}"
         JSONObject jsonObject = new JSONObject()
         if(!user){
             log.error("Already logged out or user not found: ${username}")


### PR DESCRIPTION
Note - method for work:

Note: react client code is here: https://github.com/nathandunn/apollo-websocket-test 



Login from React:
- in client code, `yarn build` -> `cp build <apollo-src>/web-app/<target_dir>` assuming target_dir does not exist
- running apollo2  go to the react code (I don't even think this PR is necessary) go to `<apollo2_url>/<target_dir>`
  - fill out proper username and password
  - hit `Ajax Login`
  - hit `WebSocket Login` (establishes the connection), can probably done on the callback
  - Note that `get Current user` should work as well as the other methods
- Confirm that on `<apollo2_url>/<target_dir>` (via a refresh) that you will also be logged in

Logout from Logout:
- in client code, `yarn build` -> `cp build <apollo-src>/web-app/<target_dir>` assuming target_dir does not exist
- hit `Ajax Logout`
- note that the webscoket methods no longer work
- Confirm that on `<apollo2_url>/<target_dir>` has been logged out as well



For when in dev mode on port 3000 (note proxy in `package.json`):
- in https://github.com/nathandunn/apollo-websocket-test  do a `yarn start`
- if logged into Apollo 2, verify that clicking 




--- 

- [x`] ajax logout from react should invalidate apollo 2 session (i.e., a refresh will fail to have the session)
- [x] ajax logout from react should force other Apollo2 sessions to fail
- [x] ajax login from react should create a valid session (other react functions should connect and work), Apollo2 refresh should automatically work
- [x] clean out code

----

- [x] ajax logout from Apollo2 logs out logged in react client
- [x] ajax logged in from   Apollo2 creates a valid session for same server (shares JSESSIONID)

