### PR TITLE
Add info icon with tooltip describing meaning of fmin and fmax in "Partial"

### DIFF
--- a/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/GeneDetailPanel.ui.xml
@@ -120,6 +120,9 @@
                     <b:InputGroupAddon>Location</b:InputGroupAddon>
                     <b:TextBox stylePrimaryName="{style.location-button}" autoComplete="false" ui:field="locationField" enabled="false"/>
                     <b:InputGroupAddon>Partial:</b:InputGroupAddon>
+                    <b:Tooltip title="Indicates that the end of a gene is partial. &quot;fmin&quot; is the 5' end, and &quot;fmax&quot; is the 3' end (relative to the reference sequence, not the feature strand).">
+                        <b:Icon type="INFO_CIRCLE"/>
+                    </b:Tooltip>
                     <b:InlineCheckBox ui:field="partialMin" addStyleNames="{style.partial-button}">fmin</b:InlineCheckBox>
                     <b:InlineCheckBox ui:field="partialMax" addStyleNames="{style.partial-button}">fmax</b:InlineCheckBox>
                 </b:InputGroup>

--- a/src/gwt/org/bbop/apollo/gwt/client/TranscriptDetailPanel.ui.xml
+++ b/src/gwt/org/bbop/apollo/gwt/client/TranscriptDetailPanel.ui.xml
@@ -116,6 +116,9 @@
                     <b:InputGroupAddon>Location</b:InputGroupAddon>
                     <b:TextBox stylePrimaryName="{style.location-button}" enabled="false" ui:field="locationField"/>
                     <b:InputGroupAddon>Partial:</b:InputGroupAddon>
+                    <b:Tooltip title="Indicates that the end of a transcript is partial. &quot;fmin&quot; is the 5' end, and &quot;fmax&quot; is the 3' end (relative to the reference sequence, not the feature strand).">
+                        <b:Icon type="INFO_CIRCLE"/>
+                    </b:Tooltip>
                     <b:InlineCheckBox ui:field="partialMin" addStyleNames="{style.partial-button}">fmin</b:InlineCheckBox>
                     <b:InlineCheckBox ui:field="partialMax" addStyleNames="{style.partial-button}">fmax</b:InlineCheckBox>
                 </b:InputGroup>


### PR DESCRIPTION
Fixes #2648 by adding a tooltip that describes what "fmin" and "fmax" are in the context of "Partial"

The text reads: "Indicates that the end of a gene is partial. "fmin" is the 5' end, and "fmax" is the 3' end (relative to the reference sequence, not the feature strand)."

Here is a screenshot:

![image](https://user-images.githubusercontent.com/25592344/178345701-efbbc757-122c-4013-aa67-7600a657eaef.png)
