### PR TITLE
Update to log4j 2.19.0

### DIFF
--- a/.github/workflows/python-apollo.yml
+++ b/.github/workflows/python-apollo.yml
@@ -7,9 +7,6 @@ jobs:
     name: test-python-apollo
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8.8]
     steps:
       - name: Checkout Apollo
         uses: actions/checkout@v2
@@ -27,9 +24,9 @@ jobs:
           echo "Done sleeping, I hope it is working"
           curl -i 'http://localhost:8080/apollo/annotator/system'
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.8.7'
       - name: Checkout Pypi
         uses: actions/checkout@v2
         with:
@@ -84,5 +81,3 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-
-

--- a/.github/workflows/python-apollo.yml
+++ b/.github/workflows/python-apollo.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8.7]
+        python-version: [3.8.8]
     steps:
       - name: Checkout Apollo
         uses: actions/checkout@v2

--- a/.github/workflows/python-apollo.yml
+++ b/.github/workflows/python-apollo.yml
@@ -6,7 +6,10 @@ jobs:
   test-python-apollo:
     name: test-python-apollo
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.8.7]
     steps:
       - name: Checkout Apollo
         uses: actions/checkout@v2
@@ -24,9 +27,9 @@ jobs:
           echo "Done sleeping, I hope it is working"
           curl -i 'http://localhost:8080/apollo/annotator/system'
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v2
         with:
-          python-version: '3.8.7'
+          python-version: ${{ matrix.python-version }}
       - name: Checkout Pypi
         uses: actions/checkout@v2
         with:

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -44,7 +44,6 @@ grails.project.dependency.resolution = {
      excludes "grails-plugin-log4j", "grails-plugin-logging", "log4j"
     }
 
-    log "error" // log level of Ivy resolver, either 'error', 'warn', 'info', 'debug' or 'verbose'
     checksums true // whether to verify checksums on resolve
     legacyResolve false
     // whether to do a secondary resolve on plugin installation, not advised and here for backwards compatibility
@@ -68,6 +67,11 @@ grails.project.dependency.resolution = {
     }
 
     dependencies {
+
+
+        runtime 'org.apache.logging.log4j:log4j-api:2.19.0'
+        runtime 'org.apache.logging.log4j:log4j-core:2.19.0'
+        runtime 'org.apache.logging.log4j:log4j-1.2-api:2.19.0'
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes e.g.
         runtime 'mysql:mysql-connector-java:5.1.29'
         runtime 'org.postgresql:postgresql:9.4.1212'
@@ -133,7 +137,6 @@ grails.project.dependency.resolution = {
         compile(":shiro:1.2.1") {
             excludes([name: 'quartz', group: 'org.opensymphony.quartz'])
         }
-        compile ":audit-logging:1.0.3"
 
         // Uncomment these to enable additional asset-pipeline capabilities
         //compile ":sass-asset-pipeline:1.9.0"
@@ -163,7 +166,6 @@ grails.project.dependency.resolution = {
         //}
         compile ":yammer-metrics:3.0.1-2"
         compile "org.grails.plugins:quartz2:2.1.6.2"
-        compile "org.grails.plugins:export:1.6"
 
         //compile ":joda-time:1.4"
         // TODO: re-add when ready to install functional tests

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -137,6 +137,7 @@ grails.project.dependency.resolution = {
         compile(":shiro:1.2.1") {
             excludes([name: 'quartz', group: 'org.opensymphony.quartz'])
         }
+        compile ":audit-logging:1.0.3"
 
         // Uncomment these to enable additional asset-pipeline capabilities
         //compile ":sass-asset-pipeline:1.9.0"

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -41,6 +41,7 @@ grails.project.dependency.resolution = {
     inherits("global") {
         // specify dependency exclusions here; for example, uncomment this to disable ehcache:
         // excludes 'ehcache'
+     excludes "grails-plugin-log4j", "grails-plugin-logging", "log4j"
     }
 
     log "error" // log level of Ivy resolver, either 'error', 'warn', 'info', 'debug' or 'verbose'

--- a/grails-app/views/annotator/instructorReport.gsp
+++ b/grails-app/views/annotator/instructorReport.gsp
@@ -3,7 +3,6 @@
 <html>
 <head>
     <meta name="layout" content="report">
-    <export:resource />
     <title>Annotators</title>
 
     <script>
@@ -34,8 +33,6 @@
         <div class="groupHeader">
             <p>Group: ${userGroup.name}</p>
         </div>
-        <p><export:formats formats="['csv', 'excel', 'xml']" action="export" params="[userGroups: userGroup.id]"> </export:formats>
-        </p>
 
         <table class="reportTable">
         <thead>


### PR DESCRIPTION
this is a possible method to remove log4j jars from the resulting build

I ran 

```
./apollo deploy
cd target
mkdir output
cp apollo-2.6.7-SNAPSHOT.war output/apollo.zip
cd output
unzip apollo.zip
find .|grep log4j
```

output

```
WEB-INF/lib/log4j-1.2-api-2.19.0.jar
WEB-INF/lib/log4j-api-2.19.0.jar
WEB-INF/lib/log4j-core-2.19.0.jar
WEB-INF/lib/tomcat-embed-logging-log4j-7.0.70.jar
```

these are up to date versions of log4j v2

I then deployed this war file and it did not crash on startup


