### PR TITLE
Updated Dockerfile to use Ubuntu 20.04 as the base image. Vulnerability fixes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -s "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/blat/blat" -o
 	chmod +x /usr/local/bin/blat && \
 	curl -s "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faToTwoBit" -o /usr/local/bin/faToTwoBit && \
 	chmod +x /usr/local/bin/faToTwoBit && \
-	wget --quiet https://github.com/erasche/chado-schema-builder/releases/download/1.31-jenkins26/chado-1.31.sql.gz -O /chado.sql.gz && \
+	wget --quiet https://github.com/galaxy-genome-annotation/chado-schema-builder/releases/download/1.31-jenkins26/chado-1.31.sql.gz -O /chado.sql.gz && \
 	gunzip /chado.sql.gz
 
 #NOTE, we had problems with the build the archive-file coming in from github so using a clone instead

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Apollo2.X
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER Nathan Dunn GH @nathandunn
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Hi GMOD,

As per an earlier discussion on the Apollo mailing list, I've tested a new version of the Apollo Docker build with an Ubuntu base image update from 18.04 -> 20.04.

The change addresses three vulnerabilities (one critical) by updating Tomcat from 9.0.16 (Ubuntu 18.04) to 9.0.31 (Ubuntu 20.04). The vulnerable version of Tomcat was detected by our campus sysadmins and we were not permitted to run the Apollo Docker image until they were patched.

I haven't found any significant differences in the build logs from 18.04 versus 20.04 (both attached) and I have 20.04 working locally without any issues --is there any additional testing on your end that needs to happen before considering an update of the Dockerfile?

If there's any other information or assistance I can provide, please let me know. Thanks!

Links to Tomcat vulnerabilities:
[CVE-2019-17569](https://nvd.nist.gov/vuln/detail/CVE-2019-17569)
[CVE-2020-1935](https://nvd.nist.gov/vuln/detail/CVE-2020-1935)
[CVE-2020-1938](https://nvd.nist.gov/vuln/detail/CVE-2020-1938)

[build_18.log](https://github.com/GMOD/Apollo/files/8605180/build_18.log)
[build_20.log](https://github.com/GMOD/Apollo/files/8605181/build_20.log)