### PR TITLE
Make Python libraries installed globally in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,7 @@ COPY docker-files/build.sh /bin/build.sh
 ADD docker-files/docker-apollo-config.groovy /apollo/apollo-config.groovy
 RUN chown -R apollo:apollo /apollo
 
-# install grails and python libraries
-USER apollo
+# install python libraries
 
 # fix for pip install decode error
 # RUN locale-gen en_US.UTF-8
@@ -73,6 +72,9 @@ ENV LANGUAGE=en_US.UTF-8
 RUN pip3 install setuptools
 RUN pip3 install wheel
 RUN pip3 install nose apollo==4.2.10
+
+# install grails
+USER apollo
 
 RUN curl -s get.sdkman.io | bash && \
 	/bin/bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && yes | sdk install grails 2.5.5" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -qq update --fix-missing && \
 	zlib1g-dev libexpat1-dev curl ssl-cert zip unzip openjdk-8-jdk-headless
 
 RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list' && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+	wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN apt-get -qq update --fix-missing && \
 	apt-get --no-install-recommends -y install \
@@ -31,11 +31,11 @@ RUN apt-get -qq update --fix-missing && \
 
 
 RUN curl -s "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/blat/blat" -o /usr/local/bin/blat && \
- 		chmod +x /usr/local/bin/blat && \
- 		curl -s "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faToTwoBit" -o /usr/local/bin/faToTwoBit && \
- 		chmod +x /usr/local/bin/faToTwoBit && \
-		wget --quiet https://github.com/erasche/chado-schema-builder/releases/download/1.31-jenkins26/chado-1.31.sql.gz -O /chado.sql.gz && \
-		gunzip /chado.sql.gz
+	chmod +x /usr/local/bin/blat && \
+	curl -s "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faToTwoBit" -o /usr/local/bin/faToTwoBit && \
+	chmod +x /usr/local/bin/faToTwoBit && \
+	wget --quiet https://github.com/erasche/chado-schema-builder/releases/download/1.31-jenkins26/chado-1.31.sql.gz -O /chado.sql.gz && \
+	gunzip /chado.sql.gz
 
 #NOTE, we had problems with the build the archive-file coming in from github so using a clone instead
 RUN npm i -g yarn &&  useradd -ms /bin/bash -d /apollo apollo
@@ -63,7 +63,7 @@ RUN chown -R apollo:apollo /apollo
 # install grails and python libraries
 USER apollo
 
-# fix for pip install decode error 
+# fix for pip install decode error
 # RUN locale-gen en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
@@ -75,8 +75,8 @@ RUN pip3 install wheel
 RUN pip3 install nose apollo==4.2.10
 
 RUN curl -s get.sdkman.io | bash && \
-     /bin/bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && yes | sdk install grails 2.5.5" && \
-     /bin/bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && yes | sdk install gradle 3.2.1"
+	/bin/bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && yes | sdk install grails 2.5.5" && \
+	/bin/bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && yes | sdk install gradle 3.2.1"
 
 RUN /bin/bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && /bin/bash /bin/build.sh"
 


### PR DESCRIPTION
This makes the Python libraries (including the `arrow` cli tool) installed globally in the Docker image. Before this they were installed under the `apollo` user, and then subsequently deleted by build.sh.

Fixes #2620 