### PR TITLE
Use fmin and fmax for partial instead of 3' and 5'

### DIFF
--- a/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.ui.xml
@@ -120,8 +120,8 @@
                     <b:InputGroupAddon>Location</b:InputGroupAddon>
                     <b:TextBox stylePrimaryName="{style.location-button}" autoComplete="false" ui:field="locationField" enabled="false"/>
                     <b:InputGroupAddon>Partial:</b:InputGroupAddon>
-                    <b:InlineCheckBox ui:field="partialMin" addStyleNames="{style.partial-button}">3'</b:InlineCheckBox>
-                    <b:InlineCheckBox ui:field="partialMax" addStyleNames="{style.partial-button}">5'</b:InlineCheckBox>
+                    <b:InlineCheckBox ui:field="partialMin" addStyleNames="{style.partial-button}">fmin</b:InlineCheckBox>
+                    <b:InlineCheckBox ui:field="partialMax" addStyleNames="{style.partial-button}">fmax</b:InlineCheckBox>
                 </b:InputGroup>
             </b:Column>
         </b:Row>

--- a/src/gwt/org/bbop/apollo/gwt/client/TranscriptDetailPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/TranscriptDetailPanel.ui.xml
@@ -116,8 +116,8 @@
                     <b:InputGroupAddon>Location</b:InputGroupAddon>
                     <b:TextBox stylePrimaryName="{style.location-button}" enabled="false" ui:field="locationField"/>
                     <b:InputGroupAddon>Partial:</b:InputGroupAddon>
-                    <b:InlineCheckBox ui:field="partialMin" addStyleNames="{style.partial-button}">3'</b:InlineCheckBox>
-                    <b:InlineCheckBox ui:field="partialMax" addStyleNames="{style.partial-button}">5'</b:InlineCheckBox>
+                    <b:InlineCheckBox ui:field="partialMin" addStyleNames="{style.partial-button}">fmin</b:InlineCheckBox>
+                    <b:InlineCheckBox ui:field="partialMax" addStyleNames="{style.partial-button}">fmax</b:InlineCheckBox>
                 </b:InputGroup>
             </b:Column>
         </b:Row>


### PR DESCRIPTION
In an email from a user, they stated:

> ...we have noticed a problem with the ‘Partial’ field in the Apollo annotation editor that manifests when a gff file is created for a gene model.
>
> The current UI stores the value of 3' as fmin_partial, and 5' as fmax_partial, which is incorrect, it should be the opposite. Also fmin_partial and fmax_partial are relative to the reference sequence, not the feature on its strand which might be what the annotator expects (so its ambiguous).

From what I can tell, the "partial" feature in Apollo is based on a similar feature in Artemis, see [here](https://github.com/GMOD/Apollo/issues/2565). Artemis appears to use 5' and 3' relative to the feature on the strand, though, and Apollo does not, so I think all the above observations are correct.

After discussion with the user, we decided to change the checkboxes in the UI to say "fmin" and "fmax" instead of 3' and 5'. This accurately describes how Apollo handles the data internally, and is not ambiguous.

Before:
![image](https://user-images.githubusercontent.com/25592344/167184143-8337b665-0f63-4fe2-a5e5-0d25e6ec31a8.png)

After:
![image](https://user-images.githubusercontent.com/25592344/167182822-cea6fb5c-6352-4d0b-913f-7eb909292cf9.png)
